### PR TITLE
feat(magenta): full MRT2 conditioning in-app + SA3 GPU offload; foote…

### DIFF
--- a/backend/modules/magenta/router.py
+++ b/backend/modules/magenta/router.py
@@ -54,6 +54,9 @@ async def generate(
     drums: int = Form(-1),
     chunk_frames: int = Form(25),
     notes: str = Form(""),
+    seed: int = Form(0),
+    extend: bool = Form(False),
+    styles: str = Form(""),
     model_size: str = Form("small"),
     audio_file: UploadFile | None = File(None),
 ):
@@ -75,6 +78,7 @@ async def generate(
         "kind": "magenta-generate",
         "model_name": f"magenta-{model_size}",
         "conditioning": cond,
+        "extend": bool(extend),
         "status": "queued",
         "progress": {"step": 0, "steps": 1},
         "created_at": time.time(),
@@ -94,6 +98,9 @@ async def generate(
             drums=drums,
             chunk_frames=chunk_frames,
             notes=notes or None,
+            seed=seed,
+            extend=extend,
+            styles=styles or None,
             audio_bytes=audio_bytes,
             audio_mime=audio_mime,
         )
@@ -114,6 +121,9 @@ async def _run_generate(
     drums,
     chunk_frames,
     notes,
+    seed,
+    extend,
+    styles,
     audio_bytes,
     audio_mime,
 ):
@@ -131,6 +141,9 @@ async def _run_generate(
             drums=drums,
             chunk_frames=chunk_frames,
             notes=notes,
+            seed=seed,
+            extend=extend,
+            styles=styles,
             audio_bytes=audio_bytes,
             audio_mime=audio_mime,
         )

--- a/backend/modules/magenta/sidecar.py
+++ b/backend/modules/magenta/sidecar.py
@@ -55,6 +55,9 @@ async def generate(
     drums: int = -1,
     chunk_frames: int = 25,
     notes: list[dict] | str | None = None,
+    seed: int = 0,
+    extend: bool = False,
+    styles: list[dict] | str | None = None,
     audio_bytes: bytes | None = None,
     audio_mime: str = "audio/wav",
 ) -> tuple[bytes, dict]:
@@ -80,9 +83,13 @@ async def generate(
         "cfg_drums": str(float(cfg_drums)),
         "drums": str(int(drums)),
         "chunk_frames": str(int(chunk_frames)),
+        "seed": str(int(seed)),
+        "extend": "true" if extend else "false",
     }
     if notes:
         data["notes"] = notes if isinstance(notes, str) else json.dumps(notes)
+    if styles:
+        data["styles"] = styles if isinstance(styles, str) else json.dumps(styles)
     files = {"audio": ("style.wav", audio_bytes, audio_mime)} if audio_bytes else None
 
     # Generation can take a while for long durations; allow a long read timeout.
@@ -94,8 +101,10 @@ async def generate(
             for k in (
                 "X-RTF",
                 "X-Audio-Seconds",
+                "X-Segment-Seconds",
                 "X-Generate-Seconds",
                 "X-Sample-Rate",
+                "X-Extend",
                 "X-Conditioning",
             )
             if r.headers.get(k)

--- a/backend/server.py
+++ b/backend/server.py
@@ -81,6 +81,9 @@ _WINDOWS_RESERVED_FILENAMES = {
 }
 _generation_pipelines: dict[str, Any] = {}
 _active_model_name = DEFAULT_GENERATION_MODEL
+# True while the SA3 model(s) are parked in CPU RAM (VRAM freed for a co-resident
+# GPU workload such as the Magenta RT2 sidecar). Swapped back by /api/model/onload.
+_sa3_offloaded = False
 _generation_job_lock = asyncio.Lock()
 
 # Spectrogram cache: {job_id: {mel, stft, chromagram, cqt}}
@@ -771,6 +774,101 @@ async def model_info():
             if torch.cuda.is_available()
             else 0
         ),
+    }
+
+
+def _vram_used_gb() -> float:
+    return (
+        round(torch.cuda.memory_allocated() / 1024**3, 2)
+        if torch.cuda.is_available()
+        else 0.0
+    )
+
+
+def _move_pipelines(device: str) -> int:
+    """Move every loaded generation pipeline's weights to ``device`` (blocking).
+
+    Run off the event loop. Moving a fp16 model GPU<->CPU is a pure tensor
+    transfer (no dtype change, bit-identical weights), so an offload/onload
+    round-trip restores the exact loaded state with no disk read.
+    """
+    moved = 0
+    for pl in _generation_pipelines.values():
+        try:
+            pl.model.to(device)
+            pl.device = torch.device(device)
+            moved += 1
+        except Exception:
+            logger.exception("model.move: failed moving a pipeline to %s", device)
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        if device != "cpu":
+            torch.cuda.synchronize()
+    return moved
+
+
+@app.post("/api/model/offload")
+async def offload_model():
+    """Park the SA3 model(s) in CPU RAM, freeing VRAM, without stopping the server.
+
+    Non-destructive: the fully-loaded model stays in system RAM so a co-resident
+    GPU workload (the Magenta RT2 sidecar) can use the card, and POST
+    /api/model/onload swaps it straight back to the GPU in seconds with no disk
+    reload. The backend process, API, and all non-DiT features stay up.
+    """
+    global _sa3_offloaded
+    before = _vram_used_gb()
+    loop = asyncio.get_event_loop()
+    n = await loop.run_in_executor(None, _move_pipelines, "cpu")
+    _sa3_offloaded = True
+    after = _vram_used_gb()
+    logger.info(
+        "model.offload: parked %d pipeline(s) in CPU RAM, torch VRAM %.2f -> %.2f GB",
+        n,
+        before,
+        after,
+    )
+    return {
+        "offloaded": n,
+        "location": "cpu",
+        "vram_used_gb_before": before,
+        "vram_used_gb_after": after,
+    }
+
+
+@app.post("/api/model/onload")
+async def onload_model():
+    """Swap the SA3 model(s) back from CPU RAM to VRAM (reverse of /offload)."""
+    global _sa3_offloaded
+    target = "cuda" if torch.cuda.is_available() else "cpu"
+    before = _vram_used_gb()
+    loop = asyncio.get_event_loop()
+    n = await loop.run_in_executor(None, _move_pipelines, target)
+    _sa3_offloaded = False
+    after = _vram_used_gb()
+    logger.info(
+        "model.onload: restored %d pipeline(s) to %s, torch VRAM %.2f -> %.2f GB",
+        n,
+        target,
+        before,
+        after,
+    )
+    return {
+        "onloaded": n,
+        "location": target,
+        "vram_used_gb_before": before,
+        "vram_used_gb_after": after,
+    }
+
+
+@app.get("/api/model/offload-status")
+async def offload_status():
+    """Report whether the SA3 model is currently parked in CPU RAM."""
+    return {
+        "offloaded": _sa3_offloaded,
+        "active_model": _active_model_name,
+        "loaded_models": sorted(_generation_pipelines),
+        "vram_used_gb": _vram_used_gb(),
     }
 
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-10T06:43:05.119Z · Git revision: `ca41cd51f701` · Repomix tracked: **no**
+> Generated: 2026-06-10T16:16:00.191Z · Git revision: `6317fdb87584` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-10T06:43:05.119Z",
-  "repoRevision": "ca41cd51f701",
+  "generatedAt": "2026-06-10T16:16:00.191Z",
+  "repoRevision": "6317fdb87584",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-10T06:45:07.044Z",
+  "generatedAt": "2026-06-10T16:17:58.257Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/_capture_clips.mjs
+++ b/frontend/_capture_clips.mjs
@@ -130,6 +130,11 @@ const VW = +(process.env.CAPW || 1920), VH = +(process.env.CAPH || 1080);
 const DSF = +(process.env.DSF || 1);
 const HEADLESS = process.env.HEADLESS === '1';
 const SIZE = { width: VW, height: VH };
+// Recording size can be decoupled from the viewport (CAPRECW/CAPRECH) so the
+// 1920-logical layout the crops + mouse coords assume can be recorded at true
+// 4K via DSF=2 (viewport 1920x1080, deviceScaleFactor 2, record 3840x2160).
+const RW = +(process.env.CAPRECW || VW), RH = +(process.env.CAPRECH || VH);
+const REC = { width: RW, height: RH };
 const CX = Math.round(VW / 2), CY = Math.round(VH / 2), KX = VW / 1920, KY = VH / 1080;
 
 // Per-scene store driving. Heavy one-time builds (hero/stems/decks/studio/bucket)
@@ -847,7 +852,7 @@ const launchArgs = ['--autoplay-policy=no-user-gesture-required'];
 if (HEADLESS) launchArgs.push('--use-angle=gl', '--ignore-gpu-blocklist', '--enable-gpu', '--enable-webgl', '--enable-accelerated-2d-canvas');
 else launchArgs.push('--start-maximized');
 const browser = await chromium.launch({ headless: HEADLESS, args: launchArgs });
-const ctx = await browser.newContext({ viewport: SIZE, deviceScaleFactor: DSF, recordVideo: { dir: OUT, size: SIZE } });
+const ctx = await browser.newContext({ viewport: SIZE, deviceScaleFactor: DSF, recordVideo: { dir: OUT, size: REC } });
 const page = await ctx.newPage();
 const tRec = Date.now();       // recording starts at context/page creation → this is video t=0.
                                // (Anchoring AFTER the splash wait shifts every slice earlier by
@@ -904,7 +909,7 @@ for (const m of marks) {
   const out = path.join(OUT, `${m.id}_h.mp4`);
   try {
     execFileSync('ffmpeg', ['-y', '-loglevel', 'error', '-ss', ss, '-t', dur, '-i', sessionWebm,
-      '-an', '-vf', `scale=${VW}:${VH},fps=30,format=yuv420p`, '-c:v', 'libx264', '-preset', 'medium', '-crf', '14', out]);
+      '-an', '-vf', `scale=${RW}:${RH},fps=30,format=yuv420p`, '-c:v', 'libx264', '-preset', 'medium', '-crf', '14', out]);
     console.log(`  sliced ${m.id}_h.mp4  (${dur}s @ ${ss}s)`);
   } catch (e) { console.log(`  slice FAIL ${m.id}`, e.message); }
 }

