### PR TITLE
Feat/library stems midi first class

### DIFF
--- a/backend/_devstack.py
+++ b/backend/_devstack.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import threading
 import time
+import urllib.request
 import webbrowser
 
 RESTART_EXIT_CODE = 88
@@ -180,6 +181,31 @@ def _wait_then_open_browser() -> None:
         _open_browser()
 
 
+def _warm_sidecars() -> None:
+    """Pre-spawn the lazily-started sidecars once the backend is up, so they are
+    ready before the user needs them instead of cold-starting on first use. The
+    VJ dev server (port 5187) is the important one: a GET to /api/vj/url makes the
+    backend ``vj`` module spawn it, so the VJ tab is already warm when opened."""
+    base = "http://127.0.0.1:8600"
+    deadline = time.time() + 120.0
+    while not _shutdown.is_set() and time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base}/api/health", timeout=2) as resp:
+                if resp.status == 200:
+                    break
+        except Exception:
+            pass
+        time.sleep(0.5)
+    if _shutdown.is_set():
+        return
+    try:
+        with urllib.request.urlopen(f"{base}/api/vj/url", timeout=120) as resp:
+            resp.read()
+        _emit("stack", "VJ sidecar warmed (dev server spawning on :5187)")
+    except Exception as exc:
+        _emit("stack", f"VJ sidecar warm-up skipped: {exc}")
+
+
 def main() -> int:
     # Drop the launcher console immediately so the user sees only the app, never
     # the log stream. It keeps running (restorable from the taskbar);
@@ -213,6 +239,7 @@ def main() -> int:
         _emit("stack", "localtunnel not installed — public link skipped")
 
     threading.Thread(target=_wait_then_open_browser, daemon=True).start()
+    threading.Thread(target=_warm_sidecars, daemon=True).start()
 
     # Backend supervisor on its own thread so Ctrl-C lands in main().
     backend = threading.Thread(target=_run_backend, args=(children,), daemon=True)

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-15T20:34:21.032Z · Git revision: `84197b4d1c00` · Repomix tracked: **no**
+> Generated: 2026-06-15T20:51:03.817Z · Git revision: `a840eb61a698` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-15T17:28:58.613Z · Git revision: `9aadc4360f1a` · Repomix tracked: **no**
+> Generated: 2026-06-15T20:34:21.032Z · Git revision: `84197b4d1c00` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-15T20:34:21.032Z",
-  "repoRevision": "84197b4d1c00",
+  "generatedAt": "2026-06-15T20:51:03.817Z",
+  "repoRevision": "a840eb61a698",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-15T17:28:58.613Z",
-  "repoRevision": "9aadc4360f1a",
+  "generatedAt": "2026-06-15T20:34:21.032Z",
+  "repoRevision": "84197b4d1c00",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T20:36:43.459Z",
+  "generatedAt": "2026-06-15T20:53:23.134Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T17:31:32.472Z",
+  "generatedAt": "2026-06-15T20:36:43.459Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,7 +40,12 @@ export default function App() {
   // onComplete); the screen then holds until the backend is also ready. A safety
   // timeout guarantees handoff even if the cinematic stalls (e.g. an asset never
   // loads), so the app can never hang on the boot screen.
