### PR TITLE
Feat/models and storage

### DIFF
--- a/backend/modules/storage/router.py
+++ b/backend/modules/storage/router.py
@@ -219,6 +219,16 @@ def storage_locations(refresh: bool = False) -> dict:
     return {"locations": items}
 
 
+@router.get("/resolution-log")
+def storage_resolution_log(since: int = 0) -> dict:
+    """Every recorded model/checkpoint resolution decision this session:
+    exactly which file came from which local folder, the HF cache, or a
+    download, including download-needed blocks in local-only mode."""
+    from stable_audio_3.model_configs import resolution_events
+
+    return {"events": resolution_events(since)}
+
+
 @router.get("/hf-cache")
 def storage_hf_cache() -> dict:
     cache_dir = _hf_cache_dir()

--- a/backend/modules/storage/store.py
+++ b/backend/modules/storage/store.py
@@ -94,7 +94,7 @@ class CheckpointRegistry:
         with self._lock:
             entries = deepcopy(self._cache["checkpoints"])
         for entry in entries:
-            resolved = resolve_local_checkpoint(entry["path"])
+            resolved = resolve_local_checkpoint(entry["path"], quiet=True)
             entry["resolves"] = resolved is not None
             if resolved:
                 entry["config_path"], entry["ckpt_path"] = resolved
@@ -110,7 +110,7 @@ class CheckpointRegistry:
     def add_checkpoint(self, path: str, name: str | None = None) -> dict[str, Any]:
         """Validate and register a checkpoint folder/file. Raises ValueError
         when the path doesn't resolve to a config + checkpoint pair."""
-        resolved = resolve_local_checkpoint(path)
+        resolved = resolve_local_checkpoint(path, quiet=True)
         if resolved is None:
             raise ValueError(
                 "No usable checkpoint found there. Point at a folder holding a "

--- a/backend/server.py
+++ b/backend/server.py
@@ -1029,6 +1029,38 @@ async def offload_status():
     }
 
 
+@app.post("/api/model/load")
+async def preload_model(model: str = Form(...)):
+    """Pre-load a generation model so the first CREATE starts instantly.
+
+    Same path the generate endpoints use: clears any resident MRT2 engine,
+    then loads (or wakes) the requested pipeline. The request stays open for
+    the duration of the load — minutes on a cold first load of medium.
+    """
+    if _generation_job_lock.locked():
+        raise HTTPException(
+            status_code=409,
+            detail="A generation is running; the model can't be swapped right now.",
+        )
+    normalized = _normalize_generation_model(model)
+    if normalized != (model or "").strip().lower():
+        raise HTTPException(404, f"Unknown generation model {model!r}.")
+    from backend.core.idle import get_idle_manager
+
+    get_idle_manager().bump_activity(tag="model-load")
+    loop = asyncio.get_event_loop()
+    t0 = time.perf_counter()
+    await loop.run_in_executor(None, _ensure_gpu_clear_of_magenta)
+    await loop.run_in_executor(None, _get_or_load_generation_pipeline, normalized)
+    return {
+        "loaded": True,
+        "model": normalized,
+        "seconds": round(time.perf_counter() - t0, 2),
+        "device": str(pipeline.device) if pipeline else None,
+        "vram_used_gb": _vram_used_gb(),
+    }
+
+
 @app.post("/api/spectrogram")
 async def generate_spectrogram(
     audio_base64: Optional[str] = Form(None),

--- a/backend/server.py
+++ b/backend/server.py
@@ -1046,9 +1046,11 @@ async def preload_model(model: str = Form(...)):
     if normalized != (model or "").strip().lower():
         raise HTTPException(404, f"Unknown generation model {model!r}.")
     from backend.core.idle import get_idle_manager
+    from stable_audio_3.model_configs import resolution_events, resolution_seq
 
     get_idle_manager().bump_activity(tag="model-load")
     loop = asyncio.get_event_loop()
+    since = resolution_seq()
     t0 = time.perf_counter()
     await loop.run_in_executor(None, _ensure_gpu_clear_of_magenta)
     await loop.run_in_executor(None, _get_or_load_generation_pipeline, normalized)
@@ -1058,6 +1060,9 @@ async def preload_model(model: str = Form(...)):
         "seconds": round(time.perf_counter() - t0, 2),
         "device": str(pipeline.device) if pipeline else None,
         "vram_used_gb": _vram_used_gb(),
+        # Exactly where every file came from (local folder / HF cache /
+        # downloaded). Empty when the pipeline was already loaded or parked.
+        "resolution": resolution_events(since),
     }
 
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1472,7 +1472,11 @@ Nothing downloads at startup. The backend boots without touching a checkpoint, a
 | `GET /api/storage/hf-cache` | Per-repo breakdown of the Hugging Face cache. |
 | `GET/POST /api/storage/checkpoints` · `DELETE /api/storage/checkpoints/{id}` | List, register, and unregister local checkpoints. |
 | `GET/PUT /api/storage/local-only` | Read or set the no-download switch. |