--- a/frontend/src/catalog/CatalogueFilterBar.tsx
+++ b/frontend/src/catalog/CatalogueFilterBar.tsx
@@ -120,6 +120,7 @@ export const CatalogueFilterBar: React.FC<Props> = ({ resultCount }) => {
           <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-zinc-600 pointer-events-none" />
           <input
             type="text"
+            name="catalog-search"
             className="compact-input w-full pl-7 pr-7"
             placeholder="SEARCH CATALOGUE..."
             value={queryDraft}
@@ -170,6 +171,7 @@ export const CatalogueFilterBar: React.FC<Props> = ({ resultCount }) => {
         </div>
         <HoverTip text={TARGET_TIP}>
           <select
+            name="catalog-search-target"
             className="compact-input text-[9px]! py-0.5! bg-black/40"
             value={search.searchTarget}
             onChange={(e) => patchSearch({ searchTarget: e.target.value as CatalogueSearchTarget })}
@@ -194,6 +196,7 @@ export const CatalogueFilterBar: React.FC<Props> = ({ resultCount }) => {
 
         <HoverTip text={SORT_TIP}>
           <select
+            name="catalog-sort-by"
             className="compact-input text-[9px]! py-0.5! bg-black/40"
             value={search.sortBy}
             onChange={(e) => patchSearch({ sortBy: e.target.value as CatalogueSortBy })}
@@ -206,6 +209,7 @@ export const CatalogueFilterBar: React.FC<Props> = ({ resultCount }) => {
 
         <HoverTip text={PROVIDER_TIP}>
           <select
+            name="catalog-filter-provider"
             className="compact-input text-[9px]! py-0.5! bg-black/40"
             value={search.providerFilter ?? ''}
             onChange={(e) => patchSearch({ providerFilter: e.target.value || null })}
@@ -219,6 +223,7 @@ export const CatalogueFilterBar: React.FC<Props> = ({ resultCount }) => {
 
         <HoverTip text={SOURCE_TIP}>
           <select
+            name="catalog-filter-source"
             className="compact-input text-[9px]! py-0.5! bg-black/40"
             value={search.sourceFilter}
             onChange={(e) => patchSearch({ sourceFilter: e.target.value as CatalogueSourceFilter })}
@@ -231,6 +236,7 @@ export const CatalogueFilterBar: React.FC<Props> = ({ resultCount }) => {
 
         <HoverTip text={RATING_TIP}>
           <select
+            name="catalog-filter-rating"
             className="compact-input text-[9px]! py-0.5! bg-black/40"
             value={search.ratingFilter}
             onChange={(e) => patchSearch({ ratingFilter: e.target.value as CatalogueRatingFilter })}
@@ -244,6 +250,7 @@ export const CatalogueFilterBar: React.FC<Props> = ({ resultCount }) => {
         {models.length > 0 && (
           <HoverTip text={MODEL_TIP}>
             <select
+              name="catalog-filter-model"
               className="compact-input text-[9px]! py-0.5! bg-black/40"
               value={search.modelFilter ?? ''}
               onChange={(e) => patchSearch({ modelFilter: e.target.value || null })}

--- a/frontend/src/catalog/CatalogueInspector.tsx
+++ b/frontend/src/catalog/CatalogueInspector.tsx
@@ -249,7 +249,7 @@ export const CatalogueInspector: React.FC<Props> = ({ entry }) => {
         {entry.prompt && (
           <div className="flex flex-col gap-1">
             <span className="mono-label text-[9px]!">PROMPT</span>
-            <p className="text-[9px] font-mono text-zinc-400 leading-relaxed bg-black/30 rounded p-2 break-words">
+            <p className="text-[9px] font-mono text-zinc-400 leading-relaxed bg-black/30 rounded p-2 wrap-break-word">
               {entry.prompt}
             </p>
           </div>
@@ -257,7 +257,7 @@ export const CatalogueInspector: React.FC<Props> = ({ entry }) => {
         {entry.negativePrompt && (
           <div className="flex flex-col gap-1">
             <span className="mono-label text-[9px]! text-red-400/70!">NEGATIVE</span>
-            <p className="text-[9px] font-mono text-zinc-500 leading-relaxed bg-black/30 rounded p-2 break-words">
+            <p className="text-[9px] font-mono text-zinc-500 leading-relaxed bg-black/30 rounded p-2 wrap-break-word">
               {entry.negativePrompt}
             </p>
           </div>
@@ -274,7 +274,7 @@ export const CatalogueInspector: React.FC<Props> = ({ entry }) => {
             {lyrics && (
               <div className="flex flex-col gap-0.5">
                 <span className="text-[8px] font-mono uppercase tracking-widest text-zinc-600">Lyrics</span>
-                <p className="text-[9px] font-mono text-zinc-400 leading-relaxed bg-black/30 rounded p-2 break-words whitespace-pre-wrap max-h-40 overflow-y-auto no-scrollbar">
+                <p className="text-[9px] font-mono text-zinc-400 leading-relaxed bg-black/30 rounded p-2 wrap-break-word whitespace-pre-wrap max-h-40 overflow-y-auto no-scrollbar">
                   {lyrics}
                 </p>
               </div>
@@ -347,7 +347,7 @@ export const CatalogueInspector: React.FC<Props> = ({ entry }) => {
                   </button>
                 ))}
               </div>
-              <div className="aspect-[10/3] bg-black/40 rounded flex items-center justify-center overflow-hidden">
+              <div className="aspect-10/3 bg-black/40 rounded flex items-center justify-center overflow-hidden">
                 {activeSpec
                   ? <img src={`data:image/png;base64,${activeSpec}`} alt={`${specTab} spectrogram`} className="w-full h-full object-cover" />
                   : <span className="text-[8px] font-mono text-zinc-700">No {specTab.toUpperCase()} image</span>}
@@ -379,6 +379,7 @@ export const CatalogueInspector: React.FC<Props> = ({ entry }) => {
             ))}
           </div>
           <input
+            name="catalog-add-tag"
             className="compact-input w-full"
             placeholder="ADD TAG + ENTER"
             value={tagDraft}
@@ -391,6 +392,7 @@ export const CatalogueInspector: React.FC<Props> = ({ entry }) => {
         <div className="flex flex-col gap-1">
           <span className="mono-label text-[9px]!">NOTES</span>
           <textarea
+            name="catalog-notes"
             className="compact-input w-full min-h-16 resize-y"
             placeholder="Notes…"
             value={notesDraft}

--- a/frontend/src/components/audio/AdvancedVisualizer.tsx
+++ b/frontend/src/components/audio/AdvancedVisualizer.tsx
@@ -141,7 +141,7 @@ export const AdvancedVisualizer: React.FC = () => {
     <div className="hardware-card h-full flex flex-col bg-black/40 relative overflow-hidden group">
       {/* Background Grid */}
       <div
-        className="absolute inset-0 opacity-[0.07] pointer-events-none"
+        className="absolute inset-0 opacity-7 pointer-events-none"
         style={{
           backgroundImage: `linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)`,
           backgroundSize: '20px 20px',

--- a/frontend/src/components/audio/PianoRoll.tsx
+++ b/frontend/src/components/audio/PianoRoll.tsx
@@ -463,6 +463,7 @@ export const PianoRoll: React.FC = () => {
             <span className="text-[7px] font-mono text-zinc-600 uppercase">BPM</span>
             <input
               type="number"
+              name="piano-roll-bpm"
               min={40}
               max={240}
               value={bpm}
@@ -474,6 +475,7 @@ export const PianoRoll: React.FC = () => {
             <span className="text-[7px] font-mono text-zinc-600 uppercase">Steps</span>
             <input
               type="number"
+              name="piano-roll-total-steps"
               min={16}
               max={256}
               step={16}
@@ -497,6 +499,7 @@ export const PianoRoll: React.FC = () => {
           <label className="relative">
             <input
               type="file"
+              name="piano-roll-import-midi"
               accept=".mid,.midi,audio/midi"
               className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
               onChange={(e) => {

--- a/frontend/src/components/audio/PlayerFooter.tsx
+++ b/frontend/src/components/audio/PlayerFooter.tsx
@@ -192,8 +192,10 @@ export const PlayerFooter: React.FC = () => {
   return (
     <footer className="fixed bottom-0 left-0 right-0 h-20 bg-[#0a080f]/95 backdrop-blur-xl border-t border-white/5 z-50 px-6 flex items-center justify-between gap-8 group">
       {/* 1. G-Search + track info. The orb assistant overlaps the very
-          bottom-left corner, so pad section 1 left to clear its hit area. */}
-      <div className="flex items-center gap-3 w-75 shrink-0 pl-20">
+          bottom-left corner, so pad section 1 left to clear its hit area.
+          Width matches section 3 (w-80) so the flex-1 transport — and the PLAY
+          button at its centre — lands on the true viewport centre. */}
+      <div className="flex items-center gap-3 w-80 shrink-0 pl-20">
         {/* G-Search — global library search, available on every tab. */}
         <div className="flex items-center gap-2 px-2.5 py-1 bg-white/5 rounded-full border border-white/5 shrink-0">
           <Search className="w-3 h-3 text-zinc-600" />

--- a/frontend/src/components/audio/SlideRow.tsx
+++ b/frontend/src/components/audio/SlideRow.tsx
@@ -66,7 +66,9 @@ export function SlideRow({ label, value, onChange, min, max, step = 1, tipKey, o
         <div className="absolute top-1/2 w-3.5 h-3.5 rounded-full bg-white"
           style={{ left: `${t * 100}%`, transform: 'translate(-50%,-50%)', boxShadow: `0 0 8px ${rgba(base, 0.9)}`, transition: drag ? 'none' : 'left 0.08s ease' }} />
       </div>
-      <input type="number" className="compact-input w-11 text-center tabular-nums shrink-0"
+      <input
+        name={`slide-${label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')}`}
+        type="number" className="compact-input w-11 text-center tabular-nums shrink-0"
         style={{ color: rgb(base), fontWeight: 700 }}
         min={min} max={max} step={step} value={value} onChange={(e) => onChange(+e.target.value || 0)} />
     </div>

--- a/frontend/src/components/audio/SlideTrack.tsx
+++ b/frontend/src/components/audio/SlideTrack.tsx
@@ -6,7 +6,7 @@ const clamp = (x: number, a: number, b: number) => Math.max(a, Math.min(b, x));
 /* ── SlideTrack: the bare SLIDE glass-capsule slider ─────────────────────────
    The SLIDE look (capsule track + glowing colour-tracking fill + white knob)
    extracted from SlideRow as a label-less, drop-in replacement for a raw
-   `<input type="range" class="pro-slider">`. Each call site keeps its own label
+   `input[type=range].pro-slider`. Each call site keeps its own label
    and value readout; only the slider itself becomes SLIDE. Width/height come from
    `className` (e.g. "w-full", "flex-1", "w-16"); pass `tint` to pin the colour
    instead of having it track the value. */

--- a/frontend/src/components/audio/StepSequencer.tsx
+++ b/frontend/src/components/audio/StepSequencer.tsx
@@ -557,6 +557,7 @@ export const StepSequencer: React.FC = () => {
               <span className="text-[7px] font-mono text-zinc-600 uppercase leading-none">Tempo (BPM)</span>
               <input
                 type="number"
+                name="step-seq-bpm"
                 value={bpm}
                 min={40}
                 max={240}
@@ -598,6 +599,7 @@ export const StepSequencer: React.FC = () => {
             <Music className="w-2.5 h-2.5 text-zinc-500" />
             <input
               type="number"
+              name="step-seq-export-bars"
               min={1}
               max={16}
               value={exportBars}
@@ -659,6 +661,7 @@ export const StepSequencer: React.FC = () => {
               <div className="flex justify-between items-center mb-1 gap-1">
                 <input
                   type="text"
+                  name={`step-seq-track-name-${track.id}`}
                   value={track.name}
                   onChange={(e) => setTrackName(track.id, e.target.value)}
                   className="bg-transparent border-none outline-none text-[9px] font-black uppercase truncate hover:bg-white/5 px-1 -mx-1 rounded transition-colors flex-1 min-w-0"

--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -1411,7 +1411,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
                 >
                   {/* Header bar */}
                   <div className="absolute top-0 left-0 right-0 px-1 h-3.5 bg-black/50 backdrop-blur-sm border-b border-white/10 flex justify-between items-center text-[8px] font-mono uppercase tracking-tighter">
-                    <span className="flex items-center gap-1 min-w-0 max-w-[60%]">
+                    <span className="flex items-center gap-1 min-w-0 max-w-3/5">
                       {clip.sourceKind === 'piano-roll' && (
                         <Piano className="w-2.5 h-2.5 text-emerald-300 shrink-0" />
                       )}
@@ -1673,6 +1673,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
           {inpaintPanel.kind === 'params' && (
             <>
               <textarea
+                name="inpaint-prompt"
                 placeholder="Describe what to generate in this region…"
                 value={inpaintPrompt}
                 onChange={(e) => setInpaintPrompt(e.target.value)}
@@ -1691,7 +1692,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               <div className="flex items-center gap-2">
                 <span className="text-[9px] font-mono text-zinc-500 shrink-0">Seed</span>
                 <input
-                  type="number" value={inpaintSeed}
+                  type="number" name="inpaint-seed" value={inpaintSeed}
                   onChange={(e) => setInpaintSeed(parseInt(e.target.value) || -1)}
                   className="flex-1 bg-black/40 border border-white/10 rounded px-2 py-0.5 text-[9px] font-mono text-zinc-200 outline-none focus:border-purple-500/50 transition-colors"
                   placeholder="-1 (random)"

--- a/frontend/src/components/chimera/ChimeraControls.tsx
+++ b/frontend/src/components/chimera/ChimeraControls.tsx
@@ -53,6 +53,7 @@ export const ChimeraControls: React.FC = () => {
         <span className="text-zinc-400 uppercase tracking-widest">BPM</span>
         <input
           type="number"
+          name="chimera-target-bpm"
           min={40}
           max={240}
           step={0.1}
@@ -80,6 +81,7 @@ export const ChimeraControls: React.FC = () => {
         <Layers className="w-2.5 h-2.5 text-purple-400" />
         <span className="text-zinc-400 uppercase tracking-widest">Align</span>
         <select
+          name="chimera-align-mode"
           value={alignMode}
           onChange={(e) => setChimeraField('alignMode', e.target.value as ChimeraAlignMode)}
           className="compact-input"
@@ -98,6 +100,7 @@ export const ChimeraControls: React.FC = () => {
             <span className="text-zinc-400 uppercase tracking-widest" title="Bars per chunk">Chunk</span>
             <input
               type="number"
+              name="chimera-weave-bars"
               min={0}
               max={32}
               step={1}
@@ -114,6 +117,7 @@ export const ChimeraControls: React.FC = () => {
             <span className="text-zinc-400 uppercase tracking-widest" title="Minimum total length in bars">Total</span>
             <input
               type="number"
+              name="chimera-weave-total-bars"
               min={0}
               max={256}
               step={4}
@@ -135,6 +139,7 @@ export const ChimeraControls: React.FC = () => {
             </span>
             <input
               type="number"
+              name="chimera-weave-max-polyphony"
               min={1}
               max={8}
               step={1}

--- a/frontend/src/components/chimera/ChimeraStack.tsx
+++ b/frontend/src/components/chimera/ChimeraStack.tsx
@@ -192,6 +192,7 @@ export const ChimeraStack: React.FC = () => {
       >
         <input
           ref={fileInputRef}
+          name="chimera-audio-file"
           type="file"
           accept="audio/*"
           multiple

--- a/frontend/src/components/layout/ControllerVisionModal.tsx
+++ b/frontend/src/components/layout/ControllerVisionModal.tsx
@@ -213,7 +213,7 @@ export const ControllerVisionModal: React.FC<Props> = ({ onClose, onBuilt }) => 
               A vision model identifies your controller (brand + model) and counts its controls — far more accurate than raw shape detection. If enabled, this uploads the photo to your configured AI provider (via your Assistant keys).
             </p>
             <div className="flex gap-2">
-              <input ref={aiFileRef} type="file" accept="image/*" className="hidden"
+              <input ref={aiFileRef} type="file" name="controller-vision-ai-photo" accept="image/*" className="hidden"
                 onChange={(e) => { const f = e.target.files?.[0]; if (f) void onAiIdentify(f); }} />
               <button
                 onClick={() => aiFileRef.current?.click()}
@@ -239,6 +239,7 @@ export const ControllerVisionModal: React.FC<Props> = ({ onClose, onBuilt }) => 
               <div className="text-[9px] font-mono uppercase tracking-widest text-zinc-500">By name (Wikimedia)</div>
               <div className="flex gap-1.5">
                 <input
+                  name="controller-vision-name-search"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   onKeyDown={(e) => { if (e.key === 'Enter') void onSearch(); }}
@@ -255,7 +256,7 @@ export const ControllerVisionModal: React.FC<Props> = ({ onClose, onBuilt }) => 
             </div>
             <div className="space-y-1.5">
               <div className="text-[9px] font-mono uppercase tracking-widest text-zinc-500">Raw CV (no AI)</div>
-              <input ref={fileRef} type="file" accept="image/*" className="hidden"
+              <input ref={fileRef} type="file" name="controller-vision-cv-photo" accept="image/*" className="hidden"
                 onChange={(e) => { const f = e.target.files?.[0]; if (f) void onUpload(f); }} />
               <button
                 onClick={() => fileRef.current?.click()}
@@ -344,7 +345,7 @@ export const ControllerVisionModal: React.FC<Props> = ({ onClose, onBuilt }) => 
                   <label key={k} className="flex flex-col gap-1">
                     <span className="text-[8px] font-mono uppercase" style={{ color: KIND_COLOR[k] }}>{k}s</span>
                     <input
-                      type="number" min={0} value={counts[k]}
+                      type="number" name={`controller-vision-count-${k}`} min={0} value={counts[k]}
                       onChange={(e) => setCounts((c) => ({ ...c, [k]: Math.max(0, parseInt(e.target.value || '0', 10)) }))}
                       className="bg-black/40 border border-white/12 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-indigo-500/50"
                     />

--- a/frontend/src/components/layout/DocsModal.tsx
+++ b/frontend/src/components/layout/DocsModal.tsx
@@ -50,9 +50,16 @@ export const DocsModal: React.FC<DocsModalProps> = ({ open, onClose }) => {
     // Parse markdown → HTML and extract h1/h2/h3 for TOC.
     const renderer = new marked.Renderer();
     const collected: Heading[] = [];
+    // De-duplicate heading slugs: the guide concatenates many docs that share
+    // headings (e.g. "Purpose"), so a raw slug would collide — breaking the TOC
+    // React keys AND the scroll-to anchors. Suffix repeats with -2, -3, …
+    const slugCounts = new Map<string, number>();
     renderer.heading = ({ tokens, depth }: { tokens: Array<{ raw?: string; text?: string }>; depth: number }) => {
       const text = tokens.map((t) => t.text ?? t.raw ?? '').join('');
-      const id = slugify(text);
+      let id = slugify(text);
+      const n = (slugCounts.get(id) ?? 0) + 1;
+      slugCounts.set(id, n);
+      if (n > 1) id = `${id}-${n}`;
       if (depth <= 3) collected.push({ id, text, level: depth });
       return `<h${depth} id="${id}" class="docs-h docs-h-${depth}">${text}</h${depth}>`;
     };
@@ -181,6 +188,7 @@ export const DocsModal: React.FC<DocsModalProps> = ({ open, onClose }) => {
                 <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-zinc-600" />
                 <input
                   type="text"
+                  name="docs-toc-search"
                   className="compact-input w-full pl-7"
                   placeholder="FILTER TOC..."
                   value={search}

--- a/frontend/src/components/layout/MediaBucketView.tsx
+++ b/frontend/src/components/layout/MediaBucketView.tsx
@@ -206,6 +206,7 @@ export const MediaBucketView: React.FC = () => {
             <input
               ref={fileInputRef}
               type="file"
+              name="media-bucket-add-files"
               multiple
               accept="audio/*,.mid,.midi,image/*,video/*"
               className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
@@ -232,6 +233,7 @@ export const MediaBucketView: React.FC = () => {
         <Link2 className="w-3 h-3 text-purple-300 shrink-0" />
         <input
           type="text"
+          name="media-bucket-import-url"
           value={importUrl}
           onChange={(e) => setImportUrl(e.target.value)}
           onKeyDown={(e) => {

--- a/frontend/src/components/layout/ModuleSidebar.tsx
+++ b/frontend/src/components/layout/ModuleSidebar.tsx
@@ -50,9 +50,10 @@ export const ModuleSidebar: React.FC = () => {
         
         <div className="relative group">
           <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-zinc-600 group-focus-within:text-purple-500 transition-colors" />
-          <input 
-            type="text" 
-            placeholder="Search plugins..." 
+          <input
+            type="text"
+            name="module-search"
+            placeholder="Search plugins..."
             className="w-full bg-black/40 border border-white/5 rounded px-7 py-1.5 text-[10px] font-mono text-white outline-none focus:border-purple-500/50 transition-all placeholder:text-zinc-800"
             value={search}
             onChange={(e) => setSearch(e.target.value)}

--- a/frontend/src/components/layout/ProcessingLog.tsx
+++ b/frontend/src/components/layout/ProcessingLog.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { Trash2, Download, X, Zap, Cast } from 'lucide-react';
 import { useLogStore, type LogLevel, type LogEntry } from '../../state/logStore';
 import { useLibraryStore } from '../../state/libraryStore';
-import { useGenerateStore } from '../../state/generateStore';
+import { buildGenerateParamsFromState, useGenerateStore } from '../../state/generateStore';
 import { useGenerateParamsStore } from '../../state/generateParamsStore';
 import { useStudioStore } from '../../state/studioStore';
 import { useTrainingStore } from '../../state/trainingStore';
@@ -285,26 +285,11 @@ export const LogActionButton: React.FC = () => {
     if (tab === 'create' || tab === 'library' || tab === 'advanced') {
       if (tab !== 'create') setActiveView('create');
       if (isGenerating) { cancelPolling(); return; }
+      // Build the full param set (includes Magenta style/notes/seed/extend and
+      // initAudioEnabled) via the shared selector so CREATE and the assistant
+      // stay in sync instead of drifting from a hand-maintained field list.
       const p = useGenerateParamsStore.getState();
-      void submitGeneration({
-        prompt: p.prompt, negativePrompt: p.negativePrompt, model: p.model,
-        duration: p.duration, steps: p.steps, cfg: p.cfg, seed: p.seed, batch: p.batch,
-        initNoise: p.initNoise, initType: p.initType, initAudioFile: p.initAudioFile,
-        inpaintAudioFile: p.inpaintAudioFile, inpaintEnabled: p.inpaintEnabled,
-        maskStart: p.maskStart, maskEnd: p.maskEnd,
-        samplerType: p.samplerType, sigmaMax: p.sigmaMax, durationPaddingSec: p.durationPaddingSec,
-        apgScale: p.apgScale, cfgRescale: p.cfgRescale, cfgNormThreshold: p.cfgNormThreshold,
-        cfgIntervalMin: p.cfgIntervalMin, cfgIntervalMax: p.cfgIntervalMax,
-        shiftMode: p.shiftMode, logsnrAnchorLength: p.logsnrAnchorLength,
-        logsnrAnchorLogsnr: p.logsnrAnchorLogsnr, logsnrRate: p.logsnrRate, logsnrEnd: p.logsnrEnd,
-        fluxMinLen: p.fluxMinLen, fluxMaxLen: p.fluxMaxLen, fluxAlphaMin: p.fluxAlphaMin,
-        fluxAlphaMax: p.fluxAlphaMax, fullBaseShift: p.fullBaseShift, fullMaxShift: p.fullMaxShift,
-        fullMinLen: p.fullMinLen, fullMaxLen: p.fullMaxLen,
-        inversionSteps: p.inversionSteps, inversionGamma: p.inversionGamma,
-        inversionUnconditional: p.inversionUnconditional,
-        fileFormat: p.fileFormat, fileNaming: p.fileNaming, cutToDuration: p.cutToDuration,
-        loras: p.loras,
-      });
+      void submitGeneration(buildGenerateParamsFromState(p));
     } else if (tab === 'edit') {
       void useStudioStore.getState().triggerPendingProcess();
     } else if (tab === 'train') {

--- a/frontend/src/components/layout/SettingsModal.tsx
+++ b/frontend/src/components/layout/SettingsModal.tsx
@@ -239,9 +239,11 @@ export const SettingsModal: React.FC<{ open: boolean; onClose: () => void }> = (
             <span className="text-[9px] font-black uppercase tracking-widest text-zinc-300">VJ Recording</span>
           </div>
           <div className="mb-3">
-            <label className="block text-[9px] font-mono uppercase tracking-wider text-zinc-400 mb-1">Export root folder</label>
+            <label htmlFor="settings-vj-export-root" className="block text-[9px] font-mono uppercase tracking-wider text-zinc-400 mb-1">Export root folder</label>
             <input
+              id="settings-vj-export-root"
               type="text"
+              name="settings-vj-export-root"
               value={vjExportRoot}
               onChange={(e) => setVjExportRoot(e.target.value)}
               onBlur={() => {

--- a/frontend/src/components/layout/Shell.tsx
+++ b/frontend/src/components/layout/Shell.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense, lazy, useEffect, useMemo, useState } from 'react';
-import { Settings, BookOpen, Smartphone, X, Copy, ExternalLink, ChevronUp, ChevronDown, GripHorizontal, GripVertical } from 'lucide-react';
+import React, { Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react';
+import { Settings, BookOpen, Smartphone, X, Copy, ExternalLink, ChevronUp, ChevronDown, GripHorizontal } from 'lucide-react';
 import { LibraryView } from '../../views/LibraryView';
 import { DAWCenterPanel } from './DAWCenterPanel';
 
@@ -251,10 +251,12 @@ export const Shell: React.FC = () => {
               </div>
 
               <div className="flex flex-col gap-1.5">
-                <label className="text-[9px] font-black uppercase tracking-widest text-zinc-400">Share URL</label>
+                <label htmlFor="shell-share-url" className="text-[9px] font-black uppercase tracking-widest text-zinc-400">Share URL</label>
                 <div className="flex gap-2">
                   <input
+                    id="shell-share-url"
                     type="text"
+                    name="shell-share-url"
                     value={shareUrl}
                     readOnly
                     className="flex-1 bg-black/40 border border-white/10 rounded px-2 py-1.5 text-[10px] font-mono text-zinc-200 outline-none"
@@ -273,9 +275,11 @@ export const Shell: React.FC = () => {
               </div>
 
               <div className="flex flex-col gap-1.5">
-                <label className="text-[9px] font-black uppercase tracking-widest text-zinc-400">External URL override</label>
+                <label htmlFor="shell-share-url-override" className="text-[9px] font-black uppercase tracking-widest text-zinc-400">External URL override</label>
                 <input
+                  id="shell-share-url-override"
                   type="url"
+                  name="shell-share-url-override"
                   value={shareUrlOverride}
                   onChange={(e) => updateShareUrlOverride(e.target.value)}
                   placeholder="Paste Cloudflare tunnel URL, e.g. https://name.trycloudflare.com"
@@ -323,8 +327,9 @@ export const Shell: React.FC = () => {
 const STRIP_HEIGHT = 36;
 const DOCK_MIN_HEIGHT = 60;
 const DOCK_MAX_FRACTION = 0.85;
-const LOG_HEADER_FRACTION = '40%';
-const CREATE_FRACTION = '60%';
+// CREATE / PROCESS / TRAIN action button — a FIXED width so it never grows when
+// the LOG is drag-resized (the LOG header takes all the slack instead).
+const ACTION_WIDTH = 180;
 const LOG_MIN_WIDTH = 220;
 const LOG_MAX_WIDTH = 720;
 
@@ -333,41 +338,41 @@ const ShellBottomDock: React.FC = () => {
   const setMultiHeight = useBottomPanelStore((s) => s.setMultiHeight);
   const logWidth = useBottomPanelStore((s) => s.logWidth);
   const setLogWidth = useBottomPanelStore((s) => s.setLogWidth);
-  const setRightPanelWidth = useAppUiStore((s) => s.setRightPanelWidth);
   const isBottomOpen = useBottomPanelStore((s) => s.isOpen);
   const setBottomOpen = useBottomPanelStore((s) => s.setOpen);
   const isLogOpen = useBottomPanelStore((s) => s.isLogOpen);
   const setLogOpen = useBottomPanelStore((s) => s.setLogOpen);
   const multiMaximized = useBottomPanelStore((s) => s.multiMaximized);
 
-  const showBodyRow = isBottomOpen || isLogOpen;
-  // ONE shared dock-body height — the LOG can never grow taller than the dock
-  // and push into the center work area. Maximized fills the work area.
+  // Dock-body height — shared by the multi-tab panel (in-flow) and the floating
+  // LOG overlay. Maximized fills the work area.
   const bodyHeight = multiMaximized ? 'calc(100vh - 7rem)' : `${multiHeight}px`;
-  // The LOG column has its OWN width (logWidth); the strip + body both use it so
-  // they stay column-aligned with each other (decoupled from the right Library
-  // rail). Dragging the LOG handle also nudges the rail above — one-way: the
-  // rail's own handle never changes logWidth.
-  const stripGridStyle = { gridTemplateColumns: `minmax(0, 1fr) ${logWidth}px` };
-  const bodyGridStyle = {
-    gridTemplateColumns: `minmax(0, 1fr) ${isLogOpen ? `${logWidth}px` : '0px'}`,
-  };
-  const setLogWidthCoupled = (w: number) => {
-    setLogWidth(w);
-    setRightPanelWidth(w);
-  };
+  // The LOG strip section auto-fits its content (the telemetry readouts + the
+  // fixed action button). Mirror its measured width into logWidth so the LOG
+  // body directly below it stays column-aligned (opens to the same left edge).
+  const logSectionRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = logSectionRef.current;
+    if (!el) return;
+    const sync = () => {
+      const w = Math.round(el.getBoundingClientRect().width);
+      if (w > 0) setLogWidth(w);
+    };
+    sync();
+    const ro = new ResizeObserver(sync);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [setLogWidth]);
 
   return (
-    <div className="shrink-0 flex flex-col z-30 pointer-events-none">
-      {/* Body row — one shared height; multi (flex) + LOG (logWidth) side-by-side. */}
-      {showBodyRow && (
+    <div className="relative shrink-0 flex flex-col z-30 pointer-events-none">
+      {/* Multi-tab body — in-flow; the global bottom panel legitimately lifts the
+          work area. The LOG no longer shares this row (it floats, below). */}
+      {isBottomOpen && (
         <div
-          className="relative shrink-0 grid items-stretch pointer-events-auto"
-          style={{ ...bodyGridStyle, height: bodyHeight }}
+          className="relative shrink-0 bg-[#0a080f] overflow-hidden shadow-[0_-1px_0_rgba(168,85,247,0.08)] pointer-events-auto"
+          style={{ height: bodyHeight }}
         >
-          {/* One vertical resize handle for the whole dock body (top edge).
-              z-40 (inside the handle) keeps it above the cells regardless of
-              DOM order. Hidden while maximized. */}
           {!multiMaximized && (
             <ColumnResizeHandle
               currentHeight={multiHeight}
@@ -375,63 +380,64 @@ const ShellBottomDock: React.FC = () => {
               title="Drag to resize the bottom dock"
             />
           )}
-
-          {/* Multi body — flexible column, fills the shared height. Transparent
-              when collapsed so only the LOG block shows. */}
-          <div
-            className={`min-w-0 relative overflow-hidden ${isBottomOpen ? 'bg-[#0a080f] shadow-[0_-1px_0_rgba(168,85,247,0.08)]' : ''} ${isLogOpen && isBottomOpen && !multiMaximized ? 'border-r border-purple-500/15' : ''}`}
-          >
-            {isBottomOpen && (
-              <>
-                <div className="absolute inset-x-0 top-0 h-px bg-purple-500/20 pointer-events-none" />
-                <BottomMultiTabPanel />
-              </>
-            )}
-          </div>
-
-          {/* LOG body — independent width, fills the shared height. */}
-          {isLogOpen && (
-            <div className="min-w-0 relative bg-[#0a080f] overflow-hidden shadow-[0_-1px_0_rgba(168,85,247,0.08)]">
-              <div className="absolute inset-x-0 top-0 h-px bg-purple-500/20 pointer-events-none" />
-              {/* Horizontal handle between the multi panel and the LOG. */}
-              <WidthResizeHandle
-                currentWidth={logWidth}
-                onSet={setLogWidthCoupled}
-                title="Drag to resize the log width"
-              />
-              <LogBody />
-            </div>
-          )}
+          <div className="absolute inset-x-0 top-0 h-px bg-purple-500/20 pointer-events-none" />
+          <BottomMultiTabPanel />
         </div>
       )}
 
-      {/* Single horizontal strip — always visible. */}
-      <div className="shrink-0 grid items-stretch pointer-events-auto" style={{ ...stripGridStyle, height: STRIP_HEIGHT }}>
+      {/* LOG body — FLOATING overlay: anchored just above the strip, right-aligned,
+          only logWidth wide. It autofits under the right panel and floats over the
+          bottom-right of the work area instead of pushing the whole UI up. */}
+      {isLogOpen && (
+        <div
+          className="absolute right-0 z-40 pointer-events-auto bg-[#0a080f] overflow-hidden border-l border-purple-500/15 shadow-[-2px_-2px_12px_rgba(0,0,0,0.5)]"
+          style={{ bottom: STRIP_HEIGHT, width: logWidth, height: bodyHeight }}
+        >
+          {!multiMaximized && (
+            <ColumnResizeHandle
+              currentHeight={multiHeight}
+              onSet={setMultiHeight}
+              title="Drag to resize the log height"
+            />
+          )}
+          <div className="absolute inset-x-0 top-0 h-px bg-purple-500/20 pointer-events-none" />
+          <LogBody />
+        </div>
+      )}
 
-        {/* Multi-tab toggle — left, flex-1 */}
+      {/* Single horizontal strip — always visible. `relative` anchors the
+          viewport-centred expand chevron. */}
+      <div className="relative shrink-0 flex items-stretch pointer-events-auto" style={{ height: STRIP_HEIGHT }}>
+
+        {/* Multi-tab toggle — flex-1 clickable area (the chevron is centred
+            separately, below, so it lines up with PLAY / DJ / the mirror line). */}
         <button
           type="button"
           onClick={() => setBottomOpen(!isBottomOpen)}
-          className="min-w-0 bg-[#0a080f] flex items-center justify-center gap-2 group hover:bg-purple-500/8 transition-colors border-t border-r border-purple-500/15 shadow-[0_-1px_0_rgba(168,85,247,0.08)]"
+          className="min-w-0 flex-1 bg-[#0a080f] hover:bg-purple-500/8 transition-colors border-t border-r border-purple-500/15 shadow-[0_-1px_0_rgba(168,85,247,0.08)]"
           title={isBottomOpen ? 'Collapse bottom panel' : 'Expand bottom panel'}
           aria-label={isBottomOpen ? 'Collapse bottom panel' : 'Expand bottom panel'}
-        >
-          {isBottomOpen
-            ? <ChevronDown className="w-3.5 h-3.5 text-purple-300 group-hover:text-white transition-colors" />
-            : <ChevronUp className="w-3.5 h-3.5 text-purple-300 group-hover:text-white transition-colors" />
-          }
-        </button>
+        />
 
-        {/* LOG strip section — right, width = rightPanelWidth.
-            Internally: 40% LOG header (chevron-LEFT + label + count)
-            | 60% CREATE action button. */}
-        <div className="min-w-0 bg-[#0a080f] flex items-stretch border-t border-purple-500/15 shadow-[0_-1px_0_rgba(168,85,247,0.08)]">
-          {/* LOG header — 40%. Chevron on the LEFT per user spec. */}
+        {/* Expand chevron — centred on the viewport so it lines up with the PLAY
+            button, the DJ tab, and the layout-editor mirror line. pointer-events
+            pass through to the toggle button behind it. */}
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none">
+          {isBottomOpen
+            ? <ChevronDown className="w-3.5 h-3.5 text-purple-300" />
+            : <ChevronUp className="w-3.5 h-3.5 text-purple-300" />
+          }
+        </div>
+
+        {/* LOG strip section — CONTENT width: auto-fits the CPU/GPU/TEMP/VRAM/RAM
+            readouts (its measured width drives logWidth). The action button is a
+            FIXED width and never grows with the LOG. */}
+        <div ref={logSectionRef} className="shrink-0 bg-[#0a080f] flex items-stretch border-t border-purple-500/15 shadow-[0_-1px_0_rgba(168,85,247,0.08)]">
+          {/* LOG header — natural width so every readout shows in full. */}
           <button
             type="button"
             onClick={() => setLogOpen(!isLogOpen)}
-            className="flex items-center gap-1.5 px-2 group hover:bg-purple-500/8 transition-colors border-r border-purple-500/15 min-w-0"
-            style={{ width: LOG_HEADER_FRACTION }}
+            className="flex items-center gap-1.5 px-2 group hover:bg-purple-500/8 transition-colors border-r border-purple-500/15 shrink-0"
             title={isLogOpen ? 'Collapse log' : 'Expand log'}
             aria-label={isLogOpen ? 'Collapse log' : 'Expand log'}
           >
@@ -440,14 +446,11 @@ const ShellBottomDock: React.FC = () => {
               : <ChevronUp className="w-3.5 h-3.5 text-purple-300 group-hover:text-white transition-colors shrink-0" />
             }
             <span className="text-[10px] font-black uppercase tracking-widest text-purple-200 shrink-0">LOG</span>
-            {/* Live CPU · GPU · TEMP · VRAM · RAM. Truncates when the LOG column
-                is narrow — widen it with the horizontal handle to see them all. */}
-            <span className="flex-1 min-w-0 overflow-hidden">
-              <LogStripCompactInfo />
-            </span>
+            {/* Live CPU · GPU · TEMP · VRAM · RAM — shown in full (the section sizes to fit). */}
+            <span className="shrink-0"><LogStripCompactInfo /></span>
           </button>
-          {/* CREATE — 60%. */}
-          <div className="flex items-stretch" style={{ width: CREATE_FRACTION }}>
+          {/* Action button (CREATE / PROCESS / TRAIN) — fixed width. */}
+          <div className="flex items-stretch shrink-0" style={{ width: ACTION_WIDTH }}>
             <LogActionButton />
           </div>
         </div>
@@ -507,60 +510,6 @@ const ColumnResizeHandle: React.FC<ColumnResizeHandleProps> = ({ currentHeight, 
       >
         <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-0.5 group-hover:bg-purple-500/40 transition-colors" />
         <GripHorizontal className="w-3.5 h-3.5 text-zinc-700 group-hover:text-purple-300 opacity-0 group-hover:opacity-100 transition-opacity" />
-      </div>
-    </>
-  );
-};
-
-/**
- * Horizontal resize handle between the multi panel and the LOG. Lives at the
- * LEFT edge of the LOG cell; dragging left widens the LOG, right narrows it.
- * Same `dragging` full-window overlay trick as the vertical handle so the VJ
- * iframe can't swallow the drag. Width grows as the pointer moves left, so the
- * new width = (current right edge) - clientX, derived from the start geometry.
- */
-interface WidthResizeHandleProps {
-  currentWidth: number;
-  onSet: (w: number) => void;
-  title: string;
-}
-const WidthResizeHandle: React.FC<WidthResizeHandleProps> = ({ currentWidth, onSet, title }) => {
-  const [dragging, setDragging] = useState(false);
-  const startX = React.useRef(0);
-  const startW = React.useRef(currentWidth);
-  useEffect(() => {
-    if (!dragging) return;
-    const onMove = (e: MouseEvent) => {
-      const dx = startX.current - e.clientX; // drag left = positive = wider
-      const clamped = Math.max(LOG_MIN_WIDTH, Math.min(LOG_MAX_WIDTH, startW.current + dx));
-      onSet(clamped);
-    };
-    const onUp = () => setDragging(false);
-    document.body.style.cursor = 'col-resize';
-    window.addEventListener('mousemove', onMove);
-    window.addEventListener('mouseup', onUp);
-    return () => {
-      document.body.style.cursor = 'default';
-      window.removeEventListener('mousemove', onMove);
-      window.removeEventListener('mouseup', onUp);
-    };
-  }, [dragging, onSet]);
-
-  return (
-    <>
-      {dragging && <div className="fixed inset-0 z-50 cursor-col-resize" />}
-      <div
-        className="absolute inset-y-0 left-0 w-1.5 -ml-0.5 cursor-col-resize flex items-center justify-center group z-40"
-        onMouseDown={(e) => {
-          e.preventDefault();
-          startX.current = e.clientX;
-          startW.current = currentWidth;
-          setDragging(true);
-        }}
-        title={title}
-      >
-        <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 group-hover:bg-purple-500/40 transition-colors" />
-        <GripVertical className="w-3.5 h-3.5 text-zinc-700 group-hover:text-purple-300 opacity-0 group-hover:opacity-100 transition-opacity" />
       </div>
     </>
   );

--- a/frontend/src/components/layout/SlidePanel.tsx
+++ b/frontend/src/components/layout/SlidePanel.tsx
@@ -289,17 +289,21 @@ const StackEditor: React.FC<{ stack: StackBinding; onClose: () => void }> = ({ s
         <button onClick={onClose} aria-label="Close"><X className="w-3 h-3" /></button>
       </div>
 
-      <label className="sl-se-label">Name</label>
+      <label htmlFor="slide-stack-name" className="sl-se-label">Name</label>
       <input
+        id="slide-stack-name"
+        name="slide-stack-name"
         className="sl-se-input"
         value={stack.name}
         onChange={(e) => setName(e.target.value)}
         placeholder="Stack name"
       />
 
-      <label className="sl-se-label">Media</label>
+      <label htmlFor="slide-stack-media" className="sl-se-label">Media</label>
       <div className="sl-se-row">
         <select
+          id="slide-stack-media"
+          name="slide-stack-media"
           className="sl-se-input"
           value={stack.media?.entryId ?? ''}
           onChange={(e) => (e.target.value ? assignMedia(e.target.value) : clearMedia())}
@@ -324,6 +328,7 @@ const StackEditor: React.FC<{ stack: StackBinding; onClose: () => void }> = ({ s
       {stack.targets.map((t, i) => (
         <div className="sl-se-target" key={i}>
           <select
+            name={`slide-target-key-${i}`}
             className="sl-se-input sl-se-key"
             value={t.key}
             onChange={(e) => updateTarget(i, { key: e.target.value })}
@@ -335,6 +340,7 @@ const StackEditor: React.FC<{ stack: StackBinding; onClose: () => void }> = ({ s
             ))}
           </select>
           <input
+            name={`slide-target-from-pct-${i}`}
             className="sl-se-num"
             type="number" min={0} max={100}
             value={t.fromPct ?? 0}
@@ -342,6 +348,7 @@ const StackEditor: React.FC<{ stack: StackBinding; onClose: () => void }> = ({ s
             title="Range start % at slider 0"
           />
           <input
+            name={`slide-target-to-pct-${i}`}
             className="sl-se-num"
             type="number" min={0} max={100}
             value={t.toPct ?? 100}
@@ -623,7 +630,7 @@ export const SlidePanel: React.FC = () => {
 
   // Auto-detect the controller profile from connected MIDI device names.
   // Scored match (specific device name beats a family token). Only runs while
-  // autoDetect is on; the manual <select> sets autoDetect off so a user choice
+  // autoDetect is on; the manual profile dropdown sets autoDetect off so a user choice
   // sticks. Re-runs on hot-plug (midiInputs changes).
   const detected = useMemo(() => detectProfileFromNames(midiInputs), [midiInputs]);
   useEffect(() => {
@@ -660,7 +667,7 @@ export const SlidePanel: React.FC = () => {
   const navCooldownRef = useRef(0);
 
   // ←/→ keyboard page nav (always on, wraps). Ignored while typing in a field
-  // or when a <select> is focused; widgets are up/down-only so there's no conflict.
+  // or when a dropdown is focused; widgets are up/down-only so there's no conflict.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;

--- a/frontend/src/components/library/LineageModal.tsx
+++ b/frontend/src/components/library/LineageModal.tsx
@@ -1390,6 +1390,7 @@ const SelectRow: React.FC<{ label: string; value: string; options: Array<{ value
   <label className="flex flex-col gap-0.5">
     <span className="text-[8px] font-mono uppercase tracking-widest text-zinc-400">{label}</span>
     <select
+      name={`lineage-select-${label.toLowerCase().replace(/\s+/g, '-')}`}
       value={value}
       onChange={(e) => onChange(e.target.value)}
       className="compact-input bg-black/40 text-[10px]"

--- a/frontend/src/components/library/StemsRunModal.tsx
+++ b/frontend/src/components/library/StemsRunModal.tsx
@@ -162,6 +162,7 @@ export const StemsRunModal: React.FC<Props> = ({ open, entryLabel, onCancel, onC
           <label className="flex items-center gap-2 text-[9px] font-mono uppercase tracking-widest text-zinc-400 cursor-pointer mt-1">
             <input
               type="checkbox"
+              name="stems-persist-default"
               className="accent-purple-500"
               checked={persist}
               onChange={(e) => setPersist(e.target.checked)}

--- a/frontend/src/components/surface/AddControlModal.tsx
+++ b/frontend/src/components/surface/AddControlModal.tsx
@@ -163,6 +163,7 @@ export const AddControlModal: React.FC<{ panelId: string; onClose: () => void }>
         {/* label + actions */}
         <div className="shrink-0 flex items-center gap-2 px-3 py-2 border-t border-white/10">
           <input
+            name="add-control-label"
             value={label}
             onChange={(e) => setLabel(e.target.value)}
             placeholder="Label"

--- a/frontend/src/components/surface/SurfaceContainer.tsx
+++ b/frontend/src/components/surface/SurfaceContainer.tsx
@@ -71,6 +71,7 @@ const FrameStyleMenu: React.FC<{ node: ContainerNode; store: SurfaceStoreApi; on
         Glow {node.frameGlow ? 'on' : 'off'}
       </button>
       <input
+        name="surface-container-frame-title"
         value={node.frameTitle ?? ''}
         onChange={(e) => set({ frameTitle: e.target.value })}
         placeholder="Label (optional)"

--- a/frontend/src/components/surface/SurfacePanel.tsx
+++ b/frontend/src/components/surface/SurfacePanel.tsx
@@ -55,6 +55,7 @@ const PanelHeader: React.FC<{
       {editing ? (
         <input
           autoFocus
+          name="surface-panel-rename"
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onBlur={() => {

--- a/frontend/src/orb-kit/AssistantPanel.tsx
+++ b/frontend/src/orb-kit/AssistantPanel.tsx
@@ -851,6 +851,7 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({
                                     {editingKeyProvider === p.id && (
                                         <div className="mt-1.5 space-y-1">
                                             <textarea
+                                                name={`assistant-key-input-${p.id}`}
                                                 value={keyInput}
                                                 onChange={e => setKeyInput(e.target.value)}
                                                 placeholder="Paste keys (one per line, or comma/semicolon separated)..."
@@ -1131,6 +1132,7 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({
                 <input
                     ref={fileInputRef}
                     type="file"
+                    name="assistant-attach-files"
                     multiple
                     className="hidden"
                     accept="audio/*,image/*,video/*,.txt,.md,.json,.py,.ts,.tsx,.js,.jsx,.css,.html,.log,.yaml,.yml,.toml"
@@ -1165,6 +1167,7 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({
                     <input
                         ref={inputRef}
                         type="text"
+                        name="assistant-chat-input"
                         value={input}
                         onChange={(e) => setInput(e.target.value)}
                         placeholder={isProcessing ? 'Type to interrupt...' : 'Ask anything...'}

--- a/frontend/src/orb-kit/ProviderModelSelector.tsx
+++ b/frontend/src/orb-kit/ProviderModelSelector.tsx
@@ -238,7 +238,7 @@ export function ProviderModelSelector({
                   <div className="flex items-center gap-1.5 shrink-0 mt-0.5">
                     {isSelected && <Check className="w-3 h-3 text-primary" />}
                   </div>
-                  <div className={`flex-1 min-w-0 ${isSelected ? '' : 'ml-[18px]'}`}>
+                  <div className={`flex-1 min-w-0 ${isSelected ? '' : 'ml-4.5'}`}>
                     <div className={`text-[11px] font-mono truncate ${isSelected ? 'text-primary' : 'text-white/80'}`}>
                       {displayName}
                     </div>

--- a/frontend/src/orb-kit/chat/OrbChatPanel.tsx
+++ b/frontend/src/orb-kit/chat/OrbChatPanel.tsx
@@ -264,6 +264,7 @@ export const OrbChatPanel: React.FC<OrbChatPanelProps> = ({
                                         {editingKey === p.id ? (
                                             <div style={{ flex: 1, display: 'flex', gap: 4 }}>
                                                 <input
+                                                    name={`orb-chat-key-input-${p.id}`}
                                                     type={showKeyText ? 'text' : 'password'} value={keyInput}
                                                     onChange={e => setKeyInput(e.target.value)}
                                                     placeholder="Paste API key..."
@@ -419,6 +420,7 @@ export const OrbChatPanel: React.FC<OrbChatPanelProps> = ({
                         <input
                             ref={fileInputRef}
                             type="file"
+                            name="orb-chat-attach-files"
                             multiple
                             accept="*/*"
                             onChange={handleFileChange}
@@ -439,7 +441,7 @@ export const OrbChatPanel: React.FC<OrbChatPanelProps> = ({
                         </button>
                         <input
                             ref={inputRef}
-                            type="text" value={input} onChange={e => setInput(e.target.value)}
+                            type="text" name="orb-chat-input" value={input} onChange={e => setInput(e.target.value)}
                             placeholder={chat.isProcessing ? 'Type to interrupt...' : 'Ask anything...'}
                             style={{
                                 flex: 1, background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)',

--- a/frontend/src/state/generateParamsStore.ts
+++ b/frontend/src/state/generateParamsStore.ts
@@ -113,6 +113,20 @@ export interface GenerateParamsState {
   chimera: ChimeraState;
   /** True when the Magenta RT2 sidecar probe succeeds (transient; re-probed each session). */
   magentaAvailable: boolean;
+
+  // Magenta RT2 (text→music) sampling params — used when `model` starts with
+  // "magenta-". These replace the SA3 sampler/schedule controls in the MAKE UI;
+  // the central Chimera stack is shared across both engines.
+  magTemperature: number;
+  magTopK: number;
+  magCfgMusiccoca: number;
+  magCfgNotes: number;
+  magCfgDrums: number;
+  magDrums: number; // -1 auto · 0 off · 1 on
+  magChunkFrames: number;
+  magSeed: number; // -1 = fresh/random each run
+  magExtend: boolean; // continue the current piece (morph without a cut)
+  magNotes: number[]; // selected MIDI pitches that steer the melody
 }
 
 interface ParamsStore extends GenerateParamsState {
@@ -196,6 +210,17 @@ export const useGenerateParamsStore = create<ParamsStore>()((set) => ({
   },
 
   magentaAvailable: false,
+
+  magTemperature: 1.3,
+  magTopK: 40,
+  magCfgMusiccoca: 3.0,
+  magCfgNotes: 1.0,
+  magCfgDrums: 1.0,
+  magDrums: -1,
+  magChunkFrames: 25,
+  magSeed: -1,
+  magExtend: false,
+  magNotes: [],
 
   setField: (key, value) => set({ [key]: value } as Partial<GenerateParamsState>),
   patch: (partial) => set(partial),

--- a/frontend/src/state/generateStore.ts
+++ b/frontend/src/state/generateStore.ts
@@ -58,6 +58,18 @@ export interface GenerateParams {
   cutToDuration?: boolean;
 
   loras?: Array<{ file: File | null; weight: number }>;
+
+  // Magenta RT2 (text→music) sampling params.
+  magTemperature?: number;
+  magTopK?: number;
+  magCfgMusiccoca?: number;
+  magCfgNotes?: number;
+  magCfgDrums?: number;
+  magDrums?: number;
+  magChunkFrames?: number;
+  magSeed?: number;
+  magExtend?: boolean;
+  magNotes?: number[];
 }
 
 type JobStatus = 'idle' | 'submitting' | 'queued' | 'running' | 'completed' | 'failed';
@@ -123,12 +135,32 @@ const wait = (ms: number): Promise<void> =>
   });
 
 /** Build the form for the Magenta RT2 sidecar (/api/magenta/generate): text prompt
- *  -> audio. The model takes a prompt + duration + sampling knobs (no SA3 fields). */
+ *  -> audio. The model takes a prompt + duration + its own sampling knobs (no SA3
+ *  fields). An enabled Init clip is forwarded as the audio-style ("clone") source,
+ *  which the sidecar embeds in place of the text style. */
 export const buildMagentaFormData = (params: GenerateParams, prompt: string): FormData => {
   const formData = new FormData();
   formData.append('prompt', prompt);
   formData.append('duration', String(params.duration));
   formData.append('model_size', params.model.replace('magenta-', '') || 'small');
+  if (params.magTemperature !== undefined) formData.append('temperature', String(params.magTemperature));
+  if (params.magTopK !== undefined) formData.append('top_k', String(Math.round(params.magTopK)));
+  if (params.magCfgMusiccoca !== undefined) formData.append('cfg_musiccoca', String(params.magCfgMusiccoca));
+  if (params.magCfgNotes !== undefined) formData.append('cfg_notes', String(params.magCfgNotes));
+  if (params.magCfgDrums !== undefined) formData.append('cfg_drums', String(params.magCfgDrums));
+  if (params.magDrums !== undefined) formData.append('drums', String(Math.round(params.magDrums)));
+  if (params.magChunkFrames !== undefined) formData.append('chunk_frames', String(Math.round(params.magChunkFrames)));
+  // Seed: -1 means "fresh each run" → omit so the sidecar randomises.
+  if (params.magSeed !== undefined && params.magSeed >= 0) formData.append('seed', String(Math.round(params.magSeed)));
+  if (params.magExtend) formData.append('extend', 'true');
+  // Notes → full-duration melody events the sidecar encodes into 128-pitch states.
+  if (params.magNotes && params.magNotes.length) {
+    const events = params.magNotes.map((pitch) => ({ pitch, start: 0, end: params.duration }));
+    formData.append('notes', JSON.stringify(events));
+  }
+  if ((params.initAudioEnabled ?? false) && params.initAudioFile) {
+    formData.append('audio_file', params.initAudioFile);
+  }
   return formData;
 };
 
@@ -245,6 +277,16 @@ export const buildGenerateParamsFromState = (params: GenerateParamsState): Gener
   outputName: params.outputName,
   cutToDuration: params.cutToDuration,
   loras: params.loras.map((lora) => ({ file: lora.file, weight: lora.weight })),
+  magTemperature: params.magTemperature,
+  magTopK: params.magTopK,
+  magCfgMusiccoca: params.magCfgMusiccoca,
+  magCfgNotes: params.magCfgNotes,
+  magCfgDrums: params.magCfgDrums,
+  magDrums: params.magDrums,
+  magChunkFrames: params.magChunkFrames,
+  magSeed: params.magSeed,
+  magExtend: params.magExtend,
+  magNotes: params.magNotes,
 });
 
 export const useGenerateStore = create<GenerateStoreState>()((set, get) => ({

--- a/frontend/src/suno/SunoGenPanel.tsx
+++ b/frontend/src/suno/SunoGenPanel.tsx
@@ -90,7 +90,7 @@ const MODEL_OPTIONS = [
 /** Slim "key required" notice. The actual key INPUT lives in Settings → Suno API
  *  (SunoKeySettings); this just points the user there and opens it. */
 const KeyNotice: React.FC = () => (
-  <div className="flex items-center gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] px-3 py-2">
+  <div className="flex items-center gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/6 px-3 py-2">
     <span className="grid place-items-center w-6 h-6 rounded-md bg-amber-500/15 border border-amber-500/30 text-amber-300 shrink-0">
       <KeyRound className="w-3.5 h-3.5" />
     </span>
@@ -199,11 +199,11 @@ export const SunoGenPanel: React.FC = () => {
     <div className="absolute inset-0 flex flex-col text-zinc-200 overflow-hidden">
       {/* ── Atmosphere: aurora gradient mesh + faint grain (signals "cloud") ── */}
       <div aria-hidden className="absolute inset-0 pointer-events-none">
-        <div className="absolute -top-1/3 -left-1/4 w-[60%] h-[80%] rounded-full bg-purple-600/12 blur-[90px]" />
+        <div className="absolute -top-1/3 -left-1/4 w-3/5 h-4/5 rounded-full bg-purple-600/12 blur-[90px]" />
         <div className="absolute top-1/4 right-0 w-[45%] h-[70%] rounded-full bg-fuchsia-600/8 blur-[90px]" />
-        <div className="absolute bottom-0 left-1/3 w-[40%] h-[50%] rounded-full bg-teal-500/8 blur-[90px]" />
+        <div className="absolute bottom-0 left-1/3 w-2/5 h-1/2 rounded-full bg-teal-500/8 blur-[90px]" />
         <div
-          className="absolute inset-0 opacity-[0.04] mix-blend-soft-light"
+          className="absolute inset-0 opacity-4 mix-blend-soft-light"
           style={{
             backgroundImage:
               "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
@@ -236,6 +236,7 @@ export const SunoGenPanel: React.FC = () => {
           <HoverTip text="Switch the active model. Pick a Stable Audio model to return to the local generator; keep Suno (Cloud) for cloud generation.">
             <div className="relative">
               <select
+                name="suno-model"
                 className="appearance-none rounded-full border border-purple-400/30 bg-purple-500/10 hover:bg-purple-500/15 pl-3 pr-7 py-1 text-[10px] font-bold uppercase tracking-wider text-purple-100 outline-none transition-colors cursor-pointer"
                 value={model}
                 onChange={(e) => patchParams({ model: e.target.value })}
@@ -308,7 +309,7 @@ export const SunoGenPanel: React.FC = () => {
 
             {/* Compose card */}
             <motion.div {...fade(0.1)} className="rounded-lg border border-white/8 bg-[#0b0910]/60 overflow-hidden">
-              <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-white/5 bg-white/[0.02]">
+              <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-white/5 bg-white/2">
                 <Sparkles className="w-3 h-3 text-purple-400" />
                 <span className="mono-label text-[9px]!">Compose</span>
               </div>
@@ -326,7 +327,7 @@ export const SunoGenPanel: React.FC = () => {
                   className="group relative w-full py-2.5 rounded-lg overflow-hidden font-black uppercase tracking-[0.2em] text-[11px] text-white
                     bg-linear-to-r from-purple-600 via-fuchsia-600 to-purple-600 bg-size-[200%_100%] hover:bg-position-[100%_0]
                     shadow-[0_6px_22px_-10px_rgba(168,85,247,0.9)] transition-[background-position,transform,box-shadow] duration-500
-                    active:scale-[0.99] disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none flex items-center justify-center gap-2"
+                    active:scale-99 disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none flex items-center justify-center gap-2"
                 >
                   <span className="absolute inset-0 -translate-x-full group-hover:translate-x-full transition-transform duration-700 ease-out bg-linear-to-r from-transparent via-white/20 to-transparent skew-x-12 pointer-events-none" />
                   {submitting ? (

--- a/frontend/src/suno/SunoKeySettings.tsx
+++ b/frontend/src/suno/SunoKeySettings.tsx
@@ -103,6 +103,7 @@ export const SunoKeySettings: React.FC = () => {
           <div className="relative flex-1">
             <input
               type={show ? 'text' : 'password'}
+              name="suno-api-key"
               className="w-full bg-black/40 border border-white/10 rounded px-2 py-1.5 pr-7 text-[10px] font-mono text-zinc-200 outline-none focus:border-purple-500/50 transition-colors"
               placeholder={configured ? 'Paste a new key to replace…' : 'sk_live_…'}
               value={val}

--- a/frontend/src/suno/SunoModeFields.tsx
+++ b/frontend/src/suno/SunoModeFields.tsx
@@ -64,6 +64,7 @@ const StyleInput: React.FC<{ optional?: boolean }> = ({ optional }) => {
       />
       <div className="relative">
         <input
+          name="suno-style"
           className="compact-input w-full pr-7"
           placeholder="dreampop, reverb-heavy guitars, melancholic"
           value={style}
@@ -149,6 +150,7 @@ const LyricsInput: React.FC<{ optional?: boolean; hint?: string; placeholder?: s
       </div>
       <textarea
         ref={ref}
+        name="suno-lyrics"
         className="compact-input w-full min-h-32 resize-y font-mono text-[11px] leading-relaxed"
         placeholder={
           placeholder ??
@@ -178,7 +180,7 @@ const VoicePicker: React.FC = () => {
           type="button"
           onClick={() => patch({ voiceId: id })}
           className={`w-full flex flex-col items-center justify-center gap-1 px-1 py-2 rounded-lg border transition-all
-            ${active ? 'bg-purple-600/20 border-purple-500/50 text-purple-200' : 'bg-white/[0.02] border-white/5 text-zinc-500 hover:text-zinc-300 hover:border-white/15'}`}
+            ${active ? 'bg-purple-600/20 border-purple-500/50 text-purple-200' : 'bg-white/2 border-white/5 text-zinc-500 hover:text-zinc-300 hover:border-white/15'}`}
         >
           {icon}
           <span className="text-[8px] font-black uppercase tracking-wider">{name}</span>
@@ -232,6 +234,7 @@ export const SunoModeFields: React.FC = () => {
         <div>
           <Label text="Title" optional tip="A name for your track. Leave blank and Suno will name it for you." />
           <input
+            name="suno-title"
             className="compact-input w-full"
             placeholder="My awesome track"
             value={title}
@@ -248,6 +251,7 @@ export const SunoModeFields: React.FC = () => {
             tip="Plain-language brief for the whole song — Suno turns this into both the lyrics and the musical style."
           />
           <textarea
+            name="suno-description"
             className="compact-input w-full min-h-24 resize-y"
             placeholder="upbeat synthwave track about driving through Tokyo at night"
             value={description}
@@ -262,6 +266,7 @@ export const SunoModeFields: React.FC = () => {
           <label className="flex items-center gap-2 cursor-pointer select-none">
             <input
               type="checkbox"
+              name="suno-instrumental"
               checked={instrumental}
               onChange={(e) => patch({ instrumental: e.target.checked })}
               className="accent-purple-500"
@@ -286,6 +291,7 @@ export const SunoModeFields: React.FC = () => {
               tip="The Suno clip to re-style. Must be a track you own — paste its id or use a library track’s Cover button to prefill."
             />
             <input
+              name="suno-cover-source-id"
               className="compact-input w-full font-mono text-[11px]"
               placeholder="6e2b0f3a-…"
               value={sourceId}
@@ -306,6 +312,7 @@ export const SunoModeFields: React.FC = () => {
               tip="The base clip of the mashup — one of your own Suno tracks. Paste its id."
             />
             <input
+              name="suno-mashup-source-id"
               className="compact-input w-full font-mono text-[11px]"
               placeholder="6e2b0f3a-…"
               value={sourceId}
@@ -319,6 +326,7 @@ export const SunoModeFields: React.FC = () => {
               tip="The second clip blended into the base — another Suno track you own. Paste its id."
             />
             <input
+              name="suno-mashup-second-id"
               className="compact-input w-full font-mono text-[11px]"
               placeholder="9a9e1da2-…"
               value={additionalAudioId}

--- a/frontend/src/views/AdvancedGenPanel.tsx
+++ b/frontend/src/views/AdvancedGenPanel.tsx
@@ -4,6 +4,7 @@ import {
   Scissors, Mic2, Search, ChevronDown,
   LayoutList, AudioWaveform, Volume2, Sliders,
   Wand2, Loader2, BookOpen, Layers, Sparkles, Download,
+  Music2, Dice5, Repeat,
 } from 'lucide-react';
 import { useGenerateParamsStore, type GenerateParamsState } from '../state/generateParamsStore';
 import { useGenerateStore } from '../state/generateStore';
@@ -155,7 +156,7 @@ function TemplatesPanel() {
       </div>
       <div className="flex items-center gap-1 mb-1.5">
         <Search className="w-3 h-3 text-zinc-600 shrink-0" />
-        <input className="compact-input flex-1 text-[9px]" placeholder="Search templates..." value={searchQuery}
+        <input name="gen-template-search" className="compact-input flex-1 text-[9px]" placeholder="Search templates..." value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)} />
       </div>
       <div className="overflow-y-auto min-h-0 flex-1">
@@ -179,6 +180,65 @@ function TemplatesPanel() {
   );
 }
 
+/* ── Magenta Notes picker — tap piano keys to steer the melody ─────────── */
+/* The lit pitches are sent to the MRT2 sidecar as full-duration note events;
+   none lit = the model chooses the melody freely. */
+function MagentaNotes() {
+  const notes = useGenerateParamsStore((s) => s.magNotes);
+  const setField = useGenerateParamsStore((s) => s.setField);
+  const LOW = 48, HIGH = 72; // C3 … C5 (two octaves)
+  const isBlack = (pitch: number) => [1, 3, 6, 8, 10].includes(((pitch % 12) + 12) % 12);
+  const toggle = (pitch: number) => {
+    const set = new Set(notes);
+    if (set.has(pitch)) set.delete(pitch); else set.add(pitch);
+    setField('magNotes', [...set].sort((a, b) => a - b));
+  };
+  const whites: number[] = [];
+  for (let p = LOW; p <= HIGH; p += 1) if (!isBlack(p)) whites.push(p);
+  const NAMES = ['C', '', 'D', '', 'E', 'F', '', 'G', '', 'A', '', 'B'];
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-1.5 mb-1 shrink-0">
+        <Music2 className="w-3 h-3 text-purple-400 shrink-0" />
+        <span className={`text-[9px] font-black uppercase tracking-widest text-purple-300/70`}>NOTES</span>
+        <span className="text-[9px] text-purple-200 truncate flex-1 min-w-0">
+          {notes.length ? `${notes.length} pitch${notes.length > 1 ? 'es' : ''} steering the melody` : 'tap keys — or leave blank for free melody'}
+        </span>
+        {notes.length > 0 && (
+          <button className="btn-ghost cursor-pointer text-[9px] shrink-0" onClick={() => setField('magNotes', [])}>CLEAR</button>
+        )}
+      </div>
+      <div className="relative flex-1 min-h-0 rounded overflow-hidden border border-white/5 bg-black/40 flex select-none">
+        {whites.map((p) => {
+          const on = notes.includes(p);
+          return (
+            <button key={p} onClick={() => toggle(p)} title={`${NAMES[((p % 12) + 12) % 12]}${Math.floor(p / 12) - 1}`}
+              className={`relative flex-1 min-w-0 border-r border-black/40 last:border-r-0 cursor-pointer transition-colors flex items-end justify-center pb-0.5 ${on ? 'bg-purple-500' : 'bg-zinc-200 hover:bg-purple-200'}`}>
+              {((p % 12) + 12) % 12 === 0 && <span className={`text-[7px] font-mono ${on ? 'text-white' : 'text-zinc-500'}`}>C{Math.floor(p / 12) - 1}</span>}
+            </button>
+          );
+        })}
+        <div className="absolute inset-0 flex pointer-events-none">
+          {whites.map((p) => {
+            const bp = p + 1;
+            const hasBlack = isBlack(bp) && bp <= HIGH;
+            const on = notes.includes(bp);
+            return (
+              <div key={p} className="flex-1 relative">
+                {hasBlack && (
+                  <button onClick={() => toggle(bp)}
+                    className={`pointer-events-auto absolute top-0 z-10 rounded-b border border-black/60 cursor-pointer transition-colors ${on ? 'bg-purple-400' : 'bg-zinc-900 hover:bg-purple-700'}`}
+                    style={{ right: '-30%', width: '60%', height: '62%' }} />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /* ═══════════════════════════════════════════════════════════════════════ */
 
 export const AdvancedGenPanel: React.FC<{
@@ -187,6 +247,9 @@ export const AdvancedGenPanel: React.FC<{
   const p = useGenerateParamsStore();
   const sf = p.setField;
   const patch = p.patch;
+  // Magenta RT2 swaps the SA3 sampler/schedule controls for its own sampling
+  // params; the central Chimera stack stays shared across both engines.
+  const isMagenta = p.model.startsWith('magenta-');
 
   // Probe the Magenta RT2 sidecar once on mount; gates the Magenta model option.
   useEffect(() => {
@@ -356,20 +419,26 @@ export const AdvancedGenPanel: React.FC<{
           onDrop={async (e) => { e.preventDefault(); const f = await fileFromDrop(e); if (f) patch({ initAudioFile: f, initAudioEnabled: true }); }}>
           <div className="flex items-center gap-1.5 mb-1 shrink-0">
             <Mic2 className="w-3 h-3 text-purple-400 shrink-0" />
-            <span className={`${subTitle} flex items-center gap-1`}>INIT <InfoTip {...RICH_TOOLTIPS.initAudio} /></span>
-            <span className="text-[9px] text-purple-200 truncate flex-1 min-w-0">{p.initAudioFile ? p.initAudioFile.name : 'drop audio / load'}</span>
-            <div className="flex items-center gap-1 shrink-0">
-              <span className="text-[9px] text-zinc-400">Type</span>
-              <select className="compact-input h-5 py-0 text-[9px] w-20" value={p.initType} onChange={(e) => sf('initType', e.target.value)} style={{ colorScheme: 'dark' }}>
-                <option value="Audio">Audio</option><option value="RF-Inversion">RF-Inv</option>
-              </select>
-            </div>
-            <div className="flex items-center gap-1 shrink-0" title="Init noise — denoising strength for the init audio (0 = keep init exactly, 1 = full noise / ignore init). Set this BEFORE generating.">
-              <span className="text-[9px] text-zinc-400">Nz</span>
-              <SlideTrack min={0} max={1} step={0.01} value={p.initNoise}
-                onChange={(v) => sf('initNoise', v)} className="w-14" ariaLabel="Init noise" />
-              <span className="text-[9px] font-mono text-purple-300 tabular-nums w-7 text-right">{p.initNoise.toFixed(2)}</span>
-            </div>
+            {isMagenta
+              ? <span className={`${subTitle} flex items-center gap-1`} title="Audio style — drop a clip and the model clones its vibe (overrides the text prompt).">STYLE</span>
+              : <span className={`${subTitle} flex items-center gap-1`}>INIT <InfoTip {...RICH_TOOLTIPS.initAudio} /></span>}
+            <span className="text-[9px] text-purple-200 truncate flex-1 min-w-0">{p.initAudioFile ? p.initAudioFile.name : (isMagenta ? 'drop a clip to clone its vibe' : 'drop audio / load')}</span>
+            {!isMagenta && (
+              <>
+                <div className="flex items-center gap-1 shrink-0">
+                  <span className="text-[9px] text-zinc-400">Type</span>
+                  <select name="gen-init-type" className="compact-input h-5 py-0 text-[9px] w-20" value={p.initType} onChange={(e) => sf('initType', e.target.value)} style={{ colorScheme: 'dark' }}>
+                    <option value="Audio">Audio</option><option value="RF-Inversion">RF-Inv</option>
+                  </select>
+                </div>
+                <div className="flex items-center gap-1 shrink-0" title="Init noise — denoising strength for the init audio (0 = keep init exactly, 1 = full noise / ignore init). Set this BEFORE generating.">
+                  <span className="text-[9px] text-zinc-400">Nz</span>
+                  <SlideTrack min={0} max={1} step={0.01} value={p.initNoise}
+                    onChange={(v) => sf('initNoise', v)} className="w-14" ariaLabel="Init noise" />
+                  <span className="text-[9px] font-mono text-purple-300 tabular-nums w-7 text-right">{p.initNoise.toFixed(2)}</span>
+                </div>
+              </>
+            )}
             <button onClick={() => sf('initAudioEnabled', !p.initAudioEnabled)}
               className={`mono-tag cursor-pointer shrink-0 ${p.initAudioEnabled ? 'bg-purple-600/30 text-purple-200 border-purple-500/50' : ''}`}>
               {p.initAudioEnabled ? 'ON' : 'OFF'}
@@ -379,7 +448,7 @@ export const AdvancedGenPanel: React.FC<{
             ) : (
               <button className="btn-ghost cursor-pointer text-[9px] shrink-0" onClick={() => initRef.current?.click()}>LOAD</button>
             )}
-            <input ref={initRef} type="file" accept="audio/*" multiple className="hidden"
+            <input ref={initRef} name="gen-init-audio-file" type="file" accept="audio/*" multiple className="hidden"
               onChange={async (e) => {
                 const files = Array.from(e.target.files ?? []);
                 e.target.value = '';
@@ -398,7 +467,8 @@ export const AdvancedGenPanel: React.FC<{
         {/* INPAINT */}
         <div className={`${accentBox} flex flex-col px-2 py-1.5 min-w-0`}
           onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; }}
-          onDrop={async (e) => { e.preventDefault(); const f = await fileFromDrop(e); if (f) patch({ inpaintAudioFile: f, inpaintEnabled: true, maskStart: 0, maskEnd: 0 }); }}>
+          onDrop={async (e) => { e.preventDefault(); if (isMagenta) return; const f = await fileFromDrop(e); if (f) patch({ inpaintAudioFile: f, inpaintEnabled: true, maskStart: 0, maskEnd: 0 }); }}>
+          {isMagenta ? <MagentaNotes /> : (<>
           <div className="flex items-center gap-1.5 mb-1 shrink-0">
             <Scissors className="w-3 h-3 text-purple-400 shrink-0" />
             <span className={`${subTitle} flex items-center gap-1`}>INPAINT <InfoTip {...RICH_TOOLTIPS.inpainting} /></span>
@@ -413,13 +483,14 @@ export const AdvancedGenPanel: React.FC<{
             ) : (
               <button className="btn-ghost cursor-pointer text-[9px] shrink-0" onClick={() => inpaintRef.current?.click()}>LOAD</button>
             )}
-            <input ref={inpaintRef} type="file" accept="audio/*" className="hidden"
+            <input ref={inpaintRef} name="gen-inpaint-audio-file" type="file" accept="audio/*" className="hidden"
               onChange={(e) => { if (e.target.files?.[0]) patch({ inpaintAudioFile: e.target.files[0], inpaintEnabled: true, maskStart: 0, maskEnd: 0 }); e.target.value = ''; }} />
           </div>
           <div className="flex-1 min-h-0 rounded overflow-hidden border border-white/5 bg-black/40">
             {inpaintAudioUrl ? <WaveformPreview audioUrl={inpaintAudioUrl} height={88} enableRegions regionStart={p.maskStart} regionEnd={p.maskEnd} onRegionChange={(s, e) => patch({ maskStart: s, maskEnd: e })} />
               : <div className="h-full flex items-center justify-center"><span className="text-[9px] text-zinc-600">No inpaint audio</span></div>}
           </div>
+          </>)}
         </div>
       </div>
 
@@ -458,7 +529,7 @@ export const AdvancedGenPanel: React.FC<{
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2">
                 <span className="text-[11px] text-zinc-300 w-16 shrink-0">Model</span>
-                <select className="compact-input flex-1" value={p.model} onChange={(e) => {
+                <select name="gen-model" className="compact-input flex-1" value={p.model} onChange={(e) => {
                   const m = e.target.value; const isRf = m.endsWith('-rf'); const isMagenta = m.startsWith('magenta-');
                   patch({ model: m, steps: isMagenta ? 1 : isRf ? 50 : 8, cfg: isMagenta ? 1.0 : isRf ? 7.0 : 1.0 });
                 }} style={{ colorScheme: 'dark' }}>
@@ -471,16 +542,29 @@ export const AdvancedGenPanel: React.FC<{
                 </select>
               </div>
               <SlideRow label="Length (s)" value={p.duration} onChange={(v) => sf('duration', v)} min={0.5} max={512} step={0.5} tipKey="duration" />
-              <SlideRow label="Steps" value={p.steps} onChange={(v) => sf('steps', v)} min={1} max={500} step={1} tipKey="steps" />
-              <SlideRow label="CFG" value={p.cfg} onChange={(v) => sf('cfg', v)} min={0} max={25} step={0.1} tipKey="cfg" />
-              <SlideRow label="Seed" value={p.seed} onChange={(v) => sf('seed', v)} min={-1} max={2147483647} step={1} tipKey="seed"
-                onRandomize={() => sf('seed', Math.floor(Math.random() * 2147483647))} />
-              {/* Batch — value field aligned (flush right) with the SlideRows above */}
-              <div className="flex items-center gap-2">
-                <span className="text-[11px] text-zinc-300 w-16 shrink-0 whitespace-nowrap">Batch</span>
-                <div className="flex-1 min-w-0" />
-                <input type="number" className="compact-input w-11 text-center tabular-nums shrink-0" min={1} max={16} step={1} value={p.batch} onChange={(e) => sf('batch', +e.target.value || 1)} />
-              </div>
+              {isMagenta ? (
+                <div className="flex items-center gap-2">
+                  <span className="text-[11px] text-zinc-300 w-16 shrink-0 whitespace-nowrap">Drums</span>
+                  <select name="gen-mag-drums" className="compact-input flex-1" value={p.magDrums} onChange={(e) => sf('magDrums', +e.target.value)} style={{ colorScheme: 'dark' }}>
+                    <option value={-1}>Auto</option>
+                    <option value={0}>Off</option>
+                    <option value={1}>On</option>
+                  </select>
+                </div>
+              ) : (
+                <>
+                  <SlideRow label="Steps" value={p.steps} onChange={(v) => sf('steps', v)} min={1} max={500} step={1} tipKey="steps" />
+                  <SlideRow label="CFG" value={p.cfg} onChange={(v) => sf('cfg', v)} min={0} max={25} step={0.1} tipKey="cfg" />
+                  <SlideRow label="Seed" value={p.seed} onChange={(v) => sf('seed', v)} min={-1} max={2147483647} step={1} tipKey="seed"
+                    onRandomize={() => sf('seed', Math.floor(Math.random() * 2147483647))} />
+                  {/* Batch — value field aligned (flush right) with the SlideRows above */}
+                  <div className="flex items-center gap-2">
+                    <span className="text-[11px] text-zinc-300 w-16 shrink-0 whitespace-nowrap">Batch</span>
+                    <div className="flex-1 min-w-0" />
+                    <input name="gen-batch" type="number" className="compact-input w-11 text-center tabular-nums shrink-0" min={1} max={16} step={1} value={p.batch} onChange={(e) => sf('batch', +e.target.value || 1)} />
+                  </div>
+                </>
+              )}
             </div>
           </div>
 
@@ -522,7 +606,25 @@ export const AdvancedGenPanel: React.FC<{
               {/* SAMPLER(+TEMP) | chimera STACK (~prompt width) | SCHEDULE(+FX) */}
               <div className="flex-1 min-h-0 grid gap-1.5" style={{ gridTemplateColumns: 'minmax(0,1fr) 600px minmax(0,1fr)' }}>
 
-                {/* SAMPLER column — TEMP knobs ride above the faders */}
+                {/* SAMPLER column (SA3) ↔ GUIDANCE column (Magenta) — knobs ride above the faders */}
+                {isMagenta ? (
+                  <div className={`${colBox} p-2 flex flex-col gap-1 min-h-0`}>
+                    <span className={subTitle}>SAMPLING</span>
+                    <div className="grid grid-cols-3 gap-1 place-items-center shrink-0">
+                      <SlideKnob label="Temp" value={p.magTemperature} onChange={(v) => sf('magTemperature', v)} min={0} max={2} step={0.05} size={32} />
+                      <SlideKnob label="Top-K" value={p.magTopK} onChange={(v) => sf('magTopK', Math.round(v))} min={0} max={250} step={1} size={32} />
+                      <SlideKnob label="Chunk" value={p.magChunkFrames} onChange={(v) => sf('magChunkFrames', Math.round(v))} min={1} max={50} step={1} size={32} />
+                    </div>
+                    <div className="border-t border-white/8 mt-0.5 pt-1 flex items-center gap-1.5 shrink-0">
+                      <span className={`${subTitle} shrink-0`}>CFG SCALES</span>
+                    </div>
+                    <div className="flex-1 min-h-0 grid grid-cols-3 gap-0.5 mb-3">
+                      <SlideFader label="Style" value={p.magCfgMusiccoca} onChange={(v) => sf('magCfgMusiccoca', v)} min={0} max={10} step={0.1} />
+                      <SlideFader label="Notes" value={p.magCfgNotes} onChange={(v) => sf('magCfgNotes', v)} min={0} max={10} step={0.1} />
+                      <SlideFader label="Drums" value={p.magCfgDrums} onChange={(v) => sf('magCfgDrums', v)} min={0} max={10} step={0.1} />
+                    </div>
+                  </div>
+                ) : (
                 <div className={`${colBox} p-2 flex flex-col gap-1 min-h-0`}>
                   <span className={subTitle}>TEMP</span>
                   <div className="grid grid-cols-3 gap-1 place-items-center shrink-0">
@@ -532,7 +634,7 @@ export const AdvancedGenPanel: React.FC<{
                   </div>
                   <div className="border-t border-white/8 mt-0.5 pt-1 flex items-center gap-1.5 shrink-0">
                     <span className={`${subTitle} shrink-0`}>SAMPLER</span>
-                    <select className="compact-input flex-1 h-6 py-0 text-[9px]" value={p.samplerType} onChange={(e) => sf('samplerType', e.target.value)} style={{ colorScheme: 'dark' }}>
+                    <select name="gen-sampler" className="compact-input flex-1 h-6 py-0 text-[9px]" value={p.samplerType} onChange={(e) => sf('samplerType', e.target.value)} style={{ colorScheme: 'dark' }}>
                       <option value="pingpong">pingpong</option><option value="euler">euler</option>
                       <option value="rk4">rk4</option><option value="dpmpp">dpmpp</option>
                     </select>
@@ -544,13 +646,35 @@ export const AdvancedGenPanel: React.FC<{
                     <SlideFader label="Rescale" value={p.cfgRescale} onChange={(v) => sf('cfgRescale', v)} min={0} max={1} tipKey="cfgRescale" />
                   </div>
                 </div>
+                )}
 
                 {/* CENTER — chimera stack, full height */}
                 <div className="rounded-lg bg-black/20 border border-purple-500/15 p-2 min-h-0 overflow-y-auto" data-chimera-anchor="init-audio">
                   <ChimeraStack />
                 </div>
 
-                {/* SCHEDULE column — FX thin rows ride above the faders */}
+                {/* SCHEDULE column (SA3) ↔ OUTPUT column (Magenta) — toggles ride above */}
+                {isMagenta ? (
+                  <div className={`${colBox} p-2 flex flex-col gap-1 min-h-0`}>
+                    <span className={subTitle}>OUTPUT</span>
+                    <div className="flex items-start justify-around gap-1 shrink-0">
+                      <RoundToggle label="Cut" icon={Scissors} on={p.cutToDuration} onChange={(v) => sf('cutToDuration', v)} />
+                      <RoundToggle label="Play" icon={Play} on={p.autoplay} onChange={(v) => sf('autoplay', v)} />
+                      <RoundToggle label="DL" icon={Download} on={p.autoDownload} onChange={(v) => sf('autoDownload', v)} />
+                    </div>
+                    <div className="border-t border-white/8 mt-0.5 pt-1 flex items-center gap-1.5 shrink-0">
+                      <span className={`${subTitle} shrink-0`}>SOURCE</span>
+                      <span className="text-[9px] font-mono text-purple-300 flex-1 text-right truncate">
+                        {p.initAudioEnabled && p.initAudioFile ? 'Style clone (Init)' : 'Text prompt'}
+                      </span>
+                    </div>
+                    <div className="flex-1 min-h-0 flex flex-col items-center justify-center text-center gap-1 px-1 mb-3">
+                      <Sparkles className="w-4 h-4 text-purple-400/80" />
+                      <span className="text-[10px] font-black uppercase tracking-widest text-purple-300/90">Magenta RT2</span>
+                      <span className="text-[9px] text-zinc-500 leading-tight">48 kHz stereo · streaming · local GPU</span>
+                    </div>
+                  </div>
+                ) : (
                 <div className={`${colBox} p-2 flex flex-col gap-1 min-h-0`}>
                   <span className={subTitle}>FX</span>
                   <div className="flex items-start justify-around gap-1 shrink-0">
@@ -574,6 +698,7 @@ export const AdvancedGenPanel: React.FC<{
                     {shiftFaders()}
                   </div>
                 </div>
+                )}
               </div>
             </div>
           )}
@@ -662,7 +787,7 @@ export const AdvancedGenPanel: React.FC<{
                           inp.click();
                         }}>Choose file…</button>
                       )}
-                      <input type="number" className="compact-input w-10 text-center text-[9px]" value={lora.weight} step={0.05} min={0} max={2}
+                      <input name={`gen-lora-weight-${i}`} type="number" className="compact-input w-10 text-center text-[9px]" value={lora.weight} step={0.05} min={0} max={2}
                         onChange={(e) => { const u = p.loras.map((l, idx) => idx === i ? { ...l, weight: +e.target.value } : l); sf('loras', u); }} />
                       <button className="text-zinc-500 hover:text-red-400 cursor-pointer" onClick={() => sf('loras', p.loras.filter((_, idx) => idx !== i))}><X className="w-3 h-3" /></button>
                     </div>
@@ -674,7 +799,7 @@ export const AdvancedGenPanel: React.FC<{
             {/* NAME — name your outputs (below LoRA) */}
             <div className="hardware-card flex flex-col shrink-0 gap-1">
               <span className={`${sectionTitle} flex items-center gap-1`}>NAME</span>
-              <input className="compact-input w-full" placeholder="name your output…" maxLength={80}
+              <input name="gen-output-name" className="compact-input w-full" placeholder="name your output…" maxLength={80}
                 value={p.outputName} onChange={(e) => sf('outputName', e.target.value)} />
             </div>
 
@@ -683,14 +808,14 @@ export const AdvancedGenPanel: React.FC<{
               <span className={`${sectionTitle} mb-1.5`}>OUTPUT</span>
               <div className="grid grid-cols-2 gap-2">
                 <div>
-                  <label className="text-[10px] text-zinc-300 flex items-center gap-1">Format <InfoTip {...RICH_TOOLTIPS.outputFormat} /></label>
-                  <select className="compact-input w-full mt-0.5" value={p.fileFormat} onChange={(e) => sf('fileFormat', e.target.value)} style={{ colorScheme: 'dark' }}>
+                  <label htmlFor="gen-output-format" className="text-[10px] text-zinc-300 flex items-center gap-1">Format <InfoTip {...RICH_TOOLTIPS.outputFormat} /></label>
+                  <select id="gen-output-format" name="gen-output-format" className="compact-input w-full mt-0.5" value={p.fileFormat} onChange={(e) => sf('fileFormat', e.target.value)} style={{ colorScheme: 'dark' }}>
                     <option value="wav">WAV</option><option value="flac">FLAC</option><option value="ogg">OGG</option>
                   </select>
                 </div>
                 <div>
-                  <label className="text-[10px] text-zinc-300 flex items-center gap-1">Naming <InfoTip {...RICH_TOOLTIPS.fileNaming} /></label>
-                  <select className="compact-input w-full mt-0.5" value={p.fileNaming} onChange={(e) => sf('fileNaming', e.target.value)} style={{ colorScheme: 'dark' }}>
+                  <label htmlFor="gen-file-naming" className="text-[10px] text-zinc-300 flex items-center gap-1">Naming <InfoTip {...RICH_TOOLTIPS.fileNaming} /></label>
+                  <select id="gen-file-naming" name="gen-file-naming" className="compact-input w-full mt-0.5" value={p.fileNaming} onChange={(e) => sf('fileNaming', e.target.value)} style={{ colorScheme: 'dark' }}>
                     <option value="verbose">Verbose</option><option value="prompt">Prompt</option><option value="seed">Seed</option>
                   </select>
                 </div>
@@ -726,7 +851,7 @@ export const AdvancedGenPanel: React.FC<{
         {/* PROMPT */}
         <div className="hardware-card flex flex-col gap-1.5 min-h-0">
           <div className="flex items-center justify-between shrink-0">
-            <span className={`${sectionTitle} flex items-center gap-1`}>PROMPT <InfoTip {...RICH_TOOLTIPS.prompt} /></span>
+            <span className={`${sectionTitle} flex items-center gap-1`}>{isMagenta ? 'STYLE PROMPT' : <>PROMPT <InfoTip {...RICH_TOOLTIPS.prompt} /></>}</span>
             <div className="flex items-center gap-1">
               <SavedPromptsDropdown type="positive" value={p.prompt} onChange={(v) => sf('prompt', v)} />
               <button
@@ -744,13 +869,30 @@ export const AdvancedGenPanel: React.FC<{
             </div>
           </div>
           <div className="relative flex-1 min-h-0">
-            <textarea className="compact-input w-full resize-none h-full"
-              placeholder="120 BPM house loop, deep sub bass, crispy hi-hats, minimal percussion…"
+            <textarea name="gen-prompt" className="compact-input w-full resize-none h-full"
+              placeholder={isMagenta ? 'describe the vibe — instruments, mood, genre, era…' : '120 BPM house loop, deep sub bass, crispy hi-hats, minimal percussion…'}
               value={p.prompt} onChange={(e) => sf('prompt', e.target.value)} maxLength={1000} />
             <span className="absolute bottom-1 right-2 text-[9px] text-zinc-500">{p.prompt.length}/1000</span>
           </div>
+          {isMagenta ? (
+            <div className="shrink-0 flex items-center gap-2">
+              <span className="text-[10px] text-zinc-400 shrink-0">Seed</span>
+              <input name="gen-mag-seed" type="number" className="compact-input w-24 text-center tabular-nums" min={-1} max={2147483647} step={1}
+                value={p.magSeed} onChange={(e) => sf('magSeed', Math.floor(+e.target.value))}
+                title="Seed — same seed + same prompt reads the style identically. -1 = fresh each run." />
+              <button className="btn-ghost cursor-pointer p-1 text-zinc-500 hover:text-purple-300" title="Lock a random seed"
+                onClick={() => sf('magSeed', Math.floor(Math.random() * 2147483647))}><Dice5 className="w-3.5 h-3.5" /></button>
+              <button className="btn-ghost cursor-pointer text-[10px]" title="Fresh each run" onClick={() => sf('magSeed', -1)}>{p.magSeed < 0 ? 'random' : 'clear'}</button>
+              <div className="flex-1" />
+              <button onClick={() => sf('magExtend', !p.magExtend)}
+                title="Extend — continue the current track seamlessly. Change the prompt to morph it without a cut."
+                className={`flex items-center gap-1 px-2 py-1 rounded text-[10px] font-bold uppercase tracking-wider transition-colors ${p.magExtend ? 'bg-purple-600/30 text-purple-200 border border-purple-500/40' : 'text-zinc-500 hover:text-zinc-300 border border-white/10'}`}>
+                <Repeat className="w-3 h-3" /> Extend
+              </button>
+            </div>
+          ) : (
           <div className="relative shrink-0">
-            <textarea className="compact-input w-full resize-none h-9"
+            <textarea name="gen-negative-prompt" className="compact-input w-full resize-none h-9"
               placeholder="negative: vocals, distortion, harshness…"
               value={p.negativePrompt} onChange={(e) => sf('negativePrompt', e.target.value)} maxLength={500} />
             <div className="absolute top-1 right-2 flex items-center gap-1">
@@ -769,6 +911,7 @@ export const AdvancedGenPanel: React.FC<{
               </button>
             </div>
           </div>
+          )}
         </div>
 
         {/* VIZ RIGHT — flipped + icons on the left so it mirrors the left panel */}

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -1008,14 +1008,14 @@ const TrackBrowser: React.FC<{ source: Source; setSource: (s: Source) => void; o
       <div className="shrink-0 flex items-center gap-1.5 px-2 py-1 border-b border-white/5">
         {isSet ? <ListMusic className="w-3.5 h-3.5 text-purple-400 shrink-0" /> : <LibraryIcon className="w-3.5 h-3.5 text-purple-400 shrink-0" />}
         {editing && set ? (
-          <input autoFocus value={editName} onChange={(e) => setEditName(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') commitRename(); if (e.key === 'Escape') setEditing(false); }} onBlur={commitRename} className="bg-black/50 border border-purple-400/50 rounded px-1.5 py-0.5 text-[10px] text-zinc-100 focus:outline-none w-36" />
+          <input autoFocus name="dj-set-rename" value={editName} onChange={(e) => setEditName(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') commitRename(); if (e.key === 'Escape') setEditing(false); }} onBlur={commitRename} className="bg-black/50 border border-purple-400/50 rounded px-1.5 py-0.5 text-[10px] text-zinc-100 focus:outline-none w-36" />
         ) : (
           <span className="text-[10px] font-black uppercase tracking-wider text-purple-300 truncate max-w-40" title={sourceLabel}>{sourceLabel}</span>
         )}
         <span className="text-[8px] font-mono text-zinc-600">{rows.length} {isSet ? 'tracks' : 'files'}</span>
-        <div className="flex items-center gap-1 ml-auto bg-black/40 border border-white/10 rounded px-1.5 w-36 max-w-[40%]">
+        <div className="flex items-center gap-1 ml-auto bg-black/40 border border-white/10 rounded px-1.5 w-36 max-w-2/5">
           <Search className="w-3 h-3 text-zinc-600 shrink-0" />
-          <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="search…" className="flex-1 min-w-0 bg-transparent text-[10px] font-mono text-zinc-200 py-1 focus:outline-none placeholder:text-zinc-600" />
+          <input name="dj-source-search" value={q} onChange={(e) => setQ(e.target.value)} placeholder="search…" className="flex-1 min-w-0 bg-transparent text-[10px] font-mono text-zinc-200 py-1 focus:outline-none placeholder:text-zinc-600" />
         </div>
         {isSet && set && (
           <div className="flex items-center gap-0.5 shrink-0">
@@ -1136,7 +1136,7 @@ const SourceTree: React.FC<{ source: Source; setSource: (s: Source) => void; lib
           <div className="px-2 py-1 flex flex-col gap-1">
             <div className="flex items-center gap-1 bg-black/40 border border-white/10 rounded px-1.5">
               <Link2 className="w-3 h-3 text-zinc-600 shrink-0" />
-              <input value={dlUrl} onChange={(e) => setDlUrl(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') void runImport(); }}
+              <input name="dj-import-url" value={dlUrl} onChange={(e) => setDlUrl(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') void runImport(); }}
                 placeholder="paste URL…" disabled={dlBusy} aria-label="Online import URL"
                 className="flex-1 min-w-0 bg-transparent text-[9px] font-mono text-zinc-200 py-1 focus:outline-none placeholder:text-zinc-600 disabled:opacity-50" />
               <button onClick={() => void runImport()} disabled={dlBusy || !dlUrl.trim()} className="shrink-0 text-purple-300 hover:text-purple-100 disabled:opacity-30" title="Download into library">
@@ -1567,7 +1567,7 @@ function buildDjRegistry(p: DjRegArgs): WidgetRegistry {
       {p.cueSupported ? (
         <div className="flex items-center gap-1 w-full" title="Headphone (cue) output device">
           <Headphones className="w-2.5 h-2.5 text-zinc-500 shrink-0" />
-          <select value={p.cueDev} onChange={(e) => { p.setCueDev(e.target.value); void djEngine.setCueSinkId(e.target.value); }} className="flex-1 min-w-0 bg-[#0e0c18] border border-white/10 text-zinc-300 text-[8px] font-mono px-1 py-0.5 rounded focus:outline-none" style={{ colorScheme: 'dark' }} title="Cue output device">
+          <select name="dj-cue-device" value={p.cueDev} onChange={(e) => { p.setCueDev(e.target.value); void djEngine.setCueSinkId(e.target.value); }} className="flex-1 min-w-0 bg-[#0e0c18] border border-white/10 text-zinc-300 text-[8px] font-mono px-1 py-0.5 rounded focus:outline-none" style={{ colorScheme: 'dark' }} title="Cue output device">
             <option value="">Default out</option>
             {p.cueDevices.map((dv) => <option key={dv.id} value={dv.id}>{dv.label}</option>)}
           </select>

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -676,6 +676,7 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
       <input
         ref={midiFileInputRef}
         type="file"
+        name="library-import-midi"
         accept=".mid,.midi,audio/midi"
         multiple
         className="hidden"

--- a/frontend/src/views/MixView.tsx
+++ b/frontend/src/views/MixView.tsx
@@ -349,7 +349,7 @@ function buildMixRegistry(p: MixRegArgs): WidgetRegistry {
         <span className={sectionTitle}>Chain {p.chain.length > 0 && <span className="text-zinc-600">({p.chain.length})</span>}</span>
         <div className="ml-auto flex items-center gap-1.5">
           <span className="text-[9px] font-mono text-zinc-500 shrink-0">FORMAT</span>
-          <select className="compact-input text-[10px] w-20" value={p.outputFormat} onChange={(e) => p.setOutputFormat(e.target.value)}>
+          <select name="mix-output-format" className="compact-input text-[10px] w-20" value={p.outputFormat} onChange={(e) => p.setOutputFormat(e.target.value)}>
             <option value="wav">WAV</option><option value="flac">FLAC</option><option value="mp3">MP3</option><option value="ogg">OGG</option>
           </select>
           <button onClick={() => p.setShowHistory(!p.showHistory)} title="Process history" className={`btn-ghost p-1 shrink-0 ${p.showHistory ? 'text-purple-300' : 'text-zinc-500 hover:text-zinc-300'}`}><History className="w-3.5 h-3.5" /></button>
@@ -561,7 +561,7 @@ export const MixView: React.FC = () => {
   return (
     <div className="relative h-full w-full overflow-hidden text-zinc-200">
       <ControlSurface surfaceId="mix" registry={registry} defaultLayout={defaultMixLayout} className="p-1.5" />
-      <input ref={fileInputRef} type="file" accept="audio/*" className="hidden" onChange={handleFileSelect} title="Upload audio file" />
+      <input ref={fileInputRef} name="mix-audio-file" type="file" accept="audio/*" className="hidden" onChange={handleFileSelect} title="Upload audio file" />
     </div>
   );
 };

--- a/frontend/src/views/TrainView.tsx
+++ b/frontend/src/views/TrainView.tsx
@@ -78,29 +78,29 @@ function buildTrainRegistry(p: TrainRegArgs): WidgetRegistry {
     <Section title="TARGET ARCHITECTURE" icon={Layers} defaultOpen={true} rightNode={<span className="mono-tag bg-blue-600/20! border-blue-500/30! text-blue-300!">L4-ACCEL</span>}>
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-1">
-          <label className="mono-label">New Lora Identity</label>
-          <input type="text" className="compact-input w-full" value={p.params.moduleName} onChange={(e) => p.setParams({ ...p.params, moduleName: e.target.value })} />
+          <label htmlFor="train-module-name" className="mono-label">New Lora Identity</label>
+          <input id="train-module-name" name="train-module-name" type="text" className="compact-input w-full" value={p.params.moduleName} onChange={(e) => p.setParams({ ...p.params, moduleName: e.target.value })} />
         </div>
         <div className="grid grid-cols-2 gap-2">
           <div className="flex flex-col gap-1">
-            <label className="mono-label">Target Module</label>
-            <select className="compact-input w-full uppercase font-mono" value={p.params.targetModule} onChange={(e) => p.setParams({ ...p.params, targetModule: e.target.value })}>
+            <label htmlFor="train-target-module" className="mono-label">Target Module</label>
+            <select id="train-target-module" name="train-target-module" className="compact-input w-full uppercase font-mono" value={p.params.targetModule} onChange={(e) => p.setParams({ ...p.params, targetModule: e.target.value })}>
               <option value="attn_kv">ATTN_KV</option>
               <option value="mlp">MLP_LAYERS</option>
               <option value="to_q">TO_Q_PROJ</option>
             </select>
           </div>
           <div className="flex flex-col gap-1">
-            <label className="mono-label">Epochs</label>
-            <input type="number" className="compact-input w-full" value={p.params.epochs} onChange={(e) => p.setParams({ ...p.params, epochs: parseInt(e.target.value) || 0 })} />
+            <label htmlFor="train-epochs" className="mono-label">Epochs</label>
+            <input id="train-epochs" name="train-epochs" type="number" className="compact-input w-full" value={p.params.epochs} onChange={(e) => p.setParams({ ...p.params, epochs: parseInt(e.target.value) || 0 })} />
           </div>
           <div className="flex flex-col gap-1">
-            <label className="mono-label">Rank</label>
-            <input type="number" className="compact-input w-full" value={p.params.rank} onChange={(e) => p.setParams({ ...p.params, rank: parseInt(e.target.value) || 0 })} />
+            <label htmlFor="train-rank" className="mono-label">Rank</label>
+            <input id="train-rank" name="train-rank" type="number" className="compact-input w-full" value={p.params.rank} onChange={(e) => p.setParams({ ...p.params, rank: parseInt(e.target.value) || 0 })} />
           </div>
           <div className="flex flex-col gap-1">
-            <label className="mono-label">Alpha</label>
-            <input type="number" className="compact-input w-full" value={p.params.alpha} onChange={(e) => p.setParams({ ...p.params, alpha: parseInt(e.target.value) || 0 })} />
+            <label htmlFor="train-alpha" className="mono-label">Alpha</label>
+            <input id="train-alpha" name="train-alpha" type="number" className="compact-input w-full" value={p.params.alpha} onChange={(e) => p.setParams({ ...p.params, alpha: parseInt(e.target.value) || 0 })} />
           </div>
         </div>
       </div>
@@ -113,7 +113,7 @@ function buildTrainRegistry(p: TrainRegArgs): WidgetRegistry {
         <UploadCloud className="w-5 h-5 text-zinc-600" />
         <span className="text-[9px] text-zinc-500 font-mono tracking-widest uppercase">Load Dataset (.zip / folder)</span>
       </div>
-      <input type="text" className="compact-input w-full mt-2" placeholder="Dataset path on local machine (required by /api/jobs/train-lora)" value={p.params.datasetPath} onChange={(e) => p.setParams({ ...p.params, datasetPath: e.target.value })} />
+      <input type="text" name="train-dataset-path" className="compact-input w-full mt-2" placeholder="Dataset path on local machine (required by /api/jobs/train-lora)" value={p.params.datasetPath} onChange={(e) => p.setParams({ ...p.params, datasetPath: e.target.value })} />
       <div className="mt-2 space-y-1">
         <div className="flex items-center justify-between p-1.5 bg-white/5 rounded"><span className="text-zinc-400">techno_kicks_2024</span><span className="text-[8px] font-mono text-zinc-600">128 samples</span></div>
         <div className="flex items-center justify-between p-1.5 bg-white/5 rounded opacity-50"><span className="text-zinc-400">ambient_pads_raw</span><span className="text-[8px] font-mono text-zinc-600">Waiting...</span></div>
@@ -217,7 +217,7 @@ export const TrainView: React.FC = () => {
     <div className="relative h-full w-full overflow-hidden text-zinc-200">
       <ControlSurface surfaceId="train" registry={registry} defaultLayout={defaultTrainLayout} className="p-1.5" />
       <input
-        ref={aeFileRef} type="file" accept="audio/*" className="hidden"
+        ref={aeFileRef} type="file" name="train-ae-encode-file" accept="audio/*" className="hidden"
         onChange={(event) => { const file = event.target.files?.[0]; if (file) void encodeAudioToLatents({ modelName: 'same-l', audioFile: file }); }}
         title="Encode audio file"
       />

--- a/showcase/build_roughcut.sh
+++ b/showcase/build_roughcut.sh
@@ -20,69 +20,75 @@ FONT="showcase/.font.ttf"
 # A "song being made in theDAW" arc, built around Et Tu Machina: hook -> make -> arrange ->
 # mix -> perform -> visualize -> lineage -> ecosystem. Order is the narrative; durations flex.
 SCENES=(
-  # hook + lineage
-  "50_cymatics|5.0|1680:945:120:70|608:1080:656:0|0.5|one machine, every instrument"
-  "01a_learn-2d-hero|1.9|full|608:1080:656:0|19.0|every track remembers its lineage"
-  # make the song
-  "08_make|1.4|full|608:1080:656:0||generate from a prompt"
-  "23_chimera|1.6|full|608:1080:656:0||fuse clips into a chimera"
-  "25_init-audio|1.4|full|608:1080:656:0||seed it with your own audio"
-  "21_inpaint|1.4|full|608:1080:656:0||repaint any section"
-  "45_saved-prompts|1.2|full|608:1080:656:0||save every prompt"
-  "05_sequencer|1.3|full|608:1080:656:0||a step sequencer"
-  "58_spectrogram|1.9|full|608:1080:656:0||mel · stft · chroma · cqt"
+  # hook
+  "50_cymatics|5.0|1680:945:120:70|608:1080:656:0|0.5|Real-time cymatics visualizer"
+  # genealogy — the 3D graph flies into the piano roll that opens make
+  "01a_learn-2d-hero|1.9|full|608:1080:656:0|19.0|Interactive lineage graph"
+  "65_3d-piano|3.5|full|608:1080:656:0|1.5|3D genealogy graph"
+  # make — opens at the piano roll the 3D graph flew into
+  "65_3d-piano|3.5|full|608:1080:656:0|5.0|Built-in piano roll"
+  "08_make|1.4|full|608:1080:656:0||Generate audio from a text prompt"
+  "23_chimera|1.6|full|608:1080:656:0||Blend multiple clips with Chimera"
+  "25_init-audio|1.4|full|608:1080:656:0||Audio-to-audio generation"
+  "21_inpaint|1.4|full|608:1080:656:0||Regenerate any section with inpainting"
+  "45_saved-prompts|1.2|full|608:1080:656:0||Save and reuse prompts"
+  "05_sequencer|1.3|full|608:1080:656:0||Built-in step sequencer"
+  "58_spectrogram|1.9|full|608:1080:656:0||Mel, STFT, chroma, and CQT spectrograms"
   # arrange + edit
-  "03_edit-stems|1.9|full|608:1080:656:0||arrange the stems on a timeline"
-  "22_cut-edit|1.5|full|608:1080:656:0||cut and chop the clips"
-  "41_delete-clip|1.3|full|608:1080:656:0||edit like a daw"
-  "31_edit-mix|1.4|full|608:1080:656:0||mix the tracks live"
-  "40_inpaint-region|1.4|full|608:1080:656:0||paintbrush inpainting"
-  "59_commit-edit|1.5|full|608:1080:656:0||commit to a 44.1khz master"
+  "03_edit-stems|1.9|full|608:1080:656:0||Arrange stems on a timeline"
+  "22_cut-edit|1.5|full|608:1080:656:0||Cut, split, and chop clips"
+  "41_delete-clip|1.3|full|608:1080:656:0||Full multitrack editing"
+  "31_edit-mix|1.4|full|608:1080:656:0||Live per-track mixing"
+  "40_inpaint-region|1.4|full|608:1080:656:0||Paintbrush region inpainting"
+  "59_commit-edit|1.5|full|608:1080:656:0||Render a 44.1 kHz master"
   # mix
-  "07_mix-effects|1.4|full|608:1080:1312:0||a studio effects rack"
-  "57_mix-all-effects|2.0|full|608:1080:400:0||every effect, on the track"
-  "66_module-gui|1.7|full|608:1080:1312:0||14 pro-grade instruments"
-  "32_mix-chain|1.4|full|608:1080:400:0||stack a mastering chain"
-  "27_lora|1.3|full|608:1080:1312:0||load loras"
-  "39_design-mode|1.6|full|608:1080:656:0||rearrange the interface"
+  "07_mix-effects|1.4|full|608:1080:1312:0||Studio effects rack"
+  "57_mix-all-effects|2.0|full|608:1080:400:0||Stack effects on any clip"
+  "66_module-gui|1.7|full|608:1080:1312:0||14 pro studio instruments"
+  "32_mix-chain|1.4|full|608:1080:400:0||Build a mastering chain"
+  "27_lora|1.3|full|608:1080:1312:0||Load custom LoRA models"
+  "39_design-mode|1.6|full|608:1080:656:0||Rearrange the entire interface"
   # perform (dj)
-  "02_dj-console|1.5|full|540:960:690:90||a two-deck dj console"
-  "54_dj-perform|2.0|full|540:960:690:90||hotcues, loops, and fx"
-  "55_dj-automix|1.5|full|540:960:690:90||automix, hands-free"
-  "56_dj-stems|1.4|full|540:960:690:90||live stems on the deck"
-  "33_dj-sampler|1.4|full|608:1080:300:0||sampler + staging deck"
+  "02_dj-console|1.5|full|540:960:690:90||Two-deck DJ console"
+  "54_dj-perform|2.0|full|540:960:690:90||Hot cues, loops, and FX"
+  "55_dj-automix|1.5|full|540:960:690:90||Hands-free automix"
+  "56_dj-stems|1.4|full|540:960:690:90||Live stem control per deck"
+  "33_dj-sampler|1.4|full|608:1080:300:0||Sampler and staging deck"
   # visualize
-  "50_cymatics|5.0|1680:945:120:70|608:1080:656:0|6.8|cymatic platform"
-  "50_cymatics|5.0|1680:945:120:70|608:1080:656:0|12.5|liquid-chrome cymatics"
-  "50_cymatics|5.0|1680:945:120:70|608:1080:656:0|18.5|ferrofluid valley"
-  "12_slide-surface|1.5|full|608:1080:500:0||performance sliders"
-  "19_vj-visualizer|3.5|full|608:1080:750:0||drive live visuals"
-  "70_vj-mobile|1.6|full|608:1080:1312:0||mirror to a phone over wi-fi"
-  "04_visualize|1.2|full|608:1080:656:0||live spectrum"
-  "15_analyzer-scope|1.2|full|608:1080:656:0||oscilloscope"
-  "16_analyzer-radial|1.3|full|540:960:830:120||radial analyzer"
-  # lineage + library + ecosystem
-  "65_3d-piano|6.5|full|608:1080:656:0|1.5|fly the lineage into the keys"
-  "48_galaxy-preset|1.3|full|608:1080:656:0||constellation view"
-  "14_catalogue|1.5|full|608:1080:300:0||your whole library"
-  "13_details|1.3|full|608:1080:300:0||full metadata on everything"
-  "24_focus|1.4|full|608:1080:656:0||focus on one control"
-  "17_controller|1.4|full|608:1080:656:0||map any midi controller"
-  "69_controller-vision|1.7|full|608:1080:656:0||identify a controller from a photo"
-  "20_train|1.7|full|608:1080:656:0||train it on your own sound"
-  "63_magenta-studio-live|1.8|full|608:1080:656:0||magenta rt2, on the local gpu"
-  "62_magenta-card|2.0|full|600:1080:540:0||the first non-mac magenta rt2 port"
-  "10_suno-cloud|1.4|full|608:1080:560:0||or render in the cloud"
-  "44_url-import|1.3|full|608:1080:120:0||pull audio from a link"
-  "18_media-bucket|1.2|full|608:1080:120:0||drop in any file"
-  "11_assistant-orb|1.6|full|608:1080:0:0||an assistant that runs the app"
-  "37_docs|1.5|full|608:1080:656:0||documented from the inside"
-  "38_settings|1.6|full|608:1080:656:0||modular, all of it"
-  "36_log|1.2|full|608:1080:1312:0||watch every job run"
+  "50_cymatics|5.0|1680:945:120:70|608:1080:656:0|6.8|Cymatic platform mode"
+  "50_cymatics|5.0|1680:945:120:70|608:1080:656:0|12.5|Liquid-chrome mode"
+  "50_cymatics|5.0|1680:945:120:70|608:1080:656:0|18.5|Ferrofluid valley mode"
+  "12_slide-surface|1.5|full|608:1080:500:0||Performance slider surface"
+  "19_vj-visualizer|3.5|full|608:1080:750:0||Live VJ visual engine"
+  "70_vj-mobile|1.6|full|608:1080:1312:0||Mirror visuals to a phone"
+  "04_visualize|1.2|full|608:1080:656:0||Live spectrum analyzer"
+  "15_analyzer-scope|1.2|full|608:1080:656:0||Oscilloscope"
+  "16_analyzer-radial|1.3|full|540:960:830:120||Radial analyzer"
+  # ecosystem
+  "14_catalogue|1.5|full|608:1080:300:0||Your entire audio library"
+  "13_details|1.3|full|608:1080:300:0||Full metadata on every track"
+  "24_focus|1.4|full|608:1080:656:0||Focus mode for any control"
+  "17_controller|1.4|full|608:1080:656:0||Map any MIDI controller"
+  "69_controller-vision|1.7|full|608:1080:656:0||Identify a controller from a photo"
+  "20_train|1.7|full|608:1080:656:0||Train LoRAs on your own sound"
+  "63_magenta-studio-live|1.8|full|608:1080:656:0||Magenta RT2 on a local GPU"
+  "62_magenta-card|2.0|full|600:1080:540:0||The first non-Mac Magenta RT2 port"
+  "10_suno-cloud|1.4|full|608:1080:560:0||Cloud generation via Suno"
+  "44_url-import|1.3|full|608:1080:120:0||Import your own audio from a URL"
+  "18_media-bucket|1.2|full|608:1080:120:0||Drop in any media file"
+  "11_assistant-orb|2.6|full|608:1080:0:0||Analyze and automate through the Orb Assistant (dozens of local or API models)"
+  "37_docs|1.5|full|608:1080:656:0||Built-in interactive docs"
+  "38_settings|1.6|full|608:1080:656:0||Modular feature toggles"
 )
 
+# Output is upscaled 2x to 4K (3840x2160 / 2160x3840) via lanczos from the crisp
+# supersampled-1080 source clips: highest quality, no native-4K reflow, no artifacts.
+# Subtitle geometry (size, bottom offset, border, line spacing) is scaled 2x to match
+# the larger canvas so text stays sharp and proportioned exactly as at 1080. WRAP is a
+# character count, so it is resolution-independent and stays the same.
 # Subtitles: bigger + raised off the bottom. Vertical sits higher (above the lower-third).
-if [ "$ORI" = "v" ]; then W=1080; H=1920; SUBY="h-470"; SUBSZ=58; else W=1920; H=1080; SUBY="h-128"; SUBSZ=46; fi
+if [ "$ORI" = "v" ]; then W=2160; H=3840; SUBY="h-1000"; SUBSZ=104; WRAP=24; else W=3840; H=2160; SUBY="h-320"; SUBSZ=88; WRAP=48; fi
+BORDERW=32; LSP=12
 
 TMP="showcase/.roughtmp_${ORI}"
 rm -rf "$TMP"; mkdir -p "$TMP"
@@ -107,8 +113,8 @@ for row in "${SCENES[@]}"; do
   clip_dur="$(ffprobe -v error -show_entries format=duration -of default=nk=1:nw=1 "$f")"
   if [ -z "$start" ]; then start="$(python -c "print(max(0.0, ${clip_dur} - ${dur} - 0.3))")"; fi
 
-  subfile="$TMP/sub_$(printf '%02d' "$i").txt"; printf '%s' "$sub" > "$subfile"
-  draw="drawtext=fontfile=${FONT}:textfile=${subfile}:x=(w-text_w)/2:y=${SUBY}:fontsize=${SUBSZ}:fontcolor=white:box=1:boxcolor=black@0.5:boxborderw=16:line_spacing=6"
+  subfile="$TMP/sub_$(printf '%02d' "$i").txt"; printf '%s' "$sub" | fold -s -w "$WRAP" | sed 's/[[:space:]]*$//' > "$subfile"
+  draw="drawtext=fontfile=${FONT}:textfile=${subfile}:x=(w-text_w)/2:y=${SUBY}:fontsize=${SUBSZ}:fontcolor=white:box=1:boxcolor=black@0.5:boxborderw=${BORDERW}:line_spacing=${LSP}"
   cseg="$(printf 'cseg_%02d.mp4' "$i")"; sseg="$(printf 'sseg_%02d.mp4' "$i")"
   # ONE high-quality encode each (clean + subtitled) — no second re-encode pass.
   ffmpeg -y -loglevel error -ss "$start" -t "$dur" -i "$f" -an -vf "${geom},fps=30,format=yuv420p" -c:v libx264 -preset slow -crf 16 -pix_fmt yuv420p "$TMP/$cseg"

--- a/sidecars/magenta/server.py
+++ b/sidecars/magenta/server.py
@@ -33,6 +33,8 @@ override with STABLEDAW_MAGENTA_URL.
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import io
 import json
 import os
@@ -68,17 +70,25 @@ class Engine:
         self.sample_rate = 48000
         self.lock = threading.Lock()
         self._embed_cache: dict[str, object] = {}
+        # Current evolving piece for extend/morph: {state, emb, key, samples, sr}.
+        self._gen: dict | None = None
 
     def load(self) -> None:
         try:
             self.status = "importing jax + magenta_rt"
             import jax
 
-            from magenta_rt import MagentaRT2System
+            # magenta-rt 2.x exposes the JAX system as ``MagentaRT2Jax`` (the
+            # pre-2.0 name ``MagentaRT2System`` is no longer re-exported at the
+            # top level). Use the current name, falling back defensively.
+            try:
+                from magenta_rt import MagentaRT2Jax as MagentaRT2
+            except ImportError:  # older/renamed API
+                from magenta_rt.jax.system import MagentaRT2System as MagentaRT2
 
             self.device = str(jax.devices()[0])
             self.status = f"loading {MODEL} + compiling (one-time)"
-            self.mrt = MagentaRT2System(size=MODEL)
+            self.mrt = MagentaRT2(size=MODEL)
             self.sample_rate = int(getattr(self.mrt, "_sample_rate", 48000))
             # Warm up so the first real request is fast.
             emb = self.mrt.embed_style("warm up", use_mapper=True)
@@ -91,22 +101,56 @@ class Engine:
             self.status = "error: " + self.error
             traceback.print_exc()
 
-    def embed_text(self, prompt: str):
-        emb = self._embed_cache.get(prompt)
+    @staticmethod
+    def _style_key(sources: list[dict], seed: int) -> str:
+        basis = [
+            (
+                s.get("type", "text"),
+                (s.get("text") or "").strip(),
+                (s.get("audio_b64") or "")[:48],
+                round(float(s.get("weight", 1.0)), 4),
+            )
+            for s in sources
+        ]
+        return hashlib.sha1((repr(basis) + f"|seed={seed}").encode()).hexdigest()
+
+    def _embed_one(self, src: dict, seed: int):
+        """Embed one style source: a text prompt OR an uploaded audio clip."""
+        if src.get("type") == "audio" and src.get("audio_b64"):
+            from magenta_rt import audio as mrt_audio
+
+            raw = base64.b64decode(src["audio_b64"])
+            samples, sr = sf.read(io.BytesIO(raw), dtype="float32", always_2d=True)
+            wf = mrt_audio.Waveform(samples, sample_rate=int(sr))
+            return self.mrt.embed_style(wf, use_mapper=True, seed=int(seed))
+        text = (src.get("text") or "warm analog pads").strip()
+        return self.mrt.embed_style(text, use_mapper=True, seed=int(seed))
+
+    def build_style(self, prompt: str, styles: list[dict] | None, seed: int):
+        """One style embedding from a prompt, or a weighted blend of text/audio
+        sources (overrides prompt). Returns (embedding, cache_key)."""
+        sources = (
+            list(styles)
+            if styles
+            else [{"type": "text", "text": prompt, "weight": 1.0}]
+        )
+        key = self._style_key(sources, seed)
+        emb = self._embed_cache.get(key)
         if emb is None:
-            emb = self.mrt.embed_style(prompt, use_mapper=True)
+            embs, weights = [], []
+            for s in sources:
+                embs.append(np.asarray(self._embed_one(s, seed), dtype=np.float32))
+                weights.append(max(0.0, float(s.get("weight", 1.0))))
+            w = np.asarray(weights, dtype=np.float32)
+            if w.sum() <= 0:
+                w = np.ones_like(w)
+            emb = np.average(np.stack(embs, axis=0), axis=0, weights=w).astype(
+                np.float32
+            )
             if len(self._embed_cache) > 32:
                 self._embed_cache.clear()
-            self._embed_cache[prompt] = emb
-        return emb
-
-    def embed_audio(self, wav_bytes: bytes):
-        """Embed a style from an uploaded audio clip (clone / style-transfer)."""
-        from magenta_rt import audio as mrt_audio
-
-        samples, sr = sf.read(io.BytesIO(wav_bytes), dtype="float32", always_2d=True)
-        waveform = mrt_audio.Waveform(samples, sample_rate=int(sr))
-        return self.mrt.embed_style(waveform, use_mapper=True)
+            self._embed_cache[key] = emb
+        return emb, key
 
 
 ENGINE = Engine()
@@ -157,6 +201,13 @@ async def health():
     }
 
 
+@app.post("/reset")
+async def reset():
+    """Drop the evolving-piece state so the next generate starts a fresh track."""
+    ENGINE._gen = None
+    return {"ok": True}
+
+
 @app.post("/generate")
 async def generate(
     prompt: str = Form(""),
@@ -169,6 +220,9 @@ async def generate(
     drums: int = Form(-1),
     chunk_frames: int = Form(FPS),
     notes: str = Form(""),
+    seed: int = Form(0),
+    extend: bool = Form(False),
+    styles: str = Form(""),
     audio: UploadFile | None = None,
 ):
     if not ENGINE.ready:
@@ -180,17 +234,32 @@ async def generate(
         timeline: list[dict] = json.loads(notes) if notes.strip() else []
     except json.JSONDecodeError:
         return JSONResponse({"error": "notes must be JSON"}, status_code=400)
+    try:
+        style_list: list[dict] = json.loads(styles) if styles.strip() else []
+    except json.JSONDecodeError:
+        return JSONResponse({"error": "styles must be JSON"}, status_code=400)
 
     audio_bytes = await audio.read() if audio is not None else None
+    # A single uploaded clip with no explicit blend list IS the audio style source.
+    if audio_bytes and not style_list:
+        style_list = [
+            {
+                "type": "audio",
+                "audio_b64": base64.b64encode(audio_bytes).decode(),
+                "weight": 1.0,
+            }
+        ]
+    has_audio_style = any(s.get("type") == "audio" for s in style_list)
 
     def _run():
         with ENGINE.lock:
             t0 = time.time()
-            emb = (
-                ENGINE.embed_audio(audio_bytes)
-                if audio_bytes
-                else ENGINE.embed_text(prompt or "warm analog pads")
+            prev = ENGINE._gen if extend else None
+            emb, key = ENGINE.build_style(
+                prompt or "warm analog pads", style_list, int(seed or 0)
             )
+            if prev is not None and prev.get("key") == key:
+                emb = prev["emb"]  # same vibe across an extend — keep the embedding
             total = max(1, int(round(float(duration) * FPS)))
             chunk = max(1, int(chunk_frames))
             common = dict(
@@ -203,10 +272,11 @@ async def generate(
                 drums=[int(drums)],
             )
 
+            # extend=True continues the current piece via the model's streaming
+            # state, so changing the prompt/style/notes morphs it without a cut.
+            state = prev["state"] if prev is not None else None
+            parts = []
             if not timeline:
-                # No MIDI: one continuous stream (state kept across chunks for continuity).
-                state = None
-                parts = []
                 done = 0
                 while done < total:
                     n = min(chunk, total - done)
@@ -215,8 +285,6 @@ async def generate(
                     done += n
             else:
                 # MIDI-conditioned accompaniment: per-chunk note states, threaded state.
-                state = None
-                parts = []
                 for start_f in range(0, total, chunk):
                     n = min(chunk, total - start_f)
                     ns = _notes_state_for_window(timeline, start_f, FPS)
@@ -225,29 +293,41 @@ async def generate(
                     )
                     parts.append(np.asarray(wav.samples, dtype=np.float32))
 
-            samples = np.concatenate(parts, axis=0)
+            seg = np.concatenate(parts, axis=0)
+            sr = ENGINE.sample_rate
+            if prev is not None and prev.get("samples") is not None:
+                full = np.concatenate([prev["samples"], seg], axis=0)
+            else:
+                full = seg
+            ENGINE._gen = {
+                "state": state,
+                "emb": emb,
+                "key": key,
+                "samples": full,
+                "sr": sr,
+            }
             compute = time.time() - t0
-        sr = ENGINE.sample_rate
         buf = io.BytesIO()
-        sf.write(buf, samples, sr, format="WAV", subtype="PCM_16")
-        return buf.getvalue(), compute, samples.shape[0] / sr, sr
+        sf.write(buf, full, sr, format="WAV", subtype="PCM_16")
+        return buf.getvalue(), compute, full.shape[0] / sr, seg.shape[0] / sr, sr
 
     try:
         import anyio
 
-        wav_bytes, compute, audio_s, sr = await anyio.to_thread.run_sync(_run)
-        rtf = (audio_s / compute) if compute > 0 else 0.0
+        wav_bytes, compute, audio_s, seg_s, sr = await anyio.to_thread.run_sync(_run)
+        rtf = (seg_s / compute) if compute > 0 else 0.0
+        cond = "audio" if has_audio_style else ("notes" if timeline else "text")
         return Response(
             content=wav_bytes,
             media_type="audio/wav",
             headers={
                 "X-Generate-Seconds": f"{compute:.2f}",
                 "X-Audio-Seconds": f"{audio_s:.2f}",
+                "X-Segment-Seconds": f"{seg_s:.2f}",
                 "X-RTF": f"{rtf:.2f}",
                 "X-Sample-Rate": str(sr),
-                "X-Conditioning": "audio"
-                if audio_bytes
-                else ("notes" if timeline else "text"),
+                "X-Extend": "1" if extend else "0",
+                "X-Conditioning": cond,
             },
         )
     except Exception as e:  # noqa: BLE001 — return the real error to the client


### PR DESCRIPTION
…r + a11y fixes

Magenta RT2 (mrt2_small) is now a first-class in-app generator:
- sidecar (sidecars/magenta/server.py): full conditioning surface - text prompt, weighted style blend, MIDI notes, seed, extend/morph (streaming state); fix the magenta-rt 2.x import (MagentaRT2Jax).
- backend: forward seed/extend/styles/notes through the magenta module (router + sidecar client); add NON-destructive SA3 VRAM offload/onload (/api/model/offload, /onload, /offload-status) so mrt2_small and SA3 can share one GPU by parking the SA3 model in CPU RAM.
- frontend MAKE panel: a per-model variant - selecting "Magenta RT2" swaps the SA3 sampler/schedule/inputs for Magenta's own [STYLE audio source, NOTES piano, STYLE PROMPT + Seed + Extend, Temp/Top-K/Chunk + CFG scales]; the central Chimera stack stays shared. CREATE now builds params via buildGenerateParamsFromState so every Magenta field is sent.
- vendor: advance the magenta-rt2-nvidia submodule to the restructured layout, with port_src checked out.

Footer/dock: action button is a fixed width [decoupled from the LOG drag]; the LOG strip auto-fits its telemetry and the LOG body floats [no longer pushes the work area]; expand chevron + PLAY centered on the viewport.

Cleanup (console/lint, fixed at root): de-duplicate DocsModal heading slugs [fixes the "two children with the same key" error on opening Docs]; add name/id + label associations to 90+ form fields; convert arbitrary Tailwind classes to their v4 canonical tokens (compiler-validated).