-  const [cinematicDone, setCinematicDone] = useState(false);
+  // A `?nocinematic` query param (used by the screenshot/capture harness) skips
+  // the boot cinematic, so captures don't sit through its ~7s runtime and it
+  // never appears in the shots.
+  const [cinematicDone, setCinematicDone] = useState(
+    typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('nocinematic'),
+  );
   useEffect(() => {
     const t = setTimeout(() => setCinematicDone(true), 20000);
     return () => clearTimeout(t);

--- a/frontend/src/components/vj/QuestCastPreview.tsx
+++ b/frontend/src/components/vj/QuestCastPreview.tsx
@@ -57,7 +57,7 @@ export const summarizeQuestCastDevices = (devices: QuestCastStatus['devices']): 
 };
 
 export const describeQuestCastStatus = (status: QuestCastStatus | null): string => {
-  if (!status) return 'QuestCast status not loaded yet.';
+  if (!status) return 'delinQuest status not loaded yet.';
   const state = typeof status.state === 'string' ? status.state : status.running ? 'running' : 'stopped';
   const parts = [`state ${state}`];
   if (status.error) parts.push(`error ${status.error}`);
@@ -148,7 +148,7 @@ export const QuestCastPreview: React.FC<QuestCastPreviewProps> = ({
       setStats({
         ...initialStats,
         connection: 'error',
-        error: 'This browser cannot preview QuestCast directly because WebCodecs VideoDecoder is unavailable. Use current Chrome or Edge.',
+        error: 'This browser cannot preview delinQuest directly because WebCodecs VideoDecoder is unavailable. Use current Chrome or Edge.',
       });
       return;
     }
@@ -222,7 +222,7 @@ export const QuestCastPreview: React.FC<QuestCastPreviewProps> = ({
       if (!closed) setStats((prev) => ({ ...prev, connection: 'connected', error: null }));
     };
 
-    socket.onerror = () => updateError('QuestCast WebSocket connection failed. Stop and start QuestCast, then try again.');
+    socket.onerror = () => updateError('delinQuest WebSocket connection failed. Stop and start delinQuest, then try again.');
     socket.onclose = () => {
       if (!closed) setStats((prev) => ({ ...prev, connection: ready ? 'idle' : prev.connection }));
     };
@@ -293,7 +293,7 @@ export const QuestCastPreview: React.FC<QuestCastPreviewProps> = ({
         <div className="flex items-center gap-2 min-w-0">
           <Tv2 className="w-3.5 h-3.5 text-sky-300 shrink-0" />
           <div className="min-w-0">
-            <div className="text-[9px] font-black uppercase tracking-widest text-sky-100">Quest Direct Preview</div>
+            <div className="text-[9px] font-black uppercase tracking-widest text-sky-100">delinQuest Preview</div>
             <div className="truncate text-[8px] font-mono text-zinc-500">No window picker. USB/ADB direct feed.</div>
           </div>
         </div>
@@ -328,7 +328,7 @@ export const QuestCastPreview: React.FC<QuestCastPreviewProps> = ({
 
       <div className="space-y-2 p-3">
         <p className="text-[8px] font-mono leading-relaxed text-zinc-400">
-          Use <span className="text-sky-200">Start Quest</span> for the direct QuestCast path. Do <span className="text-amber-200">not</span> choose a browser window for this path. The browser “choose a window” dialog is only for the separate VJ SCREEN source, and it requires an already-open scrcpy/window source.
+          Use <span className="text-sky-200">Start delinQuest</span> for the direct delinQuest path. Do <span className="text-amber-200">not</span> choose a browser window for this path. The browser “choose a window” dialog is only for the separate VJ SCREEN source, and it requires an already-open scrcpy/window source.
         </p>
         {(stats.error || status?.error || status?.message) && (
           <p className="rounded border border-rose-500/30 bg-rose-500/10 px-2 py-1.5 text-[8px] font-mono leading-relaxed text-rose-200">

--- a/frontend/src/views/VJView.tsx
+++ b/frontend/src/views/VJView.tsx
@@ -90,7 +90,7 @@ export const VJView: React.FC = () => {
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [questStatus, setQuestStatus] = useState<QuestCastStatus | null>(null);
   const [questBusy, setQuestBusy] = useState(false);
-  const [questDetail, setQuestDetail] = useState('QuestCast status not loaded yet.');
+  const [questDetail, setQuestDetail] = useState('delinQuest status not loaded yet.');
   const toggleCamera = () => {
     const next = !cameraOn;
     setCameraOn(next); // optimistic; reconciled by the camera-state echo
@@ -108,7 +108,7 @@ export const VJView: React.FC = () => {
     const response = await fetch(path, init);
     const body = (await response.json().catch(() => ({}))) as QuestCastStatus;
     if (!response.ok) {
-      throw new Error(body.detail || body.error || body.message || `QuestCast backend returned ${response.status}`);
+      throw new Error(body.detail || body.error || body.message || `delinQuest backend returned ${response.status}`);
     }
     return body;
   };
@@ -118,12 +118,12 @@ export const VJView: React.FC = () => {
     try {
       const body = await fetchQuestJson('/api/questcast/status');
       const summary = applyQuestStatus(body);
-      if (!quiet) logInfo('questcast', `Status: ${summary}`);
+      if (!quiet) logInfo('delinquest', `Status: ${summary}`);
       return body;
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       applyQuestStatus({ state: 'error', error: message });
-      if (!quiet) logError('questcast', `Status failed: ${message}`);
+      if (!quiet) logError('delinquest', `Status failed: ${message}`);
       return null;
     } finally {
       if (!quiet) setQuestBusy(false);
@@ -132,19 +132,19 @@ export const VJView: React.FC = () => {
 
   const setQuestRelay = async (action: 'start' | 'stop') => {
     setQuestBusy(true);
-    setQuestDetail(action === 'start' ? 'Starting ADB + scrcpy relay…' : 'Stopping QuestCast relay…');
+    setQuestDetail(action === 'start' ? 'Starting ADB + scrcpy relay…' : 'Stopping delinQuest relay…');
     try {
       const body = await fetchQuestJson(`/api/questcast/${action}`, { method: 'POST' });
       const summary = applyQuestStatus(body);
       if (body.ok === false || body.state === 'error' || body.error) {
-        logError('questcast', `${action} reported a problem: ${summary}`);
+        logError('delinquest', `${action} reported a problem: ${summary}`);
       } else {
-        logInfo('questcast', `${action === 'start' ? 'Started' : 'Stopped'}: ${summary}`);
+        logInfo('delinquest', `${action === 'start' ? 'Started' : 'Stopped'}: ${summary}`);
       }
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       applyQuestStatus({ state: 'error', error: message });
-      logError('questcast', `${action} failed: ${message}`);
+      logError('delinquest', `${action} failed: ${message}`);
     } finally {
       setQuestBusy(false);
     }
@@ -719,8 +719,8 @@ export const VJView: React.FC = () => {
                   ? 'border-sky-500/50 bg-sky-500/10 text-sky-200 hover:bg-sky-500/20'
                   : 'border-white/10 text-zinc-500 hover:text-zinc-200 hover:border-white/20 hover:bg-white/5'
               }`}
-              title={`${questRunning ? 'Click to stop' : 'Click to start'} direct QuestCast ADB/scrcpy relay. This does not use the browser window picker. ${questDetail}`}
-              aria-label="Toggle QuestCast ADB video relay"
+              title={`${questRunning ? 'Click to stop' : 'Click to start'} direct delinQuest ADB/scrcpy relay. This does not use the browser window picker. ${questDetail}`}
+              aria-label="Toggle delinQuest ADB video relay"
               aria-pressed={questRunning}
             >
               {questBusy ? (
@@ -732,15 +732,15 @@ export const VJView: React.FC = () => {
               ) : (
                 <Tv2 className="w-2.5 h-2.5" />
               )}
-              Quest Direct {questLabel}
+              delinQuest {questLabel}
             </button>
             <button
               type="button"
               onClick={() => void loadQuestStatus()}
               disabled={questBusy}
               className="p-1 rounded border border-white/10 text-zinc-500 hover:text-zinc-100 hover:border-white/20 hover:bg-white/5 disabled:opacity-50 disabled:pointer-events-none"
-              title={`Refresh QuestCast status. ${questDetail}`}
-              aria-label="Refresh QuestCast status"
+              title={`Refresh delinQuest status. ${questDetail}`}
+              aria-label="Refresh delinQuest status"
             >
               <RefreshCw className="w-2.5 h-2.5" />
             </button>

--- a/frontend/src/views/VJView.tsx
+++ b/frontend/src/views/VJView.tsx
@@ -157,6 +157,10 @@ export const VJView: React.FC = () => {
   const vjSetAcked = useVjSetStatusStore((s) => s.acked);
   const poppedWindowRef = useRef<Window | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  // True once the in-tab iframe has actually loaded the VJ app. Until its onLoad
+  // fires, contentWindow is about:blank (host origin), so posting with the pinned
+  // VJ origin floods the console with origin-mismatch errors.
+  const iframeLoadedRef = useRef(false);
   const iframeReadyTimerRef = useRef<number | null>(null);
   const currentEntryId = usePlayerStore((s) => s.currentEntryId);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
@@ -196,11 +200,19 @@ export const VJView: React.FC = () => {
   const postToIframe = (payload: Record<string, unknown>) => {
     const w = popped ? poppedWindowRef.current : iframeRef.current?.contentWindow;
     if (!w) return;
+    // Skip until the in-tab iframe has loaded the VJ app, else we post to
+    // about:blank (host origin) and the pinned origin mismatches (console flood).
+    if (!popped && !iframeLoadedRef.current) return;
     try { w.postMessage(payload, vjOrigin); } catch { /* mid-navigation; retried next tick */ }
   };
   // Trust inbound messages only from our own in-tab iframe (a popped-out window
   // is a separate top-level window and can't postMessage back to us anyway).
   const isFromVj = (e: MessageEvent) => e.source != null && e.source === iframeRef.current?.contentWindow;
+
+  // A new VJ src reloads the iframe — re-gate posting until its onLoad fires again.
+  useEffect(() => {
+    iframeLoadedRef.current = false;
+  }, [vjSrc]);
 
   // OS/browser page visibility — pause the bridge when SA3 is minimised or
   // backgrounded, not only when another in-app tab is shown.
@@ -294,6 +306,11 @@ export const VJView: React.FC = () => {
     const highEnd = buf.length;
 
     const tick = () => {
+      // Hold off until the iframe has loaded the VJ app (avoid posting to about:blank).
+      if (!popped && !iframeLoadedRef.current) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
       const now = performance.now();
       if (now - lastPost >= POST_DT) {
         lastPost = now;
@@ -499,7 +516,10 @@ export const VJView: React.FC = () => {
   }, [status, popped]);
 
   const handleIframeLoad = () => {
-
+    // The iframe has loaded the VJ app: contentWindow is now the VJ origin, so
+    // posting is safe. Set synchronously (ref, not state) so the sync() below
+    // isn't blocked by the not-yet-loaded gate.
+    iframeLoadedRef.current = true;
     if (iframeReadyTimerRef.current !== null) {
       window.clearTimeout(iframeReadyTimerRef.current);
       iframeReadyTimerRef.current = null;

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -37,6 +37,9 @@ import {
 } from './specs.js';
 
 const FRONTEND = process.env.SA3_FRONTEND_URL ?? 'http://localhost:5173';
+// Navigate with ?nocinematic so the boot cinematic is skipped for captures (it
+// otherwise holds for ~7s per scene and would appear in the shots).
+const NAV = FRONTEND + (FRONTEND.includes('?') ? '&' : '?') + 'nocinematic=1';
 const BACKEND = process.env.SA3_BACKEND_URL ?? 'http://localhost:8600';
 const requireFromCwd = createRequire(path.join(process.cwd(), 'package.json'));
 const { chromium } = requireFromCwd('playwright') as typeof import('playwright');
@@ -119,13 +122,16 @@ interface Scene {
  * ready (e.g. in a test scenario).
  */
 async function waitForReady(page: Page): Promise<void> {
-  const overlay = page.locator('div.fixed.inset-0.bg-\\[\\#07050a\\].z-200').first();
+  // The boot overlay is the fixed inset-0 z-200 layer (App.tsx wraps LoadingScreen
+  // in it). With ?nocinematic the cinematic is skipped, so this lifts as soon as
+  // the backend health poll succeeds.
+  const overlay = page.locator('div.fixed.inset-0.z-200').first();
   // Wait up to 25s for the overlay to disappear naturally.
   try {
     await overlay.waitFor({ state: 'hidden', timeout: 25000 });
   } catch {
-    // Fallback: click the Skip button if it appeared.
-    const skip = page.getByRole('button', { name: /skip/i }).first();
+    // Fallback: click the escape button if it appeared.
+    const skip = page.getByRole('button', { name: /continue|skip/i }).first();
     if (await skip.isVisible().catch(() => false)) {
       await skip.click();
       await overlay.waitFor({ state: 'hidden', timeout: 5000 });
@@ -170,7 +176,7 @@ const SCENES: Scene[] = [
     name: '01-shell-make',
     description: 'App opened on MAKE tab — top bar + tabs + library closed',
     run: async (page) => {
-      await page.goto(FRONTEND);
+      await page.goto(NAV);
       await waitForReady(page);
       await page.waitForTimeout(800);
       await clickTab(page, 'Make');
@@ -184,7 +190,7 @@ const SCENES: Scene[] = [
       const seed = await pickShowcaseTrack(BACKEND);
       if (!seed) throw new Error('no library entries to showcase');
       log(`showcase track: ${seed.title} (${seed.id.slice(0, 8)})`);
-      await page.goto(FRONTEND);
+      await page.goto(NAV);
       await waitForReady(page);
       await openLibrary(page);
       // Search by the showcase title so it scrolls into view.
@@ -201,7 +207,7 @@ const SCENES: Scene[] = [
     run: async (page) => {
       const seed = await pickShowcaseTrack(BACKEND);
       if (!seed) throw new Error('no library entries to showcase');
-      await page.goto(FRONTEND);
+      await page.goto(NAV);
       await waitForReady(page);
       await openLibrary(page);
       await librarySearch(page, seed.title);
@@ -220,7 +226,7 @@ const SCENES: Scene[] = [
     run: async (page) => {
       const seed = await pickShowcaseTrack(BACKEND);
       if (!seed) throw new Error('no library entries to showcase');
-      await page.goto(FRONTEND);
+      await page.goto(NAV);
       await waitForReady(page);
       await openLibrary(page);
       await librarySearch(page, seed.title);
@@ -236,7 +242,7 @@ const SCENES: Scene[] = [
     run: async (page) => {
       const seed = await pickShowcaseTrack(BACKEND);
       if (!seed) throw new Error('no library entries to showcase');
-      await page.goto(FRONTEND);
+      await page.goto(NAV);
       await waitForReady(page);
       await openLibrary(page);
       await librarySearch(page, seed.title);
@@ -250,7 +256,7 @@ const SCENES: Scene[] = [
     name: '06-learn-tab-3d-graph',
     description: 'LEARN tab — 3D lineage graph with showcase node highlighted',
     run: async (page) => {
-      await page.goto(FRONTEND);
+      await page.goto(NAV);
       await waitForReady(page);
       await clickTab(page, 'Learn');
       // 3D graph needs a beat to settle the force layout.
@@ -262,7 +268,7 @@ const SCENES: Scene[] = [
     name: '07-settings-modal-with-shutdown',
     description: 'SETTINGS modal open showing pinned Restart + Shutdown footer',
     run: async (page) => {
-      await page.goto(FRONTEND);
+      await page.goto(NAV);
       await waitForReady(page);
       // Click the gear icon top-right.
       await page.locator('button[title="Settings"]').first().click();
@@ -274,7 +280,7 @@ const SCENES: Scene[] = [
     name: '08-vj-tab-loading',
     description: 'VJ tab — either loading state OR iframe ready (whichever the sidecar is in)',
     run: async (page) => {
-      await page.goto(FRONTEND);
+      await page.goto(NAV);
       await waitForReady(page);
       await clickTab(page, 'VJ');
       // Give the iframe a beat to either load or show the loading
@@ -289,7 +295,7 @@ const SCENES: Scene[] = [
     run: async (page) => {
       const cohort = await pickCohort(BACKEND, 3);
       if (cohort.length === 0) throw new Error('no library entries');
-      await page.goto(FRONTEND);
+      await page.goto(NAV);
       await waitForReady(page);
       await openLibrary(page);
       // Select via Ctrl+click so multi-select kicks in.


### PR DESCRIPTION
[fix(vj): pre-start VJ sidecar + stop the iframe postMessage origin flood]

- _devstack: warm /api/vj/url once the backend is up so the VJ dev server (5187)
  spawns at launch, not on first VJ-tab click
- VJView: gate the host->iframe bridge on the iframe's real onLoad, so audio /
  control posts no longer hit about:blank (host origin) and flood the console
  with origin-mismatch errors
- capture harness: navigate with ?nocinematic (App honors it) and fix the stale
  boot-overlay selector

Archived the dead BootCinematic.tsx + src/cymatics under archive/ (gitignored).
@[danieljtrujillo](https://github.com/gantasmo/theDAW/commits?author=danieljtrujillo)
danieljtrujillo committed 2 hours ago
[refactor(vj): rename the Quest-video feature to delinQuest in the UI]

Host-side branding for the "free the Quest" video feature is now delinQuest:
the relay toggle ("Quest Direct" -> delinQuest), its tooltips/aria, the preview
panel title + messages, the status copy, and the log tag (questcast -> delinquest).
Internal identifiers and the /api/questcast/* paths are unchanged so the live
feed keeps working; a full internal rename can follow as its own pass.