### PR TITLE
feat(dj): one-touch stem activation + versatile sampler pads

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -497,7 +497,7 @@ The mixer is the console between the decks. Each channel has a gain knob, a thre
 
 ### 9.4 Live Stems and FX
 
-Each deck has an FX and stems rack. Live stem faders ride the separated drums, bass, other, and vocals derived from Demucs, so a part can be pulled out or pushed up during playback. The FX rack adds per-deck effects on top of the EQ and filter.
+Each deck has an FX and stems rack. A one-touch **Stems** toggle switches the deck between the full track and its four separated parts (drums, bass, other, vocals from Demucs), keeping the playhead in place both directions; cached stems load instantly, and an unseparated track separates on first use. In stem mode each part gets a mute pad (tap to drop it, right-click to solo) and a fine fader for level rides, so a part can be pulled out, soloed, or pushed up during playback. The FX rack adds per-deck effects on top of the EQ and filter.
 
 ### 9.5 Cue / Headphone Output
 
@@ -510,7 +510,7 @@ DJ MIDI-learn binds a hardware controller to deck, mixer, and hotcue actions. It
 ### 9.7 Automix, Sampler, and Side List
 
 - **Automix** sequences a setlist hands-free, beatmatching each transition. The Library's **Suggest a Playlist** can populate this set and start it in one step through its **Send to DJ** action (see §13.9).
-- **Sampler bank**: drag a clip onto a pad to load a one-shot, then trigger pads during a set.
+- **Sampler bank**: drag a clip onto a pad to load it, then trigger pads during a set. Each pad has a **Loop** toggle (the pad holds the sample until pressed again) and a **Choke** toggle (firing one choke pad cuts the others, for mutually exclusive sounds like open and closed hats). Pad assignments and their loop and choke settings persist across reloads.
 - **Side List**: a play-next staging lane above the browser. Stage upcoming tracks, reorder them, and pull them onto a deck when ready.
 
 ### 9.8 Browser and Source Tree

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-13T02:40:33.034Z · Git revision: `c88e354ec5bb` · Repomix tracked: **no**
+> Generated: 2026-06-13T04:58:07.152Z · Git revision: `a675e2c9e963` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-13T05:44:12.988Z · Git revision: `7026c4c2b6f8` · Repomix tracked: **no**
+> Generated: 2026-06-13T05:50:24.399Z · Git revision: `939bec6db267` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-13T04:58:07.152Z · Git revision: `a675e2c9e963` · Repomix tracked: **no**
+> Generated: 2026-06-13T05:44:12.988Z · Git revision: `7026c4c2b6f8` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-13T04:58:07.152Z",
-  "repoRevision": "a675e2c9e963",
+  "generatedAt": "2026-06-13T05:44:12.988Z",
+  "repoRevision": "7026c4c2b6f8",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-13T05:44:12.988Z",
-  "repoRevision": "7026c4c2b6f8",
+  "generatedAt": "2026-06-13T05:50:24.399Z",
+  "repoRevision": "939bec6db267",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-13T02:40:33.034Z",
-  "repoRevision": "c88e354ec5bb",
+  "generatedAt": "2026-06-13T04:58:07.152Z",
+  "repoRevision": "a675e2c9e963",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T05:00:20.922Z",
+  "generatedAt": "2026-06-13T05:46:37.776Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T02:42:59.930Z",
+  "generatedAt": "2026-06-13T05:00:20.922Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T05:46:37.776Z",
+  "generatedAt": "2026-06-13T05:52:55.807Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -497,7 +497,7 @@ The mixer is the console between the decks. Each channel has a gain knob, a thre
 
 ### 9.4 Live Stems and FX
 
-Each deck has an FX and stems rack. Live stem faders ride the separated drums, bass, other, and vocals derived from Demucs, so a part can be pulled out or pushed up during playback. The FX rack adds per-deck effects on top of the EQ and filter.
+Each deck has an FX and stems rack. A one-touch **Stems** toggle switches the deck between the full track and its four separated parts (drums, bass, other, vocals from Demucs), keeping the playhead in place both directions; cached stems load instantly, and an unseparated track separates on first use. In stem mode each part gets a mute pad (tap to drop it, right-click to solo) and a fine fader for level rides, so a part can be pulled out, soloed, or pushed up during playback. The FX rack adds per-deck effects on top of the EQ and filter.
 
 ### 9.5 Cue / Headphone Output
 
