### PR TITLE
feat(vj,jobs): VJ production-build sidecar + slimmer jobs list

### DIFF
--- a/backend/modules/vj/sidecar.py
+++ b/backend/modules/vj/sidecar.py
@@ -1,11 +1,18 @@
-"""Manage the GANTASMO-LIVE-VJ Vite dev server as an SA3 sidecar.
+"""Manage the GANTASMO-LIVE-VJ Vite server as an SA3 sidecar.
 
 The VJ project lives in its own repo at
 ``D:/StableAudio/GANTASMO-LIVE-VJ`` (overridable via
 ``theDAW_VJ_PROJECT``). It's a vanilla Vite/React app — no Python,
 no heavy ML deps — so the spawn logic is much simpler than the stems
-sidecar: just shell out to ``npm run dev`` with ``--port <N>`` and
-poll the port until the dev server is listening.
+sidecar: build (when stale) + ``npm run preview`` and poll the port
+until the server is listening.
+
+By default the sidecar serves a PRODUCTION build (``vite preview``
+over ``dist/``): no HMR websocket, no per-request transforms, no
+file watcher — measurably lighter than the dev server during
+performance use. ``dist/`` is rebuilt automatically when missing or
+older than the newest source file. Set ``theDAW_VJ_DEV=1`` to force
+the dev server (HMR) while working ON the VJ app itself.
 
 We deliberately use a NON-default port (5187) because:
   * 3000 (React default) is the user's explicit "don't use this"
@@ -49,6 +56,19 @@ DEFAULT_PROJECT_PATH = Path(r"D:/StableAudio/GANTASMO-LIVE-VJ")
 DEFAULT_PORT = 5187
 PORT_READY_TIMEOUT_SEC = 60.0
 PORT_POLL_INTERVAL_SEC = 0.5
+BUILD_TIMEOUT_SEC = 300.0
+
+# Inputs to the staleness check: the newest mtime across these (files
+# directly, directories recursively) is compared against dist/index.html,
+# which vite rewrites on every build.
+_SOURCE_DIRS = ("src", "assets", "public")
+_SOURCE_FILES = (
+    "index.html",
+    "vite.config.ts",
+    "package.json",
+    "package-lock.json",
+    "tsconfig.json",
+)
 
 
 @dataclass
@@ -56,6 +76,7 @@ class VJConfig:
     project_path: Path
     port: int
     npm_path: str
+    dev_mode: bool
 
 
 _state_lock = Lock()
@@ -80,7 +101,62 @@ def resolve_config() -> VJConfig:
     # generic FileNotFoundError.
     npm_path = shutil.which("npm.cmd") or shutil.which("npm") or "npm"
 
-    return VJConfig(project_path=project_path, port=port, npm_path=npm_path)
+    dev_mode = os.getenv("theDAW_VJ_DEV") == "1"
+
+    return VJConfig(
+        project_path=project_path, port=port, npm_path=npm_path, dev_mode=dev_mode
+    )
+
+
+def _newest_source_mtime(root: Path) -> float:
+    newest = 0.0
+    for name in _SOURCE_FILES:
+        f = root / name
+        if f.is_file():
+            newest = max(newest, f.stat().st_mtime)
+    for name in _SOURCE_DIRS:
+        d = root / name
+        if d.is_dir():
+            for p in d.rglob("*"):
+                if p.is_file():
+                    newest = max(newest, p.stat().st_mtime)
+    return newest
+
+
+def _build_is_stale(root: Path) -> bool:
+    """True when dist/ is missing or older than the newest source file."""
+    marker = root / "dist" / "index.html"
+    if not marker.is_file():
+        return True
+    return _newest_source_mtime(root) > marker.stat().st_mtime
+
+
+def _ensure_build(cfg: VJConfig) -> None:
+    """Run ``npm run build`` when dist/ is missing or stale. Raises
+    RuntimeError with the build log tail on failure."""
+    if not _build_is_stale(cfg.project_path):
+        return
+    log.info("vj.sidecar: dist/ missing or stale — running npm run build")
+    try:
+        proc = subprocess.run(
+            [cfg.npm_path, "run", "build"],
+            cwd=str(cfg.project_path),
+            capture_output=True,
+            timeout=BUILD_TIMEOUT_SEC,
+            shell=False,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(f"VJ sidecar: npm not found ({e}). Install Node.js.") from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"VJ build timed out after {int(BUILD_TIMEOUT_SEC)}s in {cfg.project_path}."
+        ) from e
+    if proc.returncode != 0:
+        tail = (proc.stderr or proc.stdout or b"").decode("utf-8", "replace")[-2000:]
+        raise RuntimeError(
+            f"VJ build failed (rc={proc.returncode}) in {cfg.project_path}:\n{tail}"
+        )
+    log.info("vj.sidecar: build complete")
 
 
 def _port_is_listening(port: int, host: str = "127.0.0.1") -> bool:
@@ -147,6 +223,10 @@ def probe() -> dict:
     return {
         "project_path": str(pkg),
         "port": cfg.port,
+        # "preview" = production build via `vite preview` (default);
+        # "dev" = HMR dev server (theDAW_VJ_DEV=1).
+        "mode": "dev" if cfg.dev_mode else "preview",
+        "build_stale": _build_is_stale(pkg) if pkg.is_dir() else None,
         "listening": listening,
         "process_alive": _proc is not None and _proc.poll() is None,
         "url": _resolved_url or f"http://localhost:{cfg.port}",
@@ -160,9 +240,10 @@ def probe() -> dict:
 
 
 def ensure_running(*, wait_for_ready: bool = True) -> str:
-    """Spawn the VJ Vite dev server if it isn't already, and return the
-    URL it serves on. Safe to call repeatedly — no-ops if the port is
-    already listening, even if some OTHER process started the server."""
+    """Spawn the VJ Vite server (preview by default, dev with
+    theDAW_VJ_DEV=1) if it isn't already, and return the URL it serves
+    on. Safe to call repeatedly — no-ops if the port is already
+    listening, even if some OTHER process started the server."""
     global _proc, _resolved_url
     with _state_lock:
         cfg = resolve_config()
@@ -213,7 +294,26 @@ def ensure_running(*, wait_for_ready: bool = True) -> str:
                         "Run it manually to see the full error output, then retry."
                     )
                 log.info("vj.sidecar: npm install complete")
