### PR TITLE
Feat/playlist suggester

### DIFF
--- a/backend/modules/library/db.py
+++ b/backend/modules/library/db.py
@@ -476,6 +476,25 @@ class LibraryDB:
             cur.close()
             return [dict(r) for r in rows]
 
+    def list_entries_with_analysis(self) -> list[dict[str, Any]]:
+        """Each entry joined with its analysis row (bpm / key / scale / genre /
+        loudness). Analysis columns are NULL for entries not yet analyzed. The
+        playlist suggester sequences on bpm + harmonic key from this."""
+        sql = """
+            SELECT
+                e.id, e.title, e.prompt, e.model, e.duration_sec, e.source,
+                e.favorite, e.play_count, e.last_played_at,
+                a.bpm, a.key, a.scale, a.genre, a.loudness_lufs, a.bars_estimated
+            FROM entries e
+            LEFT JOIN analysis a ON a.entry_id = e.id
+            ORDER BY e.created_at DESC
+        """
+        with self._writelock:
+            cur = self._conn.cursor()
+            rows = cur.execute(sql).fetchall()
+            cur.close()
+            return [dict(r) for r in rows]
+
     def delete_entry(self, entry_id: str) -> bool:
         with self._txn() as cur:
             cur.execute("DELETE FROM entries WHERE id = ?", (entry_id,))

--- a/backend/modules/library/router.py
+++ b/backend/modules/library/router.py
@@ -24,6 +24,7 @@ from typing import Any, Optional
 import httpx
 from fastapi import APIRouter, Body, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse, Response
+from pydantic import BaseModel
 
 from .bundle import build_bundle_bytes
 from .store import LibraryStore, _read_metadata, default_library_root
@@ -178,6 +179,41 @@ def register_play(entry_id: str) -> dict[str, Any]:
         store._sync_record_to_db(record, _read_metadata(entry_dir) or {})  # noqa: SLF001
         new_count = store.db.increment_play_count(entry_id) or 1
     return {"id": entry_id, "play_count": new_count}
+
+
+class SuggestRequest(BaseModel):
+    target_duration_sec: float = 1800.0
+    bpm_min: Optional[float] = None
+    bpm_max: Optional[float] = None
+    harmonic: bool = True
+    flow: str = "steady"
+    genre: Optional[str] = None
+    query: Optional[str] = None
+    seed_id: Optional[str] = None
+    max_tracks: int = 60
+
+
+@router.post("/suggest-playlist")
+def suggest_playlist_endpoint(req: SuggestRequest = Body(...)) -> dict[str, Any]:
+    """Build an analysis-driven playlist (harmonic + bpm-flow sequencing) that
+    fits the requested time budget. Needs the DB, where analysis lives."""
+    store = get_store()
+    if store.db is None:
+        raise HTTPException(503, "library DB not available")
+    from .suggester import suggest_playlist
+
+    return suggest_playlist(
+        store.db,
+        target_duration_sec=req.target_duration_sec,
+        bpm_min=req.bpm_min,
+        bpm_max=req.bpm_max,
+        harmonic=req.harmonic,
+        flow=req.flow,
+        genre=req.genre,
+        query=req.query,
+        seed_id=req.seed_id,
+        max_tracks=req.max_tracks,
+    )
 
 
 @router.delete("/entries/{entry_id}")

