### PR TITLE
feat(slide,midi): controller fit/zoom/pan, sticky page dock, piano transcription engine

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-13T00:02:38.114Z · Git revision: `344da9a6a78d` · Repomix tracked: **no**
+> Generated: 2026-06-13T00:46:44.551Z · Git revision: `fdc80be36820` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-13T00:02:38.114Z",
-  "repoRevision": "344da9a6a78d",
+  "generatedAt": "2026-06-13T00:46:44.551Z",
+  "repoRevision": "fdc80be36820",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T00:04:46.731Z",
+  "generatedAt": "2026-06-13T00:49:11.000Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/src/components/layout/SlidePanel.tsx
+++ b/frontend/src/components/layout/SlidePanel.tsx
@@ -530,17 +530,19 @@ const FocusStrip: React.FC<{
       </div>
       <button className="sl-nav prev" onClick={() => nudge(-1)}>◀</button>
       <button className="sl-nav next" onClick={() => nudge(1)}>▶</button>
-      <div className="sl-pagelight" style={{ ['--pl' as string]: pageColor }}>
-        {Array.from({ length: pageCount }, (_, p) => (
-          <div
-            key={p}
-            className="sl-pageseg"
-            ref={(el) => { if (el) segRefs.current[p] = el; }}
-            title={`Page ${p + 1}`}
-            onClick={() => onPickPage(p)}
-          />
-        ))}
-        <div className="sl-pagenum" ref={numRef}>PAGE 1 / {pageCount}</div>
+      <div className="sl-pagedock">
+        <div className="sl-pagelight" style={{ ['--pl' as string]: pageColor }}>
+          {Array.from({ length: pageCount }, (_, p) => (
+            <div
+              key={p}
+              className="sl-pageseg"
+              ref={(el) => { if (el) segRefs.current[p] = el; }}
+              title={`Page ${p + 1}`}
+              onClick={() => onPickPage(p)}
+            />
+          ))}
+          <div className="sl-pagenum" ref={numRef}>PAGE 1 / {pageCount}</div>
+        </div>
       </div>
     </div>
   );