-            cmd = [cfg.npm_path, "run", "dev", "--", "--port", str(cfg.port)]
+            if cfg.dev_mode:
+                cmd = [cfg.npm_path, "run", "dev", "--", "--port", str(cfg.port)]
+            else:
+                # Production serve: build once (when stale), then `vite
+                # preview` over dist/ — same port contract and SPA
+                # behavior as the dev server, none of its per-request
+                # work. `--host` (bare) binds 0.0.0.0 so the LAN/mobile
+                # URL keeps working; allowedHosts is inherited from the
+                # project's server config.
+                _ensure_build(cfg)
+                cmd = [
+                    cfg.npm_path,
+                    "run",
+                    "preview",
+                    "--",
+                    "--port",
+                    str(cfg.port),
+                    "--strictPort",
+                    "--host",
+                ]
             log.info(
                 "vj.sidecar: spawning %s (cwd=%s)",
                 " ".join(cmd),
@@ -254,7 +354,7 @@ def ensure_running(*, wait_for_ready: bool = True) -> str:
                 raise RuntimeError(
                     "VJ sidecar exited before becoming ready (rc="
                     f"{_proc.returncode}). Check the project's "
-                    "package.json `dev` script."
+                    "package.json scripts (preview/dev)."
                 )
             time.sleep(PORT_POLL_INTERVAL_SEC)
         raise RuntimeError(
@@ -275,8 +375,19 @@ def stop() -> bool:
             _proc = None
             return False
         try:
-            _proc.terminate()
-            _proc.wait(timeout=5.0)
+            if sys.platform == "win32":
+                # npm.cmd is a shim: terminate() kills the cmd wrapper
+                # and leaves the node (vite) child listening. Kill the
+                # whole tree.
+                subprocess.call(
+                    ["taskkill", "/PID", str(_proc.pid), "/T", "/F"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                _proc.wait(timeout=5.0)
+            else:
+                _proc.terminate()
+                _proc.wait(timeout=5.0)
         except subprocess.TimeoutExpired:
             _proc.kill()
         finally:

--- a/backend/server.py
+++ b/backend/server.py
@@ -1693,7 +1693,15 @@ async def generate_jobs(
 
 @app.get("/api/jobs")
 async def list_jobs():
-    return {"jobs": list(JOBS.values())}
+    # Summaries only: a completed generate job's "result" carries the
+    # full base64 audio + spectrograms (megabytes per job), and the
+    # training poller hits this list repeatedly. Payloads stay on the
+    # per-job GET below, which is what the generate flow polls.
+    return {
+        "jobs": [
+            {k: v for k, v in job.items() if k != "result"} for job in JOBS.values()
+        ]
+    }
 
 
 @app.get("/api/jobs/{job_id}")

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -529,7 +529,7 @@ A floating **Edit Layout** control turns on Design Mode. In Design Mode, panels 
 
 ### Purpose
 
-The VJ tab (`VJView`) embeds the GANTASMO-LIVE-VJ visual engine as a live, audio-reactive instrument. The backend `vj` module spawns the engine's dev server lazily, and the tab fetches its live URL from `/api/vj/url`, so the port is never hardcoded. First launch runs `npm install` in the VJ project and can take a minute; later launches are fast.
+The VJ tab (`VJView`) embeds the GANTASMO-LIVE-VJ visual engine as a live, audio-reactive instrument. The backend `vj` module serves the engine lazily as a production build (it rebuilds automatically when the engine's source is newer than the build, and `theDAW_VJ_DEV=1` forces the HMR dev server for engine development), and the tab fetches its live URL from `/api/vj/url`, so the port is never hardcoded. First launch runs `npm install` plus a one-time build in the VJ project and can take a minute; later launches are fast.
 
 ### 10.1 Inputs
 
@@ -544,7 +544,7 @@ A toolbar row toggles which signals feed the visuals. At least one input stays a
 
 The camera input extends past a webcam on the host machine. Any device that opens theDAW in a browser and grants camera permission serves as the source.
 
-- **Phone or tablet cameras on the same Wi-Fi.** The phone opens theDAW at the LAN URL (see §10.2 Mobile, or the Mobile Access panel in the shell header) and grants the camera prompt, and the phone's camera then streams into the visuals. The Vite dev server binds `0.0.0.0` and the backend auto-detects the LAN IP, so the only requirement is a network that permits device-to-device connections.
+- **Phone or tablet cameras on the same Wi-Fi.** The phone opens theDAW at the LAN URL (see §10.2 Mobile, or the Mobile Access panel in the shell header) and grants the camera prompt, and the phone's camera then streams into the visuals. The Vite server binds `0.0.0.0` and the backend auto-detects the LAN IP, so the only requirement is a network that permits device-to-device connections.
 - **Quest 3 headsets and off-network devices.** A device away from the LAN, such as a Quest 3, a phone on cellular, or a remote camera, joins through a public tunnel. A Cloudflare Tunnel or other public URL goes into the **External URL override** in the Mobile Access panel, and the headset or phone opens that URL in its browser and feeds its camera the same way. The browser exposes the Quest 3's passthrough and visible-light cameras like any other camera.
 - **Capture inputs.** Anything that presents to the operating system as a camera, including HDMI capture cards, DSLRs in webcam mode, OBS virtual camera, and NDI-to-webcam bridges, appears in the browser's device list and selects as the source.
 
@@ -1337,7 +1337,7 @@ MIDI conversion runs on full entries and, when available, separated stems. The s
 
 ### 19.17 VJ
 
-The VJ module powers the VJ center tab and its embedded iframe. The frontend fetches the engine URL from `GET /api/vj/url`, which also returns a `mobile_url` for LAN access when the machine has a non-loopback address. The backend spawns the visual engine's dev server lazily; the port and project path can be overridden through the `theDAW_VJ_PORT` and `theDAW_VJ_PROJECT` environment variables. Use the Settings modal module list and the VJ tab loading state to confirm availability.
+The VJ module powers the VJ center tab and its embedded iframe. The frontend fetches the engine URL from `GET /api/vj/url`, which also returns a `mobile_url` for LAN access when the machine has a non-loopback address. The backend serves the visual engine lazily as a production build (`vite preview`), rebuilding when the engine's source is newer than `dist/`; the port and project path can be overridden through the `theDAW_VJ_PORT` and `theDAW_VJ_PROJECT` environment variables, and `theDAW_VJ_DEV=1` forces the HMR dev server for engine development. Use the Settings modal module list and the VJ tab loading state to confirm availability.
 
 ### 19.18 Notation and Prompt Inference
 

--- a/docs/plans/2026-06-13-global-layout-vj-library-optimizations-plan.md
+++ b/docs/plans/2026-06-13-global-layout-vj-library-optimizations-plan.md
@@ -14,6 +14,10 @@
 >
 > Try to find ways we can optimize the VJ tab/sidecar so it runs more efficiently/smoothly. If there are efficiency gains to be had elsewhere (like optimizing everything in our library) I am all ears.
 
+Added later (user, verbatim):
+
+> finish integrating the live stems in DJ, have the sampler and stem activation super simple, but versatile. Fill some of those gaps.
+
 Already shipped from the same request batch (PR #19): SLIDE Row/Focus bottom-anchored lanes + sticky `.sl-pagedock`, controller view fit-on-open/wheel-zoom/drag-pan, piano-transcription-inference installed + declared. Visual sign-off on the SLIDE behaviors is still pending the user's eyes.
 
 ---
@@ -51,6 +55,8 @@ Already shipped from the same request batch (PR #19): SLIDE Row/Focus bottom-anc
 2. **Phase B — VJ video library** (4 sub-phases below).
 3. **Phase C — global Edit Layout**: MAKE → EDIT → LEARN, one PR each.
 4. **Phase D — micro-perf**: rVFC in VJ loop, selector-izing big views, H264 recording option.
+5. **Phase E — DJ live stems finish + simple sampler/stem activation** (section 6.5). Can be pulled ahead of C/D on green-light; it is independent of the layout and VJ work.
+6. **Phase F — library Opus autoconvert** (section 6.6). Audit-first: a compatibility matrix of every consumer of library audio BEFORE any conversion code. User: library is getting big quickly; this is a real disk-pressure item.
 
 ---
 
@@ -129,6 +135,45 @@ Each phase: tsc + manual visual pass + user eyes before merge; one PR per tab.
 4. (Investigate-only) the global ~1.1x transform: prototype `zoom` property behind a flag; verify every canvas surface (memory `project_ui_css_transform_scale`) before any switch.
 
 ---
+
+## 6.5. Phase E — DJ live stems finish + simple/versatile sampler & stem activation
+
+User ask (verbatim, added after the original batch): "finish integrating the live stems in DJ, have the sampler and stem activation super simple, but versatile. Fill some of those gaps."
+
+### Verified current state (2026-06-12)
+- `frontend/src/lib/djStems.ts` — `listStems()` (cached stems via `/api/stems/{entry}` → `/api/library/stems/{id}/audio`) and `ensureStems()` (foreground `POST /api/stems/{entry}/run`, 4-stem fast default, 1.5s progress polling).
+- `frontend/src/state/djEngine.ts` — D4 plumbing DONE: `loadDeckStems()` decodes N stems → per-stem gain → deck `srcBus` (frees the full buffer), `setStemGain()`, stem-mode transport parity (start/seek/loop/duration all handle `stemMode`), `teardownStems()` on track swap.
+- `frontend/src/views/DJView.tsx` — per-deck stems activation calls `ensureStems` then `loadDeckStems` (~line 828), per-stem faders via `onStem` (~839); `SamplerRail` (D7, ~706): 10 one-shot pads, library-track drag-drop, persisted pad→entry map in `djSamplerStore` (`thedaw.dj.sampler.v1`), buffers re-decoded on mount, right-click clears.
+- Memory `project_dj_feature` pending items that overlap: deck persistence, true real-time stems.
+
+### Gaps to fill (candidate list; scope confirmed at green-light)
+- **E1. One-touch stem activation.** Single per-deck STEMS toggle with visible states (OFF → SEPARATING n% → ON) instead of the current run-then-faders flow. Switching deck ↔ stem mode must preserve playhead position both directions (full→stems already does; verify stems→full restores the buffer instead of leaving the deck empty — today `loadDeckStems` frees `d.buffer`, so OFF requires a re-decode path).
+- **E2. Pre-separation in the background.** DOWNGRADED per user 2026-06-12: "almost anything being pulled from the library should have stems already, so dont sweat that. Realtime stemming while performing would be fairly uncommon." The primary path is instant load of CACHED stems; live separation stays as the existing fallback flow, no background queue needed. E1's toggle should therefore show ON-ready (cached) vs a small "needs separation" state instead of optimistic auto-runs.
+- **E3. Stem pads, not just faders.** Four big mute/solo-style toggle pads per deck (vocals/drums/bass/other) as the primary control — tap kills/restores a stem; faders remain for fine control (hold/expand). MIDI-mappable through the existing djControlMap learn flow.
+- **E4. Sampler ↔ stems versatility.** Pads accept ANY source: library track (today), a deck's isolated stem, or a loop slice. Per-pad gain + one-shot/loop toggle + optional choke group. Keep the 10-pad rail layout; persistence extends `djSamplerStore` (new pad source types must round-trip the reload re-decode path).
+- **E5. Deck + stem persistence.** Reload restores per-deck loaded track, stem mode, and stem levels (folds in the long-pending "deck persistence" item).
+- **E6. Automix stem transitions (stretch).** Automix transitions can do stem swaps (bass-kill cross, vocal-only intro) for tracks whose stems are cached. Only after E1–E3 land.
+
+Validation: live A/B on the rig with real separated tracks (user's eyes + ears; headless checks are insufficient). Watch VRAM/RAM — stem mode quadruples decoded buffers per deck; the 6 GB card is not the constraint here (Web Audio is CPU/RAM) but demucs separation runs on it, so never auto-separate while an SA3/Magenta generate is in flight (respect the existing GPU guards).
+
+## 6.6. Phase F — library Opus autoconvert
+
+User ask (2026-06-12, verbatim): "We also forgot to finish the autoconvert to opus feature (verify what features of ours can and can't use that so we don't screw ourselves). It would be very helpful as my library is getting big quickly."
+
+State check (2026-06-12): NO partial implementation exists — `grep` for autoconvert/transcode/opusify across the repo finds nothing library-side. Opus is already a first-class format elsewhere: ytimport imports as Opus (stream-copy when possible, 192k transcode otherwise, `backend/modules/ytimport/engine.py`), delivery + effects modules export Opus (`libopus`), `backend/core/module_base.py` maps the mime, library tag reader handles `.opus`. So this phase is greenfield: convert library WAV generations to Opus (likely 192k VBR, matching ytimport's transparency choice) to reclaim disk.
+
+**F1 — compatibility audit (MANDATORY before any conversion code).** Build the matrix of every consumer of a library entry's audio file and verify Opus-readiness empirically, not by reasoning:
+- Web Audio `decodeAudioData` (player, DJ decks, live mixer, sampler pads) — expected fine, verify in OUR app.
+- Stems separation (demucs sidecar) — ffmpeg-backed load, expected fine; verify the sidecar venv's torchcodec/FFmpeg path decodes Opus.
+- Analysis (aubio/librosa BPM/key), waveform peaks, spectrograms — librosa needs soundfile/audioread Opus support; aubio may NOT read Opus directly. Verify each.
+- MIDI transcription (basic-pitch, piano-transcription-inference) — check their loaders.
+- Notation/partitura/music21 pipelines that start from audio.
+- Init-audio / inpainting / chimera / remix flows that feed audio BACK into generation — lossy input changes results; these may warrant keeping WAV or decoding to a temp WAV.
+- EDIT tools (49 FFmpeg edit-tool endpoints) — ffmpeg-backed, expected fine.
+- Export/delivery — re-encoding lossy→lossy is a quality cliff; UI should surface "source is Opus" where relevant.
+Output of F1: a table in this plan (or a follow-up doc) with VERIFIED yes/no/needs-shim per consumer, plus the decision on which consumers get a decode-to-temp-WAV shim vs. which block conversion.
+**F2 — conversion mechanics (after F1).** Per-entry convert + bulk "convert older than N days / all" action, default-on toggle for NEW generations vs. keep-WAV setting, originals deleted only after a verified ffprobe pass on the new file, `metadata.json` + DB mime/size updates, stems and artifacts unaffected (separate files). Settings → Storage surface showing reclaimable space estimate.
+**F3 — guard rails.** Never convert entries referenced as init/inpaint sources if F1 says lossless matters there (or always keep a flag for "this entry was lossy-converted" so generation flows can warn).
 
 ## 7. Standing constraints (apply to all phases)
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-13T01:17:47.894Z · Git revision: `c0314f671305` · Repomix tracked: **no**
+> Generated: 2026-06-13T01:36:45.192Z · Git revision: `b74152f3e145` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-13T01:36:45.192Z · Git revision: `b74152f3e145` · Repomix tracked: **no**
+> Generated: 2026-06-13T01:56:33.643Z · Git revision: `36780211cc46` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-13T01:17:47.894Z",
-  "repoRevision": "c0314f671305",
+  "generatedAt": "2026-06-13T01:36:45.192Z",
+  "repoRevision": "b74152f3e145",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-13T01:36:45.192Z",
-  "repoRevision": "b74152f3e145",
+  "generatedAt": "2026-06-13T01:56:33.643Z",
+  "repoRevision": "36780211cc46",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T01:38:58.090Z",
+  "generatedAt": "2026-06-13T01:58:38.718Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T01:20:01.149Z",
+  "generatedAt": "2026-06-13T01:38:58.090Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -529,7 +529,7 @@ A floating **Edit Layout** control turns on Design Mode. In Design Mode, panels 
 
 ### Purpose
 
-The VJ tab (`VJView`) embeds the GANTASMO-LIVE-VJ visual engine as a live, audio-reactive instrument. The backend `vj` module spawns the engine's dev server lazily, and the tab fetches its live URL from `/api/vj/url`, so the port is never hardcoded. First launch runs `npm install` in the VJ project and can take a minute; later launches are fast.
+The VJ tab (`VJView`) embeds the GANTASMO-LIVE-VJ visual engine as a live, audio-reactive instrument. The backend `vj` module serves the engine lazily as a production build (it rebuilds automatically when the engine's source is newer than the build, and `theDAW_VJ_DEV=1` forces the HMR dev server for engine development), and the tab fetches its live URL from `/api/vj/url`, so the port is never hardcoded. First launch runs `npm install` plus a one-time build in the VJ project and can take a minute; later launches are fast.
 
 ### 10.1 Inputs
 
@@ -544,7 +544,7 @@ A toolbar row toggles which signals feed the visuals. At least one input stays a
 
 The camera input extends past a webcam on the host machine. Any device that opens theDAW in a browser and grants camera permission serves as the source.
 
-- **Phone or tablet cameras on the same Wi-Fi.** The phone opens theDAW at the LAN URL (see §10.2 Mobile, or the Mobile Access panel in the shell header) and grants the camera prompt, and the phone's camera then streams into the visuals. The Vite dev server binds `0.0.0.0` and the backend auto-detects the LAN IP, so the only requirement is a network that permits device-to-device connections.
+- **Phone or tablet cameras on the same Wi-Fi.** The phone opens theDAW at the LAN URL (see §10.2 Mobile, or the Mobile Access panel in the shell header) and grants the camera prompt, and the phone's camera then streams into the visuals. The Vite server binds `0.0.0.0` and the backend auto-detects the LAN IP, so the only requirement is a network that permits device-to-device connections.
 - **Quest 3 headsets and off-network devices.** A device away from the LAN, such as a Quest 3, a phone on cellular, or a remote camera, joins through a public tunnel. A Cloudflare Tunnel or other public URL goes into the **External URL override** in the Mobile Access panel, and the headset or phone opens that URL in its browser and feeds its camera the same way. The browser exposes the Quest 3's passthrough and visible-light cameras like any other camera.
 - **Capture inputs.** Anything that presents to the operating system as a camera, including HDMI capture cards, DSLRs in webcam mode, OBS virtual camera, and NDI-to-webcam bridges, appears in the browser's device list and selects as the source.
 
@@ -1337,7 +1337,7 @@ MIDI conversion runs on full entries and, when available, separated stems. The s
 
 ### 19.17 VJ
 
-The VJ module powers the VJ center tab and its embedded iframe. The frontend fetches the engine URL from `GET /api/vj/url`, which also returns a `mobile_url` for LAN access when the machine has a non-loopback address. The backend spawns the visual engine's dev server lazily; the port and project path can be overridden through the `theDAW_VJ_PORT` and `theDAW_VJ_PROJECT` environment variables. Use the Settings modal module list and the VJ tab loading state to confirm availability.
+The VJ module powers the VJ center tab and its embedded iframe. The frontend fetches the engine URL from `GET /api/vj/url`, which also returns a `mobile_url` for LAN access when the machine has a non-loopback address. The backend serves the visual engine lazily as a production build (`vite preview`), rebuilding when the engine's source is newer than `dist/`; the port and project path can be overridden through the `theDAW_VJ_PORT` and `theDAW_VJ_PROJECT` environment variables, and `theDAW_VJ_DEV=1` forces the HMR dev server for engine development. Use the Settings modal module list and the VJ tab loading state to confirm availability.
 
 ### 19.18 Notation and Prompt Inference
 


### PR DESCRIPTION
## Phase A — VJ production-build sidecar + slimmer jobs list

First slice of the global-layout / VJ-library / optimization plan (`docs/plans/2026-06-13-...`). Two independent, low-risk wins.

### VJ served as a production build
The `vj` sidecar previously ran `npm run dev` (HMR websocket, per-request transforms, file watcher) for live performance use. It now:
- Builds the engine when `dist/` is missing or older than the newest source file (cheap newest-mtime compare over `src/`, `assets/`, `public/`, and the key config files), then serves it with `vite preview` on the same port contract.
- Keeps the `0.0.0.0` bind so the LAN/mobile URL and QR still work.
- Exposes `theDAW_VJ_DEV=1` to force the HMR dev server when developing the VJ engine itself.
- `mode` and `build_stale` are surfaced in `/api/vj/status`.
- `stop()` now kills the whole npm process tree on Windows; terminating only the `npm.cmd` shim left the `node`/vite child holding the port.

### Slimmer `GET /api/jobs`
The list endpoint returned every job's full `result` (base64 audio + spectrograms, megabytes each); the TRAIN poller fetched it repeatedly. The list now returns summaries without `result`. The per-job `GET /api/jobs/{id}` keeps the full payload, and that is what the generate flow polls — verified the caller before changing.

### Validation (live rig)
- Standalone harness on a scratch port: preview path serves a production build (`/assets/` bundles, no `/@vite/client`); `build_stale` flips true after a source `touch` and the build fires on next spawn; `theDAW_VJ_DEV=1` falls back to the dev server; `stop()` frees the port with no orphan.
- Backend restarted on the real rig: `/api/vj/status` → `mode=preview`, `/api/vj/url` serves the production build, `/api/jobs` carries no `result` keys.
- `ruff check` + `ruff format --check` clean at repo root.

Visual sign-off on the VJ tab still wants your eyes (the harness only checks the served HTML, not the rendered visuals).