### PR TITLE
feat(dj): full vinyl mode — scratch, wind-down, spin-up (worklet)

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-13T06:27:48.589Z · Git revision: `6c410a5a78d9` · Repomix tracked: **no**
+> Generated: 2026-06-13T06:48:28.516Z · Git revision: `c202cc3ff839` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-13T06:27:48.589Z",
-  "repoRevision": "6c410a5a78d9",
+  "generatedAt": "2026-06-13T06:48:28.516Z",
+  "repoRevision": "c202cc3ff839",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T06:30:01.951Z",
+  "generatedAt": "2026-06-13T06:50:56.077Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/public/vinyl-scratch.worklet.js
+++ b/frontend/public/vinyl-scratch.worklet.js
@@ -1,0 +1,112 @@
+/* Vinyl-scratch AudioWorklet for the DJ decks.
+ *
+ * A standard AudioBufferSourceNode can't play backward or at an arbitrary
+ * hand-driven speed, which is exactly what a scratch is. This processor holds
+ * the deck's decoded samples and outputs them from a read-head it advances
+ * each sample by a velocity (1 = normal forward, -1 = reverse, 0 = stopped).
+ * The main thread drives that velocity from the jog wheel; a still hold eases
+ * it to 0 (record wind-down) and release eases it back to 1 (spin-up).
+ *
+ * Two voices:
+ *   classic — clean linear-interpolated resampling (turntable feel).
+ *   cyber   — fragmented/glitch: speed-driven sample-hold + bit-crush +
+ *             occasional grain stutter for a cyberpunk edge.
+ *
+ * Messages in:  {type:'load', l, r, len} | {type:'pos', sec} |
+ *               {type:'vel', vel, immediate?} | {type:'ease', ease} |
+ *               {type:'mode', mode} | {type:'play', on} | {type:'gain', gain}
+ * Messages out: {type:'pos', sec}  (read-head, ~per block, for handoff/UI)
+ */
+class VinylScratchProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.l = null;
+    this.r = null;
+    this.len = 0;
+    this.readPos = 0;     // float sample index
+    this.vel = 1;         // current velocity (audio samples per output sample)
+    this.targetVel = 1;   // eased toward
+    this.ease = 0.1;      // velocity smoothing per sample (brake/spin-up feel)
+    this.mode = 'classic';
+    this.playing = false;
+    this.gain = 1;
+    // cyber voice state
+    this._holdL = 0;
+    this._holdR = 0;
+    this._holdN = 0;
+    this._postCtr = 0;
+    this.port.onmessage = (e) => {
+      const d = e.data;
+      switch (d.type) {
+        case 'load': this.l = d.l; this.r = d.r || d.l; this.len = d.len | 0; break;
+        case 'pos': this.readPos = Math.max(0, Math.min(this.len - 1, d.sec * sampleRate)); break;
+        case 'vel': this.targetVel = d.vel; if (d.immediate) this.vel = d.vel; break;
+        case 'ease': this.ease = Math.max(0.001, Math.min(1, d.ease)); break;
+        case 'mode': this.mode = d.mode === 'cyber' ? 'cyber' : 'classic'; break;
+        case 'play': this.playing = !!d.on; if (d.on) this._postCtr = 0; break;
+        case 'gain': this.gain = d.gain; break;
+        default: break;
+      }
+    };
+  }
+
+  read(ch, pos) {
+    if (!ch) return 0;
+    if (pos < 0 || pos >= this.len - 1) return 0;
+    const i = pos | 0;
+    const f = pos - i;
+    return ch[i] * (1 - f) + ch[i + 1] * f;
+  }
+
+  process(_inputs, outputs) {
+    const out = outputs[0];
+    if (!out || out.length === 0) return true;
+    const oL = out[0];
+    const oR = out.length > 1 ? out[1] : null;
+    const n = oL.length;
+
+    if (!this.l || !this.playing) {
+      for (let i = 0; i < n; i++) { oL[i] = 0; if (oR) oR[i] = 0; }
+      return true;
+    }
+
+    const cyber = this.mode === 'cyber';
+    for (let i = 0; i < n; i++) {
+      // Ease the velocity toward its target (the brake / spin-up curve).
+      this.vel += (this.targetVel - this.vel) * this.ease;
+      let l = this.read(this.l, this.readPos);
+      let r = this.read(this.r, this.readPos);
+
+      if (cyber) {
+        const speed = Math.abs(this.vel);
+        // Sample-hold proportional to speed → gritty downsampled edge.
+        const hold = 1 + (Math.min(8, speed * 6) | 0);
+        if (this._holdN <= 0) { this._holdL = l; this._holdR = r; this._holdN = hold; }
+        this._holdN--;
+        l = this._holdL; r = this._holdR;
+        // Bit-crush to ~5 bits for the digital fragmentation.
+        const q = 32; // 2^5
+        l = Math.round(l * q) / q;
+        r = Math.round(r * q) / q;
+      }
+
+      oL[i] = l * this.gain;
+      if (oR) oR[i] = r * this.gain;
+
+      this.readPos += this.vel;
+      if (this.readPos < 0) { this.readPos = 0; this.vel = 0; }
+      else if (this.readPos >= this.len - 1) { this.readPos = this.len - 1; this.vel = 0; }
+    }
+
+    // Report the read-head a few times a second so the engine can hand back to
+    // the normal source at the right spot and the UI can track it.
+    this._postCtr += n;
+    if (this._postCtr >= 2048) {
+      this._postCtr = 0;
+      this.port.postMessage({ type: 'pos', sec: this.readPos / sampleRate });
+    }
+    return true;
+  }
+}
+
+registerProcessor('vinyl-scratch', VinylScratchProcessor);