@@ -577,13 +579,43 @@ export const SlidePanel: React.FC = () => {
   const commitLearn = useLearnedProfilesStore((s) => s.commit);
   const [cvOpen, setCvOpen] = useState(false);
   // Controller-view zoom — lets a big device (e.g. a 92-control rig) be seen
-  // whole (zoom out) or a section worked closely (zoom in). 1 = fit.
+  // whole (the view OPENS fitted to the window) or a section worked up close.
   const [ctrlZoom, setCtrlZoom] = useState(1);
-  const clampZoom = (z: number) => Math.max(0.4, Math.min(2, Math.round(z * 20) / 20));
+  const clampZoom = (z: number) => Math.max(0.25, Math.min(2.5, Math.round(z * 20) / 20));
+  const ctrlSurfaceRef = useRef<HTMLDivElement | null>(null);
+  const ctrlContentRef = useRef<HTMLDivElement | null>(null);
+  // Natural (unscaled) size of the rendered device; sizes the scale wrapper so
+  // zooming never leaves ghost scroll space.
+  const [ctrlNat, setCtrlNat] = useState<{ w: number; h: number } | null>(null);
+
+  const fitZoom = useCallback(() => {
+    const surf = ctrlSurfaceRef.current;
+    const content = ctrlContentRef.current;
+    const scrollport = surf?.parentElement;
+    if (!surf || !content || !scrollport) return;
+    const natW = content.offsetWidth;
+    const natH = content.offsetHeight;
+    if (!natW || !natH) return;
+    setCtrlNat({ w: natW, h: natH });
+    const fit = Math.min(
+      (scrollport.clientWidth - 28) / natW,
+      (scrollport.clientHeight - 28) / natH,
+    );
+    setCtrlZoom(clampZoom(fit));
+  }, []);
+
+  // Open fitted: whenever the controller view activates or the device changes,
+  // size the whole rig into the window. (deviceSize derives from profileId, so
+  // profileId is the change signal.)
+  useEffect(() => {
+    if (view !== 'controller') return;
+    const t = setTimeout(fitZoom, 60);
+    return () => clearTimeout(t);
+  }, [view, profileId, fitZoom]);
+
   // Mouse-wheel zoom over the controller surface. React's delegated onWheel is
   // passive, so preventDefault (to stop the panel scrolling) needs a native
   // non-passive listener bound while the controller view is active.
-  const ctrlSurfaceRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     if (view !== 'controller') return;
     const el = ctrlSurfaceRef.current;
@@ -595,6 +627,50 @@ export const SlidePanel: React.FC = () => {
     };
     el.addEventListener('wheel', onWheel, { passive: false });
     return () => el.removeEventListener('wheel', onWheel);
+  }, [view]);
+
+  // Left-click drag on the background pans the view (controls keep their own
+  // pointer handling; panning only starts from empty surface).
+  useEffect(() => {
+    if (view !== 'controller') return;
+    const el = ctrlSurfaceRef.current;
+    const scrollport = el?.parentElement as HTMLElement | null;
+    if (!el || !scrollport) return;
+    let panning = false;
+    let sx = 0;
+    let sy = 0;
+    let sl = 0;
+    let st = 0;
+    const onDown = (e: PointerEvent) => {
+      if (e.button !== 0) return;
+      const t = e.target as HTMLElement;
+      if (t.closest('.ts-body, .tk-dial, .tp-btn, .sl-grip, .sl-lock, button, input, select, [role="slider"]')) return;
+      panning = true;
+      sx = e.clientX;
+      sy = e.clientY;
+      sl = scrollport.scrollLeft;
+      st = scrollport.scrollTop;
+      el.style.cursor = 'grabbing';
+    };
+    const onMove = (e: PointerEvent) => {
+      if (!panning) return;
+      scrollport.scrollLeft = sl - (e.clientX - sx);
+      scrollport.scrollTop = st - (e.clientY - sy);
+    };
+    const onUp = () => {
+      panning = false;
+      el.style.cursor = 'grab';
+    };
+    el.style.cursor = 'grab';
+    el.addEventListener('pointerdown', onDown);
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    return () => {
+      el.style.cursor = '';
+      el.removeEventListener('pointerdown', onDown);
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
   }, [view]);
   const setPageNavBinding = useSlideStore((s) => s.setPageNavBinding);
   const swapSlots = useSlideStore((s) => s.swapSlots);
@@ -1007,58 +1083,66 @@ export const SlidePanel: React.FC = () => {
       </div>
 
       {/* surface */}
-      <div className="flex-1 min-h-0 overflow-auto p-3 relative">
+      <div className={`flex-1 min-h-0 overflow-auto relative flex flex-col ${view === 'controller' ? 'p-3' : 'px-3 pt-3 pb-0'}`}>
         {view === 'controller' ? (
-          // Controller view is CENTERED and ZOOMABLE so a whole device (even a
-          // big custom rig) fits, or a section can be worked up close.
+          // Controller view OPENS FITTED to the window, mouse-wheel zooms, and
+          // left-click drag on the background pans around the device.
           <>
             <div className="absolute top-2 right-2 z-20 flex items-center gap-1 rounded-md border border-white/12 bg-black/60 backdrop-blur px-1 py-0.5">
               <button onClick={() => setCtrlZoom((z) => clampZoom(z - 0.1))} className="px-1.5 py-0.5 text-zinc-300 hover:text-white text-[11px]" title="Zoom out">−</button>
-              <button onClick={() => setCtrlZoom(1)} className="px-1.5 py-0.5 text-[8px] font-mono text-zinc-400 hover:text-white tabular-nums" title="Reset zoom (fit)">{Math.round(ctrlZoom * 100)}%</button>
+              <button onClick={fitZoom} className="px-1.5 py-0.5 text-[8px] font-mono text-zinc-400 hover:text-white tabular-nums" title="Fit the whole controller in the window">{Math.round(ctrlZoom * 100)}%</button>
               <button onClick={() => setCtrlZoom((z) => clampZoom(z + 0.1))} className="px-1.5 py-0.5 text-zinc-300 hover:text-white text-[11px]" title="Zoom in">+</button>
             </div>
-            <div ref={ctrlSurfaceRef} className="min-h-full flex items-start justify-center" title="Scroll to zoom">
-              <div style={{ transform: `scale(${ctrlZoom})`, transformOrigin: 'top center', transition: 'transform 0.12s ease' }}>
-                <ControllerView
-                  profile={profile}
-                  content={content}
-                  bank={bank}
-                  deviceSize={deviceSize}
-                  pageCount={pageCount}
-                  pageColor={pageColor}
-                  resolve={resolve}
-                  onDropItem={onDropItem}
-                  onPickPage={setBank}
-                  profileId={profileId}
-                  mapMode={mapMode}
-                  learnPos={learnPos}
-                  autoWalk={autoWalk}
-                />
+            <div ref={ctrlSurfaceRef} className="min-h-full flex items-start justify-center" title="Scroll to zoom · drag the background to pan">
+              <div style={ctrlNat ? { width: ctrlNat.w * ctrlZoom, height: ctrlNat.h * ctrlZoom } : undefined}>
+                <div ref={ctrlContentRef} style={{ transform: `scale(${ctrlZoom})`, transformOrigin: 'top left', transition: 'transform 0.12s ease', width: 'fit-content' }}>
+                  <ControllerView
+                    profile={profile}
+                    content={content}
+                    bank={bank}
+                    deviceSize={deviceSize}
+                    pageCount={pageCount}
+                    pageColor={pageColor}
+                    resolve={resolve}
+                    onDropItem={onDropItem}
+                    onPickPage={setBank}
+                    profileId={profileId}
+                    mapMode={mapMode}
+                    learnPos={learnPos}
+                    autoWalk={autoWalk}
+                  />
+                </div>
               </div>
             </div>
           </>
         ) : view === 'focus' ? (
-          <FocusStrip
-            content={content}
-            items={focusItems}
-            pageSize={pageSize}
-            startPage={bank}
-            pageColor={pageColor}
-            pageCount={pageCount}
-            onDropItem={onDropItem}
-            onPickPage={setBank}
-          />
+          // mt-auto anchors the lanes to the BOTTOM of the panel; the page
+          // controller below them is sticky so it never scrolls away.
+          <div className="mt-auto">
+            <FocusStrip
+              content={content}
+              items={focusItems}
+              pageSize={pageSize}
+              startPage={bank}
+              pageColor={pageColor}
+              pageCount={pageCount}
+              onDropItem={onDropItem}
+              onPickPage={setBank}
+            />
+          </div>
         ) : (
-          <RowView
-            content={content}
-            bank={bank}
-            pageSize={pageSize}
-            pageCount={pageCount}
-            pageColor={pageColor}
-            resolve={resolve}
-            onDropItem={onDropItem}
-            onPickPage={setBank}
-          />
+          <div className="mt-auto">
+            <RowView
+              content={content}
+              bank={bank}
+              pageSize={pageSize}
+              pageCount={pageCount}
+              pageColor={pageColor}
+              resolve={resolve}
+              onDropItem={onDropItem}
+              onPickPage={setBank}
+            />
+          </div>
         )}
       </div>
 
@@ -1105,7 +1189,9 @@ const RowView: React.FC<{
           );
         })}
       </div>
