### PR TITLE
feat(library,vj): video/image media library + VJ cue persistence

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-13T02:25:56.166Z · Git revision: `e709585f21c2` · Repomix tracked: **no**
+> Generated: 2026-06-13T02:40:33.034Z · Git revision: `c88e354ec5bb` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-13T02:25:56.166Z",
-  "repoRevision": "e709585f21c2",
+  "generatedAt": "2026-06-13T02:40:33.034Z",
+  "repoRevision": "c88e354ec5bb",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T02:28:09.251Z",
+  "generatedAt": "2026-06-13T02:42:59.930Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/src/views/VJView.tsx
+++ b/frontend/src/views/VJView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Tv2,
   ExternalLink,
@@ -121,6 +121,21 @@ export const VJView: React.FC = () => {
   // URL (fallback '*' if unparseable) instead of a blanket wildcard, and route
   // to the popped-out window when detached, else the in-tab iframe.
   const vjOrigin = (() => { try { return url ? new URL(url).origin : '*'; } catch { return '*'; } })();
+
+  // The VJ uploads media it imports straight to the library so the cue
+  // survives a reload. It can't read our (cross-origin) location, so we
+  // hand it our origin via `?api=`; it serves /api directly (production)
+  // or through the Vite dev proxy (development) either way.
+  const vjSrc = useMemo(() => {
+    if (!url) return null;
+    try {
+      const u = new URL(url);
+      u.searchParams.set('api', window.location.origin);
+      return u.toString();
+    } catch {
+      return url;
+    }
+  }, [url]);
   const postToIframe = (payload: Record<string, unknown>) => {
     const w = popped ? poppedWindowRef.current : iframeRef.current?.contentWindow;
     if (!w) return;
@@ -445,12 +460,12 @@ export const VJView: React.FC = () => {
   }, [popped]);
 
   const popOut = () => {
-    if (!url) return;
+    if (!vjSrc) return;
     // 1280x800 is a reasonable default for a VJ canvas — big enough
     // to look good on a second monitor, small enough to not auto-
     // maximize on a single-screen setup.
     const w = window.open(
-      url,
+      vjSrc,
       'sa3-vj-window',
       'noopener=no,width=1280,height=800,location=no,menubar=no,toolbar=no,status=no',
     );
@@ -766,10 +781,10 @@ export const VJView: React.FC = () => {
             </button>
           </div>
         )}
-        {status === 'ready' && !popped && url && (
+        {status === 'ready' && !popped && vjSrc && (
           <iframe
             ref={iframeRef}
-            src={url}
+            src={vjSrc}
             onLoad={handleIframeLoad}
             // The VJ project hosts its own controls + canvas. We grant
             // microphone permission so the user can VJ to mic input


### PR DESCRIPTION
## Phase B — Library video/image media + VJ cue persistence

Part of the global-layout/VJ-library/optimization plan. Adds first-class video and image media to the library and routes VJ imports through it so a VJ cue survives a reload. (Overlays = a follow-up.)

### B1 — backend media entries
- `backend/modules/library/media.py`: ffprobe + Pillow probing for dimensions, duration, and alpha (overlay-capable detection), and poster-thumbnail rendering. Degrades gracefully when ffmpeg/ffprobe are absent.
- store: `LibraryRecord` carries `kind`/`media_url`/`thumb_url`/`width`/`height`/`has_alpha`; `import_media()` stores the original untouched, probes it, renders `thumb.jpg`; `list_entries(kinds=...)` filters by kind.
- router: `GET /entries?kind=audio|video|image|media|all` (default **audio**, so the audio library is byte-for-byte unchanged), `POST /import-media`, `GET /media/{id}` (Range-capable), `GET /media/{id}/thumb`.
- 11 new tests with real PIL + ffmpeg fixtures; the existing library suite stays green.

### B2 — Library Video tab
- `LibraryEntry` gains the media fields; `lib/mediaLibrary.ts` is a typed list/import/delete client kept separate from the audio StorageProvider.
- `LibraryView`: a **Video** sub-tab with a thumbnail grid (poster, duration, **Alpha** badge), a multi-file Import button, drag-out with a stable URL, and remove. The audio tabs are untouched.

### B3 — VJ cue persistence
- `VJView` passes `?api=<origin>` to the iframe + pop-out so the VJ app can reach the library (the host serves `/api` directly in prod, via the Vite dev proxy in dev).
- The **GANTASMO-LIVE-VJ side** (separate repo, committed locally on `feat/library-media-persistence`, not pushed here): VJ imports upload to `POST /api/library/import-media` and swap their session `blob:` URL for the stable `/api/library/media/<id>` URL, so the cue survives a reload. The clip `<video>` already carries `crossOrigin=anonymous` and the image backdrop is CSS, so there's no canvas-taint fix to make.

### Verification
- B1 verified live end-to-end against the running backend: import → kind/alpha/dimensions, media stream, thumbnail, media-list inclusion, audio-list exclusion, delete.
- Cross-origin plumbing the VJ relies on confirmed with an Origin of port 5187: `POST /import-media`, `GET /media`, and the **206 Range** response all return `Access-Control-Allow-Origin: *`.
- Both frontends typecheck; the VJ production build compiles.
- **Pending the user's eyes** (per the visual-verification rule): the Library Video tab rendering, and a VJ import surviving a reload while rendering on the canvas.