### PR TITLE
feat(questmidi): Quest MIDI into theDAW with no loopMIDI / no Node br…

### DIFF
--- a/backend/modules/questmidi/bridge.py
+++ b/backend/modules/questmidi/bridge.py
@@ -1,0 +1,219 @@
+"""Quest MIDI bridge — the loopMIDI-free path.
+
+Replaces the standalone Node bridge + loopMIDI: theDAW's own backend hosts a
+localhost TCP listener that the Quest app reaches over USB (``adb reverse``),
+and relays MIDI to/from the browser over a WebSocket. Inbound Quest MIDI is
+published to the frontend ``midiBus``; return MIDI from the browser (e.g. an
+audio-reactive feed for the GANTASMO Visor) is framed back to the headset.
+
+Everything runs on uvicorn's asyncio loop — the TCP server, the WebSocket
+relay, and the broadcast are all coroutines, so there are no threads to manage.
+
+Wire format on the TCP socket (matches QuestMidiSender / the Node bridge):
+``[len:1][midi bytes…]``. Over the WebSocket each message is JSON
+``{"type": "midi", "data": [status, d1, d2]}``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import subprocess
+from typing import Awaitable, Callable, Optional
+
+log = logging.getLogger(__name__)
+
+DEFAULT_PORT = 8765
+ClientSend = Callable[[list[int]], Awaitable[None]]
+
+
+def _port() -> int:
+    try:
+        return int(os.getenv("theDAW_QUESTMIDI_PORT") or DEFAULT_PORT)
+    except ValueError:
+        return DEFAULT_PORT
+
+
+def _adb_path() -> Optional[str]:
+    """Resolve adb: explicit env override, else PATH."""
+    env = os.getenv("theDAW_QUESTMIDI_ADB")
+    if env and os.path.isfile(env):
+        return env
+    return shutil.which("adb") or shutil.which("adb.exe")
+
+
+class _State:
+    server: Optional[asyncio.AbstractServer] = None
+    quest_writer: Optional[asyncio.StreamWriter] = None
+    quest_peer: Optional[str] = None
+    clients: set[ClientSend] = set()
+    adb_reverse_ok: bool = False
+    started: bool = False
+    starting: bool = False
+
+
+_s = _State()
+
+
+# ---- frontend WebSocket clients ----------------------------------------------
+
+
+def add_client(send: ClientSend) -> None:
+    _s.clients.add(send)
+
+
+def remove_client(send: ClientSend) -> None:
+    _s.clients.discard(send)
+
+
+async def _broadcast(msg: list[int]) -> None:
+    if not _s.clients:
+        return
+    dead: list[ClientSend] = []
+    for send in list(_s.clients):
+        try:
+            await send(msg)
+        except Exception:
+            dead.append(send)
+    for d in dead:
+        _s.clients.discard(d)
+
+
+# ---- return path: browser -> Quest -------------------------------------------
+
+
+def send_to_quest(data: object) -> bool:
+    """Frame a MIDI message and write it to the connected Quest. Returns False
+    when no Quest is connected or the payload is unusable."""
+    w = _s.quest_writer
+    if w is None or not isinstance(data, (list, tuple)) or not data:
+        return False
+    n = min(len(data), 255)
+    try:
+        frame = bytes([n] + [int(b) & 0xFF for b in list(data)[:n]])
+        w.write(frame)
+        return True
+    except Exception as e:  # noqa: BLE001 — a broken pipe just means no Quest
+        log.debug("questmidi: send_to_quest failed: %s", e)
+        return False
+
+
+# ---- inbound path: Quest -> browser ------------------------------------------
+
+
+async def _handle_quest(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+) -> None:
+    peer = writer.get_extra_info("peername")
+    _s.quest_writer = writer
+    _s.quest_peer = str(peer)
+    log.info("questmidi: Quest connected %s", peer)
+    buf = bytearray()
+    try:
+        while True:
+            chunk = await reader.read(4096)
+            if not chunk:
+                break
+            buf.extend(chunk)
+            off = 0
+            while off < len(buf):
+                ln = buf[off]
+                if off + 1 + ln > len(buf):
+                    break  # wait for the rest of the frame
+                if ln > 0:
+                    await _broadcast(list(buf[off + 1 : off + 1 + ln]))
+                off += 1 + ln
+            if off:
+                del buf[:off]
+    except Exception as e:  # noqa: BLE001
+        log.debug("questmidi: quest read error: %s", e)
+    finally:
+        if _s.quest_writer is writer:
+            _s.quest_writer = None
+            _s.quest_peer = None
+        try:
+            writer.close()
+        except Exception:
+            pass
+        log.info("questmidi: Quest disconnected")
+
+
+# ---- lifecycle ---------------------------------------------------------------
+
+
+def _run_adb_reverse(port: int) -> bool:
+    adb = _adb_path()
+    if not adb:
+        return False
+    try:
+        subprocess.run(
+            [adb, "reverse", f"tcp:{port}", f"tcp:{port}"],
+            capture_output=True,
+            timeout=10,
+            check=True,
+        )
+        return True
+    except Exception as e:  # noqa: BLE001
+        log.info("questmidi: adb reverse failed: %s", e)
+        return False
+
+
+async def reattach_adb() -> bool:
+    """Re-run ``adb reverse`` (after re-plugging the headset / accepting the
+    USB-debugging prompt) without restarting the listener."""
+    loop = asyncio.get_running_loop()
+    _s.adb_reverse_ok = await loop.run_in_executor(None, _run_adb_reverse, _port())
+    return _s.adb_reverse_ok
+
+
+async def ensure_started() -> None:
+    """Start the TCP listener (once) and run adb reverse. Idempotent."""
+    if _s.started or _s.starting:
+        return
+    _s.starting = True
+    try:
+        port = _port()
+        await reattach_adb()
+        _s.server = await asyncio.start_server(_handle_quest, "127.0.0.1", port)
+        _s.started = True
+        log.info(
+            "questmidi: listening on 127.0.0.1:%d (adb reverse %s)",
+            port,
+            "ok" if _s.adb_reverse_ok else "not set",
+        )
+    except Exception as e:  # noqa: BLE001
+        log.warning("questmidi: failed to start: %s", e)
+    finally:
+        _s.starting = False
+
+
+async def stop() -> None:
+    if _s.server is not None:
+        _s.server.close()
+        try:
+            await _s.server.wait_closed()
+        except Exception:
+            pass
+    _s.server = None
+    _s.started = False
+    if _s.quest_writer is not None:
+        try:
+            _s.quest_writer.close()
+        except Exception:
+            pass
+        _s.quest_writer = None
+        _s.quest_peer = None
+
+
+def status() -> dict:
+    return {
+        "started": _s.started,
+        "port": _port(),
+        "adb_path": _adb_path(),
+        "adb_reverse_ok": _s.adb_reverse_ok,
+        "quest_connected": _s.quest_writer is not None,
+        "quest_peer": _s.quest_peer,
+        "clients": len(_s.clients),
+    }

--- a/backend/modules/questmidi/module.json
+++ b/backend/modules/questmidi/module.json
@@ -1,0 +1,10 @@
+{
+  "name": "questmidi",
+  "label": "Quest MIDI",
+  "enabled": true,
+  "icon": "Hand",
+  "sidebar": false,
+  "api_prefix": "/api/questmidi",
+  "backend": true,
+  "description": "Bridges the GANTASMO-MIDI Quest app straight into theDAW with no loopMIDI and no separate Node bridge. Hosts a localhost TCP listener (adb reverse over USB), relays Quest MIDI to the frontend midiBus over a WebSocket, and forwards return MIDI back to the headset (e.g. to drive the GANTASMO Visor). Disable to skip the auto-start on backend launch."
+}

--- a/backend/modules/questmidi/router.py
+++ b/backend/modules/questmidi/router.py
@@ -1,0 +1,74 @@
+"""FastAPI router for the Quest MIDI bridge module.
+
+Endpoints (prefix /api/questmidi):
+    GET  /status   listener + adb + connection state
+    POST /start    start the listener and (re)run adb reverse
+    POST /stop     stop the listener
+    POST /reattach re-run adb reverse only (after re-plugging the headset)
+    WS   /ws       browser relay: receives Quest MIDI, sends return MIDI
+
+The WebSocket is the live path the frontend keeps open. Inbound Quest MIDI
+arrives as {"type":"midi","data":[...]}; the browser publishes it to midiBus.
+The browser sends {"data":[...]} to push return MIDI back to the headset.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from . import bridge
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(tags=["questmidi"])
+
+
+@router.get("/status")
+async def get_status() -> dict:
+    return bridge.status()
+
+
+@router.post("/start")
+async def start() -> dict:
+    await bridge.ensure_started()
+    await bridge.reattach_adb()
+    return bridge.status()
+
+
+@router.post("/stop")
+async def stop() -> dict:
+    await bridge.stop()
+    return bridge.status()
+
+
+@router.post("/reattach")
+async def reattach() -> dict:
+    """Re-run adb reverse without restarting the listener (re-plug recovery)."""
+    ok = await bridge.reattach_adb()
+    return {"adb_reverse_ok": ok, **bridge.status()}
+
+
+@router.websocket("/ws")
+async def ws(websocket: WebSocket) -> None:
+    await websocket.accept()
+    # Make sure the TCP listener + adb tunnel are up the moment a browser attaches.
+    await bridge.ensure_started()
+
+    async def send(msg: list[int]) -> None:
+        await websocket.send_json({"type": "midi", "data": msg})
+
+    bridge.add_client(send)
+    try:
+        while True:
+            data = await websocket.receive_json()
+            payload = data.get("data") if isinstance(data, dict) else None
+            if payload:
+                bridge.send_to_quest(payload)
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:  # noqa: BLE001 — client went away mid-message
+        log.debug("questmidi: ws error: %s", e)
+    finally:
+        bridge.remove_client(send)

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-13T06:48:28.516Z · Git revision: `c202cc3ff839` · Repomix tracked: **no**
+> Generated: 2026-06-13T13:00:04.808Z · Git revision: `bc466fda402d` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-13T06:48:28.516Z",
-  "repoRevision": "c202cc3ff839",
+  "generatedAt": "2026-06-13T13:00:04.808Z",
+  "repoRevision": "bc466fda402d",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T06:50:56.077Z",
+  "generatedAt": "2026-06-13T13:02:09.249Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { useLibraryStore } from './state/libraryStore';
 import { useLayoutPrefs } from './state/layoutPrefsStore';
 import { triggerPianoNoteFromMidi } from './components/audio/PianoRoll';
 import { publishMidi } from './state/midiBus';