-      <PageLight count={pageCount} active={bank} color={pageColor} onPick={onPickPage} />
+      <div className="sl-pagedock">
+        <PageLight count={pageCount} active={bank} color={pageColor} onPick={onPickPage} />
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/layout/track-controls.css
+++ b/frontend/src/components/layout/track-controls.css
@@ -570,6 +570,25 @@
 .sl-nav.next { right: 2px; }
 
 .sl-section { margin-bottom: 16px; }
+
+/* Sticky page controller: docked to the bottom of the SLIDE surface in ROW and
+   FOCUS so paging never scrolls away; the lanes sit just above it (the views
+   bottom-anchor via mt-auto). Bleeds over the surface's horizontal padding and
+   fades the lanes that scroll beneath it. */
+.sl-pagedock {
+  position: sticky;
+  bottom: 0;
+  z-index: 12;
+  margin: 0 -12px;
+  padding: 2px 12px 10px;
+  background: linear-gradient(to top, rgba(9, 7, 13, 0.95) 0%, rgba(9, 7, 13, 0.7) 65%, transparent 100%);
+  backdrop-filter: blur(3px);
+}
+/* Bottom-anchored views: the dock IS the bottom edge, so the section's usual
+   trailing gap would float it above the panel floor. */
+.sl-pagedock .sl-pagelight { margin-bottom: 0; }
+.mt-auto > .sl-section { margin-bottom: 0; }
+
 .sl-section-head {
   font: 800 8px/1 system-ui;
   letter-spacing: 0.22em;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ dependencies = [
     # These were installed manually but undeclared, so `uv sync` pruned them and
     # broke the MIDI module; declared here so the working set is stable.
     "basic-pitch>=0.4.0",
+    # Piano-roll transcription engine (the midi module's second engine beside
+    # basic-pitch). Downloads its checkpoint (~165 MB) to ~/piano_transcription
+    # on first use.
+    "piano-transcription-inference>=0.0.5",
     "pretty_midi>=0.2.11",
     "mido>=1.3.3",
     # notation module — symbolic music conversion / analysis backbone.

--- a/uv.lock
+++ b/uv.lock
@@ -3719,6 +3719,21 @@ wheels = [
 ]
 
 [[package]]
+name = "piano-transcription-inference"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librosa" },
+    { name = "matplotlib" },
+    { name = "mido" },
+    { name = "torchlibrosa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/d8/8b2d1f2f9dba01c122686e2b7910ced8dfe14fc246099d44607c6fa460f1/piano_transcription_inference-0.0.6.tar.gz", hash = "sha256:b6dd00f9b4bcacb6140725f03b4139a5e0f4acd35a69e492a5d1f734ecfbd231", size = 13881, upload-time = "2025-01-26T02:30:41.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/64/2360ab1eecf4c01a6c5d1bfb308f08a196236a559bcc135ca203e6742a5b/piano_transcription_inference-0.0.6-py3-none-any.whl", hash = "sha256:64348200b700a0ee792aa62386803fb2a638e378b3835b9a7ccff4701f0612f5", size = 14988, upload-time = "2025-01-26T02:30:39.045Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5348,6 +5363,7 @@ dependencies = [
     { name = "opencv-python-headless" },
     { name = "packaging" },
     { name = "partitura" },
+    { name = "piano-transcription-inference" },
     { name = "pillow" },
     { name = "pretty-midi" },
     { name = "psutil" },
@@ -5416,6 +5432,7 @@ requires-dist = [
     { name = "opencv-python-headless", specifier = ">=4.9.0" },
     { name = "packaging", specifier = ">=26.0" },
     { name = "partitura", specifier = ">=1.9.0" },
+    { name = "piano-transcription-inference", specifier = ">=0.0.5" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pretty-midi", specifier = ">=0.2.11" },
     { name = "psutil", specifier = ">=5.9.0" },
@@ -5954,6 +5971,20 @@ wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.7.1%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:4586e3106701b06a4f9377f5c1da9e1d8555e16bd58fd7d810aa3f6cf50bd713", upload-time = "2025-06-03T18:37:40Z" },
     { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.7.1%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:170ca262fad47188ce35010fd34d5b3661c46a2c053383fd72ef653f713329ce", upload-time = "2025-06-03T18:37:40Z" },
     { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.7.1%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:cb435329019d441d8177db2d84e8d397881896d100efb4f4c15f0d3732f92a81", upload-time = "2025-06-03T18:37:40Z" },
+]
+
+[[package]]
+name = "torchlibrosa"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librosa" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/67/e4c79da3f15777b9bc2b655d47dac553fc31e40360500fef5e66d6877ce8/torchlibrosa-0.1.0.tar.gz", hash = "sha256:62a8beedf9c9b4141a06234df3f10229f7ba86e67678ccee02489ec4ef044028", size = 11719, upload-time = "2023-02-21T09:40:54.968Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/af/ccf007edf442c3c0cd3a98be2c82bc99edc957c04436a759b6e1e01077e0/torchlibrosa-0.1.0-py3-none-any.whl", hash = "sha256:89b65fd28b833ceb6bc74a3d0d87e2924ddc5a845d0a246b194952a4e12a38cb", size = 11741, upload-time = "2023-02-21T09:40:52.58Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- SLIDE controller view opens with the whole device fitted to the window; mouse-wheel zooms (0.25-2.5x), left-click drag on the background pans, the percent button re-fits
- SLIDE Row and Focus bottom-anchor the slider lanes and dock the page controller sticky to the panel floor, so paging never scrolls away and lanes no longer justify to the top
- piano-transcription-inference installed and declared in pyproject + lock; the MIDI provider card now reports both engines

## Validation
- tsc -b clean; ruff clean; engine_capabilities() returns both engines True
- Visual sign-off on the SLIDE behaviors pending a live look