--- a/frontend/src/components/audio/JogWheel.tsx
+++ b/frontend/src/components/audio/JogWheel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { rgb, rgba, type RGB } from '../../lib/trackColor';
 import * as djEngine from '../../state/djEngine';
+import { useDjVinyl } from '../../state/djVinylStore';
 
 /* ── JogWheel ──────────────────────────────────────────────────────────
    A DJ deck platter: a spinning disc with a position-progress ring and a
@@ -30,6 +31,11 @@ export function JogWheel({ deckId, color, size = 132, disabled, fill }: {
   const ringRef = useRef<SVGCircleElement>(null);
   const [dim, setDim] = useState(size);
 
+  // Scratch character (shared by both decks), pushed live to the engine.
+  const scratchMode = useDjVinyl((s) => s.mode);
+  const toggleScratch = useDjVinyl((s) => s.toggle);
+  useEffect(() => { djEngine.setScratchMode(scratchMode); }, [scratchMode]);
+
   // In fill mode, track the container's smaller side as the platter diameter.
   useEffect(() => {
     if (!fill) { setDim(size); return; }
@@ -58,28 +64,63 @@ export function JogWheel({ deckId, color, size = 132, disabled, fill }: {
     }
   }), [deckId, circ]);
 
-  // Vinyl scrub — rotational drag seeks proportionally.
-  const scrubbing = useRef(false);
-  const startAngle = useRef(0);
-  const startTime = useRef(0);
-  const pendingT = useRef<number | null>(null);
-  const raf = useRef(0);
   const angleOf = (e: React.PointerEvent) => {
     const el = rootRef.current;
     if (!el) return 0;
     const rect = el.getBoundingClientRect();
     return Math.atan2(e.clientY - (rect.top + rect.height / 2), e.clientX - (rect.left + rect.width / 2));
   };
+
+  // ── Vinyl / scratch: grab hands playback to the scratch worklet; hand
+  //    motion sets velocity (forward + reverse), a still hold winds down to a
+  //    stop, release spins back up. Only when the deck can scratch (full-track
+  //    buffer); stem mode / empty falls back to the silent seek-scrub below. ──
+  const vinylOn = useRef(false);
+  const lastA = useRef(0);
+  const lastT = useRef(0);
+  const stall = useRef(0);
+  const VEL_K = SEC_PER_REV / (2 * Math.PI); // angular speed → playback velocity
+  const clampV = (v: number) => Math.max(-16, Math.min(16, v));
+  const armStall = () => {
+    window.clearTimeout(stall.current);
+    stall.current = window.setTimeout(() => djEngine.setVinylVelocity(deckId, 0, 0.06), 70);
+  };
+
+  // ── Fallback silent seek-scrub (stem mode / no decoded buffer) ──────────
+  const scrubbing = useRef(false);
+  const startAngle = useRef(0);
+  const startTime = useRef(0);
+  const pendingT = useRef<number | null>(null);
+  const raf = useRef(0);
   const apply = () => { raf.current = 0; const t = pendingT.current; pendingT.current = null; if (t != null) djEngine.seekDeck(deckId, t); };
+
   const onDown = (e: React.PointerEvent) => {
     if (disabled || djEngine.getStatus(deckId).duration <= 0) return;
-    scrubbing.current = true;
-    startAngle.current = angleOf(e);
-    startTime.current = djEngine.getStatus(deckId).currentTime;
     e.currentTarget.setPointerCapture?.(e.pointerId);
     e.preventDefault();
+    lastA.current = angleOf(e); lastT.current = e.timeStamp;
+    if (djEngine.canScratch(deckId)) {
+      vinylOn.current = true;
+      void djEngine.enterVinyl(deckId);
+      armStall();
+    } else {
+      scrubbing.current = true;
+      startAngle.current = angleOf(e);
+      startTime.current = djEngine.getStatus(deckId).currentTime;
+    }
   };
   const onMove = (e: React.PointerEvent) => {
+    if (vinylOn.current) {
+      const a = angleOf(e);
+      let dA = a - lastA.current;
+      while (dA > Math.PI) dA -= 2 * Math.PI;
+      while (dA < -Math.PI) dA += 2 * Math.PI;
+      const dt = Math.max(4, e.timeStamp - lastT.current) / 1000; // seconds (min 4ms)
+      lastA.current = a; lastT.current = e.timeStamp;
+      djEngine.setVinylVelocity(deckId, clampV((dA / dt) * VEL_K), 0.5);
+      armStall(); // keep resetting the wind-down timer while the hand moves
+      return;
+    }
     if (!scrubbing.current) return;
     let d = angleOf(e) - startAngle.current;
     while (d > Math.PI) d -= 2 * Math.PI;
@@ -87,8 +128,20 @@ export function JogWheel({ deckId, color, size = 132, disabled, fill }: {
     pendingT.current = Math.max(0, startTime.current + (d / (2 * Math.PI)) * SEC_PER_REV * SCRUB_TURNS);
     if (!raf.current) raf.current = requestAnimationFrame(apply);
   };
-  const onUp = (e: React.PointerEvent) => { scrubbing.current = false; e.currentTarget.releasePointerCapture?.(e.pointerId); };
-  useEffect(() => () => { if (raf.current) cancelAnimationFrame(raf.current); }, []);
+  const onUp = (e: React.PointerEvent) => {
+    e.currentTarget.releasePointerCapture?.(e.pointerId);
+    if (vinylOn.current) {
+      vinylOn.current = false;
+      window.clearTimeout(stall.current);
+      djEngine.exitVinyl(deckId, true);
+      return;
+    }
+    scrubbing.current = false;
+  };
+  useEffect(() => () => {
+    if (raf.current) cancelAnimationFrame(raf.current);
+    window.clearTimeout(stall.current);
+  }, []);
 
   const wheel = (
     <div
@@ -121,6 +174,25 @@ export function JogWheel({ deckId, color, size = 132, disabled, fill }: {
           <span className="font-black uppercase" style={{ color: rgb(color), fontSize: Math.max(11, D * 0.1) }}>{deckId}</span>
         </div>
       </div>
+      {/* Scratch character toggle — classic vinyl vs cyber glitch (global). */}
+      {!disabled && (
+        <button
+          type="button"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => { e.stopPropagation(); toggleScratch(); }}
+          title={scratchMode === 'cyber'
+            ? 'Scratch sound: CYBER glitch — click for classic vinyl'
+            : 'Scratch sound: CLASSIC vinyl — click for cyber glitch'}
+          className={`absolute left-1/2 -translate-x-1/2 rounded-full border px-1.5 py-0.5 text-[7px] font-black uppercase tracking-wider transition-colors ${
+            scratchMode === 'cyber'
+              ? 'border-fuchsia-400/60 bg-fuchsia-500/20 text-fuchsia-200'
+              : 'border-white/15 bg-black/60 text-zinc-300 hover:border-white/30'
+          }`}
+          style={{ bottom: Math.round(D * 0.08) }}
+        >
+          {scratchMode === 'cyber' ? 'Cyber' : 'Vinyl'}
+        </button>
+      )}
     </div>
   );
 