+import { startQuestMidi, stopQuestMidi } from './state/questMidiClient';
 import { useMidiDevicesStore } from './state/midiDevicesStore';
 import { isMidiAudioMuted, useMidiTriggerStore } from './state/midiTriggerStore';
 
@@ -183,6 +184,16 @@ export default function App() {
         access.onstatechange = null;
       }
     };
+  }, [midiEnabled]);
+
+  // Quest MIDI bridge (loopMIDI-free): when MIDI is on, open the WebSocket to
+  // the backend `questmidi` module. It hosts the localhost TCP listener + adb
+  // reverse and relays the headset's MIDI onto the same midiBus as hardware
+  // controllers, so nothing else needs to change to react to the Quest.
+  useEffect(() => {
+    if (!midiEnabled) return;
+    startQuestMidi();
+    return () => stopQuestMidi();
   }, [midiEnabled]);
 
   const handleAssistantAction = useCallback((action: { type: string; payload?: any }) => {

--- a/frontend/src/state/questMidiClient.ts
+++ b/frontend/src/state/questMidiClient.ts
@@ -1,0 +1,101 @@
+/**
+ * Quest MIDI client — the loopMIDI-free path.
+ *
+ * Holds a WebSocket to the backend `questmidi` module (`/api/questmidi/ws`),
+ * which bridges the Quest app over USB (adb reverse) with no loopMIDI and no
+ * separate Node bridge. Inbound Quest MIDI is republished on the global
+ * `midiBus`, so every existing consumer (piano synth, VJ forwarder, MidiMapper,
+ * the questControlStore) sees it exactly like a hardware controller. Return MIDI
+ * (e.g. an audio-reactive feed for the GANTASMO Visor) goes back via
+ * `sendQuestMidi`.
+ *
+ * Same-origin URL so it rides the Vite dev proxy (ws:true) in development and is
+ * direct in production. Auto-reconnects while running.
+ */
+
+import { publishMidi } from './midiBus';
+import { logInfo, logWarn } from './logStore';
+
+let ws: WebSocket | null = null;
+let reconnectTimer = 0;
+let running = false;
+let everConnected = false;
+
+function wsUrl(): string {
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${window.location.host}/api/questmidi/ws`;
+}
+
+function scheduleReconnect(): void {
+  if (!running || reconnectTimer) return;
+  reconnectTimer = window.setTimeout(() => {
+    reconnectTimer = 0;
+    connect();
+  }, 2000);
+}
+
+function connect(): void {
+  if (!running || ws) return;
+  let sock: WebSocket;
+  try {
+    sock = new WebSocket(wsUrl());
+  } catch {
+    scheduleReconnect();
+    return;
+  }
+  ws = sock;
+  sock.onopen = () => {
+    everConnected = true;
+    logInfo('questmidi', 'Bridge connected — Quest MIDI flowing into theDAW (no loopMIDI).');
+  };
+  sock.onmessage = (e) => {
+    try {
+      const m = JSON.parse(typeof e.data === 'string' ? e.data : '');
+      if (m && m.type === 'midi' && Array.isArray(m.data)) publishMidi(m.data);
+    } catch {
+      /* ignore malformed frame */
+    }
+  };
+  sock.onerror = () => {
+    try { sock.close(); } catch { /* already closing */ }
+  };
+  sock.onclose = () => {
+    if (ws === sock) ws = null;
+    if (running && everConnected) logWarn('questmidi', 'Bridge disconnected — retrying…');
+    scheduleReconnect();
+  };
+}
+
+/** Open (and keep open) the Quest MIDI bridge. Safe to call repeatedly. */
+export function startQuestMidi(): void {
+  if (running) return;
+  running = true;
+  everConnected = false;
+  connect();
+}
+
+/** Close the bridge and stop reconnecting. */
+export function stopQuestMidi(): void {
+  running = false;
+  if (reconnectTimer) {
+    window.clearTimeout(reconnectTimer);
+    reconnectTimer = 0;
+  }
+  if (ws) {
+    try { ws.close(); } catch { /* already closing */ }
+    ws = null;
+  }
+}
+
+/** Send return MIDI to the headset (e.g. to drive the GANTASMO Visor). */
+export function sendQuestMidi(data: number[]): boolean {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ data }));
+    return true;
+  }
+  return false;
+}
+
+export function isQuestMidiConnected(): boolean {
+  return !!ws && ws.readyState === WebSocket.OPEN;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig(({mode}) => {
         '/api': {
           target: 'http://localhost:8600',
           changeOrigin: true,
+          ws: true, // proxy WebSocket upgrades too (e.g. /api/questmidi/ws)
           timeout: 0,
           proxyTimeout: 0,
           configure: (proxy) => {


### PR DESCRIPTION
…idge

Adds a 'questmidi' backend module that hosts a localhost TCP listener the Quest app reaches over USB (adb reverse) and relays MIDI to/from the browser over a WebSocket — replacing loopMIDI + the standalone Node bridge for the theDAW case.

- backend/modules/questmidi/bridge.py: asyncio TCP server (frame format [len][bytes]), adb reverse, broadcast to WS clients, return path back to the headset. All on uvicorn's loop; no threads.
- router.py: GET /status, POST /start|/stop|/reattach, WS /ws.
- frontend questMidiClient.ts: WS client that republishes inbound Quest MIDI on the global midiBus (so every consumer sees it like a hardware controller) and sends return MIDI; auto-reconnect.
- App.tsx opens it when the master MIDI toggle is on; vite proxy gains ws:true so the WS rides the dev proxy.

Relay verified end-to-end headlessly (fake Quest TCP <-> WS, both directions). Live headset verification pending.