### PR TITLE
feat(models): local checkpoints, Models & Storage panel, no-download switch, Magenta SETUP pill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ codegraph/
 data/api_key_pools.json
 data/generations/
 data/settings.json
+data/local_checkpoints.json
 data/library.db
 data/library.db-*
 # Suno cloud-gen key/jobs + local session change logs (never committed)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ theDAW is an all-in-one application for music creation. The generative engine re
 
 theDAW also ships the first non-Mac port of Google's Magenta RealTime 2, which runs on Windows with WSL2 and NVIDIA, on native Linux, and on cloud GPUs. Magenta lives in the same Model dropdown as the local Stable Audio engines, and selecting it swaps the GPU automatically: Stable Audio parks in system RAM, the engine starts in WSL2, and a status pill tracks it to READY. Picking a Stable Audio model reverses the swap. The [Generate](#generate-cloud-and-real-time) section describes it. Live coding and Unity integration are in development.
 
+Models stay under the user's control. Nothing downloads at startup; a model loads at the first CREATE that needs it, resolving local folders first, then the Hugging Face cache, and only then a one-time download. **Settings → Models & Storage** registers any checkpoint already on disk (it then appears in the Model dropdown), pins generation to local-only so nothing ever downloads, and maps every model location on the machine, with sizes and one-click open-in-Explorer, from the HF cache to the Magenta WSL venv.
+
 <p align="center">
   <a href="showcase/clips-recorded/_showcase_h.mp4">
     <img src="docs/readme/showcase-poster.png" alt="Watch the theDAW feature-tour video" width="900">

--- a/backend/modules/magenta/router.py
+++ b/backend/modules/magenta/router.py
@@ -49,6 +49,24 @@ async def engine_start():
         # The extended engine is already up (ready or still loading) — keep it.
         return {"ok": True, "already_running": True, **h}
 
+    # Refuse with a precise diagnosis when the WSL side was never set up —
+    # spawning would just die on a missing venv and read as a vague ERROR.
+    loop_probe = asyncio.get_event_loop()
+    setup = await loop_probe.run_in_executor(None, sidecar.setup_state)
+    if not setup.get("ready"):
+        raise HTTPException(
+            412,
+            {
+                "setup_required": True,
+                **setup,
+                "message": (
+                    "The Magenta RT2 engine is not installed yet. Run "
+                    "Setup-MRT2.bat (sidecars/magenta-rt2-nvidia) once — it "
+                    "checks the PC, asks consent, and installs everything."
+                ),
+            },
+        )
+
     # Park SA3 first so the engine's JAX runtime finds a free GPU. The import is
     # deferred to request time: the server module is fully initialized by then.
     from backend import server as srv
@@ -82,7 +100,14 @@ async def engine_stop():
 @router.get("/engine/status")
 async def engine_status():
     h = await sidecar.health()
-    return {**h, "process_alive": sidecar.engine_process_alive()}
+    out = {**h, "process_alive": sidecar.engine_process_alive()}
+    if not (h.get("reachable") and h.get("protocol_ok")):
+        setup = await asyncio.get_event_loop().run_in_executor(
+            None, sidecar.setup_state
+        )
+        out["setup_required"] = not setup.get("ready")
+        out["setup"] = setup
+    return out
 
 
 @router.get("/jobs/{job_id}")

--- a/backend/modules/magenta/sidecar.py
+++ b/backend/modules/magenta/sidecar.py
@@ -25,6 +25,7 @@ import os
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 
 import httpx
@@ -110,6 +111,56 @@ def _wsl_path(p: Path) -> str:
 
 def engine_process_alive() -> bool:
     return _engine_proc is not None and _engine_proc.poll() is None
