### PR TITLE
Docs: clarify Windows setup preflight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ right stack automatically:
 - torch + torchaudio come from the cu128 index (no manual `--index-url` step)
 - `soundfile` is a base dependency (torchaudio's Windows backend), installed by `uv sync`
 - Flash Attention installs from the pinned `kingbri1` cu128/cp310 wheel, gated to `sys_platform == 'win32' and python_version < '3.11'` (so the venv must be Python 3.10; `.python-version` pins it)
-- `theDAW.bat` installs the prerequisite tools on first run; `docs/windows/setup-guide.md` has the full walkthrough and fallbacks
+- `theDAW.bat` preflights prerequisites and invokes `install/setup.ps1` for consent-based tool installation when something is missing; `docs/windows/setup-guide.md` has the full walkthrough and fallbacks
 
 ## RAG Index Maintenance
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T11:02:52.465Z · Git revision: `d1654d68adbf` · Repomix tracked: **no**
+> Generated: 2026-06-12T11:24:42.274Z · Git revision: `f057e6e6a3f2` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T11:02:52.465Z",
-  "repoRevision": "d1654d68adbf",
+  "generatedAt": "2026-06-12T11:24:42.274Z",
+  "repoRevision": "f057e6e6a3f2",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T11:04:57.062Z",
+  "generatedAt": "2026-06-12T11:26:51.700Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/docs/windows/setup-guide.md
+++ b/docs/windows/setup-guide.md
@@ -18,10 +18,13 @@ never run a manual install command.
 .\theDAW.bat
 ```
 
-On a fresh clone with the prerequisites below on PATH, `theDAW.bat` verifies the
-tools, runs `uv sync --group dev` and `npm install` on first launch, then starts
-the backend, the frontend, and the optional tunnel in a single window and opens
-<http://localhost:5173>. Everything after this section is detail and fallbacks.
+On a fresh clone, `theDAW.bat` verifies the prerequisites below. If required
+tools are missing, it invokes `install/setup.ps1`, which performs a read-only
+hardware/tool check and asks for consent before installing anything. Once the
+tools are present, the launcher runs `uv sync --group dev` and `npm install` on
+first launch, then starts the backend, the frontend, and the optional tunnel in a
+single window and opens <http://localhost:5173>. Everything after this section is
+detail and fallbacks.
 
 ---
 
@@ -45,9 +48,11 @@ the backend, the frontend, and the optional tunnel in a single window and opens
 
 ### Install the tools
 
-The easiest path is to let theDAW do it: double-click **`theDAW.bat`**, which
-detects your hardware and installs uv / Node / FFmpeg / Git for you after a
-single confirmation. The commands below are the manual fallback.
+The easiest path is to let theDAW do it: double-click **`theDAW.bat`**. When a
+tool is missing, it runs **`install/setup.ps1`**, which detects your hardware,
+lists the missing uv / Node / FFmpeg / Git pieces, and asks for confirmation
+before downloading or installing anything. The commands below are the manual
+fallback.
 
 ```powershell
 winget install astral-sh.uv          # uv

--- a/docs/windows/troubleshooting.md
+++ b/docs/windows/troubleshooting.md
@@ -147,14 +147,19 @@ If this errors, reinstall flash-attn (see above).
 
 ## `theDAW.bat` fails immediately, or "X is not recognized"
 
-**Cause:** A required tool isn't on PATH. The launcher preflights uv/node/npm and
-bootstraps the venv + `node_modules`, but it can't run if those tools are missing.
+**Cause:** A required tool is not on PATH, or the consent-based setup helper was
+declined/failed. The launcher preflights uv/node/npm/FFmpeg/Git and, when a tool
+is missing, runs `install/setup.ps1` to detect hardware and ask before installing
+anything. If setup installed a tool, the parent Command Prompt still needs a
+fresh run so PATH refreshes.
 
-**Fix by what's reported missing:**
+**Fix:** first re-run `theDAW.bat`. If the setup helper opens, approve the listed
+installs or use the manual fallback for the reported tool:
 
 - **`uv`** — install from <https://docs.astral.sh/uv/getting-started/installation/>, then reopen the terminal.
 - **`node` / `npm`** — install Node.js **v20.19+ or v22.12+** from <https://nodejs.org/> (npm ships with it). An older Node also makes Vite 7 crash with an opaque error; check `node -v`.
 - **`ffmpeg`** — `winget install Gyan.FFmpeg`, or a build from <https://www.gyan.dev/ffmpeg/builds/> with its `bin\` on PATH. The launcher only warns about this one; the servers start, but every audio effect, export, and library ingest fails until FFmpeg is present.
 - **`lt` (localtunnel)** — optional. The launcher skips the public tunnel when it's absent; run `npm i -g localtunnel` if you want the shareable link.
 
-After installing a tool, open a NEW terminal so PATH refreshes, then re-run `theDAW.bat`.
+After installing a tool, close the current launcher window (or open a NEW
+terminal) so PATH refreshes, then re-run `theDAW.bat`.


### PR DESCRIPTION
﻿## Summary
- Clarify that theDAW.bat invokes install/setup.ps1 when prerequisite tools are missing
- Update Windows troubleshooting to reflect the consent-based setup helper and PATH refresh behavior
- Tighten CLAUDE.md Windows setup guidance
- Confirmed RAG DOC_PATHS resolves all listed docs; no backend/rag.py change needed

## Validation
- RAG DOC_PATHS sanity check returned missing 0
- uv run ruff check .
- uv run ruff format --check .
- pre-commit docs hook regenerated feature coverage and screenshots