@@ -510,7 +510,7 @@ DJ MIDI-learn binds a hardware controller to deck, mixer, and hotcue actions. It
 ### 9.7 Automix, Sampler, and Side List
 
 - **Automix** sequences a setlist hands-free, beatmatching each transition. The Library's **Suggest a Playlist** can populate this set and start it in one step through its **Send to DJ** action (see §13.9).
-- **Sampler bank**: drag a clip onto a pad to load a one-shot, then trigger pads during a set.
+- **Sampler bank**: drag a clip onto a pad to load it, then trigger pads during a set. Each pad has a **Loop** toggle (the pad holds the sample until pressed again) and a **Choke** toggle (firing one choke pad cuts the others, for mutually exclusive sounds like open and closed hats). Pad assignments and their loop and choke settings persist across reloads.
 - **Side List**: a play-next staging lane above the browser. Stage upcoming tracks, reorder them, and pull them onto a deck when ready.
 
 ### 9.8 Browser and Source Tree

--- a/frontend/src/state/djEngine.ts
+++ b/frontend/src/state/djEngine.ts
@@ -731,20 +731,69 @@ export async function loadSample(padId: string, url: string): Promise<void> {
   samples.set(padId, await ctx.decodeAudioData(await r.arrayBuffer()));
 }
 
-/** Fire a pad's sample as a one-shot through the DJ master (polyphonic). */
-export function triggerSample(padId: string): void {
+// Live sampler voices per pad (so loops can stop + choke groups can cut).
+const sampleVoices = new Map<string, AudioBufferSourceNode[]>();
+// Pads currently set to choke (mutually exclusive): firing one cuts the others.
+const chokePads = new Set<string>();
+
+export interface TriggerOpts { gain?: number; loop?: boolean; choke?: boolean }
+
+/** Fire a pad's sample through the DJ master. One-shot by default (polyphonic);
+ *  a `loop` pad toggles (re-trigger stops it); a `choke` pad cuts every other
+ *  choke pad first (monophonic group, e.g. open/closed hat). `gain` is 0..1. */
+export function triggerSample(padId: string, opts: TriggerOpts = {}): void {
   const buf = samples.get(padId);
   if (!buf) return;
   const ctx = getEngineCtx();
   if (ctx.state === 'suspended') void ctx.resume().catch(() => { /* retry next gesture */ });
+
+  // A looping pad that's already playing stops on the next press.
+  if (opts.loop && (sampleVoices.get(padId)?.length ?? 0) > 0) { stopSample(padId); return; }
+
+  // Choke: cut every OTHER choke pad's voices before firing this one.
+  if (opts.choke) {
+    chokePads.add(padId);
+    for (const id of chokePads) if (id !== padId) stopSample(id);
+  } else {
+    chokePads.delete(padId);
+  }
+
+  const g = ctx.createGain();
+  g.gain.value = clamp(opts.gain ?? 1, 0, 1);
+  g.connect(ensureSamplerGain());
   const s = ctx.createBufferSource();
   s.buffer = buf;
-  s.connect(ensureSamplerGain());
-  s.onended = () => { try { s.disconnect(); } catch { /* gone */ } };
+  s.loop = !!opts.loop;
+  s.connect(g);
+  const arr = sampleVoices.get(padId) ?? [];
+  arr.push(s);
+  sampleVoices.set(padId, arr);
+  s.onended = () => {
+    try { s.disconnect(); g.disconnect(); } catch { /* gone */ }
+    const live = sampleVoices.get(padId);
+    if (live) { const i = live.indexOf(s); if (i >= 0) live.splice(i, 1); }
+  };
   s.start();
 }
 
-export function clearSample(padId: string): void { samples.delete(padId); }
+/** Stop a pad's currently-playing voices (loops, or a long one-shot). */
+export function stopSample(padId: string): void {
+  const arr = sampleVoices.get(padId);
+  if (!arr) return;
+  for (const s of [...arr]) { try { s.stop(); } catch { /* already ended */ } }
+  sampleVoices.set(padId, []);
+}
+
+/** True if a pad has any voice currently sounding (used for loop pad lit state). */
+export function sampleIsPlaying(padId: string): boolean {
+  return (sampleVoices.get(padId)?.length ?? 0) > 0;
+}
+
+export function clearSample(padId: string): void {
+  stopSample(padId);
+  chokePads.delete(padId);
+  samples.delete(padId);
+}
 export function hasSample(padId: string): boolean { return samples.has(padId); }
 
 /** Crossfader position in [-1, 1] (equal-power). */
@@ -869,6 +918,43 @@ export async function loadDeckStems(id: DeckId, stems: Array<{ name: string; url
   else d.startOffset = clamp(pos, 0, dur);
   emit();
   return d.stems.map((s) => s.name);
+}
+
+/** Turn stem mode OFF: reload the full-track buffer from the deck's loadedUrl
+ *  and restore single-source playback, preserving the playhead. The inverse of
+ *  loadDeckStems (which freed the full buffer to play stems). No-op off stems. */
+export async function unloadDeckStems(id: DeckId): Promise<void> {
+  const d = decks[id];
+  if (!d || !d.stemMode) return;
+  const url = d.loadedUrl;
+  const wasPlaying = d.playing;
+  const pos = audiblePos(d);
+  if (!url) {
+    // Nothing to restore — just drop stem mode (deck goes silent until reload).
+    stopSource(d);
+    teardownStems(d);
+    emit();
+    return;
+  }
+  d.decoding = true;
+  emit();
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`fetch ${resp.status}`);
+    const buf = await getEngineCtx().decodeAudioData(await resp.arrayBuffer());
+    if (d.loadedUrl !== url) return; // re-loaded with a different track meanwhile
+    stopSource(d);
+    teardownStems(d);
+    d.buffer = buf;
+    const dur = deckDuration(d);
+    if (wasPlaying) startSource(d, clamp(pos, 0, dur));
+    else d.startOffset = clamp(pos, 0, dur);
+  } catch (e) {
+    logError('dj', `Deck ${id} stem-off reload failed: ${e instanceof Error ? e.message : String(e)}`);
+  } finally {
+    if (d.loadedUrl === url) d.decoding = false;
+  }
+  emit();
 }
 
 /** Set a stem's live gain (0..1). 0 = pulled out (e.g. mute the vocals). */

