### PR TITLE
feat: Quest clean-stitch VJ source, DJ folder playlists, Worlds Collide

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,3 @@
 {
+    "cmake.sourceDirectory": "D:/StableAudio/JoshOG/stable-audio-3/frontend/node_modules/nan"
 }

--- a/backend/modules/library/router.py
+++ b/backend/modules/library/router.py
@@ -270,6 +270,62 @@ async def import_media(
     return record.to_dict()
 
 
+_FOLDER_AUDIO_EXTS = {
+    ".wav",
+    ".mp3",
+    ".flac",
+    ".ogg",
+    ".m4a",
+    ".aac",
+    ".opus",
+    ".aif",
+    ".aiff",
+    ".wma",
+}
+
+
+class ImportFolderRequest(BaseModel):
+    path: Optional[str] = None
+    recursive: bool = True
+
+
+@router.post("/import-folder")
+def import_folder(
+    req: ImportFolderRequest = Body(default=ImportFolderRequest()),
+) -> dict[str, Any]:
+    """Add a local folder of audio as a playlist, REFERENCE-IN-PLACE: each file
+    becomes a library entry that points at the on-disk file (no copy), so it
+    plays / analyses like any track. With no ``path``, opens a native folder
+    picker. Returns the created entries; the caller builds the setlist."""
+    folder = req.path
+    if not folder:
+        from backend.core.folder_dialog import pick_folder
+
+        folder = pick_folder(title="Choose a music folder to add as a playlist")
+    if not folder:
+        return {"cancelled": True, "folder": None, "entries": []}
+    root = Path(folder)
+    if not root.is_dir():
+        raise HTTPException(400, f"not a folder: {folder!r}")
+    paths = root.rglob("*") if req.recursive else root.iterdir()
+    files = sorted(
+        (p for p in paths if p.is_file() and p.suffix.lower() in _FOLDER_AUDIO_EXTS),
+        key=lambda p: str(p).lower(),
+    )
+    store = get_store()
+    entries: list[dict[str, Any]] = []
+    for f in files:
+        rec = store.register_reference(str(f), {"source": "folder"})
+        if rec is not None:
+            entries.append(rec.to_dict())
+    return {
+        "cancelled": False,
+        "folder": str(root),
+        "name": root.name,
+        "entries": entries,
+    }
+
+
 @router.patch("/entries/{entry_id}")
 def update_entry(entry_id: str, patch: dict[str, Any] = Body(...)) -> dict[str, Any]:
     record = get_store().update_entry(entry_id, patch)

--- a/backend/modules/library/store.py
+++ b/backend/modules/library/store.py
@@ -198,6 +198,14 @@ def _write_metadata(entry_dir: Path, payload: dict[str, Any]) -> None:
 def _resolve_audio_file(entry_dir: Path, meta: dict[str, Any]) -> Optional[Path]:
     """Resolve the audio file for an entry. Try the metadata-declared name
     first, then any first audio file in the entry directory."""
+    # Reference-in-place entry (folder -> playlist): the audio lives OUTSIDE the
+    # library at source_path and is never copied in. Resolve straight to it so
+    # serving, analysis, and listing all read the original file.
+    source_path = meta.get("source_path")
+    if source_path:
+        ref = Path(source_path)
+        if ref.is_file():
+            return ref
     declared = meta.get("filename") or meta.get("audio_filename")
     if declared:
         candidate = entry_dir / declared
@@ -641,6 +649,71 @@ class LibraryStore:
         _maybe_enqueue_analysis(self, entry_id, source="import")
         _maybe_enqueue_stems(self, entry_id, source="import")
         _maybe_enqueue_midi(self, entry_id, source="import")
+        return record
+
+    def register_reference(
+        self,
+        source_path: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> Optional[LibraryRecord]:
+        """Register an on-disk audio file as a library entry WITHOUT copying it
+        (reference-in-place). Only a small metadata.json is written into the
+        library; the audio is served / analysed straight from ``source_path``.
+        Used by the folder -> playlist feature. Returns None when the path is
+        not a file."""
+        src = Path(source_path)
+        if not src.is_file():
+            return None
+        entry_id = uuid.uuid4().hex
+        entry_dir = self.root / entry_id
+        entry_dir.mkdir(parents=True, exist_ok=True)
+        meta_in = dict(metadata or {})
+        ext = src.suffix.lower().lstrip(".")
+        mime = {
+            "mp3": "audio/mpeg",
+            "wav": "audio/wav",
+            "flac": "audio/flac",
+            "ogg": "audio/ogg",
+            "m4a": "audio/mp4",
+            "aac": "audio/aac",
+            "opus": "audio/opus",
+            "aif": "audio/aiff",
+            "aiff": "audio/aiff",
+            "wma": "audio/x-ms-wma",
+        }.get(ext, "audio/mpeg")
+        record_meta: dict[str, Any] = {
+            "id": entry_id,
+            "source_path": str(src.resolve()),
+            "filename": src.name,
+            "audio_filename": src.name,
+            "mime_type": mime,
+            "title": meta_in.get("title") or src.stem,
+            "prompt": "",
+            "negative_prompt": "",
+            "model": "reference",
+            "duration": 0.0,
+            "steps": 0,
+            "cfg": 0.0,
+            "seed": 0,
+            "favorite": False,
+            "rating": None,
+            "tags": list(meta_in.get("tags", [])),
+            "notes": meta_in.get("notes", ""),
+            "source": meta_in.get("source", "folder"),
+            "chimera_sources": [],
+            "saved_at": time.time(),
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        _write_metadata(entry_dir, record_meta)
+        record = _record_from_metadata(entry_dir, record_meta, self.api_prefix)
+        if record is None:
+            return None
+        record.id = entry_id
+        record.audio_url = _audio_url_for(self.api_prefix, entry_id)
+        self._sync_record_to_db(record, record_meta)
+        # Reference tracks still benefit from BG analysis (BPM/key for mixing);
+        # it reads get_audio_path, which now resolves to the external file.
+        _maybe_enqueue_analysis(self, entry_id, source="import")
         return record
 
     def import_media(

--- a/backend/modules/queststitch/bridge.py
+++ b/backend/modules/queststitch/bridge.py
@@ -1,0 +1,299 @@
+"""Quest stitch bridge — clean stitched passthrough -> VJ, over adb reverse.
+
+The Quest app (``GantasmoStitchStreamer``) MediaCodec-encodes the stitched
+passthrough RenderTexture to H.264 and pushes the NAL units over a localhost TCP
+socket. ``adb reverse tcp:PORT tcp:PORT`` tunnels that to the PC (the same trick
+``QuestMidiSender`` uses). This module hosts the TCP listener on uvicorn's
+asyncio loop, re-frames each packet into the SAME WebSocket wire format the
+``questcast`` relay uses, and fans it out to the VJ — so the VJ's existing
+WebCodecs decoder (``useQuestCast``) is reused verbatim for a new source.
+
+Why this exists separately from questcast/delinQuest: delinQuest mirrors the
+whole Quest *display* (scrcpy), which carries the MR scene + MIDI surface the
+performer is looking at. This carries ONLY the clean stitch.
+
+Wire format on the TCP socket (Quest -> here):
+    [u32 frameLen LE][u8 type][u8 keyframe][f64 ptsUs LE][payload]
+    frameLen counts the 10-byte header + payload (everything after the u32).
+    type 0 = codec config (Annex-B SPS/PPS), 1 = data NALs, 2 = meta (JSON {w,h,fps,codec}).
+
+Wire format on the WebSocket (here -> browser), IDENTICAL to questcast:
+    - first text message: {"type":"metadata","codec":"h264","width":..,"height":..}
+    - binary frames: [u8 type(0=config,1=data)][u8 keyframe][6 pad][f64 ptsUs LE][...H.264]
+    - the latest config packet is replayed to late-joining clients.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import struct
+import subprocess
+from typing import Any, Optional
+
+from fastapi import WebSocket
+
+from backend.core.adb import resolve_adb_path
+
+log = logging.getLogger(__name__)
+
+DEFAULT_PORT = 8940
+
+# Quest -> here packet types.
+_T_CONFIG = 0
+_T_DATA = 1
+_T_META = 2
+
+
+def _port() -> int:
+    try:
+        return int(os.getenv("theDAW_QUESTSTITCH_PORT") or DEFAULT_PORT)
+    except ValueError:
+        return DEFAULT_PORT
+
+
+def _adb_path() -> Optional[str]:
+    """Resolve adb the same way questmidi/questcast do, so all three share one adb."""
+    return resolve_adb_path(
+        "theDAW_QUESTSTITCH_ADB", "theDAW_QUESTMIDI_ADB", "theDAW_ADB"
+    )
+
+
+class _State:
+    server: Optional[asyncio.AbstractServer] = None
+    quest_peer: Optional[str] = None
+    clients: set[WebSocket] = set()
+    adb_reverse_ok: bool = False
+    started: bool = False
+    starting: bool = False
+    # Last config packet (already in browser wire format) for late joiners.
+    last_config: Optional[bytes] = None
+    # Source dimensions reported by the Quest's meta packet.
+    width: Optional[int] = None
+    height: Optional[int] = None
+    fps: Optional[int] = None
+    # Rolling counters for diagnostics.
+    frames: int = 0
+    keyframes: int = 0
+
+
+_s = _State()
+
+
+# ---- browser WebSocket clients -----------------------------------------------
+
+
+def metadata_message() -> str:
+    return json.dumps(
+        {
+            "type": "metadata",
+            "codec": "h264",
+            "width": _s.width,
+            "height": _s.height,
+        }
+    )
+
+
+async def add_client(ws: WebSocket) -> None:
+    """Register a browser client and prime it with metadata + last config."""
+    _s.clients.add(ws)
+    try:
+        await ws.send_text(metadata_message())
+        if _s.last_config is not None:
+            await ws.send_bytes(_s.last_config)
+    except Exception:  # noqa: BLE001 — client went away immediately
+        _s.clients.discard(ws)
+
+
+def remove_client(ws: WebSocket) -> None:
+    _s.clients.discard(ws)
+
+
+async def _broadcast_bytes(frame: bytes) -> None:
+    if not _s.clients:
+        return
+    dead: list[WebSocket] = []
+    for ws in list(_s.clients):
+        try:
+            await ws.send_bytes(frame)
+        except Exception:  # noqa: BLE001
+            dead.append(ws)
+    for d in dead:
+        _s.clients.discard(d)
+
+
+async def _broadcast_text(msg: str) -> None:
+    if not _s.clients:
+        return
+    dead: list[WebSocket] = []
+    for ws in list(_s.clients):
+        try:
+            await ws.send_text(msg)
+        except Exception:  # noqa: BLE001
+            dead.append(ws)
+    for d in dead:
+        _s.clients.discard(d)
+
+
+# ---- Quest -> browser frame translation --------------------------------------
+
+
+def _browser_frame(
+    packet_type: int, keyframe: int, pts_us: float, payload: bytes
+) -> bytes:
+    """Pack one H.264 packet into the questcast browser wire format
+    ([u8 type][u8 keyframe][6 pad][f64 ptsUs LE][...h264])."""
+    header = bytearray(16)
+    header[0] = 1 if packet_type == _T_DATA else 0
+    header[1] = 1 if keyframe else 0
+    struct.pack_into("<d", header, 8, float(pts_us))
+    return bytes(header) + payload
+
+
+async def _on_packet(
+    packet_type: int, keyframe: int, pts_us: float, payload: bytes
+) -> None:
+    if packet_type == _T_META:
+        try:
+            meta = json.loads(payload.decode("utf-8"))
+            _s.width = int(meta.get("w")) if meta.get("w") else _s.width
+            _s.height = int(meta.get("h")) if meta.get("h") else _s.height
+            _s.fps = int(meta.get("fps")) if meta.get("fps") else _s.fps
+        except Exception as e:  # noqa: BLE001
+            log.debug("queststitch: bad meta packet: %s", e)
+            return
+        await _broadcast_text(metadata_message())
+        return
+
+    frame = _browser_frame(packet_type, keyframe, pts_us, payload)
+    if packet_type == _T_CONFIG:
+        _s.last_config = frame
+    else:
+        _s.frames += 1
+        if keyframe:
+            _s.keyframes += 1
+    await _broadcast_bytes(frame)
+
+
+# ---- inbound TCP from the Quest ----------------------------------------------
+
+
+async def _handle_quest(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+) -> None:
+    peer = writer.get_extra_info("peername")
+    _s.quest_peer = str(peer)
+    log.info("queststitch: Quest connected %s", peer)
+    try:
+        while True:
+            header = await reader.readexactly(4)
+            (body_len,) = struct.unpack("<I", header)
+            if body_len < 10 or body_len > 8_000_000:
+                log.warning(
+                    "queststitch: implausible frame len %d, dropping peer", body_len
+                )
+                break
+            body = await reader.readexactly(body_len)
+            packet_type = body[0]
+            keyframe = body[1]
+            (pts_us,) = struct.unpack_from("<d", body, 2)
+            payload = body[10:]
+            await _on_packet(packet_type, keyframe, pts_us, payload)
+    except asyncio.IncompleteReadError:
+        pass  # Quest disconnected mid-frame
+    except Exception as e:  # noqa: BLE001
+        log.debug("queststitch: quest read error: %s", e)
+    finally:
+        if _s.quest_peer == str(peer):
+            _s.quest_peer = None
+            # Keep last_config across a Quest TCP blip: the encoder does not re-emit
+            # SPS/PPS on reconnect, so dropping it here would strand a VJ that joins
+            # before the streamer's per-keyframe config resend lands. A new config
+            # packet overwrites it in _on_packet when the stream genuinely changes.
+        try:
+            writer.close()
+        except Exception:
+            pass
+        log.info("queststitch: Quest disconnected")
+
+
+# ---- lifecycle ---------------------------------------------------------------
+
+
+def _run_adb_reverse(port: int) -> bool:
+    adb = _adb_path()
+    if not adb:
+        return False
+    try:
+        subprocess.run(
+            [adb, "reverse", f"tcp:{port}", f"tcp:{port}"],
+            capture_output=True,
+            timeout=10,
+            check=True,
+        )
+        return True
+    except Exception as e:  # noqa: BLE001
+        log.info("queststitch: adb reverse failed: %s", e)
+        return False
+
+
+async def reattach_adb() -> bool:
+    """Re-run ``adb reverse`` (after re-plugging the headset / accepting the
+    USB-debugging prompt) without restarting the listener."""
+    loop = asyncio.get_running_loop()
+    _s.adb_reverse_ok = await loop.run_in_executor(None, _run_adb_reverse, _port())
+    return _s.adb_reverse_ok
+
+
+async def ensure_started() -> None:
+    """Start the TCP listener (once) and run adb reverse. Idempotent."""
+    if _s.started or _s.starting:
+        return
+    _s.starting = True
+    try:
+        port = _port()
+        await reattach_adb()
+        _s.server = await asyncio.start_server(_handle_quest, "127.0.0.1", port)
+        _s.started = True
+        log.info(
+            "queststitch: listening on 127.0.0.1:%d (adb reverse %s)",
+            port,
+            "ok" if _s.adb_reverse_ok else "not set",
+        )
+    except Exception as e:  # noqa: BLE001
+        log.warning("queststitch: failed to start: %s", e)
+    finally:
+        _s.starting = False
+
+
+async def stop() -> None:
+    if _s.server is not None:
+        _s.server.close()
+        try:
+            await _s.server.wait_closed()
+        except Exception:
+            pass
+    _s.server = None
+    _s.started = False
+    _s.quest_peer = None
+    _s.last_config = None
+
+
+def status() -> dict[str, Any]:
+    return {
+        "started": _s.started,
+        "port": _port(),
+        "adb_path": _adb_path(),
+        "adb_reverse_ok": _s.adb_reverse_ok,
+        "quest_connected": _s.quest_peer is not None,
+        "quest_peer": _s.quest_peer,
+        "clients": len(_s.clients),
+        "width": _s.width,
+        "height": _s.height,
+        "fps": _s.fps,
+        "frames": _s.frames,
+        "keyframes": _s.keyframes,
+        "have_config": _s.last_config is not None,
+    }

--- a/backend/modules/queststitch/module.json
+++ b/backend/modules/queststitch/module.json
@@ -1,0 +1,10 @@
+{
+  "name": "queststitch",
+  "label": "Quest Stitch",
+  "enabled": true,
+  "icon": "Camera",
+  "sidebar": false,
+  "api_prefix": "/api/queststitch",
+  "backend": true,
+  "description": "Brings the CLEAN stitched Quest passthrough into theDAW as a live VJ source, separate from delinQuest (which mirrors the whole headset display). The Quest app encodes the stitch RenderTexture to H.264 and pushes it over adb reverse to this module, which relays it to the VJ over WebSocket in the same wire format questcast uses, so the VJ's WebCodecs decoder is reused. Disable to skip it entirely."
+}

--- a/backend/modules/queststitch/router.py
+++ b/backend/modules/queststitch/router.py
@@ -1,0 +1,67 @@
+"""FastAPI router for the Quest stitch module.
+
+Endpoints (prefix /api/queststitch):
+    GET  /status   listener + adb + connection state, source dims, frame counters
+    POST /start    start the TCP listener and (re)run adb reverse
+    POST /stop     stop the listener
+    POST /reattach re-run adb reverse only (after re-plugging the headset)
+    WS   /ws       browser relay: streams the clean stitch as H.264 (questcast wire format)
+
+The VJ's ``useQuestStitch`` hook opens /ws and decodes with WebCodecs — the exact
+same decoder used for delinQuest, since the wire format is identical.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from . import bridge
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(tags=["queststitch"])
+
+
+@router.get("/status")
+async def get_status() -> dict:
+    return bridge.status()
+
+
+@router.post("/start")
+async def start() -> dict:
+    await bridge.ensure_started()
+    await bridge.reattach_adb()
+    return bridge.status()
+
+
+@router.post("/stop")
+async def stop() -> dict:
+    await bridge.stop()
+    return bridge.status()
+
+
+@router.post("/reattach")
+async def reattach() -> dict:
+    """Re-run adb reverse without restarting the listener (re-plug recovery)."""
+    ok = await bridge.reattach_adb()
+    return {"adb_reverse_ok": ok, **bridge.status()}
+
+
+@router.websocket("/ws")
+async def ws(websocket: WebSocket) -> None:
+    await websocket.accept()
+    # Make sure the TCP listener + adb tunnel are up the moment a browser attaches.
+    await bridge.ensure_started()
+    await bridge.add_client(websocket)
+    try:
+        # The stream is one-way (Quest -> browser); we only await to detect close.
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:  # noqa: BLE001 — client went away mid-message
+        log.debug("queststitch: ws error: %s", e)
+    finally:
+        bridge.remove_client(websocket)

--- a/docs/plans/2026-06-16-punchlist-audit-vj-quest-handtracking-plan.md
+++ b/docs/plans/2026-06-16-punchlist-audit-vj-quest-handtracking-plan.md
@@ -1,0 +1,189 @@
+# Punchlist Audit + VJ/Quest Hand-Tracking Plan (2026-06-16)
+
+Verified each carried-over punchlist item against the actual code via a
+fan-out of read-only research agents across the VJ app
+(`D:\StableAudio\GANTASMO-LIVE-VJ`), the main DAW
+(`d:\StableAudio\JoshOG\stable-audio-3`), and the Unity project
+(`d:\Dev\Unity\GANTASMO-MIDI`). Status tags reflect what the code shows,
+not what prior memory claimed. Items marked [DONE (code)] still need the
+user's eyes or a runtime/headset check before they count as truly done.
+
+## Already shipped (was listed as open; remove from active queue)
+
+- [DONE (code)] **delinQuest "flaky on main VJ stream"** — `useQuestCast.ts`
+  now self-heals: reconnect backoff (265-285), stall watchdog (454-466),
+  visibility-change recovery (468-475). No bug markers remain in the path.
+  Reframe as: confirm stability live; it is no longer an open code bug.
+- [DONE] **VJ layout refactor** — Resolume-style "preview" layout exists
+  (`types.ts:17` layoutMode union; `VJControls.tsx:369`; ClipGrid documented
+  Resolume-style). There is no literal "resoDAW" name; the layout work itself
+  is done.
+- [DONE] **Knobs/sliders** — `Fader` (VJControls.tsx:181-226) and `TogglePad`
+  (228-250) exist and drive the effect decks.
+- [DONE] **VJ UI punchlist (all sub-items)** — banks=rows (ClipGrid.tsx:14),
+  wheel/ctrl-wheel scroll (123-136), SOURCE relabel (VJControls.tsx:437),
+  Import Media + filetype tooltip (31-37, 665-668), drag Library->banks
+  (ClipGrid 28-31 / LibraryPool 113-116), footer play/pause bidirectional
+  sync (App.tsx:127-180). "Kill verbose empty-state copy" — current copy is
+  already concise; the verbose text described is not present.
+- [DONE (code)] **Cymatics VJ source** — committed (ee98728), `three ^0.184`
+  + `@types/three` in package.json, `public/piz_compressed.exr` shipped, four
+  modes (orb / cymatics / landscape-chrome / landscape-ferrofluid), wired to
+  the CAM<->MEM crossfader. "Live eyes" was a label mix-up; there is no eyes
+  mode. Needs the user's eyes on the four modes.
+- [DONE] **DJ FOSS WASM time-stretcher** — `signalsmith-stretch ^1.3.2` in
+  package.json, integrated into `djEngine.ts` with per-deck key-lock.
+- [DONE (code)] **Magenta RT2** — submodule `sidecars/magenta-rt2-nvidia`,
+  extended sidecar accepting text + MIDI notes + audio-style
+  (`backend/modules/magenta/sidecar.py`), full frontend control set
+  (`AdvancedGenPanel.tsx` notes picker, style upload, sampling knobs),
+  target port 8777. Needs a WSL/NVIDIA runtime check.
+- [DONE (code)] **loopMIDI-into-app** — `backend/modules/questmidi/bridge.py`
+  is the loopMIDI-free path (TCP listener over adb reverse, WebSocket relay to
+  the frontend midiBus). It is implemented, not a pending recommendation.
+- [DONE] **Pitch/tempo detection** — `backend/modules/analysis/{key,pitch}.py`
+  + tempo/beat detection in the analysis engine.
+
+## In progress / partial
+
+- [PARTIAL] **VJ watch-link/broadcast** — backend signaling relay + STUN/TURN
+  config done (`backend/modules/broadcast/router.py`). Still to build: VJ-side
+  GO-LIVE broadcaster (no `useBroadcast` hook, no toggle) and the DJ-audio
+  host->iframe WebRTC hop.
+- [PARTIAL] **questcast end-to-end** — backend module + sidecar committed
+  (ec5f5a7); `useQuestCast.ts` and `useMedia.ts` currently have UNCOMMITTED
+  edits. End-to-end headset verification is undocumented.
+- [PARTIAL] **Global layout phases** — A + B1-B3 shipped (PR #21, #24). B4
+  overlays: spec only, not implemented. C (MAKE/EDIT/LEARN -> ControlSurface):
+  not started; panels still bespoke. D (micro-perf): not started. E (DJ): see
+  below. F (Opus autoconvert): greenfield, not started.
+- [PARTIAL / NEEDS RECONCILIATION] **DJ suite** — 2 decks only
+  (`djEngine.ts:35` DeckId = 'A' | 'B'), not 4. D3 key-lock done; D4 stems are
+  cached/offline-foreground separation, not real-time. Prior memory claims D5
+  (FX rack + limiter) and D6 (cue via setSinkId) shipped; a focused search did
+  not confirm those, though `effectChainStore.ts` and `djControlMap.ts` exist.
+  Reconcile before relying on DJ status. Not started: D7 4-deck refactor, D8,
+  deck+stem persistence (this is "E5"), true real-time stems.
+- [PARTIAL] **Controller recognition CV photo layout** — `controllervision`
+  module exists (classical CV: Hough circles, contour analysis) and suggests
+  control counts/positions. It does NOT infer MIDI mapping (mapping stays on
+  the learn-capture path). So this is partly built, not merely planned.
+- [PARTIAL] **VJ library visual organizer** — LibraryPool is a basic thumbnail
+  grid. A Resolume-style organizer (folders, color-coding, metadata, filter,
+  in-library preview) is not started.
+- [PARTIAL] **Zero-terminal onboarding** — theDAW.bat, install/setup.ps1,
+  Setup-MRT2.bat, exit-code contract, and the SETUP status pill exist. Missing:
+  an in-app button to actually run Setup-MRT2 (the pill is informational only),
+  and setup-script tests.
+- [PARTIAL / DRIFT] **RAG maintenance** — all 17 DOC_PATHS resolve. Missing
+  docs for shipped features: broadcast, questcast, questmidi, cymatics, and
+  stems/MIDI as first-class library items. Doc edits are approval-based; these
+  are proposals only.
+
+## Not started (accurate)
+
+- [NOT STARTED] **Quest hand tracking** — no hand-tracking, gesture, pose, or
+  MediaPipe code anywhere in the VJ or Unity projects.
+- [NOT STARTED] **Quest microgestures in the "add ___" menu** — Quest
+  hand-tracking thumb microgestures, to be addable in a Quest/Unity-side menu.
+  Exact menu location is an OPEN QUESTION (see below).
+- [NOT STARTED] **3-cam passthrough stitch** — no multi-cam / stitch /
+  panorama / passthrough-compositing code. Prior plan filed Quest passthrough
+  as research-only/deferred. Target output is an OPEN QUESTION (see below).
+- [NOT STARTED] **Stems/MIDI I2** — soundfonts + custom-instrument builder.
+  I1 (play/delete/favorite/route stems+MIDI, schema v5, shared midiSynth) is
+  shipped; midiSynth is a single sawtooth synth with no soundfont loader.
+- [NOT STARTED] **Library folders** — data model is flat (no folder/crate/
+  collection field). One-folder-vs-crates decision still pending.
+- [NOT STARTED] **Notation Phase 4 (MT3) and Phase 5 (OMR)** — both listed as
+  "future" in `notation/engine.py`. "Phase 8 visuals" is not a tracked phase;
+  MusicXML already renders via OSMD. Clarify what Phase 8 should be.
+- [NOT STARTED] **Model streaming loader** — lazy-load + RAM-parking of models
+  is done (`server.py`). No streaming loader. The crash itself is disk/pagefile
+  pressure, an environment issue.
+- [NOT STARTED] **2026-06-10 audit application** — 124 findings + judge rulings
+  exist (`CODEBASE_AUDIT_2026-06-10.md`, `audit-reports/2026-06-10/10-judge.md`).
+  Rulings have not been applied to the master doc.
+- [NOT STARTED] **Opus-on-import** — Opus export support exists; library-side
+  auto-conversion on import is greenfield (Phase F, F1 audit first).
+
+## Open / unchanged
+
+- **CRISPR DNA punchlist** — the code in `ChimeraDnaScene.tsx` reportedly
+  implements all nine visual goals, but the item was listed as open, so the
+  visual result does not yet match the target. Keep OPEN pending the user's
+  eyes against the reference choreography. The agreed 3-wave execution plan
+  lives in the punchlist memory, not a separate doc.
+
+## Hand tracking + passthrough stitch + microgestures (Quest / Unity)
+
+Scope answered by the user: hand interactions touch virtual knobs/sliders and
+drive theDAW everywhere (VJ/DJ/edit); gestures (hand pose) and microgestures
+behave like a MIDI controller, emitting a signal that the user maps in theDAW's
+MIDI learn; a new GANTASMO/MIDI menu in Unity is the "add ___" surface that holds
+addable input sources (gestures, microgestures, knobs, sliders, buttons,
+crossfaders), each bindable through MIDI learn; gestures/microgestures render with
+Meta's own gesture icons. Stitch output is a clean composite (16:9 / 17:9) of the
+passthrough images sent to the VJ as a source.
+
+### What already exists (Unity 6000.4.11f1, Meta XR SDK 203.0.0)
+
+- Passthrough stitch is BUILT: `Assets/GantasmoPassthrough/Runtime/
+  GantasmoPassthroughStitch.cs` composites the two forward RGB passthrough cameras
+  (PassthroughCameraAccess Left + Right) into a 16:9 RenderTexture via homography
+  reprojection + feather blend, with an in-headset preview quad and a
+  `GANTASMO > Add Passthrough Stitch To Scene` menu. Its `OutputTexture` is the
+  handoff point for downstream streaming (which does not exist yet).
+- Microgesture API present: `OVRMicrogestureEventSource` +
+  `OVRHand.GetMicrogestureType()` -> SwipeLeft/Right/Forward/Backward + ThumbTap.
+- Gesture-pose system present and IMPORTED: `Assets/Samples/XR Hands/1.7.3/
+  Gestures/` (StaticHandGesture + XRHandShape assets) with the matching icon set.
+- Meta microgesture arrow icons in the core package
+  (`OVRMicrogesturesNavigationIcons.prefab`).
+- MIDI bridge: `QuestMidiSender` (framed MIDI over TCP:8765 via adb reverse),
+  `MidiControlSurface` router, and `MidiKnob`/`MidiSlider`/`MidiButton` controls.
+- All gameplay scripts compile into Assembly-CSharp (no asmdef), which already
+  references the Meta SDK, so gesture->MIDI scripts need no assembly wiring.
+
+### Build order
+
+1. [DONE, compiles clean in live editor; NOT runtime-verified]
+   `MicrogestureMidiSource.cs` — maps the five microgestures (per hand) to a
+   momentary MIDI Note (or CC pulse) via `MidiControlSurface`, debounced, mappable
+   in theDAW. Needs on-headset verification: real microgesture -> note in MIDI learn.
+2. `HandPoseMidiSource.cs` — wrap the imported XR Hands `StaticHandGesture`
+   (fist / palm-up / point / shaka / thumbs up-down) to emit a MIDI Note on pose
+   enter, carrying the matching XR Hands icon for the menu.
+3. Bring the gesture/microgesture icons into `Assets/` (from the XR Hands
+   `Samples~` set and the Meta arrow icons) so the menu can show them.
+4. GANTASMO/MIDI in-VR "add ___" menu: a registry + 3D panel listing addable
+   input sources (gesture, microgesture, knob, slider, button, crossfader), each
+   emitting MIDI for learn-mapping, persisted like `SurfaceLayoutStore`, with an
+   editor menu to drop it into the QuestMIDI scene.
+5. Stitch -> VJ source: encode/stream `GantasmoPassthroughStitch.OutputTexture`
+   through the existing questcast/delinQuest path so it shows up in the VJ as a
+   camera source.
+
+### Stitch "3rd cam" resolved: it is the depth camera
+
+The Quest Passthrough Camera API exposes two forward RGB cameras (Left + Right);
+the "3rd cam" is the environment depth, used to make the existing two-camera
+stitch reproject correctly. `EnvironmentDepthManager` ships in Meta XR Core SDK
+203.0.0 and publishes `_EnvironmentDepthTexture` + `_EnvironmentDepthReprojectionMatrices`
++ `_EnvironmentDepthZBufferParams` globally.
+
+- [DONE, compiles clean; NOT runtime/headset-verified] Depth-aware reproject:
+  `PassthroughStitch.shader` now has a `GANTASMO_DEPTH_STITCH` path that replaces
+  the fixed `_FocalDist` plane with the real per-pixel scene distance (sampled from
+  environment depth, left/right eye per output side), so every depth lines up across
+  the seam instead of only the focal plane. `GantasmoPassthroughStitch.cs` brings up
+  `EnvironmentDepthManager` and flips the keyword on only while depth is flowing,
+  falling back to the proven focal-plane path otherwise (toggle: `useEnvironmentDepth`).
+  Needs on-headset tuning: the reconstruction approximates the virtual camera as the
+  mid-eye, so seam alignment and any residual offset must be eyeballed on a Quest 3.
+
+### Verification
+
+All of this is Quest-side and needs the headset plus theDAW MIDI learn to confirm
+end to end. In-editor compilation can be checked via the Unity MCP; runtime
+behavior cannot. Nothing here is "done" until seen working on the headset.

--- a/docs/plans/2026-06-18-master-action-plan.md
+++ b/docs/plans/2026-06-18-master-action-plan.md
@@ -1,0 +1,69 @@
+# Master Action Plan — 2026-06-18
+
+Consolidated list of every open / unfinished task across the three codebases
+(theDAW = this repo, VJ = GANTASMO-LIVE-VJ, Quest = GANTASMO-MIDI Unity). Status
+tags: **[built]** = in the working tree, compile/typecheck-verified, not yet
+live-verified; **[uncommitted]** = not in version control yet; **[not started]**;
+**[deferred]** = blocked on a decision; **[proposed]** = designed, not applied;
+**[open bug]**.
+
+## 0. Verify + land the stacking work (immediate)
+- Headset-verify the Stitch -> VJ pipeline end to end: >=24 fps after the scene
+  optimizations, hand poke/grab still works after the layer move + controller
+  disable, the MIDI surface is still visible in-headset, correct colours /
+  orientation. **[built, needs live test]**
+- Save the Unity scene so the layer move / disabled controllers / component
+  settings persist into the build.
+- Live-test Worlds Collide (on-screen twin) and the DJ folder -> playlist add.
+  **[built, needs live test]**
+
+## 1. Stitch -> VJ (clean passthrough + 3D composite)
+- Optional next perf lever: consolidate the apparent double hand-rendering
+  (Hand Tracking building block + the rig's OVRHandVisual). **[not started]**
+- Move any other 3D content (holograms) onto the `GantasmoStream` layer so it
+  appears in the stream (only the MIDI surface is on it today).
+- delinQuest flaky on the main stream. **[open bug]**
+
+## 2. Two-PC / live-set connectivity (biggest)
+- Two computers hooked up, both feeds mixable via the VJ or autoplay. Broadcast
+  module needs host / multi-input / audio-in rework. **[not started]**
+- VJ GO-LIVE broadcaster + DJ-audio host -> iframe hop + TURN (watch-link).
+  Backend signaling module exists; the rest is unbuilt. **[not started]**
+
+## 3. Quest / Unity
+- MR free-roam: suppress the Guardian boundary + MRUK floor/scene-mesh collider,
+  no manual Space Setup. **[proposed]**
+- Hand POSE -> MIDI on the Quest (only microgestures exist today). **[not started]**
+- In-VR "add ___" menu for sources / microgestures. **[planned]**
+- Finish the comprehensive-rig cleanup (controllers disabled, locomotor already
+  off; fuller strip optional).
+- Headset-verify the earlier compile-only work: microgesture->MIDI, depth-aware
+  stitch, the XR-surface material system.
+
+## 4. theDAW feature backlog
+- Soundfonts + custom-instrument builder (stems/MIDI Phase I2). **[not started]**
+- Library folders / crates. **[deferred — one-folder-vs-crates decision]**
+- Opus auto-convert on import. **[not started]**
+- DJ: 4-deck mode (D7), D8, deck persistence, true real-time stems. **[not started]**
+- Notation: Phase 4 (MT3 transcription), Phase 5 (OMR), Phase 8 (visuals).
+- Magenta RT2: vendor submodule + extend sidecar (notes/audio) + full frontend.
+- VJ UI punchlist: banks=rows + wheel/ctrl-wheel scroll, kill empty-state copy,
+  "SOURCE" + "Import Media" + filetype tooltip, drag Library -> banks, footer
+  play/pause reflects real playback. **[not started]**
+- Cymatics VJ source. **[built, needs live eyes]** (needs `three` dep + EXR asset)
+- VJ Resolume layout + native folder dialog. **[built, needs eyes]**
+- VJ library UX: visual pass modelled on Resolume. **[research]**
+- Controller recognition: CV-inferred photo layout. **[planned]**
+
+## 5. Visual / creative
+- CRISPR DNA punchlist (OPEN): hero panel backdrop, ~3-coil hero strand, full-run
+  chunk lift/travel, blend-on-overlap, per-lane desync, no black rungs, water/
+  leaves motion. 3-wave execution plan on file. **[open]**
+
+## 6. Infra / maintenance
+- Model-load segfault: free disk + pagefile, OR approved streaming loader.
+  **[open]**
+- 2026-06-10 codebase audit: 124 findings, judge rulings unapplied.
+- Zero-terminal onboarding remainder: in-app surface for Setup-MRT2, setup-script
+  tests.
+- RAG index maintenance: periodic doc/index sanity (edits are approval-based).

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-15T20:51:03.817Z · Git revision: `a840eb61a698` · Repomix tracked: **no**
+> Generated: 2026-06-18T18:02:53.541Z · Git revision: `5d97e30cd290` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-15T20:51:03.817Z",
-  "repoRevision": "a840eb61a698",
+  "generatedAt": "2026-06-18T18:02:53.541Z",
+  "repoRevision": "5d97e30cd290",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-15T20:53:23.134Z",
+  "generatedAt": "2026-06-18T18:05:05.682Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/src/components/layout/SlidePanel.tsx
+++ b/frontend/src/components/layout/SlidePanel.tsx
@@ -24,6 +24,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Rows3, Crosshair, LayoutGrid, RotateCcw, ChevronLeft, ChevronRight, Plus, Settings2, X, Trash2, Film, Target, Wand2, Sliders, Sparkles, Radio, Crosshair as MapPin, Check } from 'lucide-react';
 import './track-controls.css';
 import { TrackFader, TrackKnob, TrackPad } from './TrackControls';
+import WorldsCollidePanel from './WorldsCollidePanel';
 import {
   useSlideStore,
   resolveItem,
@@ -43,6 +44,7 @@ import {
   profileControlCount,
   profileKindCount,
   detectProfileFromNames,
+  GANTASMO_WORLDS_COLLIDE_ID,
   type ControlKind,
 } from '../../state/controllerProfiles';
 import { useEditorStore } from '../../state/editorStore';
@@ -953,6 +955,12 @@ export const SlidePanel: React.FC = () => {
           className="bg-[#111114] text-zinc-300 border border-white/12 rounded-md px-2 py-1 text-[9px] font-bold uppercase tracking-wider outline-none"
           title="Controller profile — picking one turns Auto off so your choice sticks"
         >
+          {/* GANTASMO on-screen XR twin — always first in the list. */}
+          {CONTROLLER_PROFILES.filter((p) => p.id === GANTASMO_WORLDS_COLLIDE_ID).map((p) => (
+            <optgroup key="gantasmo" label="GANTASMO">
+              <option value={p.id}>{p.name} · {profileControlCount(p)}</option>
+            </optgroup>
+          ))}
           {learnedProfiles.length > 0 && (
             <optgroup label="LEARNED (your devices)">
               {learnedProfiles
@@ -965,7 +973,7 @@ export const SlidePanel: React.FC = () => {
           )}
           {(['dj', 'pad', 'mixer', 'keys', 'generic'] as const).map((cat) => {
             const inCat = CONTROLLER_PROFILES
-              .filter((p) => (p.category ?? 'generic') === cat)
+              .filter((p) => (p.category ?? 'generic') === cat && p.id !== GANTASMO_WORLDS_COLLIDE_ID)
               .sort((a, b) => a.name.localeCompare(b.name)); // alpha within each group
             if (inCat.length === 0) return null;
             return (
@@ -1085,6 +1093,10 @@ export const SlidePanel: React.FC = () => {
       {/* surface */}
       <div className={`flex-1 min-h-0 overflow-auto relative flex flex-col ${view === 'controller' ? 'p-3' : 'px-3 pt-3 pb-0'}`}>
         {view === 'controller' ? (
+          profileId === GANTASMO_WORLDS_COLLIDE_ID ? (
+            // GANTASMO on-screen twin of the Quest XR MIDI surface.
+            <WorldsCollidePanel profileId={profileId} />
+          ) : (
           // Controller view OPENS FITTED to the window, mouse-wheel zooms, and
           // left-click drag on the background pans around the device.
           <>
@@ -1115,6 +1127,7 @@ export const SlidePanel: React.FC = () => {
               </div>
             </div>
           </>
+          )
         ) : view === 'focus' ? (
           // mt-auto anchors the lanes to the BOTTOM of the panel; the page
           // controller below them is sticky so it never scrolls away.

--- a/frontend/src/components/layout/WorldsCollidePanel.tsx
+++ b/frontend/src/components/layout/WorldsCollidePanel.tsx
@@ -1,0 +1,374 @@
+/**
+ * GANTASMO — Worlds Collide.
+ *
+ * An on-screen twin of the Quest "GANTASMO XR MIDI" control surface, living in
+ * theDAW's controller section. It emits the SAME MIDI as the headset surface so
+ * theDAW treats it identically to the hardware:
+ *
+ *   6 faders     -> CC 1..6
+ *   8 knobs      -> CC 40..47
+ *   12 buttons   -> Note 36..47 (momentary)
+ *   1 crossfade  -> CC 7        (rests at centre / 64, moves both ways)
+ *   hand poses   -> Note 53..59 (momentary; placeholders that line up with a
+ *                                future HandPoseMidiSource on the Quest)
+ *
+ * Everything publishes on the global midiBus (channel 1, matching the Quest
+ * MidiControlSurface), so it is mappable / usable everywhere a hardware
+ * controller is. In MAP mode each of the 27 standard controls shows the same
+ * learn chip the generic controller grid uses: click it, touch the control, and
+ * its CC/Note binds to that slot — the SlidePanel learn/route runtime does the
+ * rest. Incoming bus traffic on the same numbers is reflected back into the
+ * controls, so moving the headset surface animates this one and vice-versa.
+ *
+ * Control positions follow the profile's section order (faders, crossfade,
+ * knobs, buttons) so the learn chips line up with controllerMapStore + routing,
+ * even though the visual layout puts knobs between faders and pads and the
+ * crossfade under the pads.
+ */
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { publishMidi, subscribeToMidi } from '../../state/midiBus';
+import { useControllerMapStore, bindingLabel } from '../../state/controllerMapStore';
+
+const CH = 0; // MIDI channel 1 (0-indexed) — matches MidiControlSurface.channel = 1
+const STATUS_CC = 0xb0;
+const STATUS_NOTE_ON = 0x90;
+const STATUS_NOTE_OFF = 0x80;
+
+const FADER_CC = [1, 2, 3, 4, 5, 6];
+const CROSSFADE_CC = 7;
+const KNOB_CC = [40, 41, 42, 43, 44, 45, 46, 47];
+const BUTTON_NOTES = Array.from({ length: 12 }, (_, i) => 36 + i); // 36..47
+
+// Positions in profile-section order [faders 6, crossfade 1, knobs 8, buttons 12]
+// so the learn chips align with controllerMapStore + the SlidePanel routing.
+const FADER_POS = (i: number) => i;            // 0..5
+const CROSSFADE_POS = 6;                        // 6
+const KNOB_POS = (i: number) => 7 + i;          // 7..14
+const BUTTON_POS = (i: number) => 15 + i;       // 15..26
+
+interface Pose {
+  id: string;
+  label: string;
+  note: number;
+  icon: string; // file under /hand-poses (the real Meta / XR Hands gesture icons)
+}
+const POSES: Pose[] = [
+  { id: 'fist', label: 'Fist', note: 53, icon: 'fist.png' },
+  { id: 'open', label: 'Open', note: 54, icon: 'open.png' },
+  { id: 'point', label: 'Point', note: 55, icon: 'point.png' },
+  { id: 'pinch', label: 'Pinch', note: 56, icon: 'pinch.png' },
+  { id: 'shaka', label: 'Shaka', note: 57, icon: 'shaka.png' },
+  { id: 'thumbup', label: 'Thumb +', note: 58, icon: 'thumb-up.png' },
+  { id: 'thumbdown', label: 'Thumb -', note: 59, icon: 'thumb-down.png' },
+];
+
+const clamp127 = (v: number) => Math.max(0, Math.min(127, Math.round(v)));
+
+function emitCC(cc: number, v127: number) { publishMidi([STATUS_CC | CH, cc, clamp127(v127)]); }
+function emitNoteOn(note: number, vel = 110) { publishMidi([STATUS_NOTE_ON | CH, note, vel]); }
+function emitNoteOff(note: number) { publishMidi([STATUS_NOTE_OFF | CH, note, 0]); }
+
+/* ----------------------------- learn chip -------------------------------- */
+// Mirrors the generic controller grid's chip (.sl-mapchip from track-controls.css).
+const MapChip: React.FC<{ profileId: string; pos: number }> = ({ profileId, pos }) => {
+  const binding = useControllerMapStore((s) => s.bindings[profileId]?.[pos]);
+  const learnPos = useControllerMapStore((s) => s.learnPos);
+  const setLearnPos = useControllerMapStore((s) => s.setLearnPos);
+  const clearPos = useControllerMapStore((s) => s.clearPos);
+  const learning = learnPos === pos;
+  return (
+    <button
+      type="button"
+      className={`sl-mapchip${learning ? ' learning' : ''}${binding ? ' bound' : ''}`}
+      onClick={() => setLearnPos(learning ? null : pos)}
+      onContextMenu={(e) => { e.preventDefault(); clearPos(profileId, pos); }}
+      title={
+        learning
+          ? 'Waiting — touch this control to bind it. Right-click to clear.'
+          : binding
+            ? `Bound to ${bindingLabel(binding)} (ch ${binding.channel + 1}). Click to relearn, right-click to clear.`
+            : 'Unmapped — click, then touch this control.'
+      }
+    >
+      {learning ? 'LEARN' : bindingLabel(binding)}
+    </button>
+  );
+};
+
+/* ----------------------------- vertical fader ---------------------------- */
+const VFader: React.FC<{ label: string; value: number; onChange: (v: number) => void; chip?: React.ReactNode }> = memo(
+  ({ label, value, onChange, chip }) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const dragging = useRef(false);
+    const fromY = (clientY: number) => {
+      const el = ref.current;
+      if (!el) return value;
+      const r = el.getBoundingClientRect();
+      const yl = Math.max(0, Math.min(clientY - r.top, r.height));
+      return clamp127((1 - yl / r.height) * 127);
+    };
+    const down = (e: React.PointerEvent) => {
+      if (e.pointerType === 'mouse' && e.button !== 0) return;
+      dragging.current = true;
+      (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+      onChange(fromY(e.clientY));
+      e.preventDefault();
+    };
+    const move = (e: React.PointerEvent) => { if (dragging.current) onChange(fromY(e.clientY)); };
+    const up = (e: React.PointerEvent) => { dragging.current = false; (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId); };
+    const pct = (value / 127) * 100;
+    return (
+      <div className="flex flex-col items-center gap-1 select-none">
+        <div
+          ref={ref}
+          onPointerDown={down}
+          onPointerMove={move}
+          onPointerUp={up}
+          onPointerCancel={up}
+          className="relative w-3.5 h-32 rounded-full bg-black/50 border border-white/12 cursor-ns-resize"
+        >
+          <div className="absolute inset-x-0 bottom-0 rounded-full bg-fuchsia-500/70" style={{ height: `${Math.max(pct, 2)}%` }} />
+          <div className="absolute left-1/2 -translate-x-1/2 w-6 h-2.5 rounded-sm bg-fuchsia-100 shadow-[0_0_8px_rgba(217,70,239,0.7)]" style={{ top: `calc(${100 - pct}% - 5px)` }} />
+        </div>
+        <span className="text-[7px] font-mono uppercase tracking-widest text-zinc-500">{label}</span>
+        {chip}
+      </div>
+    );
+  },
+);
+VFader.displayName = 'VFader';
+
+/* ----------------------------- rotary knob ------------------------------- */
+const Knob: React.FC<{ label: string; value: number; onChange: (v: number) => void; chip?: React.ReactNode }> = memo(
+  ({ label, value, onChange, chip }) => {
+    const dragging = useRef(false);
+    const lastY = useRef(0);
+    const down = (e: React.PointerEvent) => {
+      if (e.pointerType === 'mouse' && e.button !== 0) return;
+      dragging.current = true;
+      lastY.current = e.clientY;
+      (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+      e.preventDefault();
+    };
+    const move = (e: React.PointerEvent) => {
+      if (!dragging.current) return;
+      const dy = lastY.current - e.clientY;
+      lastY.current = e.clientY;
+      onChange(clamp127(value + (dy / 150) * 127 * (e.shiftKey ? 0.25 : 1)));
+    };
+    const up = (e: React.PointerEvent) => { dragging.current = false; (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId); };
+    const sweep = (value / 127) * 270;
+    const arcBg =
+      `conic-gradient(from 225deg, rgb(217 70 239) 0deg ${sweep}deg, ` +
+      `rgba(255,255,255,0.08) ${sweep}deg 270deg, rgba(255,255,255,0) 270deg 360deg)`;
+    return (
+      <div className="flex flex-col items-center gap-1 select-none">
+        <div
+          onPointerDown={down}
+          onPointerMove={move}
+          onPointerUp={up}
+          onPointerCancel={up}
+          className="relative w-11 h-11 rounded-full cursor-ns-resize"
+          role="slider"
+          aria-label={label}
+          aria-valuemin={0}
+          aria-valuemax={127}
+          aria-valuenow={value}
+        >
+          <div className="absolute inset-0 rounded-full" style={{ background: arcBg }} />
+          <div className="absolute inset-[4px] rounded-full bg-zinc-900 border border-white/10" />
+          <div className="absolute inset-0" style={{ transform: `rotate(${225 + sweep}deg)` }}>
+            <span className="absolute left-1/2 top-1 -translate-x-1/2 w-1 h-2.5 rounded-full bg-fuchsia-100 shadow-[0_0_6px_rgba(217,70,239,0.8)]" />
+          </div>
+        </div>
+        <span className="text-[7px] font-mono uppercase tracking-widest text-zinc-500">{label}</span>
+        {chip}
+      </div>
+    );
+  },
+);
+Knob.displayName = 'Knob';
+
+/* ----------------------------- crossfade --------------------------------- */
+const Crossfade: React.FC<{ value: number; onChange: (v: number) => void; chip?: React.ReactNode }> = memo(({ value, onChange, chip }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const dragging = useRef(false);
+  const fromX = (clientX: number) => {
+    const el = ref.current;
+    if (!el) return value;
+    const r = el.getBoundingClientRect();
+    const xl = Math.max(0, Math.min(clientX - r.left, r.width));
+    return clamp127((xl / r.width) * 127);
+  };
+  const down = (e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    dragging.current = true;
+    (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+    onChange(fromX(e.clientX));
+    e.preventDefault();
+  };
+  const move = (e: React.PointerEvent) => { if (dragging.current) onChange(fromX(e.clientX)); };
+  const up = (e: React.PointerEvent) => { dragging.current = false; (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId); };
+  const pct = (value / 127) * 100;
+  return (
+    <div className="flex flex-col items-center gap-1 select-none">
+      <div
+        ref={ref}
+        onPointerDown={down}
+        onPointerMove={move}
+        onPointerUp={up}
+        onPointerCancel={up}
+        onDoubleClick={() => onChange(64)}
+        className="relative h-3.5 w-64 rounded-full bg-black/50 border border-white/12 cursor-ew-resize"
+        title="Crossfade (CC 7) — double-click to centre"
+      >
+        <span className="absolute left-1/2 top-0 bottom-0 w-px -translate-x-1/2 bg-white/20" />
+        <div className="absolute top-1/2 -translate-y-1/2 w-2.5 h-6 rounded-sm bg-fuchsia-100 shadow-[0_0_8px_rgba(217,70,239,0.7)]" style={{ left: `calc(${pct}% - 5px)` }} />
+      </div>
+      <span className="text-[7px] font-mono uppercase tracking-widest text-zinc-500">XFADE · CC 7</span>
+      {chip}
+    </div>
+  );
+});
+Crossfade.displayName = 'Crossfade';
+
+/* ----------------------------- momentary pad ----------------------------- */
+const Pad: React.FC<{ label: string; lit: boolean; onDown: () => void; onUp: () => void; chip?: React.ReactNode }> = memo(
+  ({ label, lit, onDown, onUp, chip }) => {
+    const down = (e: React.PointerEvent) => {
+      if (e.pointerType === 'mouse' && e.button !== 0) return;
+      (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+      onDown();
+      e.preventDefault();
+    };
+    const up = (e: React.PointerEvent) => { (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId); onUp(); };
+    return (
+      <div className="flex flex-col items-center gap-1">
+        <button
+          type="button"
+          onPointerDown={down}
+          onPointerUp={up}
+          onPointerCancel={up}
+          onPointerLeave={(e) => { if (e.buttons) onUp(); }}
+          className={`h-9 w-full rounded-md border text-[8px] font-mono uppercase tracking-wider transition-colors ${
+            lit
+              ? 'border-fuchsia-400 bg-fuchsia-500/30 text-fuchsia-100 shadow-[0_0_10px_rgba(217,70,239,0.6)]'
+              : 'border-white/12 bg-white/5 text-zinc-500 hover:text-zinc-300 hover:bg-white/8'
+          }`}
+        >
+          {label}
+        </button>
+        {chip}
+      </div>
+    );
+  },
+);
+Pad.displayName = 'Pad';
+
+/* ----------------------------- the surface ------------------------------- */
+const WorldsCollidePanel: React.FC<{ profileId: string }> = ({ profileId }) => {
+  const initCC: Record<number, number> = {};
+  FADER_CC.forEach((cc) => (initCC[cc] = 0));
+  KNOB_CC.forEach((cc) => (initCC[cc] = 64));
+  initCC[CROSSFADE_CC] = 64;
+  const [cc, setCc] = useState<Record<number, number>>(initCC);
+  const [lit, setLit] = useState<Set<number>>(new Set());
+  const mapMode = useControllerMapStore((s) => s.mapMode);
+
+  const setCcVal = useCallback((num: number, v: number) => {
+    setCc((prev) => (prev[num] === v ? prev : { ...prev, [num]: v }));
+  }, []);
+
+  // Reflect incoming bus traffic (the Quest surface, or any mapped hardware) so
+  // the on-screen twin animates. Display-only: it never re-emits, so no loop.
+  useEffect(() => {
+    return subscribeToMidi((msg) => {
+      const [status, d1, d2] = msg.data;
+      if ((status & 0x0f) !== CH) return;
+      const cmd = status & 0xf0;
+      const isPoseOrButton = BUTTON_NOTES.includes(d1) || POSES.some((p) => p.note === d1);
+      if (cmd === STATUS_CC && (FADER_CC.includes(d1) || KNOB_CC.includes(d1) || d1 === CROSSFADE_CC)) {
+        setCcVal(d1, clamp127(d2 ?? 0));
+      } else if (cmd === STATUS_NOTE_ON && (d2 ?? 0) > 0 && isPoseOrButton) {
+        setLit((prev) => { const n = new Set(prev); n.add(d1); return n; });
+      } else if ((cmd === STATUS_NOTE_OFF || (cmd === STATUS_NOTE_ON && (d2 ?? 0) === 0)) && isPoseOrButton) {
+        setLit((prev) => { if (!prev.has(d1)) return prev; const n = new Set(prev); n.delete(d1); return n; });
+      }
+    });
+  }, [setCcVal]);
+
+  const onCc = (ccNum: number, v: number) => { setCcVal(ccNum, v); emitCC(ccNum, v); };
+  const padDown = (note: number) => { setLit((p) => { const n = new Set(p); n.add(note); return n; }); emitNoteOn(note); };
+  const padUp = (note: number) => { setLit((p) => { if (!p.has(note)) return p; const n = new Set(p); n.delete(note); return n; }); emitNoteOff(note); };
+  const chip = (pos: number) => (mapMode ? <MapChip profileId={profileId} pos={pos} /> : null);
+
+  return (
+    <div className="mx-auto my-2 w-fit rounded-xl border border-fuchsia-500/25 bg-[#0d0a14] p-4 shadow-[0_0_40px_rgba(139,92,246,0.12)]">
+      {/* title */}
+      <div className="mb-3 flex items-baseline justify-between gap-6 border-b border-white/10 pb-2">
+        <h2 className="text-[13px] font-black uppercase tracking-[0.2em] text-fuchsia-200">
+          GANTASMO <span className="text-zinc-500">·</span> WORLDS COLLIDE
+        </h2>
+        <span className="text-[8px] font-mono uppercase tracking-widest text-zinc-500">XR MIDI SURFACE · CH 1</span>
+      </div>
+
+      {/* faders (sliders) */}
+      <div className="mb-4 flex justify-center gap-3">
+        {FADER_CC.map((num, i) => (
+          <VFader key={num} label={`F${i + 1}·${num}`} value={cc[num]} onChange={(v) => onCc(num, v)} chip={chip(FADER_POS(i))} />
+        ))}
+      </div>
+
+      {/* knobs — between the sliders and the pads */}
+      <div className="mb-4 flex justify-center gap-3">
+        {KNOB_CC.map((num, i) => (
+          <Knob key={num} label={`K${i + 1}·${num}`} value={cc[num]} onChange={(v) => onCc(num, v)} chip={chip(KNOB_POS(i))} />
+        ))}
+      </div>
+
+      {/* buttons — two rows of six, Note 36..47 */}
+      <div className="mb-4 grid grid-cols-6 gap-2">
+        {BUTTON_NOTES.map((note, i) => (
+          <Pad key={note} label={`${i + 1}·${note}`} lit={lit.has(note)} onDown={() => padDown(note)} onUp={() => padUp(note)} chip={chip(BUTTON_POS(i))} />
+        ))}
+      </div>
+
+      {/* crossfade — under the pads */}
+      <div className="mb-4 flex justify-center">
+        <Crossfade value={cc[CROSSFADE_CC]} onChange={(v) => onCc(CROSSFADE_CC, v)} chip={chip(CROSSFADE_POS)} />
+      </div>
+
+      {/* hand poses */}
+      <div className="rounded-lg border border-white/10 bg-black/30 p-2">
+        <div className="mb-1.5 text-[8px] font-mono uppercase tracking-widest text-zinc-500">Hand Poses</div>
+        <div className="flex justify-between gap-2">
+          {POSES.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onPointerDown={(e) => { (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId); padDown(p.note); e.preventDefault(); }}
+              onPointerUp={(e) => { (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId); padUp(p.note); }}
+              onPointerCancel={() => padUp(p.note)}
+              title={`${p.label} · Note ${p.note}`}
+              className={`flex flex-1 flex-col items-center gap-1 rounded-md border px-1 py-1.5 transition-colors ${
+                lit.has(p.note)
+                  ? 'border-fuchsia-400 bg-fuchsia-500/25 shadow-[0_0_10px_rgba(217,70,239,0.55)]'
+                  : 'border-white/10 bg-white/5 hover:bg-white/8'
+              }`}
+            >
+              <img
+                src={`/hand-poses/${p.icon}`}
+                alt={p.label}
+                draggable={false}
+                className={`h-5 w-5 object-contain ${lit.has(p.note) ? 'opacity-100' : 'opacity-80'}`}
+              />
+              <span className={`text-[7px] font-mono uppercase tracking-wider ${lit.has(p.note) ? 'text-fuchsia-100' : 'text-zinc-400'}`}>{p.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default memo(WorldsCollidePanel);

--- a/frontend/src/lib/mediaLibrary.ts
+++ b/frontend/src/lib/mediaLibrary.ts
@@ -104,6 +104,27 @@ export async function deleteMedia(id: string): Promise<void> {
   }
 }
 
+/** Add a local folder of audio as a playlist, REFERENCE-IN-PLACE — nothing is
+ *  copied; theDAW registers entries that point at the on-disk files. With no
+ *  path, the backend opens a native folder picker. Returns the registered
+ *  entries (id + title) for the caller to build a setlist from. */
+export async function importFolder(
+  path?: string,
+): Promise<{ cancelled: boolean; folder: string | null; name?: string; entries: { id: string; title: string }[] }> {
+  const r = await fetch(`${BASE}/import-folder`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(path ? { path } : {}),
+  });
+  if (!r.ok) throw new Error(`importFolder: ${await errorText(r)}`);
+  return (await r.json()) as {
+    cancelled: boolean;
+    folder: string | null;
+    name?: string;
+    entries: { id: string; title: string }[];
+  };
+}
+
 /** The MIME types the media import input accepts. */
 export const MEDIA_ACCEPT =
   'video/*,image/*,.mp4,.webm,.mov,.mkv,.m4v,.avi,.ogv,.png,.webp,.gif,.jpg,.jpeg,.bmp,.avif,.apng';

--- a/frontend/src/state/controllerProfiles.ts
+++ b/frontend/src/state/controllerProfiles.ts
@@ -91,6 +91,11 @@ type Row = [id: string, name: string, vendor: string, category: ControllerCatego
 // first profile to reach a given match length wins ⇒ specifics must precede
 // fallbacks (they do).
 const ROWS: Row[] = [
+  /* ───────── GANTASMO (on-screen twin of the Quest XR MIDI surface; rendered by
+     WorldsCollidePanel and shown first in the controller picker). match=[] so it
+     never auto-detects a real device — it is picked manually / is the default. ───────── */
+  ['gantasmo-worlds-collide', 'GANTASMO - Worlds Collide', 'GANTASMO', 'mixer', [], [F(1, 6, 'FADERS'), F(1, 1, 'CROSSFADE'), K(1, 8, 'KNOBS'), B(2, 6, 'BUTTONS')]],
+
   /* ───────── Pioneer DJ ───────── */
   ['pioneer-ddj-flx2', 'Pioneer DDJ-FLX2', 'Pioneer DJ', 'dj', ['ddj-flx2', 'flx2'], DJ2],
   ['pioneer-ddj-flx4', 'Pioneer DDJ-FLX4', 'Pioneer DJ', 'dj', ['ddj-flx4', 'flx4'], DJ2],
@@ -319,7 +324,13 @@ export const CONTROLLER_PROFILES: ControllerProfile[] = ROWS.map(([id, name, ven
   id, name, vendor, category, match, sections,
 }));
 
-export const DEFAULT_PROFILE_ID = 'akai-midimix';
+/** The on-screen GANTASMO XR twin surface (see WorldsCollidePanel). */
+export const GANTASMO_WORLDS_COLLIDE_ID = 'gantasmo-worlds-collide';
+
+// Default to the on-screen GANTASMO surface so it is front-and-centre with no
+// hardware connected. Auto-detect still switches to a real controller when one
+// is connected.
+export const DEFAULT_PROFILE_ID = GANTASMO_WORLDS_COLLIDE_ID;
 
 /**
  * LEARNED profiles — built from a MIDI capture session (learnedProfilesStore).

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -25,7 +25,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Disc, Play, Pause, Plus, Save, Trash2, Cast, Music2,
   ChevronDown, ChevronRight, Magnet, Gauge, Lock,
-  KeyRound, Pencil, Search, Library as LibraryIcon, ListMusic, Layers, Sparkles, Download, Link2, Loader2, Shield, Headphones, Piano, X,
+  KeyRound, Pencil, Search, Library as LibraryIcon, ListMusic, Layers, Sparkles, Download, Link2, Loader2, FolderPlus, Shield, Headphones, Piano, X,
 } from 'lucide-react';
 import { subscribeToMidi } from '../state/midiBus';
 import { useDjControlMap, sigLabel, type MidiKind } from '../state/djControlMap';
@@ -39,6 +39,7 @@ import { useAppUiStore } from '../state/appUiStore';
 import { useSetlistStore, type SetlistEntry } from '../state/setlistStore';
 import { useDjAutomix } from '../state/djAutomixStore';
 import { useLibraryStore } from '../state/libraryStore';
+import { importFolder } from '../lib/mediaLibrary';
 import type { LibraryEntry } from '../state/libraryStore';
 import { useDjAnalysisStore } from '../state/djAnalysisStore';
 import { useDjBrowser, type DjColKey, DJ_COL_MIN_WIDTH } from '../state/djBrowserStore';
@@ -1312,11 +1313,35 @@ const TrackBrowser: React.FC<{ source: Source; setSource: (s: Source) => void; o
 /** Source tree — every entry is live: filtered views over the library
  *  (Library / Favorites / Generated / Imports), real Online Download, and the
  *  user's Sets. No placeholder/streaming stubs. */
+// Add a local folder as a reference-in-place playlist: register the audio files
+// (no copy), refresh the library so they resolve, then build + open a setlist.
+async function addFolderAsPlaylist(actions: {
+  createSetlist: (name: string) => string;
+  appendToSet: (id: string, entries: SetlistEntry[]) => void;
+  setActive: (id: string | null) => void;
+  setSource: (s: Source) => void;
+  refreshLibrary: () => Promise<void>;
+}): Promise<void> {
+  const res = await importFolder();
+  if (res.cancelled || res.entries.length === 0) return;
+  await actions.refreshLibrary();
+  const id = actions.createSetlist(res.name || 'Folder');
+  actions.appendToSet(
+    id,
+    res.entries.map((e) => ({ entryId: e.id, label: e.title, kind: 'audio' as const })),
+  );
+  actions.setActive(id);
+  actions.setSource({ kind: 'set', id });
+}
+
 const SourceTree: React.FC<{ source: Source; setSource: (s: Source) => void; libCount: number }> = ({ source, setSource, libCount }) => {
   const entries = useLibraryStore((s) => s.entries);
   const setlists = useSetlistStore((s) => s.setlists);
   const createSetlist = useSetlistStore((s) => s.create);
   const setActive = useSetlistStore((s) => s.setActive);
+  const appendToSet = useSetlistStore((s) => s.append);
+  const refreshLibrary = useLibraryStore((s) => s.refresh);
+  const [addingFolder, setAddingFolder] = useState(false);
   const sets = Object.values(setlists).sort((a, b) => b.updatedAt - a.updatedAt);
   const favCount = entries.filter((e) => e.favorite).length;
   const genCount = entries.filter((e) => e.source === 'generate').length;
@@ -1388,7 +1413,17 @@ const SourceTree: React.FC<{ source: Source; setSource: (s: Source) => void; lib
           </div>
         )}
 
-        <Group label="Sets" right={<button onClick={() => { const id = createSetlist(`Set ${new Date().toLocaleDateString()}`); setActive(id); setSource({ kind: 'set', id }); }} className="ml-auto p-0.5 text-purple-300 hover:text-purple-100" title="New set"><Plus className="w-3 h-3" /></button>} />
+        <Group label="Sets" right={
+          <span className="ml-auto flex items-center gap-0.5">
+            <button
+              onClick={() => { setAddingFolder(true); void addFolderAsPlaylist({ createSetlist, appendToSet, setActive, setSource, refreshLibrary }).finally(() => setAddingFolder(false)); }}
+              disabled={addingFolder}
+              className="p-0.5 text-purple-300 hover:text-purple-100 disabled:opacity-40"
+              title="Add a local folder as a playlist (referenced in place — no copy)"
+            >{addingFolder ? <Loader2 className="w-3 h-3 animate-spin" /> : <FolderPlus className="w-3 h-3" />}</button>
+            <button onClick={() => { const id = createSetlist(`Set ${new Date().toLocaleDateString()}`); setActive(id); setSource({ kind: 'set', id }); }} className="p-0.5 text-purple-300 hover:text-purple-100" title="New empty set"><Plus className="w-3 h-3" /></button>
+          </span>
+        } />
         {sets.length === 0 ? (
           <div className="pl-4 pr-1.5 py-0.5 text-[9px] font-mono text-zinc-700">No sets — click +</div>
         ) : sets.map((s) => (


### PR DESCRIPTION
Add the queststitch backend module: an asyncio TCP listener that receives H.264 from the Quest stitch streamer over adb reverse and a FastAPI WebSocket that fans it out to the VJ in the same wire format questcast uses, so the VJ WebCodecs decoder is reused for a new clean-stitch source.

DJ folder to playlist (reference in place, no copy): library register_reference plus the /api/library/import-folder route and source_path resolution, with a folder button in the DJ source tree and mediaLibrary.importFolder on the client.

Worlds Collide: an on-screen twin of the Quest XR MIDI surface (faders, knobs, pads, crossfade, hand-pose bar) wired to the global midiBus and controllerMapStore, plus a gantasmo-worlds-collide controller profile.

Add the 2026-06-16 punchlist audit and 2026-06-18 master action plan docs.