### PR TITLE
docs+ux: guide intro, MAKE model list (add Magenta + Suno), in-app im…

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2,7 +2,15 @@
 
 _by GANTASMO_
 
-This guide documents theDAW end to end, from generating a piece out of a prompt through arranging it, mixing it, performing it live, and exporting the finished master. The in-app **Docs** button renders this guide as an interactive modal with Markdown download, print, and PDF export.
+theDAW is a complete digital audio workstation built on Stable Audio 3, the state-of-the-art open audio model from Stability AI. The model turns a text prompt into high-fidelity 44.1 kHz stereo audio, and theDAW surrounds that core with a full production environment. A React front end and a FastAPI backend run together from one launcher, so the whole studio starts with a single double-click.
+
+Audio generation happens in the MAKE workspace. A prompt becomes finished audio through Stable Audio 3, and the same model menu also reaches Magenta RealTime 2 for streaming text-to-music and Suno for cloud generation. Chimera fusion can blend several clips into one downbeat-aligned piece, while init signals, inpainting, and LoRA adapters give finer control over the result. When the model selection moves between Stable Audio and the Magenta sidecar, the GPU swap runs on its own.
+
+Editing and mastering come next. The EDIT workspace opens a piece in a waveform editor that supports region inpainting. Effects and loudness work happens in MIX, which hosts the Edit Tool Stack alongside Quick Master macros. For live use, the DJ workspace provides a two-deck engine with beatmatch sync, key-lock, live stems, an FX rack, hot cues, and hands-free automix. WebGL visuals in the VJ workspace respond to the audio and accept MIDI, microphone, and mobile input.
+
+Everything generated is kept. The Library stores each piece on disk together with its analysis, stems, and MIDI, and LEARN renders the relationships between pieces as a navigable 3D genealogy. A symbolic-music pipeline produces sheet music, tablature, and multi-instrument arrangements, and it can read a score back into a usable text prompt. LoRA training and autoencoder round-trips have a home in the TRAIN workspace. An in-app assistant answers questions from this guide, and a paste-a-URL importer pulls audio from YouTube, SoundCloud, and Bandcamp.
+
+The in-app **Docs** button renders this guide as an interactive modal with a filterable table of contents, raw Markdown download, and print-to-PDF. Each workspace and the backend are documented in full below.
 
 ---
 
@@ -212,7 +220,7 @@ Six controls arranged in a 3-column grid:
 
 | Control | Type | Notes |
 |---|---|---|
-| **Model** | Dropdown | `small`, `medium`, `small-rf`, `medium-rf`. Selecting an `-rf` variant automatically sets Steps to 50 and CFG to 7.0. |
+| **Model** | Dropdown | `small`, `medium`, `small-rf`, `medium-rf`, plus `magenta-small` for Magenta RealTime 2 (§27) and `suno` for Suno cloud generation (§26). An `-rf` variant raises Steps to 50 and CFG to 7.0. Picking Magenta drops Steps to 1 and brings up the MRT2 conditioning controls. The Suno entry opens the Aurora Cloud Console in place of the local panel. |
 | **Duration (s)** | Integer | Total output length in seconds. Small model: max 120 s. Medium and Large: max 380 s. |
 | **Batch** | Integer | Number of simultaneous variations. Each variation produces a distinct library entry with its own seed. |
 | **Steps** | Integer | Sampler denoising steps. ARC default: 8. RF default: 50. |
@@ -1403,6 +1411,8 @@ Full parameter reference: `stable_audio_3/model.py:StableAudioModel.generate`.
 | `same-l` | Autoencoder | 1.7 B | n/a | GPU | n/a |
 
 ARC checkpoints bundle the autoencoder. Standalone SAME checkpoints share weights with the bundled version and reuse the cached full checkpoint when both are available. The Small model runs on modest GPUs; the Medium model needs around 8 GB of VRAM.
+
+The MAKE Model dropdown also lists two engines beyond these checkpoints. `magenta-small` reaches the Magenta RealTime 2 sidecar for streaming text-to-music (§27). Suno cloud generation sits under `suno` (§26). Both options share the dropdown with the local Stable Audio models, so one session can move across them without leaving MAKE.
 
 ---
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T01:42:22.031Z · Git revision: `b6c4eb0f1905` · Repomix tracked: **no**
+> Generated: 2026-06-12T02:21:47.033Z · Git revision: `94216033cc15` · Repomix tracked: **no**
 
 ## Audit Dashboard
 