--- a/frontend/src/state/djEngine.ts
+++ b/frontend/src/state/djEngine.ts
@@ -117,6 +117,15 @@ interface Deck {
   fx: DeckFx | null;
   // Cue/headphone send (D6): filter → cueSend → cueBus → headphone sink. 0 = off.
   cueSend: GainNode;
+  // Vinyl/scratch mode (jog wheel): a worklet that reads the full-track buffer
+  // at a hand-driven velocity (forward/reverse), feeding delayComp directly so
+  // it rides the EQ/filter/crossfader but bypasses key-lock (scratch must pitch-
+  // bend). Lazily created; null when never scratched.
+  vinyl: AudioWorkletNode | null;
+  vinylActive: boolean;
+  vinylPos: number; // last read-head position (sec) the worklet reported
+  vinylWasPlaying: boolean; // deck playing state captured on grab, to restore
+  vinylLoadedUrl: string | null; // which track's samples the worklet holds
 }
 
 const RAMP_TC = 0.012;
@@ -262,6 +271,7 @@ function buildDeck(id: DeckId): Deck {
     loopActive: false, loopIn: 0, loopOut: 0, rollResume: false,
     slip: false, virtualBase: 0, virtualStart: 0,
     fx: null,
+    vinyl: null, vinylActive: false, vinylPos: 0, vinylWasPlaying: false, vinylLoadedUrl: null,
   };
   decks[id] = deck;
   return deck;
