### PR TITLE
docs(accuracy): correct UI-shell description + Windows setup in CLAUD…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,11 +173,13 @@ This project uses **Tailwind CSS v4**. The following v3 forms are forbidden and 
 
 ## Windows-Specific Setup
 
-The `pyproject.toml` CUDA index mapping only covers Linux. On Windows:
-- PyTorch must be manually installed with `--index-url https://download.pytorch.org/whl/cu128`
-- `soundfile` package is required (torchaudio has no default backend on Windows)
-- Flash Attention requires pre-built wheels from `kingbri1/flash-attention` GitHub releases
-- See `docs/windows/setup-guide.md` for full instructions
+`pyproject.toml` maps the CUDA wheels per-platform under `[tool.uv.sources]`
+(Linux x86_64 → cu126, Windows → cu128), so `uv sync` on Windows installs the
+right stack automatically:
+- torch + torchaudio come from the cu128 index (no manual `--index-url` step)
+- `soundfile` is a base dependency (torchaudio's Windows backend), installed by `uv sync`
+- Flash Attention installs from the pinned `kingbri1` cu128/cp310 wheel, gated to `sys_platform == 'win32' and python_version < '3.11'` (so the venv must be Python 3.10; `.python-version` pins it)
+- `theDAW.bat` / `Setup-theDAW.bat` install the prerequisite tools; `docs/windows/setup-guide.md` has the full walkthrough and fallbacks
 
 ## RAG Index Maintenance
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -162,23 +162,23 @@ cd frontend && npm run dev
 
 ## 5. UI Shell
 
-The application window is divided into three persistent regions:
+The application window has five regions:
 
-- **Left panel** (resizable): brand, tab controls content, run CTA, processing log.
-- **Center workspace**: the center tab bar at the top, the active workspace below it, and a collapsible bottom multi-tab panel in the global footer.
-- **Player footer**: a fixed transport bar across the bottom of the app.
+- **Full-width header** (top): the theDAW logo, a global search input, and action buttons (Docs, mobile access QR/link, Settings, user avatar, AI Assistant orb).
+- **Center workspace**: the center tab bar at the top and the active workspace below it, including that tab's own controls and run action.
+- **Library rail** (right, collapsible): browse and route library material without leaving the active workspace.
+- **Global bottom dock**: the bottom multi-tab panel and the processing log, side by side.
+- **Player footer** (bottom): a fixed transport bar.
 
-**Full-width header:** a fixed bar spanning the entire window width. It contains the left-panel collapse/reveal toggle (chevron), the theDAW logo dot, a global search input, and action buttons (Docs, mobile access QR/link, Settings, User avatar, AI Assistant orb).
-
-**Left panel resize:** drag the vertical handle on the panel's right edge. Range: 300 px to 500 px.
-
-**Left panel collapse:** click the chevron in the header. The workspace expands to full width. Click again to restore.
+**Full-width header:** a fixed bar spanning the entire window width. It holds the theDAW logo dot, a global search input, and the action buttons listed above. There is no left panel and no left-panel toggle; the only collapsible side panel is the Library rail on the right.
 
 **Center tab switching:** the active workspace is controlled by the center tab bar in the locked order **MAKE / EDIT / MIX / DJ / VJ / TRAIN / LEARN** (`CENTER_TABS`). Each tab carries its own accent color. Legacy navigation targets such as `create`, `advanced`, `edit`, and `train` are translated into these center tabs, so assistant actions, library sends, and older shortcuts still route correctly.
 
 **DJ and VJ persistence:** the DJ and VJ tabs host live performance state (a multi-deck mixer and an embedded WebGL VJ iframe). Once first visited, they stay mounted and only toggle CSS visibility on tab switch, so deck state and the warm VJ pipeline survive a switch. A backgrounded VJ tab is told to park its render loop, so it costs close to 0% GPU while hidden.
 
-**Right-side library rail:** the Library is a collapsible right-side panel. Use the library button at the right edge of the center tab bar to expand or collapse it; the rail width persists between 280 px and 640 px. This lets MAKE, MIX, LEARN, VJ, and editor workflows stay visible while selecting or routing library material.
+**Right-side library rail:** the Library is a collapsible panel on the right edge. A compact, vertically-centered pull handle on the right edge of the work area (present in every workspace) toggles it open or closed, and a drag handle on the rail's inner edge resizes it; the width persists between 280 px and 640 px. Expanded fully, the rail becomes the full-width Catalogue. This lets MAKE, MIX, LEARN, VJ, and editor workflows stay visible while browsing or routing library material.
+
+**Global bottom dock:** pinned across the bottom of the app are two independent columns, the bottom multi-tab panel on the left (Visualize / Piano / Sequence / Details / Media / SLIDE / Score) and the processing log on the right, aligned under the library rail. Each column has its own height, collapse toggle, and resize handle, so expanding or resizing one does not move the other, and the dock stays put regardless of the library panel's state.
 
 **Docs modal:** click the Docs button in the header to open this guide in-app. The modal supports anchor links, syntax-highlighted Markdown tables and code blocks, raw Markdown download, and browser print/PDF export. The assistant RAG index is built from the same guide, so doc updates improve in-app help and assistant context together.
 
@@ -298,7 +298,7 @@ Appears below the accordion after a job is submitted or completed.
 
 ### 6.8 Run Generation
 
-A sticky bar fixed at the bottom of the left panel submits the generation job to `POST /api/generate-jobs`. While a job is active, the button changes to a red **ABORT** button showing an estimated percentage. Clicking Abort cancels the polling loop; the backend job keeps running, but its result is discarded by the UI.
+A sticky bar fixed at the bottom of the MAKE workspace submits the generation job to `POST /api/generate-jobs`. While a job is active, the button changes to a red **ABORT** button showing an estimated percentage. Clicking Abort cancels the polling loop; the backend job keeps running, but its result is discarded by the UI.
 
 ---
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T01:05:59.027Z · Git revision: `ebd77289935f` · Repomix tracked: **no**
+> Generated: 2026-06-12T01:42:22.031Z · Git revision: `b6c4eb0f1905` · Repomix tracked: **no**
 
 ## Audit Dashboard
 
@@ -43,7 +43,7 @@
 | `suno-cloud-generation` | Suno cloud generation (Aurora Cloud Console) with simple/custom/cover/mashup, server-side key, and library lineage | create | implemented | **documented** | #table-of-contents<br>#1-repository-anatomy<br>#6-3-1-chimera-fusion-stack<br>#12-3-how-the-visualizations-are-rendered<br>#19-14-chimera<br>#26-cloud-generation-suno<br>#26-1-modes<br>#26-2-flow-and-library-integration<br>#26-3-endpoints<br>#29-catalogue<br>#credits | Matched 5/5 guide terms. |
 | `magenta-rt2-generate` | Magenta RealTime 2 generation (text/notes/audio-style) via the WSL2 NVIDIA sidecar, the first non-Mac MRT2 port | create | experimental | **documented** | #table-of-contents<br>#27-magenta-realtime-2<br>#27-1-the-sidecar-and-conditioning<br>#27-2-first-non-mac-port-of-magenta-realtime-2<br>#33-6-prompt-inference | Matched 5/5 guide terms. |
 | `edit-tool-stack-modules` | Edit Tool Stack: six /api/edit/* processor families (mastering, restoration, enhance, delivery, creative-fx, creative-neural) plus AI analyzer | edit | implemented | **documented** | #table-of-contents<br>#1-repository-anatomy<br>#28-edit-tool-stack | Matched 5/5 guide terms. |
-| `catalogue-cross-provider-browser` | Catalogue cross-provider library gallery with provider badges, inspector spectrograms, and lineage | library | implemented | **documented** | #table-of-contents<br>#26-2-flow-and-library-integration<br>#29-catalogue | Matched 5/5 guide terms. |
+| `catalogue-cross-provider-browser` | Catalogue cross-provider library gallery with provider badges, inspector spectrograms, and lineage | library | implemented | **documented** | #table-of-contents<br>#5-ui-shell<br>#26-2-flow-and-library-integration<br>#29-catalogue | Matched 5/5 guide terms. |
 | `controller-vision-detect-identify` | Controller Vision: detect/identify a MIDI controller from a photo (OpenCV + vision-LLM) with LAN phone pairing | daw | implemented | **documented** | #table-of-contents<br>#31-controller-vision | Matched 5/5 guide terms. |
 | `ytimport-youtube-import` | YouTube import: fetch audio from a URL into the Library as a first-class, lineage-tracked entry | library | implemented | **documented** | #table-of-contents<br>#1-repository-anatomy<br>#prerequisites<br>#30-youtube-import | Matched 4/4 guide terms. |
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T01:05:59.027Z",
-  "repoRevision": "ebd77289935f",
+  "generatedAt": "2026-06-12T01:42:22.031Z",
+  "repoRevision": "b6c4eb0f1905",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,
@@ -861,6 +861,7 @@
       "featureId": "catalogue-cross-provider-browser",
       "docAnchors": [
         "#table-of-contents",
+        "#5-ui-shell",
         "#26-2-flow-and-library-integration",
         "#29-catalogue"
       ],

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -162,23 +162,23 @@ cd frontend && npm run dev
 
 ## 5. UI Shell
 
-The application window is divided into three persistent regions:
+The application window has five regions:
 
-- **Left panel** (resizable): brand, tab controls content, run CTA, processing log.
-- **Center workspace**: the center tab bar at the top, the active workspace below it, and a collapsible bottom multi-tab panel in the global footer.
-- **Player footer**: a fixed transport bar across the bottom of the app.
+- **Full-width header** (top): the theDAW logo, a global search input, and action buttons (Docs, mobile access QR/link, Settings, user avatar, AI Assistant orb).
+- **Center workspace**: the center tab bar at the top and the active workspace below it, including that tab's own controls and run action.
+- **Library rail** (right, collapsible): browse and route library material without leaving the active workspace.
+- **Global bottom dock**: the bottom multi-tab panel and the processing log, side by side.
+- **Player footer** (bottom): a fixed transport bar.
 
-**Full-width header:** a fixed bar spanning the entire window width. It contains the left-panel collapse/reveal toggle (chevron), the theDAW logo dot, a global search input, and action buttons (Docs, mobile access QR/link, Settings, User avatar, AI Assistant orb).
-
-**Left panel resize:** drag the vertical handle on the panel's right edge. Range: 300 px to 500 px.
-
-**Left panel collapse:** click the chevron in the header. The workspace expands to full width. Click again to restore.
+**Full-width header:** a fixed bar spanning the entire window width. It holds the theDAW logo dot, a global search input, and the action buttons listed above. There is no left panel and no left-panel toggle; the only collapsible side panel is the Library rail on the right.
 
 **Center tab switching:** the active workspace is controlled by the center tab bar in the locked order **MAKE / EDIT / MIX / DJ / VJ / TRAIN / LEARN** (`CENTER_TABS`). Each tab carries its own accent color. Legacy navigation targets such as `create`, `advanced`, `edit`, and `train` are translated into these center tabs, so assistant actions, library sends, and older shortcuts still route correctly.
 
 **DJ and VJ persistence:** the DJ and VJ tabs host live performance state (a multi-deck mixer and an embedded WebGL VJ iframe). Once first visited, they stay mounted and only toggle CSS visibility on tab switch, so deck state and the warm VJ pipeline survive a switch. A backgrounded VJ tab is told to park its render loop, so it costs close to 0% GPU while hidden.
 
-**Right-side library rail:** the Library is a collapsible right-side panel. Use the library button at the right edge of the center tab bar to expand or collapse it; the rail width persists between 280 px and 640 px. This lets MAKE, MIX, LEARN, VJ, and editor workflows stay visible while selecting or routing library material.
+**Right-side library rail:** the Library is a collapsible panel on the right edge. A compact, vertically-centered pull handle on the right edge of the work area (present in every workspace) toggles it open or closed, and a drag handle on the rail's inner edge resizes it; the width persists between 280 px and 640 px. Expanded fully, the rail becomes the full-width Catalogue. This lets MAKE, MIX, LEARN, VJ, and editor workflows stay visible while browsing or routing library material.
+
+**Global bottom dock:** pinned across the bottom of the app are two independent columns, the bottom multi-tab panel on the left (Visualize / Piano / Sequence / Details / Media / SLIDE / Score) and the processing log on the right, aligned under the library rail. Each column has its own height, collapse toggle, and resize handle, so expanding or resizing one does not move the other, and the dock stays put regardless of the library panel's state.
 
 **Docs modal:** click the Docs button in the header to open this guide in-app. The modal supports anchor links, syntax-highlighted Markdown tables and code blocks, raw Markdown download, and browser print/PDF export. The assistant RAG index is built from the same guide, so doc updates improve in-app help and assistant context together.
 
@@ -298,7 +298,7 @@ Appears below the accordion after a job is submitted or completed.
 
 ### 6.8 Run Generation
 
-A sticky bar fixed at the bottom of the left panel submits the generation job to `POST /api/generate-jobs`. While a job is active, the button changes to a red **ABORT** button showing an estimated percentage. Clicking Abort cancels the polling loop; the backend job keeps running, but its result is discarded by the UI.
+A sticky bar fixed at the bottom of the MAKE workspace submits the generation job to `POST /api/generate-jobs`. While a job is active, the button changes to a red **ABORT** button showing an estimated percentage. Clicking Abort cancels the polling loop; the backend job keeps running, but its result is discarded by the UI.
 
 ---
 


### PR DESCRIPTION
…E.md

- USER_GUIDE 5: drop the stale "Left panel" three-region model. The shell is header + center workspace + collapsible right Library rail (with a vertically-centered edge pull handle) + a global bottom dock (multi-tab panel + processing log side by side) + player footer. Fix 6.8 so the run bar is described at the bottom of the MAKE workspace, not a left panel.
- CLAUDE.md Windows-Specific Setup: torch/torchaudio (cu128), soundfile, and flash-attn install automatically via pyproject [tool.uv.sources]; point to theDAW.bat / Setup-theDAW.bat. Removes the stale "install by hand" claims that contradicted the rewritten setup guide.
- Sync USER_GUIDE mirror.