--- a/backend/modules/library/suggester.py
+++ b/backend/modules/library/suggester.py
@@ -1,0 +1,237 @@
+"""Analysis-driven playlist suggester.
+
+Given a target duration and a few preferences (a bpm range, harmonic mixing, an
+energy flow, an optional text/genre filter, an optional seed track), build an
+ordered playlist from the library by sequencing analyzed entries so consecutive
+tracks mix well:
+
+  - harmonically-compatible keys (Camelot wheel),
+  - bpm that follows the requested flow (steady / build / wind-down / wave),
+  - a nudge toward popular picks and stylistically-varied neighbours (the
+    "unique juxtaposition" a user asks for).
+
+Pure stdlib plus the library DB. The Camelot logic mirrors
+``frontend/src/lib/camelot.ts`` so the wheel matches what the DJ tab shows.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+# --------------------------------------------------------------------------- #
+#  Camelot wheel (ported from frontend/src/lib/camelot.ts)
+# --------------------------------------------------------------------------- #
+_NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+_FLAT_TO_SHARP = {"Db": "C#", "Eb": "D#", "Gb": "F#", "Ab": "G#", "Bb": "A#"}
+_MAJOR_NUM = {
+    "C": 8, "C#": 3, "D": 10, "D#": 5, "E": 12, "F": 7,
+    "F#": 2, "G": 9, "G#": 4, "A": 11, "A#": 6, "B": 1,
+}
+_MINOR_NUM = {
+    "A": 8, "A#": 3, "B": 10, "C": 5, "C#": 12, "D": 7,
+    "D#": 2, "E": 9, "F": 4, "F#": 11, "G": 6, "G#": 1,
+}
+
+
+def _normalize_note(note: str) -> str:
+    n = note.strip()
+    if len(n) >= 2:
+        head = n[0].upper() + n[1:]
+        if head in _FLAT_TO_SHARP:
+            return _FLAT_TO_SHARP[head]
+    return (n[0].upper() + n[1:]) if n else ""
+
+
+def _is_minor(scale: Optional[str]) -> bool:
+    s = (scale or "").lower()
+    return s.startswith("min") or s == "m" or s == "aeolian"
+
+
+def to_camelot(note: Optional[str], scale: Optional[str]) -> Optional[dict[str, Any]]:
+    """Resolve note+scale to ``{code, number, letter, compatible}`` or None."""
+    if not note:
+        return None
+    n = _normalize_note(note)
+    if n not in _NOTE_NAMES:
+        return None
+    minor = _is_minor(scale)
+    number = (_MINOR_NUM if minor else _MAJOR_NUM).get(n)
+    if number is None:
+        return None
+    letter = "A" if minor else "B"
+    up = (number % 12) + 1
+    down = ((number + 10) % 12) + 1
+    other = "B" if letter == "A" else "A"
+    compatible = [
+        f"{number}{letter}",
+        f"{up}{letter}",
+        f"{down}{letter}",
+        f"{number}{other}",
+    ]
+    return {"code": f"{number}{letter}", "number": number, "letter": letter, "compatible": compatible}
+
+
+def _harmonic_score(a: Optional[dict], b: Optional[dict]) -> float:
+    """3 for the same key, 2 for a Camelot-compatible neighbour, else 0."""
+    if not a or not b:
+        return 0.0
+    if a["code"] == b["code"]:
+        return 3.0
+    if b["code"] in a["compatible"]:
+        return 2.0
+    return 0.0
+
+
+def _flow_target_bpm(flow: str, base: float, pos: float) -> float:
+    """Target bpm at normalized position ``pos`` (0..1) for the given flow.
+    The spread is +/-15% of the pool's median bpm."""
+    spread = base * 0.15
+    if flow == "build":
+        return base - spread + 2.0 * spread * pos
+    if flow == "wind_down":
+        return base + spread - 2.0 * spread * pos
+    if flow == "wave":
+        return base + spread * (1.0 - abs(2.0 * pos - 1.0))
+    return base  # steady
+
+
+# --------------------------------------------------------------------------- #
+#  Suggester
+# --------------------------------------------------------------------------- #
+def suggest_playlist(
+    db: Any,
+    *,
+    target_duration_sec: float,
+    bpm_min: Optional[float] = None,
+    bpm_max: Optional[float] = None,
+    harmonic: bool = True,
+    flow: str = "steady",
+    genre: Optional[str] = None,
+    query: Optional[str] = None,
+    seed_id: Optional[str] = None,
+    max_tracks: int = 60,
+) -> dict[str, Any]:
+    """Return an ordered playlist that fits the time budget and the criteria.
+
+    ``db`` is a ``LibraryDB`` (needs ``list_entries_with_analysis``). The result
+    is ``{tracks: [...], total_duration_sec, track_count, flow, base_bpm}`` where
+    each track carries its bpm / key / camelot / play_count and a short reason."""
+    rows = db.list_entries_with_analysis()
+
+    pool: list[dict[str, Any]] = []
+    for raw in rows:
+        dur = float(raw.get("duration_sec") or 0.0)
+        if dur <= 0:
+            continue
+        bpm = raw.get("bpm")
+        if bpm_min is not None and (bpm is None or bpm < bpm_min):
+            continue
+        if bpm_max is not None and (bpm is None or bpm > bpm_max):
+            continue
+        if genre and (raw.get("genre") or "").lower() != genre.lower():
+            continue
+        if query:
+            hay = " ".join(
+                str(raw.get(k) or "") for k in ("title", "prompt", "genre", "model")
+            ).lower()
+            if query.lower() not in hay:
+                continue
+        item = dict(raw)
+        item["_camelot"] = to_camelot(raw.get("key"), raw.get("scale"))
+        pool.append(item)
+
+    if not pool:
+        return {
+            "tracks": [],
+            "total_duration_sec": 0.0,
+            "track_count": 0,
+            "flow": flow,
+            "base_bpm": 0.0,
+            "reason": "no analyzed tracks match the criteria",
+        }
+
+    bpms = sorted(b for b in (p.get("bpm") for p in pool) if b)
+    base_bpm = float(bpms[len(bpms) // 2]) if bpms else 120.0
+
+    budget = float(target_duration_sec)
+    tolerance = budget * 0.12
+
+    # Seed: an explicit pick, else the most-played track nearest the flow's
+    # opening bpm.
+    seed = next((p for p in pool if p["id"] == seed_id), None)
+    if seed is None:
+        start_bpm = _flow_target_bpm(flow, base_bpm, 0.0)
+        seed = max(
+            pool,
+            key=lambda p: (
+                p.get("play_count") or 0,
+                -abs((p.get("bpm") or base_bpm) - start_bpm),
+            ),
+        )
+
+    used: set[str] = {seed["id"]}
+    seq: list[dict[str, Any]] = [seed]
+    total = float(seed.get("duration_sec") or 0.0)
+
+    while total < budget and len(seq) < max_tracks:
+        current = seq[-1]
+        pos = min(1.0, total / budget) if budget > 0 else 0.0
+        target_bpm = _flow_target_bpm(flow, base_bpm, pos)
+        best: Optional[dict[str, Any]] = None
+        best_score = -1e9
+        for cand in pool:
+            if cand["id"] in used:
+                continue
+            cdur = float(cand.get("duration_sec") or 0.0)
+            if total + cdur > budget + tolerance:
+                continue
+            h = _harmonic_score(current["_camelot"], cand["_camelot"]) if harmonic else 0.0
+            cbpm = cand.get("bpm")
+            bpm_pen = abs((cbpm if cbpm else target_bpm) - target_bpm)
+            bpm_score = max(0.0, 1.0 - bpm_pen / 12.0)
+            pop = min(1.0, (cand.get("play_count") or 0) / 5.0) * 0.3
+            jux = 0.2 if (cand.get("genre") and cand.get("genre") != current.get("genre")) else 0.0
+            score = h * 1.5 + bpm_score + pop + jux
+            if score > best_score:
+                best_score = score
+                best = cand
+        if best is None:
+            break
+        used.add(best["id"])
+        seq.append(best)
+        total += float(best.get("duration_sec") or 0.0)
+
+    tracks: list[dict[str, Any]] = []
+    for i, t in enumerate(seq):
+        prev = seq[i - 1] if i > 0 else None
+        bits: list[str] = []
+        if prev and harmonic and t["_camelot"] and prev["_camelot"]:
+            hs = _harmonic_score(prev["_camelot"], t["_camelot"])
+            if hs >= 3:
+                bits.append("same key")
+            elif hs >= 2:
+                bits.append(f"harmonic {prev['_camelot']['code']}->{t['_camelot']['code']}")
+        if t.get("bpm"):
+            bits.append(f"{round(float(t['bpm']))} bpm")
+        tracks.append(
+            {
+                "id": t["id"],
+                "title": t.get("title") or t["id"],
+                "duration_sec": float(t.get("duration_sec") or 0.0),
+                "bpm": t.get("bpm"),
+                "key": t.get("key"),
+                "scale": t.get("scale"),
+                "camelot": t["_camelot"]["code"] if t["_camelot"] else None,
+                "genre": t.get("genre"),
+                "play_count": t.get("play_count") or 0,
+                "reason": ", ".join(bits) or "seed",
+            }
+        )
+
+    return {
+        "tracks": tracks,
+        "total_duration_sec": round(total, 1),
+        "track_count": len(tracks),
+        "flow": flow,
+        "base_bpm": round(base_bpm, 1),
+    }

--- a/backend/modules/library/suggester.py
+++ b/backend/modules/library/suggester.py
@@ -24,12 +24,32 @@ from typing import Any, Optional
 _NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
 _FLAT_TO_SHARP = {"Db": "C#", "Eb": "D#", "Gb": "F#", "Ab": "G#", "Bb": "A#"}
 _MAJOR_NUM = {
-    "C": 8, "C#": 3, "D": 10, "D#": 5, "E": 12, "F": 7,
-    "F#": 2, "G": 9, "G#": 4, "A": 11, "A#": 6, "B": 1,
+    "C": 8,
+    "C#": 3,
+    "D": 10,
+    "D#": 5,
+    "E": 12,
+    "F": 7,
+    "F#": 2,
+    "G": 9,
+    "G#": 4,
+    "A": 11,
+    "A#": 6,
+    "B": 1,
 }
 _MINOR_NUM = {
-    "A": 8, "A#": 3, "B": 10, "C": 5, "C#": 12, "D": 7,
-    "D#": 2, "E": 9, "F": 4, "F#": 11, "G": 6, "G#": 1,
+    "A": 8,
+    "A#": 3,
+    "B": 10,
+    "C": 5,
+    "C#": 12,
+    "D": 7,
+    "D#": 2,
+    "E": 9,
+    "F": 4,
+    "F#": 11,
+    "G": 6,
+    "G#": 1,
 }
 
 
@@ -68,7 +88,12 @@ def to_camelot(note: Optional[str], scale: Optional[str]) -> Optional[dict[str, 
         f"{down}{letter}",
         f"{number}{other}",
     ]
-    return {"code": f"{number}{letter}", "number": number, "letter": letter, "compatible": compatible}
+    return {
+        "code": f"{number}{letter}",
+        "number": number,
+        "letter": letter,
+        "compatible": compatible,
+    }
 
 
 def _harmonic_score(a: Optional[dict], b: Optional[dict]) -> float:
@@ -185,12 +210,20 @@ def suggest_playlist(
             cdur = float(cand.get("duration_sec") or 0.0)
             if total + cdur > budget + tolerance:
                 continue
-            h = _harmonic_score(current["_camelot"], cand["_camelot"]) if harmonic else 0.0
+            h = (
+                _harmonic_score(current["_camelot"], cand["_camelot"])
+                if harmonic
+                else 0.0
+            )
             cbpm = cand.get("bpm")
             bpm_pen = abs((cbpm if cbpm else target_bpm) - target_bpm)
             bpm_score = max(0.0, 1.0 - bpm_pen / 12.0)
             pop = min(1.0, (cand.get("play_count") or 0) / 5.0) * 0.3
-            jux = 0.2 if (cand.get("genre") and cand.get("genre") != current.get("genre")) else 0.0
+            jux = (
+                0.2
+                if (cand.get("genre") and cand.get("genre") != current.get("genre"))
+                else 0.0
+            )
             score = h * 1.5 + bpm_score + pop + jux
             if score > best_score:
                 best_score = score
@@ -210,7 +243,9 @@ def suggest_playlist(
             if hs >= 3:
                 bits.append("same key")
             elif hs >= 2:
-                bits.append(f"harmonic {prev['_camelot']['code']}->{t['_camelot']['code']}")
+                bits.append(
+                    f"harmonic {prev['_camelot']['code']}->{t['_camelot']['code']}"
+                )
         if t.get("bpm"):
             bits.append(f"{round(float(t['bpm']))} bpm")
         tracks.append(

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T03:51:35.456Z · Git revision: `18790592a465` · Repomix tracked: **no**
+> Generated: 2026-06-12T03:58:27.568Z · Git revision: `4f1d1db98716` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T03:58:27.568Z · Git revision: `4f1d1db98716` · Repomix tracked: **no**
+> Generated: 2026-06-12T04:05:20.651Z · Git revision: `bc736c7a25fe` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T04:18:43.897Z · Git revision: `ebf1a5a729c9` · Repomix tracked: **no**
+> Generated: 2026-06-12T04:41:08.604Z · Git revision: `bd893fb590fb` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T04:05:20.651Z · Git revision: `bc736c7a25fe` · Repomix tracked: **no**
+> Generated: 2026-06-12T04:18:43.897Z · Git revision: `ebf1a5a729c9` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T03:51:35.456Z",
-  "repoRevision": "18790592a465",
+  "generatedAt": "2026-06-12T03:58:27.568Z",
+  "repoRevision": "4f1d1db98716",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T04:18:43.897Z",
-  "repoRevision": "ebf1a5a729c9",
+  "generatedAt": "2026-06-12T04:41:08.604Z",
+  "repoRevision": "bd893fb590fb",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T03:58:27.568Z",
-  "repoRevision": "4f1d1db98716",
+  "generatedAt": "2026-06-12T04:05:20.651Z",
+  "repoRevision": "bc736c7a25fe",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T04:05:20.651Z",
-  "repoRevision": "bc736c7a25fe",
+  "generatedAt": "2026-06-12T04:18:43.897Z",
+  "repoRevision": "ebf1a5a729c9",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/frontend/src/components/library/SuggestPlaylistModal.tsx
+++ b/frontend/src/components/library/SuggestPlaylistModal.tsx
@@ -1,0 +1,187 @@
+import React, { useState } from 'react';
+import { X, Sparkles, Play, ListPlus, RefreshCw, Music } from 'lucide-react';
+import { startQueue } from '../../state/playlistQueue';
+import { useDjSideList } from '../../state/djSideListStore';
+import { logInfo } from '../../state/logStore';
+
+interface SuggestTrack {
+  id: string;
+  title: string;
+  duration_sec: number;
+  bpm: number | null;
+  key: string | null;
+  scale: string | null;
+  camelot: string | null;
+  genre: string | null;
+  play_count: number;
+  reason: string;
+}
+
+interface SuggestResult {
+  tracks: SuggestTrack[];
+  total_duration_sec: number;
+  track_count: number;
+  flow: string;
+  base_bpm: number;
+  reason?: string;
+}
+
+const FLOWS = [
+  { value: 'steady', label: 'Steady' },
+  { value: 'build', label: 'Build up' },
+  { value: 'wind_down', label: 'Wind down' },
+  { value: 'wave', label: 'Wave' },
+];
+
+const fmtDur = (sec: number): string => {
+  const m = Math.floor(sec / 60);
+  const s = Math.round(sec % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+};
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const SuggestPlaylistModal: React.FC<Props> = ({ open, onClose }) => {
+  const [durationMin, setDurationMin] = useState(30);
+  const [bpmMin, setBpmMin] = useState('');
+  const [bpmMax, setBpmMax] = useState('');
+  const [flow, setFlow] = useState('steady');
+  const [harmonic, setHarmonic] = useState(true);
+  const [query, setQuery] = useState('');
+  const [result, setResult] = useState<SuggestResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addToSideList = useDjSideList((s) => s.add);
+
+  const run = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const body = {
+        target_duration_sec: Math.max(60, durationMin * 60),
+        bpm_min: bpmMin ? Number(bpmMin) : null,
+        bpm_max: bpmMax ? Number(bpmMax) : null,
+        harmonic,
+        flow,
+        query: query.trim() || null,
+      };
+      const r = await fetch('/api/library/suggest-playlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setResult((await r.json()) as SuggestResult);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const playAll = () => {
+    if (!result?.tracks.length) return;
+    void startQueue(result.tracks.map((t) => t.id));
+    onClose();
+  };
+
+  const sendToDj = () => {
+    if (!result?.tracks.length) return;
+    result.tracks.forEach((t) => addToSideList({ entryId: t.id, label: t.title }));
+    logInfo('library', `Sent ${result.tracks.length} tracks to the DJ side list`);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-100 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-[min(640px,95vw)] h-[min(760px,92vh)] bg-[#0a080f] border border-purple-500/30 rounded-lg shadow-[0_0_40px_rgba(139,92,246,0.2)] flex flex-col overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-white/10 px-4 py-2.5 bg-linear-to-r from-purple-900/30 to-indigo-900/20 shrink-0">
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-purple-300" />
+            <span className="font-black text-[13px] tracking-widest text-white">SUGGEST A PLAYLIST</span>
+          </div>
+          <button type="button" onClick={onClose} className="p-1.5 rounded hover:bg-white/10 text-zinc-400 hover:text-white">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="shrink-0 px-4 py-3 border-b border-white/10 flex flex-col gap-2.5">
+          <div className="flex items-center gap-2">
+            <label htmlFor="sp-dur" className="text-[11px] text-zinc-300 w-20 shrink-0">Length (min)</label>
+            <input id="sp-dur" name="sp-dur" type="number" min={1} max={600} value={durationMin} onChange={(e) => setDurationMin(Math.max(1, Number(e.target.value) || 1))} className="compact-input w-20" />
+            <span className="text-[10px] text-zinc-500 ml-1">flow</span>
+            <select id="sp-flow" name="sp-flow" value={flow} onChange={(e) => setFlow(e.target.value)} className="compact-input flex-1" style={{ colorScheme: 'dark' }}>
+              {FLOWS.map((f) => <option key={f.value} value={f.value}>{f.label}</option>)}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label htmlFor="sp-bpmmin" className="text-[11px] text-zinc-300 w-20 shrink-0">BPM range</label>
+            <input id="sp-bpmmin" name="sp-bpmmin" type="number" placeholder="min" value={bpmMin} onChange={(e) => setBpmMin(e.target.value)} className="compact-input w-20" />
+            <input id="sp-bpmmax" name="sp-bpmmax" type="number" placeholder="max" value={bpmMax} onChange={(e) => setBpmMax(e.target.value)} className="compact-input w-20" />
+            <label htmlFor="sp-harm" className="flex items-center gap-1.5 text-[11px] text-zinc-300 ml-auto cursor-pointer">
+              <input id="sp-harm" name="sp-harm" type="checkbox" checked={harmonic} onChange={(e) => setHarmonic(e.target.checked)} /> harmonic
+            </label>
+          </div>
+          <div className="flex items-center gap-2">
+            <label htmlFor="sp-query" className="text-[11px] text-zinc-300 w-20 shrink-0">Filter</label>
+            <input id="sp-query" name="sp-query" type="text" placeholder="genre / artist / text (optional)" value={query} onChange={(e) => setQuery(e.target.value)} className="compact-input flex-1" />
+            <button type="button" onClick={run} disabled={loading} className="flex items-center gap-1.5 px-3 py-1.5 rounded border border-purple-500/40 bg-purple-500/15 hover:bg-purple-500/25 text-purple-200 text-[11px] font-black uppercase tracking-widest disabled:opacity-50">
+              {loading ? <RefreshCw className="w-3 h-3 animate-spin" /> : <Sparkles className="w-3 h-3" />} Suggest
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3">
+          {error && <p className="text-rose-300 text-[11px]">Failed: {error}</p>}
+          {!error && result && result.tracks.length === 0 && (
+            <p className="text-zinc-500 text-[11px] italic">{result.reason || 'No tracks matched. Try a wider BPM range, or analyze more of your library.'}</p>
+          )}
+          {!error && !result && (
+            <p className="text-zinc-600 text-[11px] italic">Set the criteria and hit Suggest. The playlist sequences on harmonic key and a BPM flow, and fills your time budget.</p>
+          )}
+          {result && result.tracks.length > 0 && (
+            <>
+              <div className="text-[10px] font-mono text-zinc-500 mb-2">{result.track_count} tracks · {fmtDur(result.total_duration_sec)} · base {Math.round(result.base_bpm)} bpm · {result.flow}</div>
+              <ol className="flex flex-col gap-1">
+                {result.tracks.map((t, i) => (
+                  <li key={t.id} className="flex items-center gap-2 px-2 py-1.5 rounded bg-white/3 hover:bg-white/5">
+                    <span className="text-[10px] font-mono text-zinc-600 w-5 text-right shrink-0">{i + 1}</span>
+                    <Music className="w-3 h-3 text-purple-400/70 shrink-0" />
+                    <span className="text-[11px] text-zinc-200 truncate flex-1">{t.title}</span>
+                    <span className="text-[9px] font-mono text-zinc-500 shrink-0">{t.bpm ? `${Math.round(t.bpm)}bpm` : ''} {t.camelot ?? ''}</span>
+                    <span className="text-[8px] font-mono text-purple-300/50 shrink-0 w-28 truncate text-right" title={t.reason}>{t.reason}</span>
+                  </li>
+                ))}
+              </ol>
+            </>
+          )}
+        </div>
+
+        {result && result.tracks.length > 0 && (
+          <div className="shrink-0 border-t border-white/10 px-4 py-2.5 flex items-center gap-2">
+            <button type="button" onClick={playAll} className="flex items-center gap-1.5 px-3 py-1.5 rounded border border-emerald-500/40 bg-emerald-500/15 hover:bg-emerald-500/25 text-emerald-200 text-[11px] font-black uppercase tracking-widest">
+              <Play className="w-3 h-3 fill-current" /> Play All
+            </button>
+            <button type="button" onClick={sendToDj} className="flex items-center gap-1.5 px-3 py-1.5 rounded border border-cyan-500/40 bg-cyan-500/15 hover:bg-cyan-500/25 text-cyan-200 text-[11px] font-black uppercase tracking-widest">
+              <ListPlus className="w-3 h-3" /> Send to DJ
+            </button>
+            <button type="button" onClick={run} disabled={loading} className="flex items-center gap-1.5 px-3 py-1.5 rounded border border-white/10 hover:bg-white/10 text-zinc-300 text-[11px] font-bold uppercase tracking-widest ml-auto disabled:opacity-50">
+              <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} /> Regenerate
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/state/playerStore.ts
+++ b/frontend/src/state/playerStore.ts
@@ -22,6 +22,9 @@ let _objectUrl: string | null = null;
 // Set by load() to a real library entry id; the first 'play' event after a
 // load counts one play for it (then clears, so resume/seek do not re-count).
 let _pendingPlayCountId: string | null = null;
+// Set by the playlist queue; fired when a (non-looping) track ends so the queue
+// can auto-advance. Null for ordinary single-track playback.
+let _onEnded: (() => void) | null = null;
 
 type EngineHandles = {
   ctx: AudioContext;
@@ -86,7 +89,10 @@ export const ensureEngine = (): EngineHandles => {
     usePlayerStore.setState({ isPlaying: false });
   });
   audioEl.addEventListener('ended', () => {
-    if (!audioEl.loop) usePlayerStore.setState({ isPlaying: false, currentTime: 0 });
+    if (!audioEl.loop) {
+      usePlayerStore.setState({ isPlaying: false, currentTime: 0 });
+      _onEnded?.();
+    }
   });
   audioEl.addEventListener('error', () => {
     logError('player', `Audio element error: ${audioEl.error?.message ?? 'unknown'}`);
@@ -121,6 +127,12 @@ export interface LiveTransport {
 let _live: LiveTransport | null = null;
 export const setLiveTransport = (t: LiveTransport | null): void => {
   _live = t;
+};
+
+/** Register a callback fired when a non-looping track ends (the playlist queue
+ *  uses this to advance). Pass null to clear. */
+export const setQueueOnEnded = (cb: (() => void) | null): void => {
+  _onEnded = cb;
 };
 
 // Auto-warm-up: the first time the user interacts with the page in

--- a/frontend/src/state/playlistQueue.ts
+++ b/frontend/src/state/playlistQueue.ts
@@ -1,0 +1,60 @@
+/**
+ * Sequential play queue for the playlist suggester. Plays a list of library
+ * entry ids in order through the global player, auto-advancing when each track
+ * ends. Loop is turned off while a queue is active (so tracks actually end) and
+ * the user's loop preference is restored when the queue finishes.
+ */
+import { usePlayerStore, setQueueOnEnded } from './playerStore';
+import { useLibraryStore } from './libraryStore';
+import { logInfo } from './logStore';
+
+let _queue: string[] = [];
+let _pos = -1;
+let _restoreLoop = false;
+
+const playId = async (id: string): Promise<boolean> => {
+  const entry = useLibraryStore.getState().entries.find((e) => e.id === id);
+  if (!entry) return false;
+  try {
+    const blob = await useLibraryStore.getState().fetchAudioBlob(entry);
+    await usePlayerStore.getState().load(blob, { label: entry.title, entryId: entry.id });
+    usePlayerStore.getState().play();
+    useLibraryStore.getState().setPlayingId(entry.id);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const advance = async (): Promise<void> => {
+  _pos += 1;
+  while (_pos < _queue.length) {
+    if (await playId(_queue[_pos])) return;
+    _pos += 1; // skip a track that failed to load and try the next
+  }
+  stopQueue();
+};
+
+/** Play the given entry ids in order, auto-advancing track to track. */
+export const startQueue = async (ids: string[]): Promise<void> => {
+  if (ids.length === 0) return;
+  _queue = ids.slice();
+  _pos = -1;
+  // Loop must be off so each track ends and the queue can advance.
+  const ps = usePlayerStore.getState();
+  _restoreLoop = ps.isLooping;
+  if (ps.isLooping) ps.toggleLoop();
+  setQueueOnEnded(advance);
+  logInfo('library', `Playing a suggested playlist of ${ids.length} tracks`);
+  await advance();
+};
+
+/** Stop the queue and restore the prior loop preference. */
+export const stopQueue = (): void => {
+  _queue = [];
+  _pos = -1;
+  setQueueOnEnded(null);
+  const ps = usePlayerStore.getState();
+  if (_restoreLoop && !ps.isLooping) ps.toggleLoop();
+  _restoreLoop = false;
+};

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Search, Database, Clock, Play, Pause, Download, Trash2,
-  Music, Star, Tag, Filter, ArrowUpDown,
+  Music, Star, Tag, Filter, ArrowUpDown, Sparkles,
   LayoutGrid, List as ListIcon, Activity, Scissors, Layers, Wand2, PenLine,
   Package, Network, FileMusic, Loader2, Mic, Piano, ListOrdered,
   CheckSquare, Square, MoreHorizontal, Combine, Paintbrush, FileText, ChevronDown, Maximize2,
 } from 'lucide-react';
 import { ContextMenu, useContextMenu, type ContextMenuItem } from '../components/ui/ContextMenu';
 import { LineageModal } from '../components/library/LineageModal';
+import { SuggestPlaylistModal } from '../components/library/SuggestPlaylistModal';
 import { StemsRunModal, type StemsRunOptions } from '../components/library/StemsRunModal';
 import { MicRecorder } from '../components/audio/MicRecorder';
 import { Section } from '../components/ui/Section';
@@ -67,6 +68,7 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('list');
   const [subTab, setSubTab] = useState<'tracks' | 'stems' | 'midi'>('tracks');
   const [lineageOpen, setLineageOpen] = useState<string | null>(null);
+  const [suggestOpen, setSuggestOpen] = useState(false);
   const [selectedEntryIds, setSelectedEntryIds] = useState<string[]>([]);
   const [selectionAnchorId, setSelectionAnchorId] = useState<string | null>(null);
   // Per-entry right-click menu now uses the shared ContextMenu
@@ -764,6 +766,9 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
             <button className={`mono-tag flex items-center gap-1 whitespace-nowrap ${sortBy === 'plays' ? 'bg-purple-600/20! text-purple-300!' : 'bg-white/5! text-zinc-400!'}`} onClick={() => setSortBy('plays')}>
               <Play className="w-2 h-2" /> PLAYS
             </button>
+            <button className="mono-tag flex items-center gap-1 whitespace-nowrap bg-purple-600/30! text-purple-200! border border-purple-500/40" onClick={() => setSuggestOpen(true)} title="Suggest a playlist from your library">
+              <Sparkles className="w-2 h-2" /> SUGGEST
+            </button>
           </div>
         </div>
 
@@ -1102,6 +1107,8 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
         rootEntryId={lineageOpen === '__library__' ? null : lineageOpen}
         onClose={() => setLineageOpen(null)}
       />
+
+      <SuggestPlaylistModal open={suggestOpen} onClose={() => setSuggestOpen(false)} />
 
       {/* Maintenance actions (Clear Non-Favorites / Clear All) moved
           into the icon toolbar's OPTIONS submenu per user request

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -906,6 +906,11 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-[8px] font-mono text-purple-400/80 uppercase tracking-wider">{entry.model}</span>
                   <div className="flex items-center gap-3 shrink-0">
+                    {(entry.playCount ?? 0) > 0 && (
+                      <span className="text-[8px] font-mono text-purple-300/70 flex items-center gap-0.5" title={`Played ${entry.playCount}x`}>
+                        <Play className="w-2 h-2 fill-current" />{entry.playCount}
+                      </span>
+                    )}
                     <span className="text-[8px] font-mono text-zinc-600">{formatDuration(entry.duration)}</span>
                     <span className="text-[8px] font-mono text-zinc-700">{formatDate(entry.timestamp)}</span>
                     <span className="text-[8px] font-mono text-zinc-700">{formatSize(entry.fileSizeBytes)}</span>

--- a/tests/test_library_db.py
+++ b/tests/test_library_db.py
@@ -70,7 +70,12 @@ def test_suggest_playlist(tmp_path: Path):
     from backend.modules.library.suggester import suggest_playlist
 
     db = LibraryDB(tmp_path / "library.db")
-    specs = [(120, "C", "major"), (122, "G", "major"), (124, "D", "major"), (118, "A", "minor")]
+    specs = [
+        (120, "C", "major"),
+        (122, "G", "major"),
+        (124, "D", "major"),
+        (118, "A", "minor"),
+    ]
     for i, (bpm, key, scale) in enumerate(specs):
         eid = f"e{i}"
         db.upsert_entry(_make_entry_payload(eid, title=f"t{i}", duration=120))

--- a/tests/test_library_db.py
+++ b/tests/test_library_db.py
@@ -66,6 +66,39 @@ def test_upsert_preserves_play_count(tmp_path: Path):
     assert db.get_entry("e1")["play_count"] == 2
 
 
+def test_suggest_playlist(tmp_path: Path):
+    from backend.modules.library.suggester import suggest_playlist
+
+    db = LibraryDB(tmp_path / "library.db")
+    specs = [(120, "C", "major"), (122, "G", "major"), (124, "D", "major"), (118, "A", "minor")]
+    for i, (bpm, key, scale) in enumerate(specs):
+        eid = f"e{i}"
+        db.upsert_entry(_make_entry_payload(eid, title=f"t{i}", duration=120))
+        db.upsert_analysis(eid, {"bpm": bpm, "key": key, "scale": scale})
+
+    res = suggest_playlist(db, target_duration_sec=360, harmonic=True, flow="steady")
+    assert 2 <= res["track_count"] <= 4
+    assert res["total_duration_sec"] <= 360 * 1.13
+    ids = [t["id"] for t in res["tracks"]]
+    assert len(ids) == len(set(ids))
+    assert all(t["camelot"] for t in res["tracks"])
+
+
+def test_suggest_playlist_respects_bpm_filter(tmp_path: Path):
+    from backend.modules.library.suggester import suggest_playlist
+
+    db = LibraryDB(tmp_path / "library.db")
+    db.upsert_entry(_make_entry_payload("slow", duration=120))
+    db.upsert_analysis("slow", {"bpm": 90, "key": "C", "scale": "major"})
+    db.upsert_entry(_make_entry_payload("fast", duration=120))
+    db.upsert_analysis("fast", {"bpm": 140, "key": "C", "scale": "major"})
+
+    res = suggest_playlist(db, target_duration_sec=300, bpm_min=130, bpm_max=150)
+    ids = [t["id"] for t in res["tracks"]]
+    assert "slow" not in ids
+    assert "fast" in ids
+
+
 def test_upsert_entry_round_trip(tmp_path: Path):
     db = LibraryDB(tmp_path / "library.db")
     db.upsert_entry(_make_entry_payload("e1"))


### PR DESCRIPTION
feat(library): show a play-count badge on entries

A small "▶ N" badge appears on each library entry (list + grid) once its
play_count is above zero, so the count surfaced by the persistent play counter
is visible, not just sortable.

POST /api/library/suggest-playlist builds an ordered playlist that fits a target
duration by sequencing analyzed tracks on harmonic key (Camelot wheel, ported
from camelot.ts), a bpm flow (steady / build / wind-down / wave), and small
nudges toward popular + stylistically-varied picks. Filters by bpm range, genre,
and a text query; can start from a seed track.

- suggester.py: the sequencing engine (pure stdlib).
- db.list_entries_with_analysis(): entries LEFT JOIN analysis in one query.
- SuggestRequest endpoint + 2 tests. ruff clean; 21 library tests pass.

Frontend UI (criteria form + result + play-through) is the next step.

feat(library): playlist suggester UI - criteria form, play queue, send-to-DJ

A SUGGEST button in the library opens a modal: pick length, BPM range, flow,
harmonic on/off, and an optional text/genre filter; it calls the suggester and
lists the ordered result with per-track BPM / Camelot / reason.

- Play All loads the sequence into the footer player and auto-advances
  (playlistQueue.ts; playerStore gains an on-ended hook and turns loop off for
  the queue, restoring the preference afterward).
- Send to DJ pushes the order into the DJ SideList staging lane.
- tsc clean.