@@ -358,7 +368,9 @@ function statusOf(id: DeckId): DeckStatus {
     playing: d.playing,
     decoding: d.decoding,
     hasBuffer: !!d.buffer || (d.stemMode && !!d.stems?.length),
-    currentTime: audiblePos(d),
+    // During a scratch the worklet drives playback, so the read-head it
+    // reports (vinylPos) is the true position for the platter + waveform.
+    currentTime: d.vinylActive ? clamp(d.vinylPos, 0, deckDuration(d)) : audiblePos(d),
     duration: deckDuration(d),
     loopActive: d.loopActive,
     loopIn: d.loopActive ? d.loopIn : null,
@@ -971,6 +983,126 @@ export function getDeckStemNames(id: DeckId): string[] {
 
 export function hasStems(id: DeckId): boolean {
   return !!decks[id]?.stemMode;
+}
+
+/* -------------------------------- vinyl / scratch (jog) -------------------- */
+
+let _vinylModule: Promise<void> | null = null;
+let _scratchMode: 'classic' | 'cyber' = 'classic';
+
+function ensureVinylModule(ctx: AudioContext): Promise<void> {
+  if (!_vinylModule) {
+    _vinylModule = ctx.audioWorklet.addModule('/vinyl-scratch.worklet.js').catch((e) => {
+      _vinylModule = null; // allow a later retry
+      throw e;
+    });
+  }
+  return _vinylModule;
+}
+
+/** Scratch character for all decks: 'classic' (clean turntable) or 'cyber'
+ *  (fragmented, bit-crushed glitch). Pushed live to any active vinyl node. */
+export function setScratchMode(mode: 'classic' | 'cyber'): void {
+  _scratchMode = mode;
+  for (const id of ['A', 'B'] as DeckId[]) {
+    decks[id]?.vinyl?.port.postMessage({ type: 'mode', mode });
+  }
+}
+export function getScratchMode(): 'classic' | 'cyber' {
+  return _scratchMode;
+}
+
+/** True when a deck can scratch: it needs a decoded full-track buffer. Stem
+ *  mode and empty decks fall back to plain jog-seek. */
+export function canScratch(id: DeckId): boolean {
+  const d = decks[id];
+  return !!d && !!d.buffer && !d.stemMode;
+}
+
+/** Grab the platter: hand playback to the scratch worklet at the current
+ *  position. The jog then drives velocity via setVinylVelocity; release spins
+ *  up and hands back to the normal source (exitVinyl). */
+export async function enterVinyl(id: DeckId): Promise<boolean> {
+  const d = decks[id];
+  if (!d || !d.buffer || d.stemMode || d.vinylActive) return false;
+  const ctx = getEngineCtx();
+  if (ctx.state === 'suspended') void ctx.resume().catch(() => { /* retry next gesture */ });
+  try {
+    await ensureVinylModule(ctx);
+  } catch (e) {
+    logError('dj', `Deck ${id} scratch unavailable: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
+  }
+  // The deck may have been re-loaded / gone to stems while the module loaded.
+  if (!d.buffer || d.stemMode || d.vinylActive) return false;
+  if (d.vinyl == null) {
+    d.vinyl = new AudioWorkletNode(ctx, 'vinyl-scratch', { numberOfInputs: 0, outputChannelCount: [2] });
+    d.vinyl.port.onmessage = (e) => { if (e.data?.type === 'pos') d.vinylPos = e.data.sec; };
+  }
+  // (Re)load the track's samples into the worklet when the track changed.
+  if (d.vinylLoadedUrl !== d.loadedUrl) {
+    const mono = d.buffer.numberOfChannels <= 1;
+    const lc = new Float32Array(d.buffer.getChannelData(0));
+    const rc = mono ? lc : new Float32Array(d.buffer.getChannelData(1));
+    d.vinyl.port.postMessage(
+      { type: 'load', l: lc, r: rc, len: d.buffer.length },
+      mono ? [lc.buffer] : [lc.buffer, rc.buffer],
+    );
+    d.vinylLoadedUrl = d.loadedUrl;
+  }
+  const pos = audiblePos(d);
+  d.vinylWasPlaying = d.playing;
+  d.vinylPos = pos;
+  stopSource(d); // silence the normal source; the worklet sounds now
+  d.vinyl.port.postMessage({ type: 'mode', mode: _scratchMode });
+  d.vinyl.port.postMessage({ type: 'pos', sec: pos });
+  d.vinyl.port.postMessage({ type: 'vel', vel: d.vinylWasPlaying ? d.rate : 0, immediate: true });
+  d.vinyl.port.postMessage({ type: 'ease', ease: 0.4 });
+  d.vinyl.port.postMessage({ type: 'play', on: true });
+  // Feed straight into delayComp so it rides EQ/filter/crossfader but bypasses
+  // the key-lock stretch (a scratch must be allowed to pitch-bend).
+  try { d.vinyl.connect(d.delayComp); } catch { /* already connected */ }
+  d.vinylActive = true;
+  d.playing = true;
+  emit();
+  return true;
+}
+
+/** Drive scratch velocity from the jog: 1 = normal forward, -1 = reverse, 0 =
+ *  stopped. `ease` is high for hand scratches (snappy) and low for the
+ *  wind-down / spin-up ramps. */
+export function setVinylVelocity(id: DeckId, vel: number, ease = 0.4): void {
+  const d = decks[id];
+  if (!d?.vinyl || !d.vinylActive) return;
+  d.vinyl.port.postMessage({ type: 'ease', ease });
+  d.vinyl.port.postMessage({ type: 'vel', vel });
+}
+
+/** Release the platter: spin back up to speed (if it was playing) then hand
+ *  playback back to the normal source at the read-head. `spinUp=false` settles
+ *  immediately. */
+export function exitVinyl(id: DeckId, spinUp = true): void {
+  const d = decks[id];
+  if (!d?.vinyl || !d.vinylActive) return;
+  const finalize = () => {
+    const dd = decks[id];
+    if (!dd?.vinyl || !dd.vinylActive) return;
+    const pos = clamp(dd.vinylPos, 0, deckDuration(dd));
+    dd.vinyl.port.postMessage({ type: 'play', on: false });
+    try { dd.vinyl.disconnect(); } catch { /* gone */ }
+    dd.vinylActive = false;
+    dd.startOffset = pos;
+    if (dd.vinylWasPlaying) startSource(dd, pos);
+    else dd.playing = false;
+    emit();
+  };
+  if (spinUp && d.vinylWasPlaying) {
+    setVinylVelocity(id, d.rate, 0.06); // slow ramp back to speed = spin-up
+    setTimeout(finalize, 320);
+  } else {
+    setVinylVelocity(id, 0, 0.08); // wind down to a stop
+    setTimeout(finalize, spinUp ? 240 : 0);
+  }
 }
 
 /** Tear everything down (DJ tab unmount). Rarely called — the tab is warmed. */

--- a/frontend/src/state/djVinylStore.ts
+++ b/frontend/src/state/djVinylStore.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+/* DJ scratch character (vinyl mode), persisted. 'classic' = a clean
+ * turntable resample; 'cyber' = fragmented, bit-crushed glitch. Shared by both
+ * decks; the engine pushes it live to any active scratch worklet. */
+
+export type ScratchMode = 'classic' | 'cyber';
+
+interface DjVinylState {
+  mode: ScratchMode;
+  setMode: (m: ScratchMode) => void;
+  toggle: () => void;
+}
+
+export const useDjVinyl = create<DjVinylState>()(
+  persist(
+    (set) => ({
+      mode: 'classic',
+      setMode: (mode) => set({ mode }),
+      toggle: () => set((s) => ({ mode: s.mode === 'classic' ? 'cyber' : 'classic' })),
+    }),
+    { name: 'thedaw.dj.vinyl.v1' },
+  ),
+);


### PR DESCRIPTION
Grabbing a deck's jog wheel now hands playback to a vinyl-scratch AudioWorklet that reads the full-track buffer at a hand-driven velocity (forward and reverse — which a buffer source can't do), feeding delayComp so it rides the EQ/filter/crossfader but bypasses key-lock so a scratch pitch-bends. Hand motion sets velocity; holding the platter still winds it down to a stop; releasing spins it back up and hands playback back to the normal source at the read-head.

Two scratch voices, toggled on the platter and persisted (djVinylStore): classic (clean turntable resample) and cyber (speed-driven sample-hold + bit-crush glitch). Stem mode / empty decks fall back to the old silent seek-scrub. The platter and waveform follow the read-head during a scratch (status reports vinylPos while active).

Worklet served from public/vinyl-scratch.worklet.js (loads in dev+prod); syntax-checked and confirmed served. Scratch feel + sound need ears.