@@ -40,8 +40,8 @@
 | `media-bucket-routing` | Media Bucket send targets for editor, library, init audio, and Chimera stack | daw | implemented | **documented** | #6-3-1-chimera-fusion-stack<br>#8-4-source-output-and-routing<br>#13-4-per-entry-controls<br>#16-5-media | Matched 3/4 guide terms. |
 | `vj-sidecar-tab-mobile-share` | VJ tab and mobile share link for iframe/tunnel-backed performance access | vj | experimental | **documented** | #table-of-contents<br>#5-ui-shell<br>#10-vj-tab<br>#purpose<br>#10-3-bridges<br>#10-4-export<br>#19-17-vj | Matched 3/4 guide terms. |
 | `backend-module-loader-settings` | Backend module loader with module manifests and runtime enable/disable settings | backend-module | implemented | **documented** | #1-repository-anatomy<br>#19-12-module-loader<br>#adding-a-backend-module<br>#zustand-store-architecture<br>#32-admin-module-and-assistant-key-apis | Matched 4/4 guide terms. |
-| `suno-cloud-generation` | Suno cloud generation (Aurora Cloud Console) with simple/custom/cover/mashup, server-side key, and library lineage | create | implemented | **documented** | #table-of-contents<br>#1-repository-anatomy<br>#6-3-1-chimera-fusion-stack<br>#12-3-how-the-visualizations-are-rendered<br>#19-14-chimera<br>#26-cloud-generation-suno<br>#26-1-modes<br>#26-2-flow-and-library-integration<br>#26-3-endpoints<br>#29-catalogue<br>#credits | Matched 5/5 guide terms. |
-| `magenta-rt2-generate` | Magenta RealTime 2 generation (text/notes/audio-style) via the WSL2 NVIDIA sidecar, the first non-Mac MRT2 port | create | experimental | **documented** | #table-of-contents<br>#27-magenta-realtime-2<br>#27-1-the-sidecar-and-conditioning<br>#27-2-first-non-mac-port-of-magenta-realtime-2<br>#33-6-prompt-inference | Matched 5/5 guide terms. |
+| `suno-cloud-generation` | Suno cloud generation (Aurora Cloud Console) with simple/custom/cover/mashup, server-side key, and library lineage | create | implemented | **documented** | #table-of-contents<br>#1-repository-anatomy<br>#6-2-generation-parameters<br>#6-3-1-chimera-fusion-stack<br>#12-3-how-the-visualizations-are-rendered<br>#19-14-chimera<br>#21-models<br>#26-cloud-generation-suno<br>#26-1-modes<br>#26-2-flow-and-library-integration<br>#26-3-endpoints<br>#29-catalogue<br>#credits | Matched 5/5 guide terms. |
+| `magenta-rt2-generate` | Magenta RealTime 2 generation (text/notes/audio-style) via the WSL2 NVIDIA sidecar, the first non-Mac MRT2 port | create | experimental | **documented** | #table-of-contents<br>#6-2-generation-parameters<br>#21-models<br>#27-magenta-realtime-2<br>#27-1-the-sidecar-and-conditioning<br>#27-2-first-non-mac-port-of-magenta-realtime-2<br>#33-6-prompt-inference | Matched 5/5 guide terms. |
 | `edit-tool-stack-modules` | Edit Tool Stack: six /api/edit/* processor families (mastering, restoration, enhance, delivery, creative-fx, creative-neural) plus AI analyzer | edit | implemented | **documented** | #table-of-contents<br>#1-repository-anatomy<br>#28-edit-tool-stack | Matched 5/5 guide terms. |
 | `catalogue-cross-provider-browser` | Catalogue cross-provider library gallery with provider badges, inspector spectrograms, and lineage | library | implemented | **documented** | #table-of-contents<br>#5-ui-shell<br>#26-2-flow-and-library-integration<br>#29-catalogue | Matched 5/5 guide terms. |
 | `controller-vision-detect-identify` | Controller Vision: detect/identify a MIDI controller from a photo (OpenCV + vision-LLM) with LAN phone pairing | daw | implemented | **documented** | #table-of-contents<br>#31-controller-vision | Matched 5/5 guide terms. |

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T01:42:22.031Z",
-  "repoRevision": "b6c4eb0f1905",
+  "generatedAt": "2026-06-12T02:21:47.033Z",
+  "repoRevision": "94216033cc15",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,
@@ -822,9 +822,11 @@
       "docAnchors": [
         "#table-of-contents",
         "#1-repository-anatomy",
+        "#6-2-generation-parameters",
         "#6-3-1-chimera-fusion-stack",
         "#12-3-how-the-visualizations-are-rendered",
         "#19-14-chimera",
+        "#21-models",
         "#26-cloud-generation-suno",
         "#26-1-modes",
         "#26-2-flow-and-library-integration",
@@ -839,6 +841,8 @@
       "featureId": "magenta-rt2-generate",
       "docAnchors": [
         "#table-of-contents",
+        "#6-2-generation-parameters",
+        "#21-models",
         "#27-magenta-realtime-2",
         "#27-1-the-sidecar-and-conditioning",
         "#27-2-first-non-mac-port-of-magenta-realtime-2",

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -2,7 +2,15 @@
 
 _by GANTASMO_
 
-This guide documents theDAW end to end, from generating a piece out of a prompt through arranging it, mixing it, performing it live, and exporting the finished master. The in-app **Docs** button renders this guide as an interactive modal with Markdown download, print, and PDF export.
+theDAW is a complete digital audio workstation built on Stable Audio 3, the state-of-the-art open audio model from Stability AI. The model turns a text prompt into high-fidelity 44.1 kHz stereo audio, and theDAW surrounds that core with a full production environment. A React front end and a FastAPI backend run together from one launcher, so the whole studio starts with a single double-click.
+
+Audio generation happens in the MAKE workspace. A prompt becomes finished audio through Stable Audio 3, and the same model menu also reaches Magenta RealTime 2 for streaming text-to-music and Suno for cloud generation. Chimera fusion can blend several clips into one downbeat-aligned piece, while init signals, inpainting, and LoRA adapters give finer control over the result. When the model selection moves between Stable Audio and the Magenta sidecar, the GPU swap runs on its own.
+
+Editing and mastering come next. The EDIT workspace opens a piece in a waveform editor that supports region inpainting. Effects and loudness work happens in MIX, which hosts the Edit Tool Stack alongside Quick Master macros. For live use, the DJ workspace provides a two-deck engine with beatmatch sync, key-lock, live stems, an FX rack, hot cues, and hands-free automix. WebGL visuals in the VJ workspace respond to the audio and accept MIDI, microphone, and mobile input.
+
+Everything generated is kept. The Library stores each piece on disk together with its analysis, stems, and MIDI, and LEARN renders the relationships between pieces as a navigable 3D genealogy. A symbolic-music pipeline produces sheet music, tablature, and multi-instrument arrangements, and it can read a score back into a usable text prompt. LoRA training and autoencoder round-trips have a home in the TRAIN workspace. An in-app assistant answers questions from this guide, and a paste-a-URL importer pulls audio from YouTube, SoundCloud, and Bandcamp.
+
+The in-app **Docs** button renders this guide as an interactive modal with a filterable table of contents, raw Markdown download, and print-to-PDF. Each workspace and the backend are documented in full below.
 
 ---
 
@@ -212,7 +220,7 @@ Six controls arranged in a 3-column grid:
 
 | Control | Type | Notes |
 |---|---|---|
-| **Model** | Dropdown | `small`, `medium`, `small-rf`, `medium-rf`. Selecting an `-rf` variant automatically sets Steps to 50 and CFG to 7.0. |
+| **Model** | Dropdown | `small`, `medium`, `small-rf`, `medium-rf`, plus `magenta-small` for Magenta RealTime 2 (§27) and `suno` for Suno cloud generation (§26). An `-rf` variant raises Steps to 50 and CFG to 7.0. Picking Magenta drops Steps to 1 and brings up the MRT2 conditioning controls. The Suno entry opens the Aurora Cloud Console in place of the local panel. |
 | **Duration (s)** | Integer | Total output length in seconds. Small model: max 120 s. Medium and Large: max 380 s. |
 | **Batch** | Integer | Number of simultaneous variations. Each variation produces a distinct library entry with its own seed. |
 | **Steps** | Integer | Sampler denoising steps. ARC default: 8. RF default: 50. |
@@ -1403,6 +1411,8 @@ Full parameter reference: `stable_audio_3/model.py:StableAudioModel.generate`.
 | `same-l` | Autoencoder | 1.7 B | n/a | GPU | n/a |
 
 ARC checkpoints bundle the autoencoder. Standalone SAME checkpoints share weights with the bundled version and reuse the cached full checkpoint when both are available. The Small model runs on modest GPUs; the Medium model needs around 8 GB of VRAM.
+
+The MAKE Model dropdown also lists two engines beyond these checkpoints. `magenta-small` reaches the Magenta RealTime 2 sidecar for streaming text-to-music (§27). Suno cloud generation sits under `suno` (§26). Both options share the dropdown with the local Stable Audio models, so one session can move across them without leaving MAKE.
 
 ---
 

--- a/frontend/src/components/layout/DocsModal.tsx
+++ b/frontend/src/components/layout/DocsModal.tsx
@@ -74,6 +74,15 @@ export const DocsModal: React.FC<DocsModalProps> = ({ open, onClose }) => {
       const isAnchor = href.startsWith('#');
       return `<a href="${href}" ${title ? `title="${title}"` : ''} class="docs-link${isExternal ? ' docs-link-external' : ''}" ${isExternal ? 'target="_blank" rel="noreferrer noopener"' : ''} data-anchor="${isAnchor ? '1' : '0'}">${text}</a>`;
     };
+    renderer.image = ({ href, title, text }: { href: string; title?: string | null; text?: string }) => {
+      // Guide images are written repo-relative (e.g. "screenshots/x.png") so
+      // they render on GitHub from docs/. The in-app modal serves the guide
+      // from the site root, so a relative path resolves to root-absolute and
+      // loads from /screenshots/… regardless of the current route.
+      let src = href || '';
+      if (src && !/^(https?:|data:|\/)/.test(src)) src = '/' + src.replace(/^\.?\//, '');
+      return `<img src="${src}" alt="${text || ''}"${title ? ` title="${title}"` : ''} loading="lazy" />`;
+    };
     const parsed = marked.parse(markdown, { renderer, gfm: true, breaks: false }) as string;
     setHtml(parsed);
     setHeadings(collected);

--- a/scripts/regenerate-docs.sh
+++ b/scripts/regenerate-docs.sh
@@ -33,6 +33,16 @@ log "Syncing $src → $dest"
 mkdir -p "$(dirname "$dest")"
 cp "$src" "$dest"
 
+# 2b. Mirror the guide screenshots into public/ so the in-app Docs modal can
+# load them (served at /screenshots/...). docs/screenshots is the tracked
+# source; frontend/public/screenshots is a derived copy (gitignored).
+if [[ -d docs/screenshots ]]; then
+  mkdir -p frontend/public/screenshots
+  cp -f docs/screenshots/*.png frontend/public/screenshots/ 2>/dev/null || true
+  rm -f frontend/public/screenshots/*-FAILED.png 2>/dev/null || true
+  log "Synced guide screenshots → frontend/public/screenshots"
+fi
+
 # 3. Frontend build (catches markdown that breaks the modal's renderer).
 log "Building frontend"
 ( cd frontend && npx --no vite build >/dev/null 2>&1 ) || {


### PR DESCRIPTION
…age fix

- USER_GUIDE: add a one-page overview intro covering the major features; fix the MAKE model list so 6.2 and 21 include magenta-small (Magenta RealTime 2) and suno (Suno cloud), matching the actual dropdown.
- DocsModal: resolve guide-relative image paths to root-absolute so the in-app modal loads screenshots regardless of the current route.
- regenerate-docs.sh: mirror docs/screenshots -> frontend/public/screenshots (the served, gitignored copy) on every regen; drop *-FAILED.png.
- Sync USER_GUIDE mirror.