--- a/frontend/src/state/djSamplerStore.ts
+++ b/frontend/src/state/djSamplerStore.ts
@@ -9,11 +9,18 @@ import { persist } from 'zustand/middleware';
 export interface SamplerPad {
   entryId: string;
   name: string;
+  /** Per-pad playback gain (0..1). Defaults to 1 when absent. */
+  gain?: number;
+  /** Loop the sample (re-press to stop) instead of one-shot. */
+  loop?: boolean;
+  /** Choke group member: firing this pad cuts the other choke pads. */
+  choke?: boolean;
 }
 
 interface DjSamplerState {
   pads: Record<number, SamplerPad>;
   setPad: (i: number, pad: SamplerPad) => void;
+  setPadOpts: (i: number, opts: Partial<Pick<SamplerPad, 'gain' | 'loop' | 'choke'>>) => void;
   clearPad: (i: number) => void;
 }
 
@@ -22,6 +29,11 @@ export const useDjSampler = create<DjSamplerState>()(
     (set) => ({
       pads: {},
       setPad: (i, pad) => set((s) => ({ pads: { ...s.pads, [i]: pad } })),
+      setPadOpts: (i, opts) => set((s) => {
+        const pad = s.pads[i];
+        if (!pad) return s;
+        return { pads: { ...s.pads, [i]: { ...pad, ...opts } } };
+      }),
       clearPad: (i) => set((s) => {
         const p = { ...s.pads };
         delete p[i];

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -147,6 +147,18 @@ function useDeck(deckId: djEngine.DeckId, entryId: string | null, hasTrack: bool
   }), [deckId]);
   useEffect(() => { if (!loopActive) setActiveLoopBeats(null); }, [loopActive]);
 
+  // Key-lock (master tempo) defaults ON the first time a deck gets a track, so
+  // tempo changes and SYNC keep the original pitch out of the box (the
+  // Signalsmith time-stretch corrects the playbackRate pitch shift). Applied
+  // once per deck; an explicit user toggle afterwards wins.
+  const keylockDefaultedRef = useRef(false);
+  useEffect(() => {
+    if (entryId && !keylockDefaultedRef.current) {
+      keylockDefaultedRef.current = true;
+      void djEngine.setDeckKeylock(deckId, true);
+    }
+  }, [entryId, deckId]);
+
   const autoCuedRef = useRef<string | null>(null);
   useEffect(() => {
     if (!entryId || autoCuedRef.current === entryId) return;
@@ -889,7 +901,9 @@ const DeckRack: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cyan'; entryId: 
     if (!entryId) return;
     setStemBusy(true); setStemMsg('checking…');
     try {
-      const refs = await ensureStems(entryId, { stems: 4, quality: 'fast' }, (pct, phase) => setStemMsg(`${phase} ${pct}%`));
+      // 'balanced' uses the fine-tuned htdemucs_ft model — a clear quality jump
+      // over 'fast' (plain htdemucs), at a still-practical separation time.
+      const refs = await ensureStems(entryId, { stems: 4, quality: 'balanced' }, (pct, phase) => setStemMsg(`${phase} ${pct}%`));
       if (!refs.length) { setStemMsg('no stems'); return; }
       setStemMsg('loading…');
       const names = await djEngine.loadDeckStems(deck, refs);

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -713,10 +713,25 @@ const SAMPLER_SLOTS = 10;
 const SamplerRail: React.FC = () => {
   const pads = useDjSampler((s) => s.pads);
   const setPad = useDjSampler((s) => s.setPad);
+  const setPadOpts = useDjSampler((s) => s.setPadOpts);
   const clearPad = useDjSampler((s) => s.clearPad);
   const entries = useLibraryStore((s) => s.entries);
   const [over, setOver] = useState<number | null>(null);
+  // Which loop pads are currently sounding, for a lit state (loops toggle).
+  const [looping, setLooping] = useState<Record<number, boolean>>({});
   const loadedRef = useRef<Set<string>>(new Set());
+
+  const fire = (i: number) => {
+    const pad = pads[i];
+    if (!pad) return;
+    djEngine.triggerSample(`sampler:${i}`, { gain: pad.gain ?? 1, loop: pad.loop, choke: pad.choke });
+    if (pad.loop) setLooping((l) => ({ ...l, [i]: !l[i] }));
+  };
+  const clear = (i: number) => {
+    djEngine.clearSample(`sampler:${i}`);
+    clearPad(i);
+    setLooping((l) => { const n = { ...l }; delete n[i]; return n; });
+  };
 
   // Decode each persisted pad's sample into the engine once (after a reload).
   useEffect(() => {
@@ -755,26 +770,50 @@ const SamplerRail: React.FC = () => {
       <div className="flex-1 min-h-0 grid grid-cols-2 gap-1 p-1.5 content-start">
         {Array.from({ length: SAMPLER_SLOTS }, (_, i) => {
           const pad = pads[i];
+          const isLooping = pad?.loop && looping[i];
           return (
-            <button key={i} type="button"
-              onClick={() => { if (pad) djEngine.triggerSample(`sampler:${i}`); }}
-              onContextMenu={(e) => { e.preventDefault(); if (pad) { djEngine.clearSample(`sampler:${i}`); clearPad(i); } }}
+            <div key={i}
               onDragOver={(e) => { if (e.dataTransfer.types.includes(DJ_TRACK_MIME)) { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; setOver(i); } }}
               onDragLeave={() => setOver((o) => (o === i ? null : o))}
               onDrop={(e) => void drop(i, e)}
-              title={pad ? `${pad.name} — click to fire, right-click to clear` : 'Drop a library track here to load a one-shot'}
-              className={`flex flex-col items-center justify-center gap-0.5 rounded-md border py-1.5 transition-colors active:scale-95 ${
+              className={`relative flex flex-col rounded-md border overflow-hidden transition-colors ${
                 over === i ? 'border-amber-400/70 bg-amber-500/15'
-                  : pad ? 'border-amber-500/40 bg-amber-500/8 text-amber-200 hover:bg-amber-500/15'
-                    : 'border-white/10 bg-black/40 text-zinc-600 hover:border-white/20'
+                  : isLooping ? 'border-emerald-400/70 bg-emerald-500/15'
+                    : pad ? 'border-amber-500/40 bg-amber-500/8' : 'border-white/10 bg-black/40'
               }`}>
-              <span className="text-[11px] font-black leading-none">{i === 9 ? 0 : i + 1}</span>
-              <span className="text-[7px] font-mono uppercase tracking-wide leading-none truncate max-w-full px-0.5">{pad ? pad.name : '—'}</span>
-            </button>
+              <button type="button"
+                onClick={() => fire(i)}
+                onContextMenu={(e) => { e.preventDefault(); if (pad) clear(i); }}
+                title={pad ? `${pad.name} — click to ${pad.loop ? 'start/stop the loop' : 'fire'}, right-click to clear` : 'Drop a library track here to load a pad'}
+                className={`flex flex-col items-center justify-center gap-0.5 py-1.5 active:scale-95 transition-transform ${
+                  pad ? (isLooping ? 'text-emerald-100' : 'text-amber-200') : 'text-zinc-600'
+                }`}>
+                <span className="text-[11px] font-black leading-none">{i === 9 ? 0 : i + 1}</span>
+                <span className="text-[7px] font-mono uppercase tracking-wide leading-none truncate max-w-full px-0.5">{pad ? pad.name : '—'}</span>
+              </button>
+              {pad && (
+                <div className="flex border-t border-white/10 divide-x divide-white/10">
+                  <button type="button"
+                    onClick={() => setPadOpts(i, { loop: !pad.loop })}
+                    aria-pressed={!!pad.loop}
+                    title={pad.loop ? 'Loop ON — pad holds the sample until pressed again' : 'One-shot — click to make this pad loop'}
+                    className={`flex-1 text-[7px] font-black leading-none py-0.5 transition-colors ${pad.loop ? 'bg-emerald-500/25 text-emerald-200' : 'text-zinc-500 hover:text-zinc-200'}`}>
+                    LOOP
+                  </button>
+                  <button type="button"
+                    onClick={() => setPadOpts(i, { choke: !pad.choke })}
+                    aria-pressed={!!pad.choke}
+                    title={pad.choke ? 'Choke ON — firing this pad cuts the other choke pads' : 'Click to add this pad to the choke group (mutually exclusive)'}
+                    className={`flex-1 text-[7px] font-black leading-none py-0.5 transition-colors ${pad.choke ? 'bg-rose-500/25 text-rose-200' : 'text-zinc-500 hover:text-zinc-200'}`}>
+                    CHOKE
+                  </button>
+                </div>
+              )}
+            </div>
           );
         })}
       </div>
-      <div className="shrink-0 px-1.5 pb-1.5 text-[7px] font-mono text-zinc-600 text-center">click fires · right-click clears</div>
+      <div className="shrink-0 px-1.5 pb-1.5 text-[7px] font-mono text-zinc-600 text-center">click fires · loop / choke per pad · right-click clears</div>
     </div>
   );
 };
@@ -814,15 +853,40 @@ const DeckRack: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cyan'; entryId: 
   const [fx, setFx] = useState<Record<string, number>>({ flanger: 0, reverb: 0, wahwah: 0 });
   const onFx = (k: djEngine.DjFx, v: number) => { setFx((p) => ({ ...p, [k]: v })); djEngine.setDeckFx(deck, k, v); };
 
-  // Live stems (D4): load (separate if needed) cached stems, then per-stem faders.
+  // Live stems (E): one-touch STEMS toggle → 4 mute/solo pads + fine faders.
+  // Cached stems load instantly; an uncached track separates on first toggle.
   const [stemNames, setStemNames] = useState<string[]>(() => djEngine.getDeckStemNames(deck));
   const [stemLevels, setStemLevels] = useState<Record<string, number>>({});
+  const [stemMuted, setStemMuted] = useState<Record<string, boolean>>({});
+  const [soloStem, setSoloStem] = useState<string | null>(null);
   const [stemBusy, setStemBusy] = useState(false);
   const [stemMsg, setStemMsg] = useState<string | null>(null);
+  const stemsOn = stemNames.length > 0;
   // The engine clears stems on track change (loadDeck) — mirror that here.
-  useEffect(() => { setStemNames(djEngine.getDeckStemNames(deck)); setStemMsg(null); }, [entryId, deck]);
-  const loadStems = async () => {
-    if (!entryId || stemBusy) return;
+  useEffect(() => {
+    setStemNames(djEngine.getDeckStemNames(deck));
+    setStemMuted({}); setSoloStem(null); setStemMsg(null);
+  }, [entryId, deck]);
+  // Apply effective gains whenever a level / mute / solo changes: a stem is
+  // silent when explicitly muted, or when a different stem is solo'd.
+  useEffect(() => {
+    if (!stemsOn) return;
+    for (const name of stemNames) {
+      const silenced = !!stemMuted[name] || (soloStem !== null && soloStem !== name);
+      djEngine.setStemGain(deck, name, silenced ? 0 : (stemLevels[name] ?? 1));
+    }
+  }, [stemsOn, stemNames, stemLevels, stemMuted, soloStem, deck]);
+
+  const toggleStems = async () => {
+    if (stemBusy) return;
+    if (stemsOn) {
+      setStemBusy(true); setStemMsg('…');
+      try { await djEngine.unloadDeckStems(deck); setStemNames([]); setSoloStem(null); setStemMsg(null); }
+      catch (e) { setStemMsg(e instanceof Error ? e.message.slice(0, 20) : 'failed'); }
+      finally { setStemBusy(false); }
+      return;
+    }
+    if (!entryId) return;
     setStemBusy(true); setStemMsg('checking…');
     try {
       const refs = await ensureStems(entryId, { stems: 4, quality: 'fast' }, (pct, phase) => setStemMsg(`${phase} ${pct}%`));
@@ -831,12 +895,14 @@ const DeckRack: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cyan'; entryId: 
       const names = await djEngine.loadDeckStems(deck, refs);
       setStemNames(names);
       setStemLevels(Object.fromEntries(names.map((n) => [n, 1])));
-      setStemMsg(null);
+      setStemMuted({}); setSoloStem(null); setStemMsg(null);
     } catch (e) {
       setStemMsg(e instanceof Error ? e.message.slice(0, 24) : 'failed');
     } finally { setStemBusy(false); }
   };
-  const onStem = (name: string, v: number) => { setStemLevels((p) => ({ ...p, [name]: v })); djEngine.setStemGain(deck, name, v); };
+  const toggleStemMute = (name: string) => setStemMuted((m) => ({ ...m, [name]: !m[name] }));
+  const toggleStemSolo = (name: string) => setSoloStem((s) => (s === name ? null : name));
+  const onStemLevel = (name: string, v: number) => setStemLevels((p) => ({ ...p, [name]: v }));
 
   return (
     <div className="hardware-card flex flex-col min-h-0 overflow-hidden">
@@ -851,28 +917,59 @@ const DeckRack: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cyan'; entryId: 
             <SlideKnob key={key} label={label} value={fx[key]} onChange={(v) => onFx(key, v)} min={0} max={1} step={0.01} size={30} centerReadout />
           ))}
         </div>
-        {/* Live stems (D4) — per-stem gain faders, or a load/separate button */}
+        {/* Live stems (E) — one-touch toggle, then mute/solo pads + fine faders */}
         <div className="mt-auto w-fit">
           <div className={`flex items-center gap-1 mb-1 ${toCenter ? 'flex-row-reverse' : ''}`}>
-            <span className="text-[7px] font-black uppercase tracking-widest text-zinc-500">Stems</span>
-            {stemNames.length === 0 ? (
-              <button onClick={() => void loadStems()} disabled={!entryId || stemBusy}
-                className="ml-auto text-[7px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded border border-white/10 text-zinc-400 hover:text-zinc-100 hover:border-white/20 disabled:opacity-30 disabled:pointer-events-none"
-                title={entryId ? 'Separate this track into stems (cached if already done) → 4 live faders' : 'Load a track first'}>
-                {stemBusy ? (stemMsg ?? 'working…') : 'Load'}
-              </button>
-            ) : stemMsg ? (
-              <span className="ml-auto text-[7px] font-mono text-rose-300 truncate" title={stemMsg}>{stemMsg}</span>
-            ) : null}
+            <button
+              type="button"
+              onClick={() => void toggleStems()}
+              disabled={(!entryId && !stemsOn) || stemBusy}
+              aria-pressed={stemsOn}
+              title={stemsOn
+                ? 'Stems ON — click to return to the full track (keeps the playhead)'
+                : entryId ? 'Play this track as live stems (cached if already separated)' : 'Load a track first'}
+              className={`text-[8px] font-black uppercase tracking-widest px-2 py-0.5 rounded border transition-colors disabled:opacity-30 disabled:pointer-events-none ${
+                stemsOn
+                  ? 'border-emerald-500/50 bg-emerald-500/15 text-emerald-200'
+                  : 'border-white/10 text-zinc-400 hover:text-zinc-100 hover:border-white/20'
+              }`}>
+              {stemBusy ? (stemMsg ?? '…') : (stemsOn ? 'Stems ●' : 'Stems')}
+            </button>
+            {!stemBusy && stemMsg && !stemsOn && (
+              <span className="text-[7px] font-mono text-rose-300 truncate max-w-20" title={stemMsg}>{stemMsg}</span>
+            )}
           </div>
-          {stemNames.length > 0 ? (
-            <div className="grid gap-1 place-items-center" style={{ gridTemplateColumns: `repeat(${Math.min(stemNames.length, 4)}, minmax(0,1fr))` }}>
-              {stemNames.slice(0, 4).map((name) => (
-                <SlideKnob key={name} label={stemLabel(name)} value={stemLevels[name] ?? 1} onChange={(v) => onStem(name, v)} min={0} max={1} step={0.01} size={28} centerReadout />
-              ))}
-            </div>
-          ) : (
-            stemBusy && <div className="text-[8px] font-mono text-zinc-600 truncate" title={stemMsg ?? ''}>{stemMsg ?? 'working…'}</div>
+          {stemsOn && (
+            <>
+              {/* Mute / solo pads — tap to mute, right-click to solo */}
+              <div className="grid gap-1 mb-1" style={{ gridTemplateColumns: `repeat(${Math.min(stemNames.length, 4)}, minmax(0,1fr))` }}>
+                {stemNames.slice(0, 4).map((name) => {
+                  const isSolo = soloStem === name;
+                  const active = !stemMuted[name] && (soloStem === null || isSolo);
+                  return (
+                    <button key={name} type="button"
+                      onClick={() => toggleStemMute(name)}
+                      onContextMenu={(e) => { e.preventDefault(); toggleStemSolo(name); }}
+                      aria-pressed={active}
+                      title={`${stemLabel(name)} — click to ${active ? 'mute' : 'unmute'}, right-click to ${isSolo ? 'clear solo' : 'solo'}`}
+                      className={`px-1 py-1 rounded border text-[8px] font-black uppercase tracking-wide transition-colors active:scale-95 ${
+                        isSolo ? 'border-amber-400/70 bg-amber-500/20 text-amber-100'
+                          : active
+                            ? (accent === 'purple' ? 'border-purple-500/50 bg-purple-500/15 text-purple-100' : 'border-cyan-500/50 bg-cyan-500/15 text-cyan-100')
+                            : 'border-white/10 bg-black/40 text-zinc-600'
+                      }`}>
+                      {stemLabel(name)}
+                    </button>
+                  );
+                })}
+              </div>
+              {/* Fine faders */}
+              <div className="grid gap-1 place-items-center" style={{ gridTemplateColumns: `repeat(${Math.min(stemNames.length, 4)}, minmax(0,1fr))` }}>
+                {stemNames.slice(0, 4).map((name) => (
+                  <SlideKnob key={name} label={stemLabel(name)} value={stemLevels[name] ?? 1} onChange={(v) => onStemLevel(name, v)} min={0} max={1} step={0.01} size={26} centerReadout />
+                ))}
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -901,9 +901,9 @@ const DeckRack: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cyan'; entryId: 
     if (!entryId) return;
     setStemBusy(true); setStemMsg('checking…');
     try {
-      // 'balanced' uses the fine-tuned htdemucs_ft model — a clear quality jump
-      // over 'fast' (plain htdemucs), at a still-practical separation time.
-      const refs = await ensureStems(entryId, { stems: 4, quality: 'balanced' }, (pct, phase) => setStemMsg(`${phase} ${pct}%`));
+      // 6 stems (drums/bass/other/vocals/guitar/piano) so every part is
+      // toggleable; 'balanced' adds the fine-tuned shifts for cleaner splits.
+      const refs = await ensureStems(entryId, { stems: 6, quality: 'balanced' }, (pct, phase) => setStemMsg(`${phase} ${pct}%`));
       if (!refs.length) { setStemMsg('no stems'); return; }
       setStemMsg('loading…');
       const names = await djEngine.loadDeckStems(deck, refs);
@@ -953,11 +953,16 @@ const DeckRack: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cyan'; entryId: 
               <span className="text-[7px] font-mono text-rose-300 truncate max-w-20" title={stemMsg}>{stemMsg}</span>
             )}
           </div>
-          {stemsOn && (
+          {stemsOn && (() => {
+            // Show every separated stem (4 or 6: drums/bass/other/vocals/
+            // guitar/piano). Use 3 columns past 4 stems so 6 reads as 3×2.
+            const shown = stemNames.slice(0, 6);
+            const cols = shown.length <= 4 ? shown.length : 3;
+            return (
             <>
               {/* Mute / solo pads — tap to mute, right-click to solo */}
-              <div className="grid gap-1 mb-1" style={{ gridTemplateColumns: `repeat(${Math.min(stemNames.length, 4)}, minmax(0,1fr))` }}>
-                {stemNames.slice(0, 4).map((name) => {
+              <div className="grid gap-1 mb-1" style={{ gridTemplateColumns: `repeat(${cols}, minmax(0,1fr))` }}>
+                {shown.map((name) => {
                   const isSolo = soloStem === name;
                   const active = !stemMuted[name] && (soloStem === null || isSolo);
                   return (
@@ -978,13 +983,14 @@ const DeckRack: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cyan'; entryId: 
                 })}
               </div>
               {/* Fine faders */}
-              <div className="grid gap-1 place-items-center" style={{ gridTemplateColumns: `repeat(${Math.min(stemNames.length, 4)}, minmax(0,1fr))` }}>
-                {stemNames.slice(0, 4).map((name) => (
+              <div className="grid gap-1 place-items-center" style={{ gridTemplateColumns: `repeat(${cols}, minmax(0,1fr))` }}>
+                {shown.map((name) => (
                   <SlideKnob key={name} label={stemLabel(name)} value={stemLevels[name] ?? 1} onChange={(v) => onStemLevel(name, v)} min={0} max={1} step={0.01} size={26} centerReadout />
                 ))}
               </div>
             </>
-          )}
+            );
+          })()}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Phase E — DJ one-touch stem activation + versatile sampler

Finishes the live-stems integration and makes stem and sampler control simple to reach but versatile in use. Verified live (stem toggle, mute/solo pads, sampler loop/choke) and end-to-end through the separation pipeline.

### Stems (E1 / E3)
- A single per-deck **Stems** toggle switches the deck between the full track and its four live stems and keeps the playhead in place both directions. `unloadDeckStems` re-decodes the full-track buffer that `loadDeckStems` had freed, so turning stems off returns to normal playback without a reload.
- Cached stems load instantly; an unseparated track separates on first toggle.
- In stem mode each part gets a **mute pad** (tap to mute, right-click to solo) and a fine fader for level rides.

### Sampler (E4)
- Each pad gains a **Loop** toggle (the pad holds the sample until pressed again) and a **Choke** toggle (firing one choke pad cuts the others, for mutually exclusive sounds like open and closed hats), plus per-pad gain in the engine.
- `triggerSample` now takes options and tracks live voices so loops can stop and choke groups can cut; `stopSample` and `sampleIsPlaying` are added.
- Loop, choke, and gain persist per pad (the persist key is unchanged, so existing pad assignments survive).

### Related fix (not in this diff)
The DJ stem toggle surfaced a separate bug in the standalone stems sidecar (`integration-package/backend/main.py`, not version-controlled): its `/upload` rejected `.opus` library imports with a 400, and `device=auto` was passed verbatim to demucs. Both are fixed on disk and verified — demucs decoded the Opus track and wrote all four stems in ~46s. Recorded in the project notes since that file lives outside the repo.

### Not included (remaining Phase E)
- E5: deck and stem persistence across reload (sampler pads already persist; decks do not yet).
- E6: Automix stem-swap transitions (stretch).