### PR TITLE
Feat/playlist suggester

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T05:24:40.906Z · Git revision: `28e78f4338a3` · Repomix tracked: **no**
+> Generated: 2026-06-12T05:28:45.204Z · Git revision: `9dec05fd4f52` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T04:41:08.604Z · Git revision: `bd893fb590fb` · Repomix tracked: **no**
+> Generated: 2026-06-12T05:24:40.906Z · Git revision: `28e78f4338a3` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T05:24:40.906Z",
-  "repoRevision": "28e78f4338a3",
+  "generatedAt": "2026-06-12T05:28:45.204Z",
+  "repoRevision": "9dec05fd4f52",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T04:41:08.604Z",
-  "repoRevision": "bd893fb590fb",
+  "generatedAt": "2026-06-12T05:24:40.906Z",
+  "repoRevision": "28e78f4338a3",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T05:26:47.791Z",
+  "generatedAt": "2026-06-12T05:30:40.357Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T01:08:01.108Z",
+  "generatedAt": "2026-06-12T05:26:47.791Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/src/state/playerStore.ts
+++ b/frontend/src/state/playerStore.ts
@@ -25,6 +25,10 @@ let _pendingPlayCountId: string | null = null;
 // Set by the playlist queue; fired when a (non-looping) track ends so the queue
 // can auto-advance. Null for ordinary single-track playback.
 let _onEnded: (() => void) | null = null;
+// The editor timeline reuses this sentinel as its entry id so the footer and
+// playhead treat it like a normally-loaded track. Transport delegation to the
+// live mixer is gated on this being the active track (see activeLive).
+const EDITOR_ENTRY_ID = 'editor-timeline';
 
 type EngineHandles = {
   ctx: AudioContext;
@@ -128,6 +132,16 @@ let _live: LiveTransport | null = null;
 export const setLiveTransport = (t: LiveTransport | null): void => {
   _live = t;
 };
+
+/** The live editor transport is the ACTIVE audio source only while the editor
+ *  timeline is the loaded track. After a real library track loads, _live can
+ *  linger because the editor stays mounted, yet the <audio> element is what is
+ *  audible. Returning null in that case routes transport to the element instead
+ *  of the idle mixer. Without this, a footer pause hit the idle mixer (whose
+ *  pause() early-returns), left isPlaying stuck true, and the button stayed on
+ *  Pause while audio kept playing. */
+const activeLive = (): LiveTransport | null =>
+  _live && usePlayerStore.getState().currentEntryId === EDITOR_ENTRY_ID ? _live : null;
 
 /** Register a callback fired when a non-looping track ends (the playlist queue
  *  uses this to advance). Pass null to clear. */
@@ -241,7 +255,8 @@ export const usePlayerStore = create<PlayerStoreState>()((set, get) => ({
     if (ctx.state === 'suspended') {
       void ctx.resume().catch(() => { /* swallowed; will retry */ });
     }
-    if (_live) { _live.play(); return; } // live editor timeline
+    const live = activeLive();
+    if (live) { live.play(); return; } // live editor timeline
     if (!audioEl.src) return;
     void audioEl.play().catch((err) => {
       logError('player', `Play rejected: ${err instanceof Error ? err.message : String(err)}`);
@@ -249,14 +264,16 @@ export const usePlayerStore = create<PlayerStoreState>()((set, get) => ({
   },
 
   pause: () => {
-    if (_live) { _live.pause(); return; }
+    const live = activeLive();
+    if (live) { live.pause(); return; }
     const { audioEl } = ensureEngine();
     audioEl.pause();
   },
 
   toggle: () => {
-    if (_live) {
-      if (get().isPlaying) _live.pause();
+    const live = activeLive();
+    if (live) {
+      if (get().isPlaying) live.pause();
       else get().play();
       return;
     }
@@ -267,7 +284,8 @@ export const usePlayerStore = create<PlayerStoreState>()((set, get) => ({
   },
 
   stop: () => {
-    if (_live) { _live.stop(); return; }
+    const live = activeLive();
+    if (live) { live.stop(); return; }
     const { audioEl } = ensureEngine();
     audioEl.pause();
     audioEl.currentTime = 0;
@@ -276,7 +294,8 @@ export const usePlayerStore = create<PlayerStoreState>()((set, get) => ({
 
   seek: (sec) => {
     if (!Number.isFinite(sec)) return;
-    if (_live) { _live.seek(sec); return; }
+    const live = activeLive();
+    if (live) { live.seek(sec); return; }
     const { audioEl } = ensureEngine();
     audioEl.currentTime = Math.max(0, Math.min(audioEl.duration || 0, sec));
     set({ currentTime: audioEl.currentTime });
@@ -284,7 +303,8 @@ export const usePlayerStore = create<PlayerStoreState>()((set, get) => ({
 
   seekByFraction: (frac) => {
     const clamped = Math.max(0, Math.min(1, frac));
-    if (_live) { _live.seek(clamped * (get().duration || 0)); return; }
+    const live = activeLive();
+    if (live) { live.seek(clamped * (get().duration || 0)); return; }
     const { audioEl } = ensureEngine();
     const dur = audioEl.duration || 0;
     if (!dur) return;

--- a/scripts/regenerate-docs.sh
+++ b/scripts/regenerate-docs.sh
@@ -23,6 +23,22 @@ if [[ ! -f "$src" ]]; then
   exit 1
 fi
 
+# 0. Auto-format Python with the project's pinned ruff, then re-stage anything
+# it changed, so a forgotten `ruff format` never reaches CI. Runs at the repo
+# root (never a subset — see CLAUDE.md HARD RULE) and via `uv run`, so it is the
+# venv's pinned ruff, bit-identical to the lint workflow's RUFF_VERSION.
+# Non-fatal: a failure here warns and continues rather than blocking the commit.
+if command -v uv >/dev/null 2>&1; then
+  log "Formatting Python (ruff, repo root)"
+  if uv run ruff format . >/dev/null 2>&1; then
+    git add -u -- '*.py' 2>/dev/null || true
+  else
+    warn "ruff format failed (dev group synced? 'uv sync --group dev'). Continuing."
+  fi
+else
+  warn "uv not found — skipping ruff format. CI will still gate it."
+fi
+
 # 1. Generate feature/docs coverage before syncing the in-app copy.
 log "Generating feature coverage report"
 ( cd frontend && npm exec -- tsx ../scripts/screenshots/featureCoverage.ts ) || \


### PR DESCRIPTION
fix(player): gate live-mixer transport on the editor timeline being active

The footer and library transport delegated to the registered live-mixer transport whenever it existed, even when a real library track was the audible source. The editor registers that transport for as long as it stays mounted (WaveformEditor liveMixer.attach), so after playing a library or suggested track the footer Pause routed into the idle mixer, whose pause() early-returns. Audio kept playing and isPlaying stayed true, leaving the button stuck on Pause.

Gate every transport method (toggle/play/pause/stop/seek/seekByFraction) on currentEntryId being the editor sentinel, so the live mixer is honored only while its timeline is the loaded track and the <audio> element drives everything else.

build(hooks): auto-format Python in the pre-commit docs step

regenerate-docs.sh now runs `uv run ruff format .` at the repo root and re-stages any reformatted Python before the commit completes, so a forgotten format pass cannot reach CI. It uses the venv's pinned ruff (bit-identical to the lint workflow) and is non-fatal: a failure warns and continues.