### PR TITLE
fix(magenta-setup): install the extended sidecar deps during Setup-MRT2

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T19:17:38.369Z · Git revision: `915b82a8cb57` · Repomix tracked: **no**
+> Generated: 2026-06-12T19:49:45.463Z · Git revision: `89a17371d796` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T19:17:38.369Z",
-  "repoRevision": "915b82a8cb57",
+  "generatedAt": "2026-06-12T19:49:45.463Z",
+  "repoRevision": "89a17371d796",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T19:19:37.411Z",
+  "generatedAt": "2026-06-12T19:51:46.071Z",
   "entries": [
     {
       "file": "01-shell-make.png",


### PR DESCRIPTION
## Summary
- Bumps the magenta-rt2-nvidia submodule to c61e052
- setup_all.sh now installs and probes fastapi / uvicorn / python-multipart in the WSL venv, and applies sidecars/magenta/requirements.txt when the repo layout is present
- The Windows-side READY probe checks the same imports, so stale installs self-heal on the next setup run
- Fixes the fresh-rig failure where Setup-MRT2 passed but the in-app engine start died on ImportError

## Validation
- bash -n parses the edited setup_all.sh
- The probe import line passes against the real WSL venv on this machine
- Pre-commit docs chain regenerated coverage + 9/9 screenshots