+
+
+_setup_cache: dict = {"t": 0.0, "state": None}
+_SETUP_CACHE_SECONDS = 30.0
+
+
+def setup_state(refresh: bool = False) -> dict:
+    """Is the WSL side actually installed? Probes the venv python and the
+    model checkpoints so the UI can say 'setup required' instead of a bare
+    error when Setup-MRT2 never ran. Cached for 30 s (the wsl spawn is
+    ~a second); pass ``refresh=True`` after a setup run."""
+    now = time.monotonic()
+    if (
+        not refresh
+        and _setup_cache["state"] is not None
+        and now - _setup_cache["t"] < _SETUP_CACHE_SECONDS
+    ):
+        return _setup_cache["state"]
+
+    state = {"wsl": False, "venv": False, "checkpoint": False, "ready": False}
+    try:
+        py = _WSL_PYTHON.replace("'", "")
+        result = subprocess.run(
+            [
+                "wsl.exe",
+                "-d",
+                _wsl_distro(),
+                "--",
+                "bash",
+                "-lc",
+                f"echo WSL_OK; test -x {py} && echo VENV_OK; "
+                "ls ~/Documents/Magenta/magenta-rt-v2/checkpoints/*.safetensors "
+                ">/dev/null 2>&1 && echo CKPT_OK",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
+            shell=False,
+        )
+        out = result.stdout
+        state["wsl"] = "WSL_OK" in out
+        state["venv"] = "VENV_OK" in out
+        state["checkpoint"] = "CKPT_OK" in out
+    except (OSError, subprocess.TimeoutExpired) as e:
+        log.debug("magenta.engine: setup probe failed: %s", e)
+    state["ready"] = state["venv"] and state["checkpoint"]
+    _setup_cache["t"] = now
+    _setup_cache["state"] = state
+    return state
 
 
 def start_engine() -> dict:

--- a/backend/modules/storage/module.json
+++ b/backend/modules/storage/module.json
@@ -1,0 +1,10 @@
+{
+  "name": "storage",
+  "label": "Models & Storage",
+  "enabled": true,
+  "icon": "HardDrive",
+  "sidebar": false,
+  "api_prefix": "/api/storage",
+  "backend": true,
+  "description": "Browse every model location on this machine (HF cache, local checkpoint folders, sidecar assets) with sizes and open-in-Explorer, register local checkpoints for the Model dropdown, and pin generation to local-only (no downloads)."
+}

--- a/backend/modules/storage/router.py
+++ b/backend/modules/storage/router.py
@@ -1,0 +1,344 @@
+"""FastAPI router for the storage module (prefix ``/api/storage``).
+
+    GET    /locations            every model/data location with size + file count
+    GET    /hf-cache             per-repo breakdown of the Hugging Face cache
+    GET    /checkpoints          registered local checkpoints + catalog availability
+    POST   /checkpoints          register a local checkpoint {path, name?}
+    DELETE /checkpoints/{ck_id}  unregister (files are never touched)
+    GET    /local-only           is no-download mode on?
+    PUT    /local-only           toggle no-download mode {enabled}
+    POST   /open                 open a known location in the OS file explorer
+
+Sizes come from a recursive walk cached for 60 seconds per path (pass
+``refresh=1`` to force). The WSL-side Magenta locations are probed through
+``wsl.exe`` with a short timeout and the same cache, so a missing distro
+degrades to ``exists: false`` instead of an error.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from stable_audio_3.model_configs import (
+    _local_override,
+    _local_search_dirs,
+    arc_models,
+    rf_models,
+)
+
+from .store import PROJECT_ROOT, get_registry
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_SIZE_TTL_SECONDS = 60.0
+_size_cache: dict[str, tuple[float, dict]] = {}
+_size_lock = threading.Lock()
+
+_WSL_TIMEOUT = 10
+_wsl_cache: dict[str, tuple[float, dict]] = {}
+
+
+def _dir_stats(path: Path) -> dict:
+    """Recursive size + file count. Junctions/symlinks are not followed."""
+    total = 0
+    files = 0
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    try:
+                        if entry.is_symlink():
+                            continue
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(Path(entry.path))
+                        elif entry.is_file(follow_symlinks=False):
+                            total += entry.stat(follow_symlinks=False).st_size
+                            files += 1
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+    return {"bytes": total, "files": files}
+
+
+def _cached_dir_stats(path: Path, refresh: bool) -> dict:
+    key = str(path).lower()
+    now = time.monotonic()
+    with _size_lock:
+        hit = _size_cache.get(key)
+        if hit and not refresh and now - hit[0] < _SIZE_TTL_SECONDS:
+            return hit[1]
+    stats = _dir_stats(path) if path.is_dir() else {"bytes": None, "files": None}
+    with _size_lock:
+        _size_cache[key] = (now, stats)
+    return stats
+
+
+def _hf_cache_dir() -> Path:
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    return Path(HF_HUB_CACHE)
+
+
+def _wsl_distro() -> str | None:
+    try:
+        from backend.modules.magenta.sidecar import _wsl_distro as magenta_distro
+
+        return magenta_distro()
+    except Exception:
+        return None
+
+
+def _wsl_location(label: str, key: str, wsl_path: str, refresh: bool) -> dict:
+    """Best-effort size probe of a WSL-side directory via ``wsl.exe du``."""
+    now = time.monotonic()
+    hit = _wsl_cache.get(key)
+    if hit and not refresh and now - hit[0] < _SIZE_TTL_SECONDS * 5:
+        return hit[1]
+
+    distro = _wsl_distro()
+    entry = {
+        "key": key,
+        "label": label,
+        "path": None,
+        "kind": "wsl",
+        "exists": False,
+        "bytes": None,
+        "files": None,
+    }
+    if distro:
+        try:
+            # The script goes in on stdin AS BYTES: wsl.exe re-joins argv after
+            # `--` without preserving quoting (which empties quoted variable
+            # assignments passed via `bash -lc '...'`), and text-mode stdin
+            # would CRLF-translate the newlines into bash syntax errors.
+            script = (
+                f'p="{wsl_path}"\n'
+                'if [ -d "$p" ]; then\n'
+                "  echo EXISTS\n"
+                '  du -sb "$p" 2>/dev/null | cut -f1\n'
+                '  readlink -f "$p"\n'
+                "fi\n"
+            )
+            result = subprocess.run(
+                ["wsl.exe", "-d", distro, "--", "bash", "-l"],
+                input=script.encode("utf-8"),
+                capture_output=True,
+                timeout=_WSL_TIMEOUT,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            stdout = result.stdout.decode("utf-8", errors="replace")
+            lines = [ln.strip() for ln in stdout.splitlines() if ln.strip()]
+            if lines and lines[0] == "EXISTS":
+                entry["exists"] = True
+                if len(lines) > 1 and lines[1].isdigit():
+                    entry["bytes"] = int(lines[1])
+                if len(lines) > 2:
+                    entry["path"] = (
+                        f"\\\\wsl.localhost\\{distro}{lines[2].replace('/', chr(92))}"
+                    )
+        except (OSError, subprocess.TimeoutExpired) as e:
+            log.debug("storage: WSL probe for %s failed: %s", key, e)
+    _wsl_cache[key] = (now, entry)
+    return entry
+
+
+def _windows_locations() -> list[tuple[str, str, Path]]:
+    """(key, label, path) for every Windows-side location worth surfacing."""
+    locations: list[tuple[str, str, Path]] = [
+        (
+            "hf-cache",
+            "Hugging Face cache (SA3 checkpoints, T5Gemma, more)",
+            _hf_cache_dir(),
+        ),
+    ]
+    seen: set[str] = set()
+    for i, d in enumerate(_local_search_dirs()):
+        norm = str(d).lower().rstrip("\\/")
+        if norm in seen:
+            continue
+        seen.add(norm)
+        locations.append((f"sa3-local-{i}", "Local model folder (SA3 search path)", d))
+    locations += [
+        (
+            "generations",
+            "Generated audio library",
+            PROJECT_ROOT / "data" / "generations",
+        ),
+        ("rag-index", "Assistant RAG index", PROJECT_ROOT / "backend" / "rag_index"),
+        (
+            "torch-cache",
+            "Torch hub cache (Demucs, MIDI models)",
+            Path(os.environ.get("TORCH_HOME", Path.home() / ".cache" / "torch")),
+        ),
+    ]
+    return locations
+
+
+@router.get("/locations")
+def storage_locations(refresh: bool = False) -> dict:
+    items = []
+    for key, label, path in _windows_locations():
+        stats = _cached_dir_stats(path, refresh)
+        items.append(
+            {
+                "key": key,
+                "label": label,
+                "path": str(path),
+                "kind": "windows",
+                "exists": path.is_dir(),
+                **stats,
+            }
+        )
+    items.append(
+        _wsl_location(
+            "Magenta RT2 model assets (WSL)",
+            "magenta-assets",
+            "$HOME/Documents/Magenta/magenta-rt-v2",
+            refresh,
+        )
+    )
+    items.append(
+        _wsl_location(
+            "Magenta RT2 engine venv (WSL)", "magenta-venv", "$HOME/mrt2", refresh
+        )
+    )
+    return {"locations": items}
+
+
+@router.get("/hf-cache")
+def storage_hf_cache() -> dict:
+    cache_dir = _hf_cache_dir()
+    if not cache_dir.is_dir():
+        return {"path": str(cache_dir), "repos": [], "total_bytes": 0}
+    try:
+        from huggingface_hub import scan_cache_dir
+
+        info = scan_cache_dir(cache_dir)
+    except Exception as e:
+        raise HTTPException(500, f"HF cache scan failed: {e}") from e
+    repos = sorted(
+        (
+            {
+                "repo_id": r.repo_id,
+                "repo_type": r.repo_type,
+                "bytes": r.size_on_disk,
+                "files": r.nb_files,
+                "path": str(r.repo_path),
+                "last_accessed": r.last_accessed,
+            }
+            for r in info.repos
+        ),
+        key=lambda r: -(r["bytes"] or 0),
+    )
+    return {"path": str(cache_dir), "repos": repos, "total_bytes": info.size_on_disk}
+
+
+@router.get("/checkpoints")
+def storage_checkpoints() -> dict:
+    from huggingface_hub import try_to_load_from_cache
+
+    registry = get_registry()
+    catalog = []
+    for name, cfg in {**arc_models, **rf_models}.items():
+        local = (
+            _local_override(cfg.repo_id, cfg.config_path) is not None
+            and _local_override(cfg.repo_id, cfg.ckpt_path) is not None
+        )
+        cached = local or (
+            isinstance(try_to_load_from_cache(cfg.repo_id, cfg.config_path), str)
+            and isinstance(try_to_load_from_cache(cfg.repo_id, cfg.ckpt_path), str)
+        )
+        catalog.append(
+            {
+                "name": name,
+                "repo_id": cfg.repo_id,
+                "source": "local" if local else "cached" if cached else "download",
+            }
+        )
+    return {
+        "registered": registry.list_checkpoints(),
+        "catalog": catalog,
+        "local_only": registry.local_only(),
+    }
+
+
+class AddCheckpointBody(BaseModel):
+    path: str
+    name: str | None = None
+
+
+@router.post("/checkpoints")
+def storage_add_checkpoint(body: AddCheckpointBody) -> dict:
+    try:
+        return get_registry().add_checkpoint(body.path, body.name)
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+
+
+@router.delete("/checkpoints/{ck_id:path}")
+def storage_remove_checkpoint(ck_id: str) -> dict:
+    if not get_registry().remove_checkpoint(ck_id):
+        raise HTTPException(404, f"No registered checkpoint {ck_id!r}")
+    return {"removed": ck_id}
+
+
+class LocalOnlyBody(BaseModel):
+    enabled: bool
+
+
+@router.get("/local-only")
+def storage_local_only() -> dict:
+    return {"enabled": get_registry().local_only()}
+
+
+@router.put("/local-only")
+def storage_set_local_only(body: LocalOnlyBody) -> dict:
+    return {"enabled": get_registry().set_local_only(body.enabled)}
+
+
+class OpenBody(BaseModel):
+    path: str
+
+
+def _allowed_open_roots() -> list[str]:
+    roots = [str(p) for _, _, p in _windows_locations()]
+    roots += [e["path"] for e in get_registry().list_checkpoints()]
+    distro = _wsl_distro()
+    if distro:
+        roots.append(f"\\\\wsl.localhost\\{distro}")
+    return [r.lower().rstrip("\\/") for r in roots]
+
+
+@router.post("/open")
+def storage_open(body: OpenBody) -> dict:
+    """Open a location in Explorer. Only paths under a known location are allowed."""
+    target = body.path.strip()
+    normalized = target.lower().rstrip("\\/")
+    if not any(
+        normalized == root
+        or normalized.startswith(root + "\\")
+        or normalized.startswith(root + "/")
+        for root in _allowed_open_roots()
+    ):
+        raise HTTPException(403, "That path is not one of theDAW's model locations.")
+    if sys.platform != "win32":
+        raise HTTPException(501, "Open-in-explorer is implemented for Windows only.")
+    try:
+        os.startfile(target)  # noqa: S606 — deliberate, validated against known roots
+    except OSError as e:
+        raise HTTPException(404, f"Could not open {target!r}: {e}") from e
+    return {"opened": target}

--- a/backend/modules/storage/store.py
+++ b/backend/modules/storage/store.py
@@ -1,0 +1,162 @@
+"""Registry for user-added local checkpoints + the local-only switch.
+
+Persisted to ``data/local_checkpoints.json``. Each entry maps a stable id
+(``local:<8-hex>``) to a display name and a path the user picked. The ids are
+what the Model dropdown submits, so renaming or moving the underlying folder
+never breaks generation history — the entry just stops resolving until the
+user re-points it.
+
+``local_only`` mirrors the ``SA3_LOCAL_ONLY`` environment switch that
+``stable_audio_3.model_configs`` reads on every resolve: when on, model
+resolution never touches the network and fails loudly instead of downloading.
+The flag is applied to ``os.environ`` at import time so a backend restart
+keeps the user's choice.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from stable_audio_3.model_configs import resolve_local_checkpoint
+
+log = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+REGISTRY_PATH = PROJECT_ROOT / "data" / "local_checkpoints.json"
+
+_DEFAULT: dict[str, Any] = {"local_only": False, "checkpoints": []}
+
+
+class CheckpointRegistry:
+    """Thread-safe JSON registry, written atomically on every change."""
+
+    def __init__(self, path: Path = REGISTRY_PATH) -> None:
+        self.path = path
+        self._lock = threading.RLock()
+        self._cache: dict[str, Any] = self._load()
+        self._apply_local_only_env()
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.is_file():
+            return deepcopy(_DEFAULT)
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            log.warning("storage.store: failed to read %s: %s", self.path, e)
+            return deepcopy(_DEFAULT)
+        if not isinstance(raw, dict):
+            return deepcopy(_DEFAULT)
+        merged = deepcopy(_DEFAULT)
+        merged["local_only"] = bool(raw.get("local_only", False))
+        entries = raw.get("checkpoints")
+        if isinstance(entries, list):
+            merged["checkpoints"] = [
+                e
+                for e in entries
+                if isinstance(e, dict) and e.get("id") and e.get("path")
+            ]
+        return merged
+
+    def _write(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(self._cache, indent=2), encoding="utf-8")
+        tmp.replace(self.path)
+
+    def _apply_local_only_env(self) -> None:
+        os.environ["SA3_LOCAL_ONLY"] = "1" if self._cache["local_only"] else "0"
+
+    # -- local-only ---------------------------------------------------------
+
+    def local_only(self) -> bool:
+        with self._lock:
+            return bool(self._cache["local_only"])
+
+    def set_local_only(self, enabled: bool) -> bool:
+        with self._lock:
+            self._cache["local_only"] = bool(enabled)
+            self._apply_local_only_env()
+            self._write()
+            return self._cache["local_only"]
+
+    # -- checkpoints ---------------------------------------------------------
+
+    def list_checkpoints(self) -> list[dict[str, Any]]:
+        """All registered entries, each stamped with whether it still resolves."""
+        with self._lock:
+            entries = deepcopy(self._cache["checkpoints"])
+        for entry in entries:
+            resolved = resolve_local_checkpoint(entry["path"])
+            entry["resolves"] = resolved is not None
+            if resolved:
+                entry["config_path"], entry["ckpt_path"] = resolved
+        return entries
+
+    def get_path(self, ck_id: str) -> str | None:
+        with self._lock:
+            for entry in self._cache["checkpoints"]:
+                if entry["id"] == ck_id:
+                    return entry["path"]
+        return None
+
+    def add_checkpoint(self, path: str, name: str | None = None) -> dict[str, Any]:
+        """Validate and register a checkpoint folder/file. Raises ValueError
+        when the path doesn't resolve to a config + checkpoint pair."""
+        resolved = resolve_local_checkpoint(path)
+        if resolved is None:
+            raise ValueError(
+                "No usable checkpoint found there. Point at a folder holding a "
+                "model config JSON plus one .safetensors file, or at the "
+                ".safetensors file itself with its config alongside."
+            )
+        config_path, ckpt_path = resolved
+        norm = str(Path(path).expanduser().resolve())
+        ck_id = "local:" + hashlib.sha1(norm.lower().encode()).hexdigest()[:8]
+        display = (name or "").strip() or Path(ckpt_path).parent.name
+        entry = {
+            "id": ck_id,
+            "name": display,
+            "path": norm,
+            "added_at": int(time.time()),
+        }
+        with self._lock:
+            self._cache["checkpoints"] = [
+                e for e in self._cache["checkpoints"] if e["id"] != ck_id
+            ] + [entry]
+            self._write()
+        out = deepcopy(entry)
+        out["resolves"] = True
+        out["config_path"], out["ckpt_path"] = config_path, ckpt_path
+        return out
+
+    def remove_checkpoint(self, ck_id: str) -> bool:
+        """Unregister an entry. Never touches the files on disk."""
+        with self._lock:
+            before = len(self._cache["checkpoints"])
+            self._cache["checkpoints"] = [
+                e for e in self._cache["checkpoints"] if e["id"] != ck_id
+            ]
+            changed = len(self._cache["checkpoints"]) != before
+            if changed:
+                self._write()
+            return changed
+
+
+_registry: CheckpointRegistry | None = None
+_registry_lock = threading.Lock()
+
+
+def get_registry() -> CheckpointRegistry:
+    global _registry
+    with _registry_lock:
+        if _registry is None:
+            _registry = CheckpointRegistry()
+        return _registry

--- a/backend/server.py
+++ b/backend/server.py
@@ -108,11 +108,30 @@ class LoraFormSlot:
     weight: float
 
 
+def _registered_local_models() -> list[str]:
+    """Ids of user-registered local checkpoints that currently resolve."""
+    try:
+        from backend.modules.storage.store import get_registry
+
+        return sorted(
+            e["id"] for e in get_registry().list_checkpoints() if e.get("resolves")
+        )
+    except Exception:
+        return []
+
+
 def _normalize_generation_model(model_name: str | None) -> str:
     """Return a supported DiT generation model, falling back away from AE-only names."""
     normalized = (model_name or "").strip().lower()
     if normalized in GENERATION_MODELS:
         return normalized
+    if normalized.startswith("local:"):
+        # User-registered local checkpoint (Models & Storage). Honor it only
+        # while the registry entry still resolves to real files.
+        from backend.modules.storage.store import get_registry
+
+        if get_registry().get_path(normalized):
+            return normalized
     return DEFAULT_GENERATION_MODEL
 
 
@@ -214,11 +233,26 @@ def _get_or_load_generation_pipeline(model_name: str):
         if normalized not in _generation_pipelines:
             from stable_audio_3.model import StableAudioModel
 
+            load_target = normalized
+            if normalized.startswith("local:"):
+                from backend.modules.storage.store import get_registry
+
+                load_target = get_registry().get_path(normalized)
+                if not load_target:
+                    raise HTTPException(
+                        404,
+                        f"Local checkpoint {normalized!r} is no longer registered. "
+                        "Re-add it under Settings → Models & Storage.",
+                    )
             _park_or_evict_other_generation_pipelines(normalized)
-            logger.info("model.load: starting from_pretrained for %r", normalized)
+            logger.info(
+                "model.load: starting from_pretrained for %r (%s)",
+                normalized,
+                load_target,
+            )
             t0 = time.perf_counter()
             _generation_pipelines[normalized] = StableAudioModel.from_pretrained(
-                normalized
+                load_target
             )
             dt = time.perf_counter() - t0
             logger.info(
@@ -866,7 +900,7 @@ async def model_info():
     return {
         "model_loaded": pipeline is not None,
         "active_model": _active_model_name,
-        "available_models": sorted(GENERATION_MODELS),
+        "available_models": sorted(GENERATION_MODELS) + _registered_local_models(),
         "loaded_models": sorted(_generation_pipelines),
         "sample_rate": sample_rate,
         "diffusion_objective": (

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1450,6 +1450,30 @@ ARC checkpoints bundle the autoencoder. Standalone SAME checkpoints share weight
 
 The MAKE Model dropdown also lists two engines beyond these checkpoints. `magenta-small` reaches the Magenta RealTime 2 sidecar for streaming text-to-music (§27). Suno cloud generation sits under `suno` (§26). Both options share the dropdown with the local Stable Audio models, so one session can move across them without leaving MAKE.
 
+### 21.1 Models & Storage: local checkpoints and the no-download guarantee
+
+Nothing downloads at startup. The backend boots without touching a checkpoint, and a model loads only at the first CREATE that needs it. Resolution runs local-first on every load:
+
+1. **Local model folders** — any directory listed in `local_models.txt` at the repo root or in the `SA3_LOCAL_MODELS_DIR` environment variable, plus a `models/` folder in the repo if present. Each folder holds subfolders named after the HF repo (for example `stable-audio-3-medium/`).
+2. **The Hugging Face cache** — anything a previous session already downloaded.
+3. **A one-time download** from the model's HF repo, only when neither local source has the files.
+
+**Settings → Models & Storage** puts all of this on screen:
+
+- **Local only (never download)** pins resolution to steps 1 and 2. A missing model then fails with a clear message instead of downloading. The switch persists across restarts (it drives `SA3_LOCAL_ONLY`).
+- **Catalog chips** show where each built-in model would come from right now: `local`, `cached`, or `download`.
+- **Add a checkpoint you already have** registers any checkpoint on disk: point it at a folder containing a model config JSON plus one `.safetensors` file, or at the `.safetensors` file itself with its config alongside. Registered checkpoints appear under **LOCAL CHECKPOINTS** in the MAKE Model dropdown and generate exactly like catalog models. Removing an entry only removes the dropdown entry; files are never touched.
+- **Where everything lives** lists every model location with its size and an **Open** button that reveals it in Explorer: the HF cache, each local model folder, the generated-audio library, the assistant's RAG index, the Torch hub cache, and the Magenta WSL assets and engine venv (via `\\wsl.localhost\…`).
+- **Hugging Face cache breakdown** expands to a per-repo size table, each row openable in Explorer.
+
+| Method · Path | Purpose |
+|---|---|
+| `GET /api/storage/locations` | Every model/data location with size and file count (`?refresh=1` recomputes). |
+| `GET /api/storage/hf-cache` | Per-repo breakdown of the Hugging Face cache. |
+| `GET/POST /api/storage/checkpoints` · `DELETE /api/storage/checkpoints/{id}` | List, register, and unregister local checkpoints. |
+| `GET/PUT /api/storage/local-only` | Read or set the no-download switch. |
+| `POST /api/storage/open` | Open a known location in Explorer. |
+
 ---
 
 ## 22. LoRA Adapter Types
@@ -1731,7 +1755,7 @@ Two offline helpers under `scripts/` bulk-import an existing SunoHarvester cache
 
 ## 27. Magenta RealTime 2
 
-The `magenta` module (`/api/magenta`) brings Google's **Magenta RealTime 2 (MRT2)** real-time music model into the Generate workspace as a text→music option. **"Magenta RT2 (text→music)"** is always present in the Model dropdown, and selecting it runs the GPU swap automatically: the Stable Audio model parks in CPU RAM (`POST /api/model/offload`), any other MRT2 engine is stopped, and the extended sidecar starts inside WSL2. A status pill beside the dropdown tracks the engine (amber **LOADING** during the one-time model load and compile, green **READY**, red **ERROR**). Selecting any Stable Audio model reverses the swap: the engine stops and the Stable Audio model returns to the GPU. No terminal is involved at any point.
+The `magenta` module (`/api/magenta`) brings Google's **Magenta RealTime 2 (MRT2)** real-time music model into the Generate workspace as a text→music option. **"Magenta RT2 (text→music)"** is always present in the Model dropdown, and selecting it runs the GPU swap automatically: the Stable Audio model parks in CPU RAM (`POST /api/model/offload`), any other MRT2 engine is stopped, and the extended sidecar starts inside WSL2. A status pill beside the dropdown tracks the engine (amber **LOADING** during the one-time model load and compile, green **READY**, red **ERROR**). On a machine where the WSL engine was never installed, the swap stops before touching the GPU and the pill shows amber **SETUP** instead; its tooltip points at `Setup-MRT2.bat`, the one-time consent-based installer. Selecting any Stable Audio model reverses the swap: the engine stops and the Stable Audio model returns to the GPU. No terminal is involved at any point.
 
 ![Magenta RealTime 2 text→music panel in the Generate workspace, the first non-Mac MRT2 port](screenshots/make-magenta-rt2.png)
 
@@ -1752,7 +1776,7 @@ The sidecar's `/health` carries an identity field (`app: "mrt2-extended"`), and 
 | `GET /api/magenta/probe` | Sidecar health + whether the model is loaded. |
 | `POST /api/magenta/generate` | Generate from text, notes, and/or an audio-style clip. |
 | `GET /api/magenta/jobs/{id}` | Poll a generation job. |
-| `POST /api/magenta/engine/start` | The automatic swap: parks the SA3 model in CPU RAM, stops any other MRT2 engine, spawns the extended sidecar in WSL2. Refuses with 409 while a generation runs. |
+| `POST /api/magenta/engine/start` | The automatic swap: parks the SA3 model in CPU RAM, stops any other MRT2 engine, spawns the extended sidecar in WSL2. Refuses with 409 while a generation runs, and with 412 (`setup_required`) when the WSL venv or model checkpoint is missing. |
 | `POST /api/magenta/engine/stop` | Stops every MRT2 engine and restores the SA3 model to the GPU. |
 | `GET /api/magenta/engine/status` | Engine health, protocol identity, and spawned-process state. |
 | `POST /api/model/offload` · `POST /api/model/onload` · `GET /api/model/offload-status` | The SA3 side of the swap: park the loaded model(s) in CPU RAM, restore them to VRAM, and report the parked state. The engine endpoints call these automatically. |

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T19:17:38.369Z · Git revision: `915b82a8cb57` · Repomix tracked: **no**
+> Generated: 2026-06-12T20:41:30.671Z · Git revision: `89a17371d796` · Repomix tracked: **no**
 
 ## Audit Dashboard
 
@@ -33,7 +33,7 @@
 | `library-bundle-download-lineage-export` | Library bundle downloads and lineage graph exports including metadata, stems, MIDI, and relations | library | implemented | **documented** | #12-2-3d-graph-controls<br>#13-4-per-entry-controls<br>#13-5-bundle-downloads-and-lineage<br>#19-13-disk-backed-library | Matched 2/4 guide terms. |
 | `library-stems-sidecar` | Stem separation sidecar with install/start/stop/status/progress/abort and persisted stem rows | library | implemented | **documented** | #13-4-per-entry-controls<br>#13-6-stem-separation<br>#19-15-stems<br>#credits | Matched 3/4 guide terms. |
 | `library-midi-conversion` | Audio-to-MIDI conversion with installable engines, persisted MIDI rows, and editor send targets | library | implemented | **documented** | #6-4-1-microphone-recorder<br>#13-4-per-entry-controls<br>#13-7-midi-conversion<br>#19-16-midi<br>#33-notation-score-tabs-and-arrangements | Matched 4/4 guide terms. |
-| `settings-feature-toggles-modules-admin` | Settings modal for feature toggles, module enablement, restart, and shutdown controls | settings | implemented | **documented** | #one-shot-launcher-windows<br>#13-4-per-entry-controls<br>#19-8-jobs-list<br>#19-11-assistant<br>#19-12-module-loader<br>#api-unreachable-banner-in-the-header<br>#backend-job-persistence<br>#25-3-current-feature-to-screenshot-map<br>#32-admin-module-and-assistant-key-apis | Matched 4/5 guide terms. |
+| `settings-feature-toggles-modules-admin` | Settings modal for feature toggles, module enablement, restart, and shutdown controls | settings | implemented | **documented** | #one-shot-launcher-windows<br>#13-4-per-entry-controls<br>#19-8-jobs-list<br>#19-11-assistant<br>#19-12-module-loader<br>#21-1-models-storage-local-checkpoints-and-the-no-download-guarantee<br>#api-unreachable-banner-in-the-header<br>#backend-job-persistence<br>#25-3-current-feature-to-screenshot-map<br>#32-admin-module-and-assistant-key-apis | Matched 4/5 guide terms. |
 | `waveform-editor-inpaint-review` | Waveform editor paintbrush inpainting workflow with crop-aware mask submission and accept/discard review | daw | implemented | **documented** | #frontend-dependencies<br>#6-5-inpainting-regen-region<br>#6-8-run-generation<br>#7-4-inpainting-from-the-editor<br>#10-2-pop-out-and-mobile<br>#14-2-voice-synthesis<br>#16-5-media<br>#controls<br>#19-4-generation-async-thedaw-ui<br>#19-12-module-loader<br>#19-13-disk-backed-library<br>#19-14-chimera<br>#26-1-modes | Matched 5/5 guide terms. |
 | `sequencer-midi-export-render` | Step sequencer Standard MIDI export plus single-track/multi-track render-to-editor flows | daw | implemented | **documented** | #13-7-midi-conversion<br>#14-5-midi-export<br>#15-5-midi-import-and-export | Matched 2/4 guide terms. |
 | `piano-roll-linked-clip-editing` | Piano roll MIDI import/export, render-to-editor, and linked clip re-editing | daw | implemented | **documented** | #15-5-midi-import-and-export<br>#15-7-edit-in-piano-roll<br>#16-6-slide | Matched 4/4 guide terms. |

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T19:17:38.369Z",
-  "repoRevision": "915b82a8cb57",
+  "generatedAt": "2026-06-12T20:41:30.671Z",
+  "repoRevision": "89a17371d796",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,
@@ -735,6 +735,7 @@
         "#19-8-jobs-list",
         "#19-11-assistant",
         "#19-12-module-loader",
+        "#21-1-models-storage-local-checkpoints-and-the-no-download-guarantee",
         "#api-unreachable-banner-in-the-header",
         "#backend-job-persistence",
         "#25-3-current-feature-to-screenshot-map",

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T19:19:37.411Z",
+  "generatedAt": "2026-06-12T20:43:38.678Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -1450,6 +1450,30 @@ ARC checkpoints bundle the autoencoder. Standalone SAME checkpoints share weight
 
 The MAKE Model dropdown also lists two engines beyond these checkpoints. `magenta-small` reaches the Magenta RealTime 2 sidecar for streaming text-to-music (§27). Suno cloud generation sits under `suno` (§26). Both options share the dropdown with the local Stable Audio models, so one session can move across them without leaving MAKE.
 
+### 21.1 Models & Storage: local checkpoints and the no-download guarantee
+
+Nothing downloads at startup. The backend boots without touching a checkpoint, and a model loads only at the first CREATE that needs it. Resolution runs local-first on every load:
+
+1. **Local model folders** — any directory listed in `local_models.txt` at the repo root or in the `SA3_LOCAL_MODELS_DIR` environment variable, plus a `models/` folder in the repo if present. Each folder holds subfolders named after the HF repo (for example `stable-audio-3-medium/`).
+2. **The Hugging Face cache** — anything a previous session already downloaded.
+3. **A one-time download** from the model's HF repo, only when neither local source has the files.
+
+**Settings → Models & Storage** puts all of this on screen:
+
+- **Local only (never download)** pins resolution to steps 1 and 2. A missing model then fails with a clear message instead of downloading. The switch persists across restarts (it drives `SA3_LOCAL_ONLY`).
+- **Catalog chips** show where each built-in model would come from right now: `local`, `cached`, or `download`.
+- **Add a checkpoint you already have** registers any checkpoint on disk: point it at a folder containing a model config JSON plus one `.safetensors` file, or at the `.safetensors` file itself with its config alongside. Registered checkpoints appear under **LOCAL CHECKPOINTS** in the MAKE Model dropdown and generate exactly like catalog models. Removing an entry only removes the dropdown entry; files are never touched.
+- **Where everything lives** lists every model location with its size and an **Open** button that reveals it in Explorer: the HF cache, each local model folder, the generated-audio library, the assistant's RAG index, the Torch hub cache, and the Magenta WSL assets and engine venv (via `\\wsl.localhost\…`).
+- **Hugging Face cache breakdown** expands to a per-repo size table, each row openable in Explorer.
+
+| Method · Path | Purpose |
+|---|---|
+| `GET /api/storage/locations` | Every model/data location with size and file count (`?refresh=1` recomputes). |
+| `GET /api/storage/hf-cache` | Per-repo breakdown of the Hugging Face cache. |
+| `GET/POST /api/storage/checkpoints` · `DELETE /api/storage/checkpoints/{id}` | List, register, and unregister local checkpoints. |
+| `GET/PUT /api/storage/local-only` | Read or set the no-download switch. |
+| `POST /api/storage/open` | Open a known location in Explorer. |
+
 ---
 
 ## 22. LoRA Adapter Types
@@ -1731,7 +1755,7 @@ Two offline helpers under `scripts/` bulk-import an existing SunoHarvester cache
 
 ## 27. Magenta RealTime 2
 
-The `magenta` module (`/api/magenta`) brings Google's **Magenta RealTime 2 (MRT2)** real-time music model into the Generate workspace as a text→music option. **"Magenta RT2 (text→music)"** is always present in the Model dropdown, and selecting it runs the GPU swap automatically: the Stable Audio model parks in CPU RAM (`POST /api/model/offload`), any other MRT2 engine is stopped, and the extended sidecar starts inside WSL2. A status pill beside the dropdown tracks the engine (amber **LOADING** during the one-time model load and compile, green **READY**, red **ERROR**). Selecting any Stable Audio model reverses the swap: the engine stops and the Stable Audio model returns to the GPU. No terminal is involved at any point.
+The `magenta` module (`/api/magenta`) brings Google's **Magenta RealTime 2 (MRT2)** real-time music model into the Generate workspace as a text→music option. **"Magenta RT2 (text→music)"** is always present in the Model dropdown, and selecting it runs the GPU swap automatically: the Stable Audio model parks in CPU RAM (`POST /api/model/offload`), any other MRT2 engine is stopped, and the extended sidecar starts inside WSL2. A status pill beside the dropdown tracks the engine (amber **LOADING** during the one-time model load and compile, green **READY**, red **ERROR**). On a machine where the WSL engine was never installed, the swap stops before touching the GPU and the pill shows amber **SETUP** instead; its tooltip points at `Setup-MRT2.bat`, the one-time consent-based installer. Selecting any Stable Audio model reverses the swap: the engine stops and the Stable Audio model returns to the GPU. No terminal is involved at any point.
 
 ![Magenta RealTime 2 text→music panel in the Generate workspace, the first non-Mac MRT2 port](screenshots/make-magenta-rt2.png)
 
@@ -1752,7 +1776,7 @@ The sidecar's `/health` carries an identity field (`app: "mrt2-extended"`), and 
 | `GET /api/magenta/probe` | Sidecar health + whether the model is loaded. |
 | `POST /api/magenta/generate` | Generate from text, notes, and/or an audio-style clip. |
 | `GET /api/magenta/jobs/{id}` | Poll a generation job. |
-| `POST /api/magenta/engine/start` | The automatic swap: parks the SA3 model in CPU RAM, stops any other MRT2 engine, spawns the extended sidecar in WSL2. Refuses with 409 while a generation runs. |
+| `POST /api/magenta/engine/start` | The automatic swap: parks the SA3 model in CPU RAM, stops any other MRT2 engine, spawns the extended sidecar in WSL2. Refuses with 409 while a generation runs, and with 412 (`setup_required`) when the WSL venv or model checkpoint is missing. |
 | `POST /api/magenta/engine/stop` | Stops every MRT2 engine and restores the SA3 model to the GPU. |
 | `GET /api/magenta/engine/status` | Engine health, protocol identity, and spawned-process state. |
 | `POST /api/model/offload` · `POST /api/model/onload` · `GET /api/model/offload-status` | The SA3 side of the swap: park the loaded model(s) in CPU RAM, restore them to VRAM, and report the parked state. The engine endpoints call these automatically. |

--- a/frontend/src/components/layout/SettingsModal.tsx
+++ b/frontend/src/components/layout/SettingsModal.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { Settings, X, Package, RefreshCw, AlertTriangle, ToggleLeft, ToggleRight, Activity, Scissors, Music, Power, CheckCircle2, AlertCircle, PowerOff, ChevronRight, LayoutGrid } from 'lucide-react';
+import { Settings, X, Package, RefreshCw, AlertTriangle, ToggleLeft, ToggleRight, Activity, Scissors, Music, Power, CheckCircle2, AlertCircle, PowerOff, ChevronRight, LayoutGrid, HardDrive } from 'lucide-react';
 import { useFeatureToggleStore } from '../../state/featureToggleStore';
+import {
+  addCheckpoint, fetchCheckpoints, fetchHfCache, fetchLocations, formatBytes,
+  openLocation, removeCheckpoint, setLocalOnly,
+  type CatalogModel, type HfRepo, type RegisteredCheckpoint, type StorageLocation,
+} from '../../lib/storageClient';
 import { useLayoutPrefs, UI_SCALE_MIN, UI_SCALE_MAX } from '../../state/layoutPrefsStore';
 import { SlideTrack } from '../audio/SlideTrack';
 // CHANGED: Suno cloud-generation API key section (surfaced in Settings).
@@ -260,6 +265,8 @@ export const SettingsModal: React.FC<{ open: boolean; onClose: () => void }> = (
             </p>
           </div>
 
+          <StorageSettingsSection />
+
           {/* Section: Modules */}
           <div className="flex items-center gap-1.5 mb-2 pt-2 border-t border-white/5">
             <Package className="w-3 h-3 text-purple-400" />
@@ -288,6 +295,230 @@ export const SettingsModal: React.FC<{ open: boolean; onClose: () => void }> = (
         </div>
       </div>
     </div>
+  );
+};
+
+/* ── Models & Storage (local checkpoints, model locations, HF cache) ──────── */
+const StorageSettingsSection: React.FC = () => {
+  const [registered, setRegistered] = useState<RegisteredCheckpoint[]>([]);
+  const [catalog, setCatalog] = useState<CatalogModel[]>([]);
+  const [localOnly, setLocalOnlyState] = useState(false);
+  const [locations, setLocations] = useState<StorageLocation[]>([]);
+  const [hfRepos, setHfRepos] = useState<HfRepo[]>([]);
+  const [hfTotal, setHfTotal] = useState(0);
+  const [hfOpen, setHfOpen] = useState(false);
+  const [addPath, setAddPath] = useState('');
+  const [addName, setAddName] = useState('');
+  const [addError, setAddError] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [sizesLoading, setSizesLoading] = useState(false);
+
+  const reload = React.useCallback(() => {
+    fetchCheckpoints()
+      .then((d) => { setRegistered(d.registered); setCatalog(d.catalog); setLocalOnlyState(d.local_only); })
+      .catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    reload();
+    setSizesLoading(true);
+    fetchLocations().then(setLocations).catch(() => setLocations([])).finally(() => setSizesLoading(false));
+    fetchHfCache().then((d) => { setHfRepos(d.repos); setHfTotal(d.total_bytes); }).catch(() => setHfRepos([]));
+  }, [reload]);
+
+  const onAdd = async () => {
+    const path = addPath.trim();
+    if (!path) return;
+    setAdding(true);
+    setAddError(null);
+    try {
+      await addCheckpoint(path, addName.trim() || undefined);
+      setAddPath('');
+      setAddName('');
+      reload();
+    } catch (e) {
+      setAddError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const sourceChip = (source: CatalogModel['source']) =>
+    source === 'local' ? 'border-emerald-500/40 text-emerald-300 bg-emerald-500/10'
+      : source === 'cached' ? 'border-sky-500/40 text-sky-300 bg-sky-500/10'
+      : 'border-zinc-600/40 text-zinc-400 bg-white/3';
+
+  return (
+    <>
+      {/* Section: Models & Storage */}
+      <div className="flex items-center gap-1.5 mb-2 pt-2 border-t border-white/5">
+        <HardDrive className="w-3 h-3 text-purple-400" />
+        <span className="text-[9px] font-black uppercase tracking-widest text-zinc-300">Models &amp; Storage</span>
+        <span className="text-[8px] font-mono text-zinc-600 ml-auto">nothing downloads at startup</span>
+      </div>
+      <p className="text-[9px] text-zinc-500 mb-2 leading-relaxed">
+        Models load on demand at the first CREATE. Resolution order: local folders, the Hugging Face cache, then a one-time download. Register any checkpoint below and it appears in the MAKE Model dropdown.
+      </p>
+
+      {/* Local-only switch */}
+      <button
+        onClick={() => { void setLocalOnly(!localOnly).then(setLocalOnlyState).catch(() => undefined); }}
+        aria-pressed={localOnly}
+        className="w-full flex items-center gap-2 px-2.5 py-1.5 mb-2 rounded border border-white/10 bg-white/3 hover:bg-white/5 transition-colors text-left"
+      >
+        {localOnly
+          ? <ToggleRight className="w-4 h-4 text-emerald-400 shrink-0" />
+          : <ToggleLeft className="w-4 h-4 text-zinc-600 shrink-0" />}
+        <span className="text-[10px] text-zinc-200 font-bold">Local only (never download)</span>
+        <span className="text-[8px] text-zinc-500 ml-auto">missing models fail loudly instead of downloading</span>
+      </button>
+
+      {/* Catalog availability */}
+      <div className="flex items-center gap-1 flex-wrap mb-2">
+        {catalog.map((m) => (
+          <span
+            key={m.name}
+            className={`text-[8px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded border ${sourceChip(m.source)}`}
+            title={`${m.repo_id} — ${m.source === 'download' ? 'will download on first use' : `resolved ${m.source}`}`}
+          >
+            {m.name}: {m.source}
+          </span>
+        ))}
+      </div>
+
+      {/* Registered local checkpoints */}
+      <div className="flex flex-col gap-1 mb-2">
+        {registered.map((ck) => (
+          <div key={ck.id} className={`flex items-center gap-2 px-2.5 py-1.5 rounded border ${ck.resolves ? 'border-white/10 bg-white/3' : 'border-red-500/30 bg-red-500/5'}`}>
+            <div className="min-w-0 flex-1">
+              <div className="text-[10px] font-bold text-zinc-200 truncate">{ck.name}</div>
+              <div className="text-[8px] font-mono text-zinc-500 truncate" title={ck.path}>{ck.path}</div>
+            </div>
+            {!ck.resolves && <span className="text-[8px] font-mono text-red-300 shrink-0">missing</span>}
+            <button
+              onClick={() => { void openLocation(ck.path).catch(() => undefined); }}
+              className="text-[8px] font-mono uppercase px-1.5 py-0.5 rounded border border-white/10 text-zinc-400 hover:text-white hover:bg-white/5 transition-colors shrink-0"
+              aria-label={`Open ${ck.name} in Explorer`}
+            >
+              Open
+            </button>
+            <button
+              onClick={() => { void removeCheckpoint(ck.id).then(reload).catch(() => undefined); }}
+              className="text-[8px] font-mono uppercase px-1.5 py-0.5 rounded border border-red-500/30 text-red-300 hover:bg-red-500/10 transition-colors shrink-0"
+              aria-label={`Remove ${ck.name} from the model list (files stay on disk)`}
+              title="Removes the dropdown entry only — the files stay on disk."
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Add a checkpoint */}
+      <div className="flex flex-col gap-1 mb-2">
+        <label htmlFor="settings-ckpt-path" className="text-[9px] font-mono uppercase tracking-wider text-zinc-400">Add a checkpoint you already have</label>
+        <input
+          id="settings-ckpt-path"
+          name="settings-ckpt-path"
+          type="text"
+          value={addPath}
+          onChange={(e) => setAddPath(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') void onAdd(); }}
+          spellCheck={false}
+          placeholder="D:\models\my-finetune  (folder, or the .safetensors file)"
+          className="w-full bg-black/40 border border-white/10 rounded px-2 py-1.5 text-[10px] font-mono text-zinc-200 focus:border-purple-500/50 focus:outline-none"
+        />
+        <div className="flex gap-1.5">
+          <label htmlFor="settings-ckpt-name" className="sr-only">Display name for the checkpoint (optional)</label>
+          <input
+            id="settings-ckpt-name"
+            name="settings-ckpt-name"
+            type="text"
+            value={addName}
+            onChange={(e) => setAddName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') void onAdd(); }}
+            spellCheck={false}
+            placeholder="Display name (optional)"
+            className="flex-1 bg-black/40 border border-white/10 rounded px-2 py-1.5 text-[10px] font-mono text-zinc-200 focus:border-purple-500/50 focus:outline-none"
+          />
+          <button
+            onClick={() => void onAdd()}
+            disabled={adding || !addPath.trim()}
+            className="text-[9px] font-black uppercase tracking-widest px-3 rounded border border-purple-500/40 text-purple-200 bg-purple-500/15 hover:bg-purple-500/25 transition-colors disabled:opacity-40"
+          >
+            {adding ? 'Checking…' : 'Add'}
+          </button>
+        </div>
+        {addError && <p className="text-[8px] text-red-300">{addError}</p>}
+        <p className="text-[8px] text-zinc-600">
+          The folder needs a model config JSON next to one .safetensors file. Entries land under LOCAL CHECKPOINTS in the MAKE Model dropdown.
+        </p>
+      </div>
+
+      {/* Locations */}
+      <div className="flex items-center gap-1.5 mb-1">
+        <span className="text-[9px] font-mono uppercase tracking-wider text-zinc-400">Where everything lives</span>
+        {sizesLoading && <RefreshCw className="w-2.5 h-2.5 animate-spin text-zinc-600" />}
+        <button
+          onClick={() => {
+            setSizesLoading(true);
+            fetchLocations(true).then(setLocations).catch(() => undefined).finally(() => setSizesLoading(false));
+          }}
+          className="text-[8px] font-mono uppercase px-1.5 py-0.5 rounded border border-white/10 text-zinc-500 hover:text-white hover:bg-white/5 transition-colors ml-auto"
+        >
+          Refresh sizes
+        </button>
+      </div>
+      <div className="flex flex-col gap-1 mb-2">
+        {locations.map((loc) => (
+          <div key={loc.key} className="flex items-center gap-2 px-2.5 py-1 rounded border border-white/5 bg-white/3">
+            <div className="min-w-0 flex-1">
+              <div className="text-[9px] text-zinc-300 truncate">{loc.label}</div>
+              <div className="text-[8px] font-mono text-zinc-600 truncate" title={loc.path ?? undefined}>{loc.path ?? 'not found'}</div>
+            </div>
+            <span className="text-[9px] font-mono text-zinc-400 tabular-nums shrink-0">{loc.exists ? formatBytes(loc.bytes) : '—'}</span>
+            {loc.exists && loc.path && (
+              <button
+                onClick={() => { void openLocation(loc.path as string).catch(() => undefined); }}
+                className="text-[8px] font-mono uppercase px-1.5 py-0.5 rounded border border-white/10 text-zinc-400 hover:text-white hover:bg-white/5 transition-colors shrink-0"
+                aria-label={`Open ${loc.label} in Explorer`}
+              >
+                Open
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* HF cache breakdown */}
+      <button
+        onClick={() => setHfOpen((v) => !v)}
+        aria-expanded={hfOpen}
+        className="w-full flex items-center gap-1.5 mb-1 text-left"
+      >
+        <ChevronRight className={`w-3 h-3 text-zinc-500 transition-transform ${hfOpen ? 'rotate-90' : ''}`} />
+        <span className="text-[9px] font-mono uppercase tracking-wider text-zinc-400">Hugging Face cache breakdown</span>
+        <span className="text-[9px] font-mono text-zinc-500 tabular-nums ml-auto">{formatBytes(hfTotal)}</span>
+      </button>
+      {hfOpen && (
+        <div className="flex flex-col gap-0.5 mb-3">
+          {hfRepos.map((r) => (
+            <div key={r.repo_id} className="flex items-center gap-2 px-2.5 py-1 rounded border border-white/5">
+              <span className="text-[9px] font-mono text-zinc-300 truncate flex-1" title={r.path}>{r.repo_id}</span>
+              <span className="text-[9px] font-mono text-zinc-500 tabular-nums shrink-0">{formatBytes(r.bytes)}</span>
+              <button
+                onClick={() => { void openLocation(r.path).catch(() => undefined); }}
+                className="text-[8px] font-mono uppercase px-1.5 py-0.5 rounded border border-white/10 text-zinc-400 hover:text-white hover:bg-white/5 transition-colors shrink-0"
+                aria-label={`Open ${r.repo_id} in Explorer`}
+              >
+                Open
+              </button>
+            </div>
+          ))}
+          {hfRepos.length === 0 && <p className="text-[8px] text-zinc-600 px-2.5">The cache is empty.</p>}
+        </div>
+      )}
+    </>
   );
 };
 

--- a/frontend/src/lib/magentaEngineClient.ts
+++ b/frontend/src/lib/magentaEngineClient.ts
@@ -16,7 +16,7 @@ let _swapToken = 0;
 
 const setField = <K extends 'magentaEngine' | 'magentaAvailable'>(
   key: K,
-  value: K extends 'magentaEngine' ? 'off' | 'starting' | 'ready' | 'error' : boolean,
+  value: K extends 'magentaEngine' ? 'off' | 'starting' | 'ready' | 'error' | 'setup' : boolean,
 ): void => {
   useGenerateParamsStore.getState().setField(key, value as never);
 };
@@ -33,7 +33,15 @@ export async function swapEngineForModel(prevModel: string, nextModel: string): 
       const r = await fetch('/api/magenta/engine/start', { method: 'POST' });
       if (!r.ok) {
         const detail = await r.json().then((j) => j?.detail).catch(() => null);
-        throw new Error(detail || `engine start → HTTP ${r.status}`);
+        if (r.status === 412 && detail?.setup_required) {
+          // The WSL side was never installed — a guided state, not an error.
+          if (_swapToken === token) setField('magentaEngine', 'setup');
+          logError('magenta', detail.message || 'Magenta engine setup required: run Setup-MRT2.bat once.');
+          return;
+        }
+        throw new Error(
+          (typeof detail === 'string' ? detail : detail?.message) || `engine start → HTTP ${r.status}`,
+        );
       }
       logInfo('magenta', 'Engine starting: SA3 parked, WSL2 sidecar spawning');
       const deadline = Date.now() + READY_DEADLINE_MS;

--- a/frontend/src/lib/storageClient.ts
+++ b/frontend/src/lib/storageClient.ts
@@ -1,0 +1,113 @@
+// Models & Storage client — thin fetch wrappers over /api/storage.
+//
+// Backs two surfaces: the LOCAL group in the MAKE Model dropdown (registered
+// checkpoints generate via their `local:<id>` ids) and the Settings → Models
+// & Storage panel (locations browser, HF cache table, local-only switch).
+
+export interface RegisteredCheckpoint {
+  id: string; // "local:<8-hex>" — what the Model dropdown submits
+  name: string;
+  path: string;
+  added_at?: number;
+  resolves: boolean;
+  config_path?: string;
+  ckpt_path?: string;
+}
+
+export interface CatalogModel {
+  name: string;
+  repo_id: string;
+  source: 'local' | 'cached' | 'download';
+}
+
+export interface StorageLocation {
+  key: string;
+  label: string;
+  path: string | null;
+  kind: 'windows' | 'wsl';
+  exists: boolean;
+  bytes: number | null;
+  files: number | null;
+}
+
+export interface HfRepo {
+  repo_id: string;
+  repo_type: string;
+  bytes: number;
+  files: number;
+  path: string;
+  last_accessed: number | null;
+}
+
+async function json<T>(r: Response): Promise<T> {
+  if (!r.ok) {
+    const detail = await r.json().then((j) => j?.detail).catch(() => null);
+    throw new Error(typeof detail === 'string' ? detail : `HTTP ${r.status}`);
+  }
+  return r.json() as Promise<T>;
+}
+
+export async function fetchCheckpoints(): Promise<{
+  registered: RegisteredCheckpoint[];
+  catalog: CatalogModel[];
+  local_only: boolean;
+}> {
+  return json(await fetch('/api/storage/checkpoints'));
+}
+
+export async function addCheckpoint(path: string, name?: string): Promise<RegisteredCheckpoint> {
+  return json(
+    await fetch('/api/storage/checkpoints', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path, name: name || null }),
+    }),
+  );
+}
+
+export async function removeCheckpoint(id: string): Promise<void> {
+  await json(await fetch(`/api/storage/checkpoints/${encodeURIComponent(id)}`, { method: 'DELETE' }));
+}
+
+export async function fetchLocations(refresh = false): Promise<StorageLocation[]> {
+  const data = await json<{ locations: StorageLocation[] }>(
+    await fetch(`/api/storage/locations${refresh ? '?refresh=1' : ''}`),
+  );
+  return data.locations;
+}
+
+export async function fetchHfCache(): Promise<{ path: string; repos: HfRepo[]; total_bytes: number }> {
+  return json(await fetch('/api/storage/hf-cache'));
+}
+
+export async function setLocalOnly(enabled: boolean): Promise<boolean> {
+  const data = await json<{ enabled: boolean }>(
+    await fetch('/api/storage/local-only', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+    }),
+  );
+  return data.enabled;
+}
+
+export async function openLocation(path: string): Promise<void> {
+  await json(await fetch('/api/storage/open', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path }),
+  }));
+}
+
+export function formatBytes(bytes: number | null | undefined): string {
+  if (bytes === null || bytes === undefined) return '—';
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let v = bytes;
+  let u = -1;
+  do {
+    v /= 1024;
+    u += 1;
+  } while (v >= 1024 && u < units.length - 1);
+  return `${v.toFixed(v >= 100 ? 0 : 1)} ${units[u]}`;
+}

--- a/frontend/src/state/generateParamsStore.ts
+++ b/frontend/src/state/generateParamsStore.ts
@@ -146,8 +146,9 @@ export interface GenerateParamsState {
   magExtend: boolean; // continue the current piece (morph without a cut)
   magNotes: number[]; // selected MIDI pitches that steer the melody
   /** Lifecycle of the WSL2 engine behind the Magenta option — drives the
-   *  dropdown pill. The swap runs automatically on Model-dropdown change. */
-  magentaEngine: 'off' | 'starting' | 'ready' | 'error';
+   *  dropdown pill. The swap runs automatically on Model-dropdown change.
+   *  'setup' means the WSL side was never installed (run Setup-MRT2 once). */
+  magentaEngine: 'off' | 'starting' | 'ready' | 'error' | 'setup';
 }
 
 interface ParamsStore extends GenerateParamsState {

--- a/frontend/src/views/AdvancedGenPanel.tsx
+++ b/frontend/src/views/AdvancedGenPanel.tsx
@@ -27,6 +27,7 @@ import { RoundToggle } from '../components/audio/RoundToggle';
 import { VisualizerPanel } from '../components/audio/VisualizerPanelLazy';
 import { getMasterGain, usePlayerStore } from '../state/playerStore';
 import { swapEngineForModel } from '../lib/magentaEngineClient';
+import { fetchCheckpoints, type RegisteredCheckpoint } from '../lib/storageClient';
 import '../components/layout/track-controls.css';
 
 /* ── Full audio player (Compare row) ──────────────────────────────────── */
@@ -259,6 +260,15 @@ export const AdvancedGenPanel: React.FC<{
       .then((r) => r.json())
       .then((d) => useGenerateParamsStore.getState().setField('magentaAvailable', d?.available === true))
       .catch(() => useGenerateParamsStore.getState().setField('magentaAvailable', false));
+  }, []);
+
+  // User-registered local checkpoints (Settings → Models & Storage) appear as
+  // a LOCAL group in the Model dropdown and generate via their `local:` ids.
+  const [localModels, setLocalModels] = useState<RegisteredCheckpoint[]>([]);
+  useEffect(() => {
+    fetchCheckpoints()
+      .then((d) => setLocalModels(d.registered.filter((e) => e.resolves)))
+      .catch(() => setLocalModels([]));
   }, []);
 
   const lastAudioUrl = useGenerateStore((s) => s.lastAudioUrl);
@@ -536,7 +546,12 @@ export const AdvancedGenPanel: React.FC<{
                 <label htmlFor="gen-model" className="text-[11px] text-zinc-300 w-16 shrink-0">Model</label>
                 <select id="gen-model" name="gen-model" className="compact-input flex-1" value={p.model} onChange={(e) => {
                   const m = e.target.value; const prev = p.model;
-                  const isRf = m.endsWith('-rf'); const isMag = m.startsWith('magenta-');
+                  const isMag = m.startsWith('magenta-');
+                  // A registered local checkpoint follows its filename's ARC/RF
+                  // convention for sampler defaults; unknown names assume ARC.
+                  const localEntry = m.startsWith('local:') ? localModels.find((l) => l.id === m) : null;
+                  const isRf = m.endsWith('-rf')
+                    || /-rf\b|-rf[.-_]/i.test(localEntry?.ckpt_path ?? localEntry?.name ?? '');
                   patch({ model: m, steps: isMag ? 1 : isRf ? 50 : 8, cfg: isMag ? 1.0 : isRf ? 7.0 : 1.0 });
                   // GPU auto-swap: magenta selected → park SA3 + start the WSL2
                   // engine; SA3 selected → stop the engine + restore SA3.
@@ -548,20 +563,32 @@ export const AdvancedGenPanel: React.FC<{
                   <option value="medium-rf">Medium-RF</option>
                   <option value="magenta-small">Magenta RT2 (text→music)</option>
                   <option value="suno">Suno (Cloud)</option>
+                  {localModels.length > 0 && (
+                    <optgroup label="Local checkpoints">
+                      {localModels.map((l) => (
+                        <option key={l.id} value={l.id}>{l.name} (local)</option>
+                      ))}
+                    </optgroup>
+                  )}
                 </select>
                 {(p.model.startsWith('magenta-') || p.magentaEngine !== 'off') && (() => {
                   const st = p.magentaEngine === 'starting' ? 'starting'
+                    : p.magentaEngine === 'setup' ? 'setup'
                     : p.magentaEngine === 'error' ? 'error'
                     : (p.magentaEngine === 'ready' || p.magentaAvailable) ? 'ready' : 'off';
                   const cls = st === 'starting' ? 'border-amber-500/40 text-amber-300 bg-amber-500/10 animate-pulse'
+                    : st === 'setup' ? 'border-amber-500/40 text-amber-300 bg-amber-500/10'
                     : st === 'error' ? 'border-red-500/40 text-red-300 bg-red-500/10'
                     : st === 'ready' ? 'border-emerald-500/40 text-emerald-300 bg-emerald-500/10'
                     : 'border-zinc-600/40 text-zinc-400 bg-white/3';
-                  const label = st === 'starting' ? 'LOADING' : st === 'error' ? 'ERROR' : st === 'ready' ? 'READY' : 'OFF';
+                  const label = st === 'starting' ? 'LOADING' : st === 'setup' ? 'SETUP' : st === 'error' ? 'ERROR' : st === 'ready' ? 'READY' : 'OFF';
+                  const title = st === 'setup'
+                    ? 'The Magenta RT2 engine is not installed yet. Double-click Setup-MRT2.bat (in sidecars/magenta-rt2-nvidia) once — it checks the PC, asks consent, and installs everything. Then pick Magenta here again.'
+                    : 'Magenta RT2 engine. The GPU swap runs by itself when the Model changes: picking Magenta parks Stable Audio and starts the engine; picking an SA3 model stops it and restores Stable Audio.';
                   return (
                     <span
                       className={`text-[8px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded border shrink-0 ${cls}`}
-                      title="Magenta RT2 engine. The GPU swap runs by itself when the Model changes: picking Magenta parks Stable Audio and starts the engine; picking an SA3 model stops it and restores Stable Audio."
+                      title={title}
                     >
                       {label}
                     </span>

--- a/stable_audio_3/model.py
+++ b/stable_audio_3/model.py
@@ -11,7 +11,11 @@ from stable_audio_3.inference.audio_utils import (
 )
 from stable_audio_3.inference.sampling import sample_diffusion
 from stable_audio_3.loading_utils import load_autoencoder, load_diffusion_cond
-from stable_audio_3.model_configs import ae_models, all_models
+from stable_audio_3.model_configs import (
+    ae_models,
+    all_models,
+    resolve_local_checkpoint,
+)
 from stable_audio_3.models.lora import (
     load_and_apply_loras,
     set_lora_strength as _set_lora_strength,
@@ -48,13 +52,18 @@ class StableAudioModel:
                 )
             model_half = False
 
-        if model_name_or_path not in all_models:
-            raise ValueError(
-                f"Unknown model '{model_name_or_path}'. Valid models: {list(all_models)}"
-            )
-
-        model_cfg = all_models[model_name_or_path]
-        local_config, local_ckpt = model_cfg.resolve()
+        if model_name_or_path in all_models:
+            model_cfg = all_models[model_name_or_path]
+            local_config, local_ckpt = model_cfg.resolve()
+        else:
+            resolved = resolve_local_checkpoint(model_name_or_path)
+            if resolved is None:
+                raise ValueError(
+                    f"Unknown model '{model_name_or_path}'. Valid models: "
+                    f"{list(all_models)}, or a local folder/file containing a "
+                    f"model config JSON + a .safetensors checkpoint."
+                )
+            local_config, local_ckpt = resolved
         with open(local_config) as f:
             model_config = json.load(f)
 

--- a/stable_audio_3/model_configs.py
+++ b/stable_audio_3/model_configs.py
@@ -1,3 +1,4 @@
+import json
 import os
 import logging
 from dataclasses import dataclass
@@ -58,6 +59,53 @@ def _local_override(repo_id: str, filename: str) -> str | None:
             if candidate.is_file():
                 logger.info("Using local model file: %s", candidate)
                 return str(candidate)
+    return None
+
+
+def _is_model_config_json(path: Path) -> bool:
+    """Cheap sanity check that a JSON file is a model config, not metadata."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        return isinstance(data, dict) and "model_type" in data
+    except (OSError, ValueError):
+        return False
+
+
+def resolve_local_checkpoint(path_str: str) -> tuple[str, str] | None:
+    """Resolve a user-supplied checkpoint (folder or .safetensors file) to (config, ckpt).
+
+    Accepts either a folder holding a model config JSON plus a .safetensors
+    checkpoint, or a direct path to the .safetensors file with the config
+    alongside it. Returns None when the layout is missing or ambiguous
+    (several checkpoints in one folder and none named model.safetensors).
+    """
+    p = Path(str(path_str)).expanduser()
+    if p.is_file() and p.suffix == ".safetensors":
+        ckpt = p
+        folder = p.parent
+    elif p.is_dir():
+        folder = p
+        preferred = folder / "model.safetensors"
+        if preferred.is_file():
+            ckpt = preferred
+        else:
+            candidates = sorted(folder.glob("*.safetensors"))
+            if len(candidates) != 1:
+                return None
+            ckpt = candidates[0]
+    else:
+        return None
+
+    config_candidates = [
+        ckpt.with_suffix(".json"),
+        folder / "model_config.json",
+        *sorted(folder.glob("*.json")),
+    ]
+    for candidate in config_candidates:
+        if candidate.is_file() and _is_model_config_json(candidate):
+            logger.info("Using local checkpoint: %s (config %s)", ckpt, candidate)
+            return str(candidate), str(ckpt)
     return None
 
 


### PR DESCRIPTION
## Summary
- Nothing downloads at startup, verified in code: models load on demand and resolve local-first (local folders -> HF cache -> one-time download)
- `from_pretrained` accepts a local folder or .safetensors file; ambiguous folders are refused rather than guessed
- New storage module (`/api/storage`): location map with sizes (incl. Magenta WSL assets/venv via wsl.exe), HF cache per-repo breakdown, open-in-Explorer gated to known roots, local-checkpoint registry, persistent local-only switch (SA3_LOCAL_ONLY)
- Registered checkpoints appear under LOCAL CHECKPOINTS in the MAKE Model dropdown and generate through the normal load/park/wake lifecycle as `local:<id>`
- Settings -> Models & Storage panel: catalog source chips, add/remove checkpoints, local-only toggle, location browser, HF cache table
- Magenta engine/start refuses with 412 `setup_required` when the WSL side is missing; the dropdown pill shows SETUP pointing at Setup-MRT2.bat instead of a bare ERROR
- USER_GUIDE 21.1 + 27 and the README models paragraph document all of it

## Validation
- ruff check + format clean at repo root; tsc -b clean
- Live against the real rig: all 7 locations with correct sizes (incl. WSL UNC paths), HF cache scan (12.3 GB), catalog chips match reality (medium local, small download)
- Registry round-trip live: registered the real D:-drive ARC checkpoint, it appeared under LOCAL CHECKPOINTS in the dropdown, then removed
- Local-only PUT round-trip live; setup_state probe returns ready on this machine
- Found + fixed two wsl.exe interop bugs en route (argv quote re-joining, CRLF stdin)
- Pre-commit docs chain green, 9/9 screenshots