+| `GET /api/storage/resolution-log` | Every resolution decision this session: which file came from which local folder, the HF cache, or a download. |
 | `POST /api/storage/open` | Open a known location in Explorer. |
+| `POST /api/model/load` | Pre-load a model (the MAKE LOAD button); the response carries the full resolution trail. |
+
+Every load also narrates itself. The backend console prints one `model resolve:` line per file with the exact path it used, and a WARNING before anything downloads (including the T5Gemma text encoder's one-time fetch). The MAKE LOAD button echoes the same trail into the in-app LOG: where each file resolved from, a loud line when a download is about to happen, and a block notice when local-only mode stops one.
 
 ---
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T20:41:30.671Z · Git revision: `89a17371d796` · Repomix tracked: **no**
+> Generated: 2026-06-12T20:59:46.276Z · Git revision: `556e08443c4d` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-12T21:02:59.675Z · Git revision: `90662e8577d2` · Repomix tracked: **no**
+> Generated: 2026-06-12T21:17:06.039Z · Git revision: `86bc63f6f779` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T20:41:30.671Z",
-  "repoRevision": "89a17371d796",
+  "generatedAt": "2026-06-12T20:59:46.276Z",
+  "repoRevision": "556e08443c4d",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-12T21:02:59.675Z",
-  "repoRevision": "90662e8577d2",
+  "generatedAt": "2026-06-12T21:17:06.039Z",
+  "repoRevision": "86bc63f6f779",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T20:43:38.678Z",
+  "generatedAt": "2026-06-12T21:01:49.282Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-12T21:05:03.816Z",
+  "generatedAt": "2026-06-12T21:19:10.481Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -1472,7 +1472,11 @@ Nothing downloads at startup. The backend boots without touching a checkpoint, a
 | `GET /api/storage/hf-cache` | Per-repo breakdown of the Hugging Face cache. |
 | `GET/POST /api/storage/checkpoints` · `DELETE /api/storage/checkpoints/{id}` | List, register, and unregister local checkpoints. |
 | `GET/PUT /api/storage/local-only` | Read or set the no-download switch. |
+| `GET /api/storage/resolution-log` | Every resolution decision this session: which file came from which local folder, the HF cache, or a download. |
 | `POST /api/storage/open` | Open a known location in Explorer. |
+| `POST /api/model/load` | Pre-load a model (the MAKE LOAD button); the response carries the full resolution trail. |
+
+Every load also narrates itself. The backend console prints one `model resolve:` line per file with the exact path it used, and a WARNING before anything downloads (including the T5Gemma text encoder's one-time fetch). The MAKE LOAD button echoes the same trail into the in-app LOG: where each file resolved from, a loud line when a download is about to happen, and a block notice when local-only mode stops one.
 
 ---
 

--- a/frontend/src/views/AdvancedGenPanel.tsx
+++ b/frontend/src/views/AdvancedGenPanel.tsx
@@ -28,7 +28,7 @@ import { VisualizerPanel } from '../components/audio/VisualizerPanelLazy';
 import { getMasterGain, usePlayerStore } from '../state/playerStore';
 import { swapEngineForModel } from '../lib/magentaEngineClient';
 import { fetchCheckpoints, type RegisteredCheckpoint } from '../lib/storageClient';
-import { logError, logInfo } from '../state/logStore';
+import { logError, logInfo, logWarn } from '../state/logStore';
 import '../components/layout/track-controls.css';
 
 /* ── Full audio player (Compare row) ──────────────────────────────────── */
@@ -286,6 +286,18 @@ export const AdvancedGenPanel: React.FC<{
   const preloadModel = useCallback(async (model: string) => {
     setModelLoadState('loading');
     try {
+      // Pre-flight: announce where this model will come from BEFORE loading,
+      // and call out loudly when a download is about to happen.
+      if (!model.startsWith('local:')) {
+        const cat = await fetchCheckpoints().then((d) => d.catalog.find((c) => c.name === model)).catch(() => null);
+        if (cat?.source === 'download') {
+          logWarn('model', `${model}: not in any local folder or the HF cache — this load DOWNLOADS it from huggingface.co/${cat.repo_id} (one-time)`);
+        } else if (cat) {
+          logInfo('model', `${model}: resolves ${cat.source === 'local' ? 'from a local folder' : 'from the HF cache'} — no download`);
+        }
+      } else {
+        logInfo('model', `${model}: registered local checkpoint — no download`);
+      }
       const form = new FormData();
       form.append('model', model);
       const r = await fetch('/api/model/load', { method: 'POST', body: form });
@@ -294,6 +306,16 @@ export const AdvancedGenPanel: React.FC<{
         throw new Error(typeof detail === 'string' ? detail : `HTTP ${r.status}`);
       }
       const d = await r.json();
+      // Echo the backend's resolution trail: the exact file paths used and
+      // whether anything was downloaded.
+      for (const ev of d.resolution ?? []) {
+        const line = `${ev.label} ← ${ev.source}${ev.path ? `  ${ev.path}` : ''}${ev.detail ? `  (${ev.detail})` : ''}`;
+        if (String(ev.source).startsWith('download')) logWarn('model', line);
+        else logInfo('model', line);
+      }
+      if (!(d.resolution ?? []).length) {
+        logInfo('model', `${d.model}: already in memory — no files re-read, nothing downloaded`);
+      }
       setActiveModel(d.model);
       setModelLoadState('idle');
       logInfo('model', `${d.model} loaded in ${d.seconds}s (${d.device ?? '?'}; ${d.vram_used_gb ?? '?'} GB VRAM)`);

--- a/frontend/src/views/AdvancedGenPanel.tsx
+++ b/frontend/src/views/AdvancedGenPanel.tsx
@@ -28,6 +28,7 @@ import { VisualizerPanel } from '../components/audio/VisualizerPanelLazy';
 import { getMasterGain, usePlayerStore } from '../state/playerStore';
 import { swapEngineForModel } from '../lib/magentaEngineClient';
 import { fetchCheckpoints, type RegisteredCheckpoint } from '../lib/storageClient';
+import { logError, logInfo } from '../state/logStore';
 import '../components/layout/track-controls.css';
 
 /* ── Full audio player (Compare row) ──────────────────────────────────── */
@@ -269,6 +270,37 @@ export const AdvancedGenPanel: React.FC<{
     fetchCheckpoints()
       .then((d) => setLocalModels(d.registered.filter((e) => e.resolves)))
       .catch(() => setLocalModels([]));
+  }, []);
+
+  // Pre-load (LOAD button): fire the checkpoint onto the GPU before CREATE.
+  // activeModel mirrors the backend's resident pipeline so the button reads
+  // LOADED when the selection is already up.
+  const [activeModel, setActiveModel] = useState<string | null>(null);
+  const [modelLoadState, setModelLoadState] = useState<'idle' | 'loading' | 'error'>('idle');
+  useEffect(() => {
+    fetch('/api/model-info')
+      .then((r) => r.json())
+      .then((d) => setActiveModel(d?.model_loaded ? d.active_model : null))
+      .catch(() => undefined);
+  }, []);
+  const preloadModel = useCallback(async (model: string) => {
+    setModelLoadState('loading');
+    try {
+      const form = new FormData();
+      form.append('model', model);
+      const r = await fetch('/api/model/load', { method: 'POST', body: form });
+      if (!r.ok) {
+        const detail = await r.json().then((j) => j?.detail).catch(() => null);
+        throw new Error(typeof detail === 'string' ? detail : `HTTP ${r.status}`);
+      }
+      const d = await r.json();
+      setActiveModel(d.model);
+      setModelLoadState('idle');
+      logInfo('model', `${d.model} loaded in ${d.seconds}s (${d.device ?? '?'}; ${d.vram_used_gb ?? '?'} GB VRAM)`);
+    } catch (e) {
+      setModelLoadState('error');
+      logError('model', `Model load failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
   }, []);
 
   const lastAudioUrl = useGenerateStore((s) => s.lastAudioUrl);
@@ -553,6 +585,7 @@ export const AdvancedGenPanel: React.FC<{
                   const isRf = m.endsWith('-rf')
                     || /-rf\b|-rf[.-_]/i.test(localEntry?.ckpt_path ?? localEntry?.name ?? '');
                   patch({ model: m, steps: isMag ? 1 : isRf ? 50 : 8, cfg: isMag ? 1.0 : isRf ? 7.0 : 1.0 });
+                  setModelLoadState('idle');
                   // GPU auto-swap: magenta selected → park SA3 + start the WSL2
                   // engine; SA3 selected → stop the engine + restore SA3.
                   void swapEngineForModel(prev, m);
@@ -571,6 +604,27 @@ export const AdvancedGenPanel: React.FC<{
                     </optgroup>
                   )}
                 </select>
+                {!isMagenta && p.model !== 'suno' && (() => {
+                  const loaded = activeModel === p.model && modelLoadState !== 'loading';
+                  const label = modelLoadState === 'loading' ? 'LOADING'
+                    : loaded ? 'LOADED'
+                    : modelLoadState === 'error' ? 'RETRY' : 'LOAD';
+                  const cls = modelLoadState === 'loading' ? 'border-amber-500/40 text-amber-300 bg-amber-500/10 animate-pulse'
+                    : loaded ? 'border-emerald-500/40 text-emerald-300 bg-emerald-500/10'
+                    : modelLoadState === 'error' ? 'border-red-500/40 text-red-300 bg-red-500/10 hover:bg-red-500/20'
+                    : 'border-purple-500/40 text-purple-200 bg-purple-500/10 hover:bg-purple-500/20';
+                  return (
+                    <button
+                      type="button"
+                      onClick={() => { if (!loaded && modelLoadState !== 'loading') void preloadModel(p.model); }}
+                      disabled={loaded || modelLoadState === 'loading'}
+                      className={`text-[8px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded border shrink-0 transition-colors disabled:cursor-default ${cls}`}
+                      title="Pre-load this model onto the GPU now so the first CREATE starts instantly. A cold first load of Medium takes a few minutes; reloads from RAM take seconds."
+                    >
+                      {label}
+                    </button>
+                  );
+                })()}
                 {(p.model.startsWith('magenta-') || p.magentaEngine !== 'off') && (() => {
                   const st = p.magentaEngine === 'starting' ? 'starting'
                     : p.magentaEngine === 'setup' ? 'setup'

--- a/stable_audio_3/model_configs.py
+++ b/stable_audio_3/model_configs.py
@@ -1,12 +1,107 @@
 import json
 import os
 import logging
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
 from huggingface_hub import hf_hub_download, try_to_load_from_cache
 
 logger = logging.getLogger(__name__)
+
+
+# ── Resolution events ────────────────────────────────────────────────────────
+# Every model/checkpoint resolution decision is recorded here AND logged to the
+# console, so it is always visible exactly where a file came from (local
+# folder, HF cache, fresh download) and when a download is about to happen.
+# The backend surfaces these events to the UI (/api/model/load response and
+# /api/storage/resolution-log).
+
+_RESOLUTION_EVENTS: list[dict] = []
+_RESOLUTION_CAP = 200
+_resolution_lock = threading.Lock()
+_resolution_seq = 0
+
+
+def note_resolution(
+    label: str,
+    source: str,
+    *,
+    path: str | None = None,
+    repo_id: str | None = None,
+    detail: str | None = None,
+    level: int = logging.INFO,
+) -> None:
+    """Record + log one resolution decision.
+
+    source: 'local-folder' | 'local-checkpoint' | 'hf-cache' |
+            'download-start' | 'downloaded' | 'download-needed'
+    """
+    global _resolution_seq
+    parts = [f"model resolve: {label} <- {source}"]
+    if path:
+        parts.append(path)
+    if detail:
+        parts.append(f"({detail})")
+    logger.log(level, " ".join(parts))
+    with _resolution_lock:
+        _resolution_seq += 1
+        _RESOLUTION_EVENTS.append(
+            {
+                "seq": _resolution_seq,
+                "ts": time.time(),
+                "label": label,
+                "source": source,
+                "path": path,
+                "repo_id": repo_id,
+                "detail": detail,
+            }
+        )
+        del _RESOLUTION_EVENTS[:-_RESOLUTION_CAP]
+
+
+def resolution_events(since_seq: int = 0) -> list[dict]:
+    with _resolution_lock:
+        return [e for e in _RESOLUTION_EVENTS if e["seq"] > since_seq]
+
+
+def resolution_seq() -> int:
+    with _resolution_lock:
+        return _resolution_seq
+
+
+def _resolve_one_file(repo_id: str, filename: str) -> str:
+    """Resolve one repo file local-first, recording every step."""
+    local = _local_override(repo_id, filename)
+    if local is not None:
+        note_resolution(
+            f"{repo_id}/{filename}", "local-folder", path=local, repo_id=repo_id
+        )
+        return local
+    cached = try_to_load_from_cache(repo_id, filename)
+    if isinstance(cached, str):
+        note_resolution(
+            f"{repo_id}/{filename}", "hf-cache", path=cached, repo_id=repo_id
+        )
+        return cached
+    note_resolution(
+        f"{repo_id}/{filename}",
+        "download-start",
+        repo_id=repo_id,
+        detail=f"not in any local folder or the HF cache -> downloading from https://huggingface.co/{repo_id}",
+        level=logging.WARNING,
+    )
+    t0 = time.perf_counter()
+    downloaded = hf_hub_download(repo_id=repo_id, filename=filename)
+    note_resolution(
+        f"{repo_id}/{filename}",
+        "downloaded",
+        path=downloaded,
+        repo_id=repo_id,
+        detail=f"{time.perf_counter() - t0:.1f}s",
+    )
+    return downloaded
 
 
 def _local_search_dirs() -> list[Path]:
@@ -72,13 +167,16 @@ def _is_model_config_json(path: Path) -> bool:
         return False
 
 
-def resolve_local_checkpoint(path_str: str) -> tuple[str, str] | None:
+def resolve_local_checkpoint(
+    path_str: str, quiet: bool = False
+) -> tuple[str, str] | None:
     """Resolve a user-supplied checkpoint (folder or .safetensors file) to (config, ckpt).
 
     Accepts either a folder holding a model config JSON plus a .safetensors
     checkpoint, or a direct path to the .safetensors file with the config
     alongside it. Returns None when the layout is missing or ambiguous
     (several checkpoints in one folder and none named model.safetensors).
+    ``quiet=True`` skips the resolution-event record (validity probes).
     """
     p = Path(str(path_str)).expanduser()
     if p.is_file() and p.suffix == ".safetensors":
@@ -104,7 +202,13 @@ def resolve_local_checkpoint(path_str: str) -> tuple[str, str] | None:
     ]
     for candidate in config_candidates:
         if candidate.is_file() and _is_model_config_json(candidate):
-            logger.info("Using local checkpoint: %s (config %s)", ckpt, candidate)
+            if not quiet:
+                note_resolution(
+                    str(ckpt.name),
+                    "local-checkpoint",
+                    path=str(ckpt),
+                    detail=f"config {candidate}",
+                )
             return str(candidate), str(ckpt)
     return None
 
@@ -139,23 +243,38 @@ class ModelConfig:
         local_ckpt = _local_override(self.repo_id, self.ckpt_path)
 
         if local_only and (local_config is None or local_ckpt is None):
+            note_resolution(
+                f"{self.repo_id}",
+                "download-needed",
+                repo_id=self.repo_id,
+                detail="blocked: local-only mode is ON and the files are not on disk",
+                level=logging.WARNING,
+            )
             raise FileNotFoundError(
                 f"SA3_LOCAL_ONLY=1 and local model files were not found for repo {self.repo_id}. "
                 f"Expected files: {self.config_path}, {self.ckpt_path}. "
                 f"Search dirs: {[str(p) for p in _local_search_dirs()]}"
             )
 
-        if local_config is None:
-            local_config = try_to_load_from_cache(self.repo_id, self.config_path)
-        if not isinstance(local_config, str):
-            local_config = hf_hub_download(
-                repo_id=self.repo_id, filename=self.config_path
+        if local_config is not None:
+            note_resolution(
+                f"{self.repo_id}/{self.config_path}",
+                "local-folder",
+                path=local_config,
+                repo_id=self.repo_id,
             )
+        else:
+            local_config = _resolve_one_file(self.repo_id, self.config_path)
 
-        if local_ckpt is None:
-            local_ckpt = try_to_load_from_cache(self.repo_id, self.ckpt_path)
-        if not isinstance(local_ckpt, str):
-            local_ckpt = hf_hub_download(repo_id=self.repo_id, filename=self.ckpt_path)
+        if local_ckpt is not None:
+            note_resolution(
+                f"{self.repo_id}/{self.ckpt_path}",
+                "local-folder",
+                path=local_ckpt,
+                repo_id=self.repo_id,
+            )
+        else:
+            local_ckpt = _resolve_one_file(self.repo_id, self.ckpt_path)
 
         return local_config, local_ckpt
 
@@ -179,35 +298,52 @@ class AutoencoderModelConfig:
         local_config = _local_override(self.ae_repo_id, self.ae_config_path)
         local_ckpt = _local_override(self.ae_repo_id, self.ae_ckpt_path)
         if local_config and local_ckpt:
+            note_resolution(
+                f"{self.ae_repo_id} (config+ckpt)",
+                "local-folder",
+                path=local_ckpt,
+                repo_id=self.ae_repo_id,
+            )
             return local_config, local_ckpt
 
         for fallback in self.stable_audio_3:
+            local_fallback_ckpt = _local_override(fallback.repo_id, fallback.ckpt_path)
             cached_config = _local_override(fallback.repo_id, fallback.config_path)
             if cached_config is None:
                 cached_config = try_to_load_from_cache(
                     fallback.repo_id, fallback.config_path
                 )
-            cached_ckpt = _local_override(fallback.repo_id, fallback.ckpt_path)
+            cached_ckpt = local_fallback_ckpt
             if cached_ckpt is None:
                 cached_ckpt = try_to_load_from_cache(
                     fallback.repo_id, fallback.ckpt_path
                 )
             if isinstance(cached_config, str) and isinstance(cached_ckpt, str):
+                note_resolution(
+                    f"{self.ae_repo_id} (via full checkpoint {fallback.repo_id})",
+                    "local-folder" if local_fallback_ckpt else "hf-cache",
+                    path=cached_ckpt,
+                    repo_id=fallback.repo_id,
+                    detail="autoencoder weights reused from an already-present full checkpoint",
+                )
                 return cached_config, cached_ckpt
 
         if local_only:
+            note_resolution(
+                f"{self.ae_repo_id}",
+                "download-needed",
+                repo_id=self.ae_repo_id,
+                detail="blocked: local-only mode is ON and the files are not on disk",
+                level=logging.WARNING,
+            )
             raise FileNotFoundError(
                 f"SA3_LOCAL_ONLY=1 and local autoencoder files were not found for repo {self.ae_repo_id}. "
                 f"Expected files: {self.ae_config_path}, {self.ae_ckpt_path}. "
                 f"Search dirs: {[str(p) for p in _local_search_dirs()]}"
             )
 
-        local_config = hf_hub_download(
-            repo_id=self.ae_repo_id, filename=self.ae_config_path
-        )
-        local_ckpt = hf_hub_download(
-            repo_id=self.ae_repo_id, filename=self.ae_ckpt_path
-        )
+        local_config = _resolve_one_file(self.ae_repo_id, self.ae_config_path)
+        local_ckpt = _resolve_one_file(self.ae_repo_id, self.ae_ckpt_path)
         return local_config, local_ckpt
 
 

--- a/stable_audio_3/models/conditioners.py
+++ b/stable_audio_3/models/conditioners.py
@@ -208,16 +208,45 @@ class T5GemmaConditioner(Conditioner):
             try:
                 from huggingface_hub import try_to_load_from_cache
 
+                from stable_audio_3.model_configs import note_resolution
+
                 candidates = [load_from]
                 if load_from == "stabilityai/t5gemma-b-b-ul2":
                     candidates.append("google/t5gemma-b-b-ul2")
 
+                requested_repo = load_from
                 for candidate_repo in candidates:
                     cached_config = try_to_load_from_cache(candidate_repo, "config.json")
                     if isinstance(cached_config, str):
                         load_from = str(Path(cached_config).parent)
                         hf_kwargs = {}
+                        note_resolution(
+                            f"T5Gemma text encoder ({candidate_repo})",
+                            "hf-cache",
+                            path=load_from,
+                            repo_id=candidate_repo,
+                        )
                         break
+                else:
+                    note_resolution(
+                        f"T5Gemma text encoder ({requested_repo})",
+                        "download-start",
+                        repo_id=requested_repo,
+                        detail=(
+                            "not in the HF cache -> transformers downloads it now "
+                            f"(~2 GB, one-time) from https://huggingface.co/{requested_repo}"
+                        ),
+                        level=logging.WARNING,
+                    )
+            except Exception:
+                pass
+        elif isinstance(load_from, str):
+            try:
+                from stable_audio_3.model_configs import note_resolution
+
+                note_resolution(
+                    "T5Gemma text encoder", "local-folder", path=load_from
+                )
             except Exception:
                 pass
 


### PR DESCRIPTION
[feat(make): LOAD button pre-fires the selected model onto the GPU](https://github.com/gantasmo/theDAW/commit/90662e8577d21b5fd6d334402891d593886cbe14) 

POST /api/model/load wraps the same loader CREATE uses (clears any
resident MRT2 engine, loads or wakes the pipeline, holds the request
open for the duration) with a 409 while a generation runs and a 404 for
unknown names instead of the silent medium fallback. The MAKE Model row
gains a LOAD button for SA3 and local checkpoints (hidden for Magenta,
which auto-swaps on selection, and Suno, which is cloud): purple LOAD,
amber LOADING pulse, green LOADED when the selection is resident, red
RETRY on failure, with the result logged with load seconds and VRAM.
@[danieljtrujillo](https://github.com/gantasmo/theDAW/commits?author=danieljtrujillo)
danieljtrujillo committed 1 hour ago
[Merge remote-tracking branch 'thedaw/feat/models-and-storage' into fe…](https://github.com/gantasmo/theDAW/commit/86bc63f6f7790701af3ff37c479fc8880cb89d90) 

…at/models-and-storage

# Conflicts:
#	docs/reports/feature-doc-coverage-report.md
#	docs/reports/feature-doc-coverage.json
#	docs/screenshots/manifest.json
@[danieljtrujillo](https://github.com/gantasmo/theDAW/commits?author=danieljtrujillo)
danieljtrujillo committed 1 hour ago
[feat(models): narrate exactly where every model file loads from](https://github.com/gantasmo/theDAW/commit/12234b76853b7bbe678a20fd236eed3002414ec5) 

Every resolution decision is now recorded and logged: one model
resolve: console line per file with the exact path used (local folder,
HF cache, registered checkpoint), a WARNING before anything downloads
(with the repo URL and timing once done), a WARNING when local-only
mode blocks a needed download, and the T5Gemma text encoder's
cache-vs-download fate. model_configs keeps the last 200 events behind
a lock; /api/model/load returns the trail of its own load and GET
/api/storage/resolution-log exposes the session history. The MAKE LOAD
button echoes it all into the in-app LOG, including a pre-flight line
saying whether the selected model resolves locally, from cache, or
would download, before the load starts.