### PR TITLE
Feat/library stems midi first class

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-21T10:44:02.402Z · Git revision: `39e81a75ab8e` · Repomix tracked: **no**
+> Generated: 2026-06-21T10:46:36.882Z · Git revision: `ecb094f59138` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-20T21:18:44.422Z · Git revision: `22eb9cd6c7a9` · Repomix tracked: **no**
+> Generated: 2026-06-21T10:44:02.402Z · Git revision: `39e81a75ab8e` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-20T21:18:44.422Z",
-  "repoRevision": "22eb9cd6c7a9",
+  "generatedAt": "2026-06-21T10:44:02.402Z",
+  "repoRevision": "39e81a75ab8e",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-21T10:44:02.402Z",
-  "repoRevision": "39e81a75ab8e",
+  "generatedAt": "2026-06-21T10:46:36.882Z",
+  "repoRevision": "ecb094f59138",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T10:45:52.513Z",
+  "generatedAt": "2026-06-21T10:48:30.598Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-20T21:20:25.808Z",
+  "generatedAt": "2026-06-21T10:45:52.513Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/public/granular-morph.worklet.js
+++ b/frontend/public/granular-morph.worklet.js
@@ -1,0 +1,228 @@
+/* Granular identity-bleed morph processor (Phase M).
+ *
+ * Concatenative / mosaicing granular synthesis. Two sources live in the audio
+ * thread: a CORPUS A (the donor / "identity") sliced into a grain pool, and a
+ * TARGET B (the host / structure). The read-head walks B's timeline; at a steady
+ * grain rate it spawns grains pulled from A, choosing — for each grain — the A
+ * grain whose loudness/brightness best matches what B is doing at that instant.
+ * The output is therefore B's structure rebuilt out of A's material: "B spoken in
+ * A's voice." `bleed` crossfades dry-B (0) -> full mosaic (1); `match` sets how
+ * strictly grains are chosen (loose = more of A's own character bleeds through).
+ *
+ * Messages in:
+ *   {type:'loadA', pcm, count, gOffset, gLoud, gBright}
+ *   {type:'loadB', pcm, frameHop, frames, fLoud, fBright}
+ *   {type:'params', bleed, grainSize, grainRate, spray, match, gain, loop}
+ *   {type:'play', on} | {type:'seek', sec}
+ * Messages out: {type:'pos', sec} (~per block, for the UI playhead)
+ */
+
+const POOL = 64; // max concurrent grain voices
+
+class GranularMorphProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+    // corpus A
+    this.aPcm = null; this.aLen = 0;
+    this.gOffset = null; this.gLoud = null; this.gBright = null; this.gSal = null; this.gCount = 0;
+    // target B
+    this.bPcm = null; this.bLen = 0;
+    this.fLoud = null; this.fBright = null; this.frameHop = 256; this.frames = 0;
+    this.onsets = null; this.onsetCount = 0; this.onsetPtr = 0;
+    // transport
+    this.playhead = 0; this.playing = false;
+    // params (+ derived)
+    this.bleed = 0.6; this.grainSize = 0.12; this.grainRate = 24;
+    this.spray = 0.2; this.match = 0.7; this.gain = 0.9; this.loop = true;
+    this.sync = 0.5; this.favor = 0.4;
+    this.grainLen = Math.floor(this.grainSize * sampleRate);
+    this.grainInterval = sampleRate / this.grainRate;
+    this.wetNorm = 1 / Math.sqrt(Math.max(1, this.grainRate * this.grainSize));
+    this.spawnCountdown = 0;
+    this._post = 0;
+    // voice pool (parallel arrays)
+    this.vActive = new Uint8Array(POOL);
+    this.vAPos = new Float32Array(POOL); // read index into A
+    this.vPos = new Float32Array(POOL);  // position within the grain
+    this.vLen = new Float32Array(POOL);  // grain length
+
+    // Offline renders (the "send to editor" bounce) seed everything through
+    // processorOptions, which reach the constructor BEFORE the first process()
+    // call. Port messages posted just before startRendering() are NOT guaranteed
+    // to arrive first on a short offline render (verified live: they don't), so a
+    // message-seeded bounce renders silence. Live playback keeps using messages.
+    const po = options && options.processorOptions;
+    if (po) {
+      if (po.a) this.loadA(po.a);
+      if (po.b) this.loadB(po.b);
+      if (po.params) this.applyParams(po.params);
+      if (po.play) { this.playing = true; this.spawnCountdown = 0; this._post = 0; }
+    }
+
+    this.port.onmessage = (e) => {
+      const d = e.data;
+      switch (d.type) {
+        case 'loadA': this.loadA(d); break;
+        case 'loadB': this.loadB(d); break;
+        case 'params': this.applyParams(d); break;
+        case 'play':
+          this.playing = !!d.on;
+          if (d.on) { this.spawnCountdown = 0; this._post = 0; }
+          break;
+        case 'seek':
+          this.playhead = Math.max(0, Math.min(this.bLen - 1, (d.sec || 0) * sampleRate));
+          this.onsetPtr = 0;
+          while (this.onsets && this.onsetPtr < this.onsetCount && this.onsets[this.onsetPtr] < this.playhead) this.onsetPtr += 1;
+          break;
+        default: break;
+      }
+    };
+  }
+
+  loadA(d) {
+    this.aPcm = d.pcm; this.aLen = d.pcm.length;
+    this.gOffset = d.gOffset; this.gLoud = d.gLoud; this.gBright = d.gBright; this.gSal = d.gSal;
+    this.gCount = d.count | 0;
+  }
+
+  loadB(d) {
+    this.bPcm = d.pcm; this.bLen = d.pcm.length;
+    this.fLoud = d.fLoud; this.fBright = d.fBright;
+    this.frameHop = d.frameHop | 0; this.frames = d.frames | 0;
+    this.onsets = d.onsets || null; this.onsetCount = this.onsets ? this.onsets.length : 0;
+    this.playhead = 0; this.onsetPtr = 0;
+  }
+
+  applyParams(d) {
+    if (d.bleed != null) this.bleed = d.bleed;
+    if (d.grainSize != null) this.grainSize = Math.max(0.01, d.grainSize);
+    if (d.grainRate != null) this.grainRate = Math.max(1, d.grainRate);
+    if (d.spray != null) this.spray = d.spray;
+    if (d.match != null) this.match = d.match;
+    if (d.sync != null) this.sync = d.sync;
+    if (d.favor != null) this.favor = d.favor;
+    if (d.gain != null) this.gain = d.gain;
+    if (d.loop != null) this.loop = !!d.loop;
+    this.grainLen = Math.floor(this.grainSize * sampleRate);
+    this.grainInterval = sampleRate / this.grainRate;
+    this.wetNorm = 1 / Math.sqrt(Math.max(1, this.grainRate * this.grainSize));
+  }
+
+  /** Pick the A grain best matching the target (loud,bright). `match` low =
+   *  sometimes roam A so its own identity bleeds through; `favor` biases toward
+   *  high-salience (punchy/cool) grains both when roaming and when matching. */
+  selectGrain(tLoud, tBright) {
+    if (this.gCount <= 0) return -1;
+    if (Math.random() > this.match) {
+      // roam, but keep the most salient of a few random draws (more draws as favor rises)
+      let pick = (Math.random() * this.gCount) | 0;
+      const tries = 1 + ((this.favor * 4) | 0);
+      for (let k = 1; k < tries; k += 1) {
+        const c = (Math.random() * this.gCount) | 0;
+        if (this.gSal && this.gSal[c] > this.gSal[pick]) pick = c;
+      }
+      return pick;
+    }
+    let best = 0;
+    let bestScore = Infinity;
+    for (let i = 0; i < this.gCount; i += 1) {
+      const dl = this.gLoud[i] - tLoud;
+      const db = this.gBright[i] - tBright;
+      let score = dl * dl + db * db;
+      if (this.gSal) score -= this.favor * this.gSal[i] * 0.6; // salient grains win near-ties
+      if (score < bestScore) { bestScore = score; best = i; }
+    }
+    return best;
+  }
+
+  spawn() {
+    if (!this.aPcm || this.gCount <= 0) return;
+    const tf = this.frames > 0 ? Math.min(this.frames - 1, (this.playhead / this.frameHop) | 0) : 0;
+    const tLoud = this.fLoud ? this.fLoud[tf] : 0.5;
+    const tBright = this.fBright ? this.fBright[tf] : 0.5;
+    const g = this.selectGrain(tLoud, tBright);
+    if (g < 0) return;
+    let start = this.gOffset[g];
+    if (this.spray > 0) start += (Math.random() * 2 - 1) * this.spray * this.grainLen;
+    start = Math.max(0, Math.min(this.aLen - 2, start));
+    // find a free voice, else steal the one nearest its end
+    let v = -1;
+    for (let i = 0; i < POOL; i += 1) if (!this.vActive[i]) { v = i; break; }
+    if (v < 0) {
+      let most = 0;
+      for (let i = 1; i < POOL; i += 1) {
+        if (this.vPos[i] / this.vLen[i] > this.vPos[most] / this.vLen[most]) most = i;
+      }
+      v = most;
+    }
+    this.vActive[v] = 1; this.vAPos[v] = start; this.vPos[v] = 0; this.vLen[v] = this.grainLen;
+  }
+
+  process(_inputs, outputs) {
+    const out = outputs[0];
+    if (!out || out.length === 0) return true;
+    const oL = out[0];
+    const oR = out.length > 1 ? out[1] : null;
+    const n = oL.length;
+
+    if (!this.playing || !this.aPcm || !this.bPcm) {
+      for (let i = 0; i < n; i += 1) { oL[i] = 0; if (oR) oR[i] = 0; }
+      return true;
+    }
+
+    const TWO_PI = Math.PI * 2;
+    for (let i = 0; i < n; i += 1) {
+      // beat-locked triggers: fire on host onsets (more of them as `sync` rises)
+      if (this.sync > 0 && this.onsets) {
+        while (this.onsetPtr < this.onsetCount && this.onsets[this.onsetPtr] <= this.playhead) {
+          if (Math.random() < this.sync) this.spawn();
+          this.onsetPtr += 1;
+        }
+      }
+      // steady grain clock: thinned as `sync` rises, so sync=1 is pure beat-lock
+      if (this.spawnCountdown <= 0) {
+        if (Math.random() < 1 - this.sync) this.spawn();
+        this.spawnCountdown += this.grainInterval * (1 + (Math.random() * 2 - 1) * this.spray * 0.5);
+      }
+      this.spawnCountdown -= 1;
+
+      // sum active grain voices (windowed)
+      let wet = 0;
+      for (let v = 0; v < POOL; v += 1) {
+        if (!this.vActive[v]) continue;
+        const idx = this.vAPos[v] | 0;
+        if (idx >= 0 && idx < this.aLen) {
+          const w = 0.5 - 0.5 * Math.cos((TWO_PI * this.vPos[v]) / this.vLen[v]);
+          wet += this.aPcm[idx] * w;
+        }
+        this.vAPos[v] += 1;
+        this.vPos[v] += 1;
+        if (this.vPos[v] >= this.vLen[v]) this.vActive[v] = 0;
+      }
+      wet *= this.wetNorm;
+
+      // dry host at the read-head
+      const ph = this.playhead | 0;
+      const dry = ph < this.bLen ? this.bPcm[ph] : 0;
+
+      const s = this.gain * (this.bleed * wet + (1 - this.bleed) * dry);
+      oL[i] = s;
+      if (oR) oR[i] = s;
+
+      this.playhead += 1;
+      if (this.playhead >= this.bLen) {
+        if (this.loop) { this.playhead = 0; this.onsetPtr = 0; }
+        else { this.playhead = this.bLen - 1; }
+      }
+    }
+
+    this._post += n;
+    if (this._post >= 4096) {
+      this._post = 0;
+      this.port.postMessage({ type: 'pos', sec: this.playhead / sampleRate });
+    }
+    return true;
+  }
+}
+
+registerProcessor('granular-morph', GranularMorphProcessor);

--- a/frontend/src/components/audio/FxRack.tsx
+++ b/frontend/src/components/audio/FxRack.tsx
@@ -1,0 +1,159 @@
+/**
+ * FxRack — UI for a real-time insert-effect chain (the psychoacoustic rack).
+ *
+ * Presentational + a11y only: it renders the add control, per-effect enable /
+ * reorder / remove, and SLIDE param sliders, and calls back into the store. The
+ * same component drives the master bus (Phase A) and per-track chains (Phase B);
+ * the caller supplies the chain array and the mutators.
+ */
+
+import { ChevronUp, ChevronDown, X } from 'lucide-react';
+import { RACK_EFFECTS, getRackEffect } from '../../lib/rackEffects';
+import type { ChainEntry } from '../../state/effectChainStore';
+import { SlideTrack } from './SlideTrack';
+import { SpatializerPad } from './SpatializerPad';
+
+interface FxRackProps {
+  chain: ChainEntry[];
+  /** Stable prefix for input ids (must be unique per rack instance). */
+  idPrefix: string;
+  onAdd: (effectId: string) => void;
+  onRemove: (entryId: string) => void;
+  onReorder: (from: number, to: number) => void;
+  onToggle: (entryId: string) => void;
+  onUpdateParams: (entryId: string, params: Record<string, number>) => void;
+}
+
+const fmtValue = (v: number, step: number, unit?: string): string => {
+  const decimals = step < 1 ? (step < 0.1 ? 2 : 1) : 0;
+  return `${v.toFixed(decimals)}${unit ? ` ${unit}` : ''}`;
+};
+
+export function FxRack({
+  chain,
+  idPrefix,
+  onAdd,
+  onRemove,
+  onReorder,
+  onToggle,
+  onUpdateParams,
+}: FxRackProps) {
+  const addId = `${idPrefix}-add`;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <label htmlFor={addId} className="sr-only">Add insert effect</label>
+        <select
+          id={addId}
+          name={addId}
+          value=""
+          onChange={(e) => {
+            if (e.target.value) onAdd(e.target.value);
+          }}
+          className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 transition-colors cursor-pointer"
+          style={{ colorScheme: 'dark' }}
+          title="Add a psychoacoustic insert effect to this chain"
+        >
+          <option value="">+ Add effect…</option>
+          {RACK_EFFECTS.map((d) => (
+            <option key={d.id} value={d.id}>{d.label}</option>
+          ))}
+        </select>
+        {chain.length === 0 && (
+          <span className="text-[9px] font-mono text-zinc-600 uppercase tracking-wider">no inserts</span>
+        )}
+      </div>
+
+      {/* Effects tile and wrap (capped width) so they use horizontal space
+          instead of one full-width column of stretched sliders. */}
+      <div className="flex flex-wrap gap-2 items-start">
+      {chain.map((entry, i) => {
+        const def = getRackEffect(entry.effect);
+        if (!def) return null;
+        const sizing = entry.effect === 'spatializer' ? 'grow basis-80 max-w-sm' : 'grow basis-60 max-w-xs';
+        return (
+          <div
+            key={entry.id}
+            className={`${sizing} rounded border border-white/5 bg-black/30 p-2 flex flex-col gap-1.5 transition-opacity ${entry.enabled ? '' : 'opacity-50'}`}
+          >
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => onToggle(entry.id)}
+                aria-pressed={entry.enabled}
+                aria-label={`${def.label} ${entry.enabled ? 'enabled' : 'bypassed'}`}
+                title={entry.enabled ? 'Bypass this effect' : 'Enable this effect'}
+                className={`w-2.5 h-2.5 rounded-full shrink-0 transition-colors ${entry.enabled ? 'bg-purple-400 shadow-[0_0_6px_rgba(168,85,247,0.8)]' : 'bg-zinc-700'}`}
+              />
+              <span className="text-[10px] font-mono text-zinc-200 flex-1 truncate" title={def.description}>
+                {def.label}
+              </span>
+              <button
+                onClick={() => onReorder(i, i - 1)}
+                disabled={i === 0}
+                aria-label={`Move ${def.label} earlier`}
+                title="Move earlier in the chain"
+                className="p-0.5 rounded text-zinc-500 hover:text-white hover:bg-white/5 disabled:opacity-20 disabled:pointer-events-none"
+              >
+                <ChevronUp className="w-3 h-3" />
+              </button>
+              <button
+                onClick={() => onReorder(i, i + 1)}
+                disabled={i === chain.length - 1}
+                aria-label={`Move ${def.label} later`}
+                title="Move later in the chain"
+                className="p-0.5 rounded text-zinc-500 hover:text-white hover:bg-white/5 disabled:opacity-20 disabled:pointer-events-none"
+              >
+                <ChevronDown className="w-3 h-3" />
+              </button>
+              <button
+                onClick={() => onRemove(entry.id)}
+                aria-label={`Remove ${def.label}`}
+                title="Remove this effect"
+                className="p-0.5 rounded text-zinc-500 hover:text-red-400 hover:bg-red-500/10"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </div>
+
+            {entry.effect === 'spatializer' ? (
+              <div className="pl-4">
+                <SpatializerPad
+                  params={entry.params}
+                  idPrefix={`${idPrefix}-${entry.id}`}
+                  onChange={(p) => onUpdateParams(entry.id, p)}
+                />
+              </div>
+            ) : (
+            <div className="flex flex-col gap-1 pl-4">
+              {def.params.map((p) => {
+                const value = entry.params[p.key] ?? p.default;
+                const labelId = `${idPrefix}-${entry.id}-${p.key}-label`;
+                return (
+                  <div key={p.key} className="flex items-center gap-2">
+                    <span id={labelId} className="text-[9px] font-mono text-zinc-500 w-16 shrink-0">{p.label}</span>
+                    <SlideTrack
+                      value={value}
+                      min={p.min}
+                      max={p.max}
+                      step={p.step}
+                      defaultValue={p.default}
+                      ariaLabelledBy={labelId}
+                      className="flex-1"
+                      onChange={(v) => onUpdateParams(entry.id, { ...entry.params, [p.key]: v })}
+                    />
+                    <span className="text-[9px] font-mono text-zinc-400 w-16 shrink-0 text-right tabular-nums">
+                      {fmtValue(value, p.step, p.unit)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+            )}
+          </div>
+        );
+      })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/audio/InstrumentPicker.tsx
+++ b/frontend/src/components/audio/InstrumentPicker.tsx
@@ -49,7 +49,8 @@ export const InstrumentPicker: React.FC = () => {
         aria-label="MIDI instrument"
         value={value}
         onChange={onChange}
-        className="bg-black/40 border border-white/10 rounded px-2 py-1 text-xs text-white/80 max-w-44"
+        className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-xs text-zinc-100 max-w-44 outline-none focus:border-purple-500/60"
+        style={{ colorScheme: 'dark' }}
       >
         <option value="basic">Basic (sawtooth)</option>
         {VOICE_GROUPS.map((g) => (

--- a/frontend/src/components/audio/MetamorphPanel.tsx
+++ b/frontend/src/components/audio/MetamorphPanel.tsx
@@ -1,0 +1,215 @@
+/**
+ * MetamorphPanel — the UI for the live granular identity-bleed morph (Phase M).
+ *
+ * Pick a DONOR (A, the "identity") and a HOST (B, the structure). Sources are the
+ * clips already on the timeline first (stems, layers, anything you dropped in),
+ * with the wider library underneath. Press play to hear B rebuilt out of A's grains
+ * in real time; `Bleed` crossfades dry-B into the mosaic, `Match` sets how strictly
+ * grains are chosen. "Send to editor" renders one pass and drops it on a new track,
+ * where it is an ordinary clip you can trim, FX, and export.
+ */
+
+import { useEffect, useState } from 'react';
+import { Play, Square, Download } from 'lucide-react';
+import { SlideTrack } from './SlideTrack';
+import { useLibraryStore } from '../../state/libraryStore';
+import { useEditorStore, computePeaks } from '../../state/editorStore';
+import { useMorphStore, type MorphParams, type MorphSource } from '../../state/morphEngine';
+
+const SLIDERS: { key: keyof MorphParams; label: string; min: number; max: number; step: number; unit?: string }[] = [
+  { key: 'bleed', label: 'Bleed', min: 0, max: 1, step: 0.01 },
+  { key: 'grainSize', label: 'Grain', min: 0.02, max: 0.4, step: 0.005, unit: 's' },
+  { key: 'grainRate', label: 'Rate', min: 2, max: 80, step: 1, unit: '/s' },
+  { key: 'spray', label: 'Spray', min: 0, max: 1, step: 0.01 },
+  { key: 'match', label: 'Match', min: 0, max: 1, step: 0.01 },
+  { key: 'sync', label: 'Sync', min: 0, max: 1, step: 0.01 },
+  { key: 'favor', label: 'Favor', min: 0, max: 1, step: 0.01 },
+  { key: 'gain', label: 'Gain', min: 0, max: 1.5, step: 0.01 },
+];
+
+const fmt = (s: number) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
+
+export function MetamorphPanel() {
+  const entries = useLibraryStore((s) => s.entries);
+  const loaded = useLibraryStore((s) => s.loaded);
+  const load = useLibraryStore((s) => s.load);
+  const audio = entries.filter((e) => (e.kind ?? 'audio') === 'audio');
+
+  const clips = useEditorStore((s) => s.clips);
+  const tracks = useEditorStore((s) => s.tracks);
+  const trackName = (id: string) => tracks.find((t) => t.id === id)?.name ?? 'Track';
+
+  const aId = useMorphStore((s) => s.aId);
+  const bId = useMorphStore((s) => s.bId);
+  const aTitle = useMorphStore((s) => s.aTitle);
+  const bTitle = useMorphStore((s) => s.bTitle);
+  const status = useMorphStore((s) => s.status);
+  const playing = useMorphStore((s) => s.playing);
+  const posSec = useMorphStore((s) => s.posSec);
+  const durSec = useMorphStore((s) => s.durSec);
+  const params = useMorphStore((s) => s.params);
+  const loadA = useMorphStore((s) => s.loadA);
+  const loadB = useMorphStore((s) => s.loadB);
+  const play = useMorphStore((s) => s.play);
+  const stop = useMorphStore((s) => s.stop);
+  const setParam = useMorphStore((s) => s.setParam);
+
+  const [sending, setSending] = useState(false);
+
+  useEffect(() => { if (!loaded) void load(); }, [loaded, load]);
+  // Silence the morph when the panel unmounts (closed, or leaving the editor).
+  useEffect(() => () => useMorphStore.getState().stop(), []);
+
+  // Resolve a select value ("clip:<id>" | "lib:<id>") to a loadable source.
+  const resolve = async (val: string): Promise<MorphSource | null> => {
+    if (val.startsWith('clip:')) {
+      const c = clips.find((x) => `clip:${x.id}` === val);
+      return c ? { id: val, title: c.label || trackName(c.trackId), blob: c.audioBlob } : null;
+    }
+    if (val.startsWith('lib:')) {
+      const e = audio.find((x) => `lib:${x.id}` === val);
+      if (!e) return null;
+      const blob = await useLibraryStore.getState().fetchAudioBlob(e);
+      return { id: val, title: e.title, blob };
+    }
+    return null;
+  };
+
+  const pick = (which: 'a' | 'b') => async (ev: React.ChangeEvent<HTMLSelectElement>) => {
+    const src = await resolve(ev.target.value);
+    if (!src) return;
+    if (which === 'a') void loadA(src); else void loadB(src);
+  };
+
+  const sendToEditor = async () => {
+    setSending(true);
+    try {
+      const blob = await useMorphStore.getState().renderToBlob();
+      if (!blob) return;
+      const ed = useEditorStore.getState();
+      const name = (`${aTitle || 'A'}→${bTitle || 'B'}`).slice(0, 24);
+      const trackId = ed.addTrack({ name });
+      const color = ed.tracks.find((t) => t.id === trackId)?.color;
+      const { peaks, duration } = await computePeaks(blob, 240);
+      const clipId = ed.addClipToTrack({
+        trackId,
+        label: name,
+        audioBlob: blob,
+        mimeType: 'audio/wav',
+        sourceDuration: duration,
+        offsetIntoSource: 0,
+        durationSec: duration,
+        startSec: 0,
+        color,
+      });
+      ed.cachePeaks(clipId, peaks);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const ready = status === 'ready' || (!!aId && !!bId);
+
+  const SourceOptions = () => (
+    <>
+      <option value="">— choose —</option>
+      {clips.length > 0 && (
+        <optgroup label="On the timeline">
+          {clips.map((c) => (
+            <option key={`clip:${c.id}`} value={`clip:${c.id}`}>{trackName(c.trackId)} · {c.label}</option>
+          ))}
+        </optgroup>
+      )}
+      {audio.length > 0 && (
+        <optgroup label="Library">
+          {audio.map((e) => (<option key={`lib:${e.id}`} value={`lib:${e.id}`}>{e.title}</option>))}
+        </optgroup>
+      )}
+    </>
+  );
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="grid grid-cols-2 gap-2">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="morph-donor" className="text-[9px] font-mono text-zinc-500">Donor A (identity)</label>
+          <select
+            id="morph-donor"
+            name="morph-donor"
+            value={aId ?? ''}
+            onChange={pick('a')}
+            className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 cursor-pointer"
+            style={{ colorScheme: 'dark' }}
+          >
+            <SourceOptions />
+          </select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="morph-host" className="text-[9px] font-mono text-zinc-500">Host B (structure)</label>
+          <select
+            id="morph-host"
+            name="morph-host"
+            value={bId ?? ''}
+            onChange={pick('b')}
+            className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 cursor-pointer"
+            style={{ colorScheme: 'dark' }}
+          >
+            <SourceOptions />
+          </select>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => (playing ? stop() : void play())}
+          disabled={!ready}
+          aria-label={playing ? 'Stop the morph' : 'Play the morph'}
+          className={`flex items-center gap-1.5 px-2.5 py-1 rounded border text-[10px] font-mono uppercase tracking-wider transition-colors disabled:opacity-30 disabled:pointer-events-none
+            ${playing ? 'bg-purple-500/30 border-purple-500/50 text-purple-200' : 'border-purple-500/30 text-purple-300 hover:bg-purple-500/10'}`}
+        >
+          {playing ? <Square className="w-3 h-3 fill-current" /> : <Play className="w-3 h-3 fill-current" />}
+          {playing ? 'Stop' : 'Play'}
+        </button>
+        <button
+          onClick={() => void sendToEditor()}
+          disabled={!ready || sending}
+          aria-label="Render the morph and add it to the timeline"
+          title="Render one pass and drop it on a new track as an ordinary clip"
+          className="flex items-center gap-1.5 px-2.5 py-1 rounded border border-white/10 text-[10px] font-mono uppercase tracking-wider text-zinc-300 hover:bg-white/5 transition-colors disabled:opacity-30 disabled:pointer-events-none"
+        >
+          <Download className={`w-3 h-3 ${sending ? 'animate-pulse' : ''}`} />
+          {sending ? 'Rendering…' : 'Send to editor'}
+        </button>
+        <span className="text-[9px] font-mono text-zinc-500 tabular-nums">{fmt(posSec)} / {fmt(durSec)}</span>
+        <span className="text-[9px] font-mono text-zinc-600">
+          {status === 'loading' ? 'loading…' : status === 'error' ? 'load failed' : ready ? '' : 'pick A + B'}
+        </span>
+      </div>
+
+      <div className="grid gap-x-4 gap-y-1 grid-cols-[repeat(auto-fill,minmax(12rem,1fr))]">
+        {SLIDERS.map((p) => {
+          const labelId = `morph-${p.key}-label`;
+          const v = params[p.key];
+          const decimals = p.step < 0.1 ? (p.step < 0.01 ? 3 : 2) : 0;
+          return (
+            <div key={p.key} className="flex items-center gap-2">
+              <span id={labelId} className="text-[9px] font-mono text-zinc-500 w-12 shrink-0">{p.label}</span>
+              <SlideTrack
+                value={v}
+                min={p.min}
+                max={p.max}
+                step={p.step}
+                ariaLabelledBy={labelId}
+                className="flex-1"
+                onChange={(nv) => setParam(p.key, nv)}
+              />
+              <span className="text-[9px] font-mono text-zinc-400 w-14 shrink-0 text-right tabular-nums">
+                {v.toFixed(decimals)}{p.unit ? ` ${p.unit}` : ''}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/audio/SpatializerPad.tsx
+++ b/frontend/src/components/audio/SpatializerPad.tsx
@@ -1,0 +1,290 @@
+/**
+ * SpatializerPad — the visual guide + motion presets for the HRTF Spatializer
+ * effect. A top-down pad (X = left/right, Z = front/back) shows the listener at
+ * center and the source position; dragging sets azimuth and distance. A motion
+ * selector + one-click presets (orbit, ping-pong, up/down, figure-8) drive the
+ * audio-rate motion, and a path overlay previews where the source travels and,
+ * for orbits, which way it spins.
+ *
+ * Rendered by FxRack in place of the generic sliders when the effect is the
+ * spatializer. Values round-trip through the same ChainEntry.params the audio
+ * factory reads, so the pad and the sound stay in sync.
+ */
+
+import { useRef } from 'react';
+import { SlideTrack } from './SlideTrack';
+import { getRackEffect, SPATIAL_MOTIONS, SPATIAL_PRESETS } from '../../lib/rackEffects';
+
+interface SpatializerPadProps {
+  params: Record<string, number>;
+  onChange: (params: Record<string, number>) => void;
+  idPrefix: string;
+}
+
+const PAD = 140;              // svg viewport (square)
+const C = PAD / 2;            // center
+const R = C - 12;             // usable radius (leave a ring margin)
+const MAX_DIST = 8;           // distance value mapped to the pad edge
+const clamp = (x: number, a: number, b: number) => Math.max(a, Math.min(b, x));
+
+/** Source azimuth/distance -> pad pixel coords (front = up, right = right). */
+const sourceXY = (azDeg: number, dist: number) => {
+  const az = (azDeg * Math.PI) / 180;
+  const r = (clamp(dist, 0, MAX_DIST) / MAX_DIST) * R;
+  return { x: C + Math.sin(az) * r, y: C - Math.cos(az) * r };
+};
+
+export function SpatializerPad({ params, onChange, idPrefix }: SpatializerPadProps) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const dragging = useRef(false);
+  const def = getRackEffect('spatializer');
+
+  const azimuth = params.azimuth ?? -30;
+  const elevation = params.elevation ?? 0;
+  const distance = params.distance ?? 1.5;
+  const motion = Math.round(params.motion ?? 0);
+  const motionRate = params.motionRate ?? 0.3;
+  const motionDepth = params.motionDepth ?? 1.5;
+
+  const set = (key: string, value: number) => onChange({ ...params, [key]: value });
+  const merge = (values: Record<string, number>) => onChange({ ...params, ...values });
+
+  const src = sourceXY(azimuth, distance);
+  const depthPx = (clamp(motionDepth, 0, MAX_DIST) / MAX_DIST) * R;
+
+  const fromPointer = (clientX: number, clientY: number) => {
+    const el = svgRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    // Map client px into the 0..PAD viewport (svg is rendered at rect size).
+    const px = ((clientX - rect.left) / rect.width) * PAD;
+    const py = ((clientY - rect.top) / rect.height) * PAD;
+    const nx = (px - C) / R;
+    const nz = -(py - C) / R; // up = front = +z
+    const dist = clamp(Math.hypot(nx, nz) * MAX_DIST, def?.params.find((p) => p.key === 'distance')?.min ?? 0.5, MAX_DIST);
+    const az = (Math.atan2(nx, nz) * 180) / Math.PI; // 0 = front, +90 = right
+    onChange({ ...params, azimuth: Math.round(az), distance: +dist.toFixed(2) });
+  };
+
+  const onDown = (e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    dragging.current = true;
+    (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+    fromPointer(e.clientX, e.clientY);
+    e.preventDefault();
+  };
+  const onMove = (e: React.PointerEvent) => { if (dragging.current) fromPointer(e.clientX, e.clientY); };
+  const onUp = (e: React.PointerEvent) => {
+    dragging.current = false;
+    (e.currentTarget as Element).releasePointerCapture?.(e.pointerId);
+  };
+
+  // Path overlay describing the motion around the source point. The pad is a
+  // top-down view (X across, Z front/back), so the Y (elevation) half of the
+  // vertical orbits is drawn dashed to read as out of the plane.
+  const renderMotionPath = () => {
+    if (motion === 0) return null;
+    const stroke = '#a855f7';
+    // Autopilot — fixed dashed orbit ring + a tiny level-meter glyph: its motion is
+    // driven by the audio at play time, not the Depth slider, so use a fixed radius.
+    if (motion === 11) {
+      const r = R * 0.6;
+      const bars = [0.5, 1, 0.7];
+      return (
+        <g>
+          <circle cx={src.x} cy={src.y} r={r} fill="none" stroke={stroke} strokeOpacity={0.4} strokeWidth={1.2} strokeDasharray="3 3" />
+          {bars.map((h, i) => (
+            <line key={i} x1={src.x + (i - 1) * 4} y1={src.y + 4} x2={src.x + (i - 1) * 4} y2={src.y + 4 - 9 * h} stroke={stroke} strokeOpacity={0.85} strokeWidth={1.6} />
+          ))}
+        </g>
+      );
+    }
+    if (depthPx < 1) return null;
+    // Horizontal orbit (XZ) — circle in the pad plane + spin-direction arrow.
+    if (motion === 1 || motion === 2) {
+      const cw = motion === 1;
+      const ax = src.x + (cw ? depthPx : -depthPx) * 0.35;
+      return (
+        <g>
+          <circle cx={src.x} cy={src.y} r={depthPx} fill="none" stroke={stroke} strokeOpacity={0.5} strokeWidth={1.2} />
+          <path
+            d={`M ${ax} ${src.y - depthPx - 3} L ${ax + (cw ? 5 : -5)} ${src.y - depthPx} L ${ax} ${src.y - depthPx + 3} Z`}
+            fill={stroke}
+          />
+        </g>
+      );
+    }
+    // Frontal orbit (XY wheel) — X span in-plane, elevation half dashed-vertical.
+    if (motion === 3) {
+      return (
+        <g stroke={stroke} strokeOpacity={0.55} strokeWidth={1.2} fill="none">
+          <ellipse cx={src.x} cy={src.y} rx={depthPx} ry={depthPx * 0.4} />
+          <line x1={src.x} y1={src.y - depthPx} x2={src.x} y2={src.y + depthPx} strokeDasharray="2 2" strokeOpacity={0.4} />
+        </g>
+      );
+    }
+    // Sagittal orbit (YZ, over the top) — front/back span in-plane, elevation dashed.
+    if (motion === 4) {
+      return (
+        <g stroke={stroke} strokeOpacity={0.55} strokeWidth={1.2} fill="none">
+          <ellipse cx={src.x} cy={src.y} rx={depthPx * 0.4} ry={depthPx} />
+          <line x1={src.x - depthPx} y1={src.y} x2={src.x + depthPx} y2={src.y} strokeDasharray="2 2" strokeOpacity={0.4} />
+        </g>
+      );
+    }
+    // Spherical — horizontal circle plus a dashed precession ring.
+    if (motion === 5) {
+      return (
+        <g fill="none" stroke={stroke} strokeOpacity={0.5} strokeWidth={1.2}>
+          <circle cx={src.x} cy={src.y} r={depthPx} />
+          <ellipse cx={src.x} cy={src.y} rx={depthPx} ry={depthPx * 0.45} strokeDasharray="2 2" strokeOpacity={0.4} />
+        </g>
+      );
+    }
+    // Ping-pong (X) — horizontal line.
+    if (motion === 6) {
+      return (
+        <line x1={src.x - depthPx} y1={src.y} x2={src.x + depthPx} y2={src.y} stroke={stroke} strokeOpacity={0.6} strokeWidth={1.2} />
+      );
+    }
+    // Up/down (Y, elevation) — vertical dashed glyph (out of the XZ plane).
+    if (motion === 7) {
+      return (
+        <line x1={src.x} y1={src.y - depthPx} x2={src.x} y2={src.y + depthPx} stroke={stroke} strokeOpacity={0.6} strokeWidth={1.2} strokeDasharray="2 2" />
+      );
+    }
+    // Figure-8 (XZ lemniscate) — two side-by-side circles.
+    if (motion === 8) {
+      const r2 = depthPx * 0.5;
+      return (
+        <g fill="none" stroke={stroke} strokeOpacity={0.5} strokeWidth={1.2}>
+          <circle cx={src.x - r2} cy={src.y} r={r2} />
+          <circle cx={src.x + r2} cy={src.y} r={r2} />
+        </g>
+      );
+    }
+    // Expand/Collapse (radial breathing) — concentric rings from the source.
+    if (motion === 9) {
+      return (
+        <g fill="none" stroke={stroke} strokeOpacity={0.5} strokeWidth={1.2}>
+          <circle cx={src.x} cy={src.y} r={depthPx} strokeDasharray="3 3" />
+          <circle cx={src.x} cy={src.y} r={depthPx * 0.5} />
+        </g>
+      );
+    }
+    // Teleport — scattered dots evoking chunks jumping to spread positions (the
+    // actual targets come from onset analysis at play time; this is just a hint).
+    if (motion === 10) {
+      const dots = Array.from({ length: 7 }, (_, i) => {
+        const a = (i * 137.508 * Math.PI) / 180;
+        const r = depthPx * (0.35 + 0.6 * ((i % 3) / 2));
+        return { x: src.x + Math.cos(a) * r, y: src.y + Math.sin(a) * r };
+      });
+      return (
+        <g fill={stroke} fillOpacity={0.55}>
+          {dots.map((d, i) => (
+            <circle key={i} cx={d.x} cy={d.y} r={1.6} />
+          ))}
+        </g>
+      );
+    }
+    return null;
+  };
+
+  const motionId = `${idPrefix}-motion`;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-3">
+        <svg
+          ref={svgRef}
+          width={PAD}
+          height={PAD}
+          viewBox={`0 0 ${PAD} ${PAD}`}
+          role="application"
+          aria-label="Spatial position pad. Drag to set azimuth and distance. Precise values are in the sliders below."
+          className="shrink-0 rounded bg-black/50 border border-white/10 cursor-crosshair touch-none"
+          onPointerDown={onDown}
+          onPointerMove={onMove}
+          onPointerUp={onUp}
+          onPointerCancel={onUp}
+        >
+          {/* distance rings */}
+          {[0.33, 0.66, 1].map((f) => (
+            <circle key={f} cx={C} cy={C} r={R * f} fill="none" stroke="#ffffff" strokeOpacity={0.08} />
+          ))}
+          {/* axes */}
+          <line x1={C} y1={C - R} x2={C} y2={C + R} stroke="#ffffff" strokeOpacity={0.06} />
+          <line x1={C - R} y1={C} x2={C + R} y2={C} stroke="#ffffff" strokeOpacity={0.06} />
+          {/* front marker */}
+          <text x={C} y={12} textAnchor="middle" fontSize={7} fill="#71717a" fontFamily="monospace">FRONT</text>
+          {renderMotionPath()}
+          {/* listener */}
+          <circle cx={C} cy={C} r={3} fill="#52525b" />
+          {/* source */}
+          <line x1={C} y1={C} x2={src.x} y2={src.y} stroke="#a855f7" strokeOpacity={0.35} strokeWidth={1} />
+          <circle cx={src.x} cy={src.y} r={5} fill="#a855f7" stroke="#fff" strokeWidth={1} />
+        </svg>
+
+        <div className="flex-1 flex flex-col gap-1.5 min-w-0">
+          <label htmlFor={motionId} className="sr-only">Motion mode</label>
+          <select
+            id={motionId}
+            name={motionId}
+            value={motion}
+            onChange={(e) => set('motion', Number(e.target.value))}
+            className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 cursor-pointer"
+            style={{ colorScheme: 'dark' }}
+          >
+            {SPATIAL_MOTIONS.map((label, i) => (
+              <option key={label} value={i}>{label}</option>
+            ))}
+          </select>
+          <div className="grid grid-cols-2 gap-1">
+            {SPATIAL_PRESETS.map((preset) => (
+              <button
+                key={preset.label}
+                onClick={() => merge(preset.values)}
+                className="text-[9px] font-mono px-1.5 py-1 rounded border border-white/5 bg-black/30 text-zinc-400 hover:text-purple-200 hover:border-purple-500/40 hover:bg-purple-500/10 transition-colors truncate"
+                title={`Apply the ${preset.label} motion preset`}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Precise + accessible numeric controls */}
+      <div className="flex flex-col gap-1">
+        {[
+          { key: 'azimuth', label: 'Azimuth', value: azimuth, min: -180, max: 180, step: 1, unit: 'deg' },
+          { key: 'elevation', label: 'Elevation', value: elevation, min: -90, max: 90, step: 1, unit: 'deg' },
+          { key: 'distance', label: 'Distance', value: distance, min: 0.5, max: 10, step: 0.1, unit: '' },
+          { key: 'motionRate', label: 'Rate', value: motionRate, min: 0, max: 4, step: 0.01, unit: 'Hz' },
+          { key: 'motionDepth', label: 'Depth', value: motionDepth, min: 0, max: 8, step: 0.1, unit: '' },
+        ].map((p) => {
+          const labelId = `${idPrefix}-${p.key}-label`;
+          const decimals = p.step < 1 ? (p.step < 0.1 ? 2 : 1) : 0;
+          return (
+            <div key={p.key} className="flex items-center gap-2">
+              <span id={labelId} className="text-[9px] font-mono text-zinc-500 w-16 shrink-0">{p.label}</span>
+              <SlideTrack
+                value={p.value}
+                min={p.min}
+                max={p.max}
+                step={p.step}
+                ariaLabelledBy={labelId}
+                className="flex-1"
+                onChange={(v) => set(p.key, v)}
+              />
+              <span className="text-[9px] font-mono text-zinc-400 w-16 shrink-0 text-right tabular-nums">
+                {p.value.toFixed(decimals)}{p.unit ? ` ${p.unit}` : ''}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -2,9 +2,15 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Scissors, Play, Pause, Square, ZoomIn, ZoomOut,
   Magnet, Trash2, Move, Plus, Volume2, Upload, Save, Piano, Paintbrush, X, Wand2, Layers,
+  SlidersHorizontal,
 } from 'lucide-react';
 import { addBlobsToChimera } from '../../lib/chimeraClient';
 import { SlideTrack } from './SlideTrack';
+import { FxRack } from './FxRack';
+import { MetamorphPanel } from './MetamorphPanel';
+import { RACK_EFFECTS, buildEffectChain, teleportXYZ, SPATIAL_TELEPORT, type ChainHandle } from '../../lib/rackEffects';
+import { sliceChunks } from '../../lib/audioAnalysis';
+import { encodeWav } from '../../lib/wavEncode';
 import type { AudioDragItem } from '../../lib/audioDnD';
 import { useExternalDragStore } from '../../state/externalDragStore';
 import { useEditorStore, computePeaks, type AudioClip, type EditorTrack, type SnapDivision } from '../../state/editorStore';
@@ -46,41 +52,6 @@ const isEditorTimelinePlaying = (): boolean => {
 // Preview routes through the shared engine context so the visualizer sees it too.
 
 // --- WAV encoder for the offline mixdown output. ---
-const encodeWav = (audioBuf: AudioBuffer): Blob => {
-  const numCh = audioBuf.numberOfChannels;
-  const sr = audioBuf.sampleRate;
-  const len = audioBuf.length;
-  const buffer = new ArrayBuffer(44 + len * numCh * 2);
-  const view = new DataView(buffer);
-  const writeStr = (off: number, s: string) => {
-    for (let i = 0; i < s.length; i += 1) view.setUint8(off + i, s.charCodeAt(i));
-  };
-  writeStr(0, 'RIFF');
-  view.setUint32(4, 36 + len * numCh * 2, true);
-  writeStr(8, 'WAVE');
-  writeStr(12, 'fmt ');
-  view.setUint32(16, 16, true);
-  view.setUint16(20, 1, true);          // PCM
-  view.setUint16(22, numCh, true);
-  view.setUint32(24, sr, true);
-  view.setUint32(28, sr * numCh * 2, true);
-  view.setUint16(32, numCh * 2, true);
-  view.setUint16(34, 16, true);
-  writeStr(36, 'data');
-  view.setUint32(40, len * numCh * 2, true);
-  // Interleave + 16-bit PCM.
-  const channels: Float32Array[] = [];
-  for (let c = 0; c < numCh; c += 1) channels.push(audioBuf.getChannelData(c));
-  let offset = 44;
-  for (let i = 0; i < len; i += 1) {
-    for (let c = 0; c < numCh; c += 1) {
-      const sample = Math.max(-1, Math.min(1, channels[c][i]));
-      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7FFF, true);
-      offset += 2;
-    }
-  }
-  return new Blob([buffer], { type: 'audio/wav' });
-};
 
 /**
  * Tiny silent WAV placeholder used when creating large MIDI clips. The real
@@ -237,7 +208,8 @@ const TrackInstrumentSelect: React.FC<{ track: EditorTrack }> = ({ track }) => {
         aria-label={`Track ${track.name} instrument`}
         value={value}
         onChange={onChange}
-        className="flex-1 min-w-0 bg-black/40 border border-white/10 rounded px-1 py-0.5 text-[8px] text-white/75 outline-none focus:border-purple-500/50"
+        className="flex-1 min-w-0 bg-zinc-900 border border-white/20 rounded px-1 py-0.5 text-[9px] text-zinc-100 outline-none focus:border-purple-500/60"
+        style={{ colorScheme: 'dark' }}
       >
         <option value="default">{defaultLabel}</option>
         {GM_NAMES.map((nm, i) => (
@@ -291,6 +263,17 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   const inpaintSelection = useEditorStore((s) => s.inpaintSelection);
   const setInpaintSelection = useEditorStore((s) => s.setInpaintSelection);
   const clearInpaintSelection = useEditorStore((s) => s.clearInpaintSelection);
+  const masterFxChain = useEditorStore((s) => s.masterFxChain);
+  const addMasterEffect = useEditorStore((s) => s.addMasterEffect);
+  const removeMasterEffect = useEditorStore((s) => s.removeMasterEffect);
+  const reorderMasterEffect = useEditorStore((s) => s.reorderMasterEffect);
+  const toggleMasterEffect = useEditorStore((s) => s.toggleMasterEffect);
+  const updateMasterEffectParams = useEditorStore((s) => s.updateMasterEffectParams);
+  const addTrackEffect = useEditorStore((s) => s.addTrackEffect);
+  const removeTrackEffect = useEditorStore((s) => s.removeTrackEffect);
+  const reorderTrackEffect = useEditorStore((s) => s.reorderTrackEffect);
+  const toggleTrackEffect = useEditorStore((s) => s.toggleTrackEffect);
+  const updateTrackEffectParams = useEditorStore((s) => s.updateTrackEffectParams);
   // Footer player — the live engine mirrors its own playhead; we just read
   // entry id + playing state to drive the editor's local transport button.
   const playerEntryId = usePlayerStore((s) => s.currentEntryId);
@@ -311,6 +294,9 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   const [isCommitting, setIsCommitting] = useState(false);
   const [isRendering, setIsRendering] = useState(false);
   const [mixdownName, setMixdownName] = useState('');
+  const [showMasterFx, setShowMasterFx] = useState(false);
+  const [showMetamorph, setShowMetamorph] = useState(false);
+  const [fxPanelTrackId, setFxPanelTrackId] = useState<string | null>(null);
   const [selectedClipIds, setSelectedClipIds] = useState<string[]>([]);
   const [selectedTrackIds, setSelectedTrackIds] = useState<string[]>([]);
 
@@ -822,6 +808,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
 
   // --- Right-click context menu (uses shared ContextMenu primitive) ---
   const clipMenu = useContextMenu<{ clipId: string; atSec: number }>();
+  const trackMenu = useContextMenu<{ trackId: string }>();
 
   const openContextMenu = (e: React.MouseEvent, clipId: string) => {
     e.stopPropagation();
@@ -865,39 +852,96 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
       } finally {
         decodeCtx.close().catch(() => {});
       }
-      for (const c of clips) {
-        const track = tracks.find((t) => t.id === c.trackId);
-        if (!track) continue;
+      // Master bus + insert rack -> destination, mirroring liveMixer's routing so
+      // the bounce carries the SAME psychoacoustic FX the user hears in preview.
+      const masterBus = offline.createGain();
+      buildEffectChain(offline, masterBus, offline.destination, masterFxChain);
+
+      // One gain + insert chain + panner per audible track; panners feed the bus.
+      const trackNodeById = new Map<string, { gain: GainNode; panner: StereoPannerNode; fx: ChainHandle }>();
+      for (const track of tracks) {
         if (track.mute) continue;
         if (anySolo && !track.solo) continue;
-        const buf = blobCache.get(c.audioBlob);
-        if (!buf) continue;
-        const src = offline.createBufferSource();
-        src.buffer = buf;
-        const gain = offline.createGain();
+        const tgain = offline.createGain();
+        tgain.gain.value = track.volume;
         const panner = offline.createStereoPanner();
         panner.pan.value = Math.max(-1, Math.min(1, track.pan));
-        src.connect(gain).connect(panner).connect(offline.destination);
+        const fx = buildEffectChain(offline, tgain, panner, track.fxChain ?? []); // tgain -> [fx] -> panner
+        panner.connect(masterBus);
+        trackNodeById.set(track.id, { gain: tgain, panner, fx });
+      }
 
-        const vol = track.volume;
-        const fadeIn = c.fadeInSec ?? 0;
-        const fadeOut = c.fadeOutSec ?? 0;
+      for (const c of clips) {
+        const tn = trackNodeById.get(c.trackId);
+        if (!tn) continue; // track muted or hidden by an active solo
+        const buf = blobCache.get(c.audioBlob);
+        if (!buf) continue;
         const safeOffset = Math.min(c.offsetIntoSource, Math.max(0, buf.duration - 0.01));
         const safeDur = Math.min(c.durationSec, buf.duration - safeOffset);
         if (safeDur <= 0) continue;
 
-        gain.gain.setValueAtTime(fadeIn > 0 ? 0 : vol, c.startSec);
+        // Per-clip gain carries ONLY the fade envelope (peak 1). Track volume lives
+        // on the track gain so per-track FX process the post-fade signal exactly as
+        // they do live.
+        const src = offline.createBufferSource();
+        src.buffer = buf;
+        const clipGain = offline.createGain();
+        const fadeIn = c.fadeInSec ?? 0;
+        const fadeOut = c.fadeOutSec ?? 0;
+        clipGain.gain.setValueAtTime(fadeIn > 0 ? 0 : 1, c.startSec);
         if (fadeIn > 0) {
-          gain.gain.linearRampToValueAtTime(vol, c.startSec + Math.min(fadeIn, safeDur));
+          clipGain.gain.linearRampToValueAtTime(1, c.startSec + Math.min(fadeIn, safeDur));
         }
         if (fadeOut > 0) {
           const foStart = c.startSec + safeDur - Math.min(fadeOut, safeDur);
-          gain.gain.setValueAtTime(vol, foStart);
-          gain.gain.linearRampToValueAtTime(0, c.startSec + safeDur);
+          clipGain.gain.setValueAtTime(1, foStart);
+          clipGain.gain.linearRampToValueAtTime(0, c.startSec + safeDur);
         }
-
+        src.connect(clipGain).connect(tn.gain);
         src.start(c.startSec, safeOffset, safeDur);
       }
+
+      // Spatializer Teleport: schedule the same onset-driven panner jumps the live
+      // preview makes, so the bounce matches. The offline ctx renders from t=0, so
+      // each event's `when` is simply its timeline time.
+      const chunkCache = new Map<Blob, ReturnType<typeof sliceChunks>>();
+      for (const track of tracks) {
+        const tn = trackNodeById.get(track.id);
+        if (!tn) continue;
+        const teleEntries = (track.fxChain ?? []).filter(
+          (e) => e.enabled && e.effect === 'spatializer' && Math.round(e.params?.motion ?? 0) === SPATIAL_TELEPORT,
+        );
+        if (teleEntries.length === 0) continue;
+        const insts = tn.fx.instances();
+        const trackClips = clips.filter((c) => c.trackId === track.id);
+        for (const entry of teleEntries) {
+          const li = insts.find((x) => x.id === entry.id);
+          if (!li?.inst.scheduleTeleport) continue;
+          const spread = entry.params?.motionDepth ?? 5;
+          const events: { when: number; x: number; y: number; z: number }[] = [];
+          let idx = 0;
+          for (const c of trackClips) {
+            const buf = blobCache.get(c.audioBlob);
+            if (!buf) continue;
+            const offset = Math.min(c.offsetIntoSource, Math.max(0, buf.duration - 0.01));
+            const cdur = Math.min(c.durationSec, buf.duration - offset);
+            if (cdur <= 0) continue;
+            let chunks = chunkCache.get(c.audioBlob);
+            if (!chunks) { chunks = sliceChunks(buf); chunkCache.set(c.audioBlob, chunks); }
+            for (const chunk of chunks) {
+              if (chunk.tSec < offset || chunk.tSec >= offset + cdur) continue;
+              const pos = teleportXYZ(idx, chunk.loudness, chunk.brightness, spread);
+              events.push({ when: c.startSec + (chunk.tSec - offset), x: pos.x, y: pos.y, z: pos.z });
+              idx += 1;
+            }
+          }
+          if (events.length > 0) {
+            events.sort((a, b) => a.when - b.when);
+            li.inst.scheduleTeleport(events);
+          }
+        }
+      }
+
       const rendered = await offline.startRendering();
       const wavBlob = encodeWav(rendered);
       const id = `mix-${Date.now()}`;
@@ -935,7 +979,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
     } finally {
       setIsCommitting(false);
     }
-  }, [clips, tracks, getTotalDurationSec, mixdownName]);
+  }, [clips, tracks, getTotalDurationSec, mixdownName, masterFxChain]);
 
   // --- Pointer math helpers. ---
   const pxToSec = useCallback((px: number) => px / zoom, [zoom]);
@@ -1374,16 +1418,6 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
       {/* Editor Toolbar */}
       <div className="flex items-center justify-between p-2 border-b border-white/5 bg-black/20 shrink-0">
         <div className="flex items-center gap-3">
-          <button
-            onClick={() => addTrack()}
-            className="btn-primary flex items-center gap-1.5 bg-purple-600/20! border-purple-500/30! text-purple-300! px-2! py-0.5! text-[9px]"
-            title="Add a new empty track"
-          >
-            <Plus className="w-3 h-3" /> ADD TRACK
-          </button>
-
-          <div className="h-4 w-px bg-white/10" />
-
           <div className="flex bg-black/40 p-0.5 rounded border border-white/5 gap-0.5">
             <button
               onClick={() => setTool('move')}
@@ -1418,7 +1452,8 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               name="editor-snap-division"
               value={snap}
               onChange={(e) => setSnap(e.target.value as SnapDivision)}
-              className="bg-transparent border-none outline-none text-[9px] font-mono uppercase text-zinc-300 cursor-pointer"
+              className="bg-transparent border-none outline-none text-[9px] font-mono uppercase text-zinc-100 cursor-pointer"
+              style={{ colorScheme: 'dark' }}
               title="Snap divisions are relative to the editor BPM"
             >
               <option value="off">Snap off</option>
@@ -1448,6 +1483,30 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
           >
             <Trash2 className="w-3.5 h-3.5" />
           </button>
+
+          <div className="h-4 w-px bg-white/10" />
+
+          <button
+            onClick={() => setShowMasterFx((v) => !v)}
+            aria-pressed={showMasterFx}
+            aria-label="Master FX rack"
+            className={`flex items-center gap-1.5 p-1 px-2 rounded border transition-colors text-[9px] font-mono uppercase tracking-wider
+              ${showMasterFx || masterFxChain.length > 0 ? 'bg-purple-600/20 border-purple-500/40 text-purple-300' : 'border-white/5 text-zinc-500 hover:text-white hover:bg-white/5'}`}
+            title="Master psychoacoustic insert rack (applies to the whole editor mix)"
+          >
+            <SlidersHorizontal className="w-3 h-3" /> MASTER FX
+          </button>
+
+          <button
+            onClick={() => setShowMetamorph((v) => !v)}
+            aria-pressed={showMetamorph}
+            aria-label="Metamorph granular identity-bleed panel"
+            className={`flex items-center gap-1.5 p-1 px-2 rounded border transition-colors text-[9px] font-mono uppercase tracking-wider
+              ${showMetamorph ? 'bg-purple-600/20 border-purple-500/40 text-purple-300' : 'border-white/5 text-zinc-500 hover:text-white hover:bg-white/5'}`}
+            title="Granular identity bleed: rebuild one sound out of another's grains, live"
+          >
+            <Wand2 className="w-3 h-3" /> METAMORPH
+          </button>
         </div>
 
         <div className="flex items-center gap-3">
@@ -1474,6 +1533,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
           >
             <Square className="w-3.5 h-3.5 fill-current" />
           </button>
+          <label htmlFor="editor-mixdown-name" className="sr-only">Mixdown filename</label>
           <input
             id="editor-mixdown-name"
             name="editor-mixdown-name"
@@ -1496,6 +1556,85 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
         </div>
       </div>
 
+      {/* MASTER FX + METAMORPH float as popups (like the per-track FX rack) so they
+          never shove the timeline down; close with the X. */}
+      {(showMasterFx || showMetamorph) && (
+        <div className="fixed top-28 left-4 z-50 flex items-start gap-3 max-w-[calc(100%-2rem)]">
+          {showMasterFx && (
+            <section aria-label="Master FX rack" className="w-90 max-h-[70vh] overflow-y-auto hardware-card bg-black/90 border border-purple-500/30 rounded-lg shadow-2xl shadow-purple-900/40 p-3 flex flex-col gap-2">
+              <div className="flex items-center justify-between gap-2 border-b border-white/10 pb-2">
+                <span className="text-[10px] font-mono uppercase tracking-wider text-purple-300">Master FX</span>
+                <button
+                  onClick={() => setShowMasterFx(false)}
+                  aria-label="Close master FX rack"
+                  className="p-0.5 rounded text-zinc-500 hover:text-white hover:bg-white/10"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              </div>
+              <FxRack
+                chain={masterFxChain}
+                idPrefix="master-fx"
+                onAdd={addMasterEffect}
+                onRemove={removeMasterEffect}
+                onReorder={reorderMasterEffect}
+                onToggle={toggleMasterEffect}
+                onUpdateParams={updateMasterEffectParams}
+              />
+            </section>
+          )}
+          {showMetamorph && (
+            <section aria-label="Metamorph" className="w-90 max-h-[70vh] overflow-y-auto hardware-card bg-black/90 border border-purple-500/30 rounded-lg shadow-2xl shadow-purple-900/40 p-3 flex flex-col gap-2">
+              <div className="flex items-center justify-between gap-2 border-b border-white/10 pb-2">
+                <span className="text-[10px] font-mono uppercase tracking-wider text-purple-300">
+                  Metamorph <span className="text-zinc-600 normal-case tracking-normal">granular identity bleed</span>
+                </span>
+                <button
+                  onClick={() => setShowMetamorph(false)}
+                  aria-label="Close Metamorph panel"
+                  className="p-0.5 rounded text-zinc-500 hover:text-white hover:bg-white/10"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              </div>
+              <MetamorphPanel />
+            </section>
+          )}
+        </div>
+      )}
+
+      {/* Per-track FX rack (floating; fixed so it escapes the card's overflow clip) */}
+      {fxPanelTrackId && (() => {
+        const t = tracks.find((tr) => tr.id === fxPanelTrackId);
+        if (!t) return null;
+        return (
+          <div className="fixed right-4 top-28 z-50 w-90 max-h-[70vh] overflow-y-auto hardware-card bg-black/90 border border-purple-500/30 rounded-lg shadow-2xl shadow-purple-900/40 p-3 flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-2 border-b border-white/10 pb-2">
+              <span className="text-[10px] font-mono uppercase tracking-wider text-zinc-400 truncate">
+                Track FX — <span style={{ color: t.color }}>{t.name}</span>
+              </span>
+              <button
+                onClick={() => setFxPanelTrackId(null)}
+                aria-label="Close track FX rack"
+                title="Close"
+                className="p-0.5 rounded text-zinc-500 hover:text-white hover:bg-white/10 shrink-0"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </div>
+            <FxRack
+              chain={t.fxChain ?? []}
+              idPrefix={`track-fx-${t.id}`}
+              onAdd={(eid) => addTrackEffect(t.id, eid)}
+              onRemove={(id) => removeTrackEffect(t.id, id)}
+              onReorder={(from, to) => reorderTrackEffect(t.id, from, to)}
+              onToggle={(id) => toggleTrackEffect(t.id, id)}
+              onUpdateParams={(id, p) => updateTrackEffectParams(t.id, id, p)}
+            />
+          </div>
+        );
+      })()}
+
       {/* Body: track headers + scrollable timeline */}
       <div className="flex-1 min-h-0 flex overflow-hidden">
         {/* Track headers (sticky, not scrolled) */}
@@ -1507,9 +1646,10 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               <div
                 key={t.id}
                 onPointerDown={(e) => handleTrackHeaderPointerDown(e, t.id)}
+                onContextMenu={(e) => { selectTrackSingle(t.id); trackMenu.open(e, { trackId: t.id }); }}
                 className={`border-b border-[#1a1528] p-2 flex flex-col gap-1.5 transition-colors ${selectedTrackIds.includes(t.id) ? 'bg-purple-500/10 ring-1 ring-inset ring-purple-500/35' : ''}`}
                 style={{ height: TRACK_HEIGHT }}
-                title="Click to select track. Ctrl/Cmd-click to multi-select tracks."
+                title="Click to select track. Ctrl/Cmd-click to multi-select tracks. Right-click for track FX."
               >
                 <div className="flex justify-between items-center gap-1">
                   <input
@@ -1531,6 +1671,13 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
                       onClick={() => toggleSolo(t.id)}
                       className={`w-4 h-4 rounded text-[8px] font-bold flex items-center justify-center ${t.solo ? 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/50' : 'bg-black/40 text-zinc-500 border border-white/5 hover:text-white'}`}
                     >S</button>
+                    <button
+                      onClick={() => setFxPanelTrackId((cur) => (cur === t.id ? null : t.id))}
+                      aria-label={`Track ${t.name} insert FX`}
+                      aria-pressed={fxPanelTrackId === t.id}
+                      title="Track insert FX rack"
+                      className={`w-4 h-4 rounded text-[8px] font-bold flex items-center justify-center ${(t.fxChain?.length ?? 0) > 0 || fxPanelTrackId === t.id ? 'bg-purple-500/20 text-purple-300 border border-purple-500/50' : 'bg-black/40 text-zinc-500 border border-white/5 hover:text-white'}`}
+                    >F</button>
                     <button
                       onClick={() => removeTrack(t.id)}
                       className="w-4 h-4 rounded text-[8px] flex items-center justify-center bg-black/40 text-zinc-600 border border-white/5 hover:text-red-400"
@@ -1556,6 +1703,15 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
                 )}
               </div>
             ))}
+            {/* Add-track affordance sits directly below the lowest (newest) track. */}
+            <button
+              onClick={() => addTrack()}
+              aria-label="Add track"
+              title="Add a new empty track"
+              className="w-full h-7 flex items-center justify-center text-zinc-500 hover:text-purple-300 hover:bg-purple-500/10 border-b border-[#1a1528] transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+            </button>
           </div>
         </div>
 
@@ -1892,6 +2048,46 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
             onClose={clipMenu.close}
             items={items}
             minWidth="10rem"
+          />
+        );
+      })()}
+
+      {/* Track context menu — insert FX, opened by right-clicking a track header. */}
+      {trackMenu.position && (() => {
+        const t = tracks.find((tr) => tr.id === trackMenu.payload?.trackId);
+        if (!t) return null;
+        const hasFx = (t.fxChain?.length ?? 0) > 0;
+        const items: ContextMenuItem[] = [
+          {
+            type: 'item',
+            icon: <SlidersHorizontal className="w-3 h-3" />,
+            label: 'Open FX rack',
+            onSelect: () => setFxPanelTrackId(t.id),
+          },
+          { type: 'separator' },
+          { type: 'header', label: 'Add insert' },
+          ...RACK_EFFECTS.map((def): ContextMenuItem => ({
+            type: 'item',
+            label: def.label,
+            onSelect: () => addTrackEffect(t.id, def.id),
+          })),
+        ];
+        if (hasFx) {
+          items.push({ type: 'separator' });
+          items.push({
+            type: 'item',
+            label: 'Clear track FX',
+            danger: true,
+            onSelect: () => updateTrack(t.id, { fxChain: [] }),
+          });
+        }
+        return (
+          <ContextMenu
+            position={trackMenu.position}
+            onClose={trackMenu.close}
+            items={items}
+            title={`Track · ${t.name}`}
+            minWidth="11rem"
           />
         );
       })()}

--- a/frontend/src/lib/audioAnalysis.ts
+++ b/frontend/src/lib/audioAnalysis.ts
@@ -1,0 +1,181 @@
+/**
+ * audioAnalysis — browser-side, FFT-free analysis of a decoded AudioBuffer.
+ *
+ * Two consumers share this:
+ *   - the spatializer's Teleport motion (slice a clip on its transients and jump
+ *     each chunk to a position chosen from its character), and
+ *   - the granular identity-bleed morph engine (index a donor's grain pool and
+ *     follow a host's onsets/energy).
+ *
+ * Everything here is time-domain so it stays cheap enough to run synchronously at
+ * play/seek time: an energy-novelty onset detector with an adaptive threshold,
+ * plus two per-chunk descriptors — loudness (RMS) and a brightness proxy (zero-
+ * crossing rate, which tracks spectral centroid without an FFT). Results are
+ * deterministic, so a live preview and the offline bounce slice identically.
+ */
+
+const clamp = (x: number, a: number, b: number) => Math.max(a, Math.min(b, x));
+
+export interface AudioChunk {
+  /** Onset time in seconds, relative to the start of the analyzed buffer. */
+  tSec: number;
+  /** Span until the next onset (or buffer end), in seconds. */
+  durSec: number;
+  /** Loudness 0..1, normalized against the loudest chunk in the buffer. */
+  loudness: number;
+  /** Brightness 0..1 (zero-crossing rate proxy for spectral centroid). */
+  brightness: number;
+  /** Salience 0..1 — transient strength (energy rise at the onset). High = a
+   *  punchy / distinctive chunk worth favouring when picking "cool" material. */
+  salience: number;
+}
+
+export interface OnsetOptions {
+  /** Peak-pick aggressiveness: higher = more onsets. Maps to a threshold scale. */
+  sensitivity?: number; // 0..1, default 0.5
+  /** Minimum gap between onsets (de-clusters dense transients). */
+  minIntervalSec?: number; // default 0.07
+  /** Window after each onset used to measure the chunk's loudness/brightness. */
+  featureWindowSec?: number; // default 0.06
+}
+
+/** Sum a buffer's channels down to a single mono Float32Array. */
+export function downmixMono(buffer: AudioBuffer): Float32Array {
+  const n = buffer.length;
+  const ch = buffer.numberOfChannels;
+  if (ch === 1) return buffer.getChannelData(0);
+  const out = new Float32Array(n);
+  for (let c = 0; c < ch; c += 1) {
+    const data = buffer.getChannelData(c);
+    for (let i = 0; i < n; i += 1) out[i] += data[i];
+  }
+  const inv = 1 / ch;
+  for (let i = 0; i < n; i += 1) out[i] *= inv;
+  return out;
+}
+
+/** RMS over a sample range. */
+function rms(mono: Float32Array, start: number, end: number): number {
+  let sum = 0;
+  const a = Math.max(0, start);
+  const b = Math.min(mono.length, end);
+  for (let i = a; i < b; i += 1) sum += mono[i] * mono[i];
+  const n = b - a;
+  return n > 0 ? Math.sqrt(sum / n) : 0;
+}
+
+/** Zero-crossing rate (fraction of adjacent samples that change sign) over a
+ *  range — a cheap brightness proxy: more crossings ~ more high-frequency energy. */
+function zeroCrossRate(mono: Float32Array, start: number, end: number): number {
+  let crossings = 0;
+  const a = Math.max(1, start);
+  const b = Math.min(mono.length, end);
+  let prev = mono[a - 1];
+  for (let i = a; i < b; i += 1) {
+    const cur = mono[i];
+    if ((cur >= 0 && prev < 0) || (cur < 0 && prev >= 0)) crossings += 1;
+    prev = cur;
+  }
+  const n = b - a;
+  return n > 0 ? crossings / n : 0;
+}
+
+/**
+ * Detect onset times (seconds) via an energy-novelty function with an adaptive
+ * median threshold and a minimum inter-onset interval. Always reports an onset at
+ * t=0 so the first chunk is covered even on a slow fade-in.
+ */
+export function detectOnsets(buffer: AudioBuffer, opts: OnsetOptions = {}): number[] {
+  const sensitivity = clamp(opts.sensitivity ?? 0.5, 0, 1);
+  const minInterval = Math.max(0.02, opts.minIntervalSec ?? 0.07);
+  const sr = buffer.sampleRate;
+  const mono = downmixMono(buffer);
+
+  const frame = 1024;
+  const hop = 512;
+  const nFrames = Math.max(0, Math.floor((mono.length - frame) / hop) + 1);
+  if (nFrames < 3) return [0];
+
+  // Per-frame energy, then half-wave-rectified first difference (the novelty).
+  const energy = new Float32Array(nFrames);
+  for (let f = 0; f < nFrames; f += 1) {
+    const s = f * hop;
+    let e = 0;
+    for (let i = 0; i < frame; i += 1) {
+      const v = mono[s + i];
+      e += v * v;
+    }
+    energy[f] = Math.log1p(e); // log compress so quiet onsets still register
+  }
+  const novelty = new Float32Array(nFrames);
+  for (let f = 1; f < nFrames; f += 1) novelty[f] = Math.max(0, energy[f] - energy[f - 1]);
+
+  // Adaptive threshold: local median * scale + small floor. Lower scale = more
+  // onsets, so higher sensitivity lowers it.
+  const win = 16; // ~0.18 s at 44.1k / hop 512
+  const scale = 2.4 - sensitivity * 1.6; // 0.8 (max sens) .. 2.4 (min sens)
+  const sorted: number[] = [];
+  const onsets: number[] = [0];
+  let lastOnsetSec = -minInterval;
+  for (let f = 1; f < nFrames; f += 1) {
+    const lo = Math.max(0, f - win);
+    const hi = Math.min(nFrames, f + win);
+    sorted.length = 0;
+    for (let k = lo; k < hi; k += 1) sorted.push(novelty[k]);
+    sorted.sort((a, b) => a - b);
+    const median = sorted[Math.floor(sorted.length / 2)];
+    const thresh = median * scale + 1e-4;
+    const isPeak = novelty[f] > thresh && novelty[f] >= novelty[f - 1] && novelty[f] >= novelty[f + 1 < nFrames ? f + 1 : f];
+    if (isPeak) {
+      const tSec = (f * hop) / sr;
+      if (tSec - lastOnsetSec >= minInterval) {
+        onsets.push(tSec);
+        lastOnsetSec = tSec;
+      }
+    }
+  }
+  return onsets;
+}
+
+/**
+ * Slice a buffer at its onsets and describe each chunk (loudness + brightness).
+ * Loudness is normalized against the loudest chunk so the descriptors are usable
+ * as 0..1 placement controls regardless of the source's absolute level.
+ */
+export function sliceChunks(buffer: AudioBuffer, opts: OnsetOptions = {}): AudioChunk[] {
+  const sr = buffer.sampleRate;
+  const mono = downmixMono(buffer);
+  const featureWin = Math.max(0.01, opts.featureWindowSec ?? 0.06);
+  const onsets = detectOnsets(buffer, opts);
+  const total = buffer.duration;
+  const winSamp = Math.floor(featureWin * sr);
+
+  const raw = onsets.map((tSec, i) => {
+    const next = i + 1 < onsets.length ? onsets[i + 1] : total;
+    const start = Math.floor(tSec * sr);
+    const end = Math.min(Math.floor((tSec + featureWin) * sr), Math.floor(next * sr), mono.length);
+    const post = rms(mono, start, end);
+    const pre = rms(mono, start - winSamp, start); // energy just before the onset
+    return {
+      tSec,
+      durSec: Math.max(0, next - tSec),
+      loudnessRaw: post,
+      // ZCR fraction ~0..0.5; scale so typical bright content lands near 1.
+      brightness: clamp(zeroCrossRate(mono, start, end) * 6, 0, 1),
+      attackRaw: Math.max(0, post - pre), // rise at the onset = transient strength
+    };
+  });
+
+  let peak = 0;
+  let peakAtk = 0;
+  for (const c of raw) { peak = Math.max(peak, c.loudnessRaw); peakAtk = Math.max(peakAtk, c.attackRaw); }
+  const inv = peak > 0 ? 1 / peak : 0;
+  const invAtk = peakAtk > 0 ? 1 / peakAtk : 0;
+  return raw.map((c) => ({
+    tSec: c.tSec,
+    durSec: c.durSec,
+    loudness: clamp(c.loudnessRaw * inv, 0, 1),
+    brightness: c.brightness,
+    salience: clamp(c.attackRaw * invAtk, 0, 1),
+  }));
+}

--- a/frontend/src/lib/fetchRetry.ts
+++ b/frontend/src/lib/fetchRetry.ts
@@ -90,9 +90,16 @@ export async function fetchBlobWithRetry(url: string, opts: RetryOpts = {}): Pro
   for (let attempt = 0; attempt <= retries; attempt += 1) {
     try {
       const res = await fetchOk(url);
-      const blob = await res.blob();
-      if (blob.size === 0) throw new Error('empty response body');
-      return blob;
+      // Build the Blob from an ArrayBuffer (kept in RAM) instead of res.blob().
+      // On a large body Chrome materializes res.blob() into its DISK-BACKED Blob
+      // store; when the disk is constrained that write fails and the whole fetch
+      // rejects with net::ERR_FAILED *after* a 200, which surfaces here as
+      // "Failed to fetch". arrayBuffer() stays in memory and is reliable.
+      // Verified live: res.blob() fails every time on a 66 MB WAV while
+      // new Blob([arrayBuffer]) succeeds every time.
+      const buf = await res.arrayBuffer();
+      if (buf.byteLength === 0) throw new Error('empty response body');
+      return new Blob([buf], { type: res.headers.get('content-type') ?? '' });
     } catch (e) {
       lastErr = e;
       if (attempt < retries) {

--- a/frontend/src/lib/morphCorpus.ts
+++ b/frontend/src/lib/morphCorpus.ts
@@ -1,0 +1,109 @@
+/**
+ * morphCorpus — turns two decoded AudioBuffers into the data the granular morph
+ * worklet needs (Phase M, identity-bleed).
+ *
+ *   - the CORPUS (sound A, the donor / "identity"): mono PCM + a grain table
+ *     (each onset-sliced grain's start offset and its descriptors), and
+ *   - the TARGET (sound B, the host / structure): mono PCM + per-frame descriptors
+ *     the worklet indexes by playhead to choose, moment to moment, which A grain
+ *     best matches what B is doing right now.
+ *
+ * v1 matches on loudness + brightness only (the cheap, robust pair). Pitch-match
+ * and harmonize are Phase M3. Everything is plain typed arrays so the controller
+ * can transfer them into the audio thread with zero copies.
+ */
+
+import { downmixMono, sliceChunks, detectOnsets, type OnsetOptions } from './audioAnalysis';
+
+const clamp = (x: number, a: number, b: number) => Math.max(a, Math.min(b, x));
+
+export interface MorphCorpus {
+  sampleRate: number;
+  pcm: Float32Array;     // mono donor samples
+  gOffset: Float32Array; // grain start, in samples
+  gLoud: Float32Array;   // 0..1
+  gBright: Float32Array; // 0..1
+  gSal: Float32Array;    // 0..1 transient salience (favour the punchy/cool grains)
+  count: number;
+}
+
+export interface MorphTarget {
+  sampleRate: number;
+  pcm: Float32Array;   // mono host samples
+  frameHop: number;    // samples between frames
+  fLoud: Float32Array; // per-frame loudness 0..1
+  fBright: Float32Array; // per-frame brightness 0..1
+  frames: number;
+  onsets: Float32Array; // host onset positions in samples (for beat-locked triggering)
+}
+
+/** Cap so the worklet's per-grain nearest-neighbour scan stays cheap and the
+ *  transfer stays small; long sources just get a coarser grain pool. */
+const MAX_GRAINS = 2000;
+
+/** Slice donor A into a grain pool with a loudness/brightness descriptor each. */
+export function buildCorpus(buffer: AudioBuffer, opts: OnsetOptions = {}): MorphCorpus {
+  const sr = buffer.sampleRate;
+  const pcm = new Float32Array(downmixMono(buffer)); // copy so it can be transferred
+  let chunks = sliceChunks(buffer, opts);
+  if (chunks.length > MAX_GRAINS) {
+    // Keep an even spread across the source rather than just the head.
+    const step = chunks.length / MAX_GRAINS;
+    const thinned = [];
+    for (let i = 0; i < MAX_GRAINS; i += 1) thinned.push(chunks[Math.floor(i * step)]);
+    chunks = thinned;
+  }
+  const count = chunks.length;
+  const gOffset = new Float32Array(count);
+  const gLoud = new Float32Array(count);
+  const gBright = new Float32Array(count);
+  const gSal = new Float32Array(count);
+  for (let i = 0; i < count; i += 1) {
+    gOffset[i] = Math.floor(chunks[i].tSec * sr);
+    gLoud[i] = chunks[i].loudness;
+    gBright[i] = chunks[i].brightness;
+    gSal[i] = chunks[i].salience;
+  }
+  return { sampleRate: sr, pcm, gOffset, gLoud, gBright, gSal, count };
+}
+
+/** Frame host B and describe each frame (loudness + brightness), so the worklet
+ *  can look up B's current character by playhead position. */
+export function buildTarget(buffer: AudioBuffer, frameHop = 256): MorphTarget {
+  const sr = buffer.sampleRate;
+  const pcm = new Float32Array(downmixMono(buffer));
+  const win = Math.max(frameHop, 512);
+  const frames = Math.max(1, Math.floor(pcm.length / frameHop));
+  const fLoud = new Float32Array(frames);
+  const fBright = new Float32Array(frames);
+
+  let peak = 0;
+  for (let f = 0; f < frames; f += 1) {
+    const start = f * frameHop;
+    const end = Math.min(start + win, pcm.length);
+    let sum = 0;
+    let crossings = 0;
+    let prev = pcm[start] || 0;
+    for (let i = start; i < end; i += 1) {
+      const v = pcm[i];
+      sum += v * v;
+      if ((v >= 0 && prev < 0) || (v < 0 && prev >= 0)) crossings += 1;
+      prev = v;
+    }
+    const n = Math.max(1, end - start);
+    fLoud[f] = Math.sqrt(sum / n);
+    fBright[f] = clamp((crossings / n) * 6, 0, 1);
+    peak = Math.max(peak, fLoud[f]);
+  }
+  // Normalize loudness against the host's own peak (matches the corpus's 0..1).
+  const inv = peak > 0 ? 1 / peak : 0;
+  for (let f = 0; f < frames; f += 1) fLoud[f] = clamp(fLoud[f] * inv, 0, 1);
+
+  // Host onsets (seconds -> sample offsets) so the worklet can lock grain spawns
+  // to B's beat grid.
+  const onsetSec = detectOnsets(buffer);
+  const onsets = new Float32Array(onsetSec.length);
+  for (let i = 0; i < onsetSec.length; i += 1) onsets[i] = Math.floor(onsetSec[i] * sr);
+
+  return { sampleRate: sr, pcm, frameHop, fLoud, fBright, frames, onsets };
+}

--- a/frontend/src/lib/rackEffects.ts
+++ b/frontend/src/lib/rackEffects.ts
@@ -1,0 +1,944 @@
+/**
+ * rackEffects — a real-time Web Audio insert-effect engine for the EDIT timeline.
+ *
+ * Each effect is a context-agnostic factory: given a BaseAudioContext (the live
+ * engine ctx OR an OfflineAudioContext at export time) and a params object, it
+ * builds a single-input / single-output node subgraph plus a live `setParams`.
+ * Because the factory takes any BaseAudioContext, the SAME graph powers live
+ * preview (liveMixer) and the offline bounce (commitEdit) with no duplication.
+ *
+ * `buildEffectChain` wires a list of ChainEntry's in series between a caller-owned
+ * `input` and `output` node, rebuilds on add/remove/reorder/toggle, and pushes
+ * live param moves into the running nodes without a rebuild.
+ *
+ * The processors are genuinely psychoacoustic (crossfeed, missing-fundamental
+ * bass, true M/S widening, aural excitation, HRTF spatialization, equal-loudness
+ * contour) rather than thin wrappers over a single filter.
+ */
+
+import { distCurve } from './synthVoiceKit';
+import type { ChainEntry } from '../state/effectChainStore';
+
+/** One scheduled spatial jump: position (x,y,z) to hold from absolute ctx time `when`. */
+export interface TeleportEvent {
+  when: number;
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface RackEffectInstance {
+  /** Feed signal in here. */
+  input: AudioNode;
+  /** Processed signal leaves here. */
+  output: AudioNode;
+  /** Push new parameter values onto the live nodes (click-free where possible). */
+  setParams: (p: Record<string, number>) => void;
+  /** Spatializer only: drive panner position from a transport-synced schedule
+   *  (Teleport motion). `when` values are absolute AudioContext times. */
+  scheduleTeleport?: (events: TeleportEvent[]) => void;
+  /** Stop oscillators / release nodes. */
+  dispose: () => void;
+}
+
+export type RackEffectFactory = (
+  ctx: BaseAudioContext,
+  params: Record<string, number>,
+) => RackEffectInstance;
+
+export interface RackParamDescriptor {
+  key: string;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  default: number;
+  unit?: string;
+}
+
+export interface RackEffectDef {
+  id: string;
+  label: string;
+  group: string;
+  description: string;
+  params: RackParamDescriptor[];
+  make: RackEffectFactory;
+}
+
+/* ── small helpers ─────────────────────────────────────────────────────────── */
+
+const clamp = (x: number, a: number, b: number) => Math.max(a, Math.min(b, x));
+
+/** Smoothly set an AudioParam toward a target (click-free for live moves). */
+const ramp = (p: AudioParam, v: number, ctx: BaseAudioContext) => {
+  // OfflineAudioContext also exposes currentTime (0 at build); setTargetAtTime is fine.
+  p.setTargetAtTime(v, ctx.currentTime, 0.02);
+};
+
+/** dB to linear gain. */
+const dbToGain = (db: number) => Math.pow(10, db / 20);
+
+/* ── 1. Headphone Crossfeed (Bauer / BS2B) ─────────────────────────────────────
+   Each channel sends a short-delayed, low-passed copy to the opposite channel.
+   On headphones this relieves the unnatural hard-panned "in-head" image by
+   approximating the inter-aural crosstalk you'd get from speakers. */
+const makeCrossfeed: RackEffectFactory = (ctx, params) => {
+  const input = ctx.createGain();
+  const output = ctx.createGain();
+  const splitter = ctx.createChannelSplitter(2);
+  const merger = ctx.createChannelMerger(2);
+  input.connect(splitter);
+
+  // Direct (same-channel) path stays full level.
+  const directL = ctx.createGain();
+  const directR = ctx.createGain();
+  splitter.connect(directL, 0);
+  splitter.connect(directR, 1);
+  directL.connect(merger, 0, 0);
+  directR.connect(merger, 0, 1);
+
+  // Cross path: delayed + low-passed copy into the opposite channel.
+  // Initial values mirror setParams exactly so the make-time state (used as-is
+  // in the offline bounce) matches the live state after any param move.
+  const amt0 = clamp(params.amount ?? 0.5, 0, 1) * 0.6;
+  const cut0 = clamp(params.cutFreq ?? 700, 200, 2000);
+  const mkCross = (fromCh: number, toCh: number) => {
+    const delay = ctx.createDelay(0.01);
+    delay.delayTime.value = 0.0003; // ~300 us inter-aural delay
+    const lp = ctx.createBiquadFilter();
+    lp.type = 'lowpass';
+    lp.frequency.value = cut0;
+    const g = ctx.createGain();
+    g.gain.value = amt0;
+    splitter.connect(delay, fromCh);
+    delay.connect(lp);
+    lp.connect(g);
+    g.connect(merger, 0, toCh);
+    return { lp, g };
+  };
+  const lr = mkCross(0, 1);
+  const rl = mkCross(1, 0);
+  merger.connect(output);
+
+  return {
+    input,
+    output,
+    setParams: (p) => {
+      const amt = clamp(p.amount ?? 0.5, 0, 1) * 0.6; // cap so it never overwhelms the direct path
+      const cut = clamp(p.cutFreq ?? 700, 200, 2000);
+      ramp(lr.g.gain, amt, ctx);
+      ramp(rl.g.gain, amt, ctx);
+      lr.lp.frequency.setValueAtTime(cut, ctx.currentTime);
+      rl.lp.frequency.setValueAtTime(cut, ctx.currentTime);
+    },
+    dispose: () => {
+      try { input.disconnect(); output.disconnect(); } catch { /* gone */ }
+    },
+  };
+};
+
+/* ── 2. Phantom Bass (missing-fundamental / residue pitch) ──────────────────────
+   Isolate the sub band, synthesize its integer harmonics with a waveshaper, then
+   high-pass those harmonics back above the crossover. The ear's residue-pitch
+   mechanism reconstructs the (possibly unreproducible) fundamental, so the low
+   end reads as deeper on small drivers without adding real sub energy. */
+const makePhantomBass: RackEffectFactory = (ctx, params) => {
+  const input = ctx.createGain();
+  const output = ctx.createGain();
+
+  const dry = ctx.createGain();
+  dry.gain.value = 1;
+  input.connect(dry).connect(output);
+
+  const subLP = ctx.createBiquadFilter();
+  subLP.type = 'lowpass';
+  subLP.frequency.value = params.crossover ?? 90;
+  subLP.Q.value = 0.7;
+  const shaper = ctx.createWaveShaper();
+  shaper.curve = distCurve(Math.round(params.drive ?? 6));
+  shaper.oversample = '2x';
+  const postHP = ctx.createBiquadFilter();
+  postHP.type = 'highpass';
+  postHP.frequency.value = params.crossover ?? 90;
+  const wet = ctx.createGain();
+  wet.gain.value = params.blend ?? 0.6;
+
+  input.connect(subLP);
+  subLP.connect(shaper);
+  shaper.connect(postHP);
+  postHP.connect(wet);
+  wet.connect(output);
+
+  return {
+    input,
+    output,
+    setParams: (p) => {
+      const xover = clamp(p.crossover ?? 90, 50, 160);
+      shaper.curve = distCurve(clamp(Math.round(p.drive ?? 6), 1, 40));
+      subLP.frequency.setValueAtTime(xover, ctx.currentTime);
+      postHP.frequency.setValueAtTime(xover, ctx.currentTime);
+      ramp(wet.gain, clamp(p.blend ?? 0.6, 0, 1.5), ctx);
+    },
+    dispose: () => {
+      try { input.disconnect(); output.disconnect(); } catch { /* gone */ }
+    },
+  };
+};
+
+/* ── 3. Stereo Widener (true mid/side) ─────────────────────────────────────────
+   Decode M = (L+R)/2 and S = (L-R)/2, scale the side, recombine. Unlike a Haas
+   delay this stays mono-compatible. An optional high-pass on the side keeps the
+   low end mono (bass stays centered and powerful while the top widens). */
+const makeStereoWidener: RackEffectFactory = (ctx, params) => {
+  const input = ctx.createGain();
+  const output = ctx.createGain();
+  const splitter = ctx.createChannelSplitter(2);
+  input.connect(splitter);
+
+  // Mid = 0.5L + 0.5R
+  const mid = ctx.createGain();
+  const lMid = ctx.createGain(); lMid.gain.value = 0.5;
+  const rMid = ctx.createGain(); rMid.gain.value = 0.5;
+  splitter.connect(lMid, 0); lMid.connect(mid);
+  splitter.connect(rMid, 1); rMid.connect(mid);
+
+  // Side = 0.5L - 0.5R
+  const side = ctx.createGain();
+  const lSide = ctx.createGain(); lSide.gain.value = 0.5;
+  const rSide = ctx.createGain(); rSide.gain.value = -0.5;
+  splitter.connect(lSide, 0); lSide.connect(side);
+  splitter.connect(rSide, 1); rSide.connect(side);
+
+  // Bass-mono: high-pass the side so lows fold to center.
+  const sideHP = ctx.createBiquadFilter();
+  sideHP.type = 'highpass';
+  sideHP.frequency.value = params.bassMonoFreq ?? 120;
+  side.connect(sideHP);
+
+  // Width scaling.
+  const sideW = ctx.createGain();
+  sideW.gain.value = params.width ?? 1.4;
+  sideHP.connect(sideW);
+  const sideWneg = ctx.createGain();
+  sideWneg.gain.value = -1;
+  sideW.connect(sideWneg);
+
+  // outL = mid + sideW ; outR = mid - sideW
+  const outL = ctx.createGain();
+  const outR = ctx.createGain();
+  mid.connect(outL); sideW.connect(outL);
+  mid.connect(outR); sideWneg.connect(outR);
+  const merger = ctx.createChannelMerger(2);
+  outL.connect(merger, 0, 0);
+  outR.connect(merger, 0, 1);
+  merger.connect(output);
+
+  return {
+    input,
+    output,
+    setParams: (p) => {
+      ramp(sideW.gain, clamp(p.width ?? 1.4, 0, 2.5), ctx);
+      sideHP.frequency.setValueAtTime(clamp(p.bassMonoFreq ?? 120, 20, 400), ctx.currentTime);
+    },
+    dispose: () => {
+      try { input.disconnect(); output.disconnect(); } catch { /* gone */ }
+    },
+  };
+};
+
+/* ── 4. Aural Exciter ──────────────────────────────────────────────────────────
+   High-pass a branch, generate harmonics with a waveshaper, blend that "air"
+   back in. Restores perceived brightness/presence the ear reads as detail. */
+const makeExciter: RackEffectFactory = (ctx, params) => {
+  const input = ctx.createGain();
+  const output = ctx.createGain();
+  input.connect(output); // dry through
+
+  const hp = ctx.createBiquadFilter();
+  hp.type = 'highpass';
+  hp.frequency.value = params.frequency ?? 3500;
+  const shaper = ctx.createWaveShaper();
+  shaper.curve = distCurve(Math.round(params.amount ?? 8));
+  shaper.oversample = '4x';
+  const wet = ctx.createGain();
+  wet.gain.value = params.mix ?? 0.4;
+
+  input.connect(hp);
+  hp.connect(shaper);
+  shaper.connect(wet);
+  wet.connect(output);
+
+  return {
+    input,
+    output,
+    setParams: (p) => {
+      hp.frequency.setValueAtTime(clamp(p.frequency ?? 3500, 1000, 9000), ctx.currentTime);
+      shaper.curve = distCurve(clamp(Math.round(p.amount ?? 8), 1, 40));
+      ramp(wet.gain, clamp(p.mix ?? 0.4, 0, 1), ctx);
+    },
+    dispose: () => {
+      try { input.disconnect(); output.disconnect(); } catch { /* gone */ }
+    },
+  };
+};
+
+/* ── 5. HRTF Spatializer ───────────────────────────────────────────────────────
+   A PannerNode in HRTF mode positions the track in 3D around the listener
+   (azimuth / elevation / distance). A motion mode adds an audio-rate orbit /
+   ping-pong / up-down / figure-8 on top of the base position; because the motion
+   comes from oscillators it renders identically in the live preview and the
+   offline bounce. The visual guide + presets live in SpatializerPad.tsx. */
+
+/** Motion-mode labels, indexed by the numeric `motion` param. */
+export const SPATIAL_MOTIONS = [
+  'Static',
+  'Orbit H CW',
+  'Orbit H CCW',
+  'Orbit Frontal',
+  'Orbit Sagittal',
+  'Spherical',
+  'Ping-Pong',
+  'Up / Down',
+  'Figure-8',
+  'Expand / Collapse',
+  'Teleport',
+  'Autopilot',
+] as const;
+
+/** Index of the data-driven Teleport mode: position is driven by a transport-
+ *  synced schedule from onset analysis (see liveMixer), not by the LFOs. */
+export const SPATIAL_TELEPORT = 10;
+
+/** Index of Autopilot: an analyser taps the signal and a live rAF loop drives the
+ *  motion, auto-cycling through the behaviours so the source is "played" by the
+ *  music. Live only — the offline bounce falls back to a bake-correct Spherical. */
+export const SPATIAL_AUTOPILOT = 11;
+
+/** One-click spatial-motion presets (merged onto the effect's current params). */
+export const SPATIAL_PRESETS: ReadonlyArray<{ label: string; values: Record<string, number> }> = [
+  { label: 'Static Front', values: { motion: 0, azimuth: 0, elevation: 0, distance: 1.5 } },
+  { label: 'Orbit CW', values: { motion: 1, motionRate: 0.3, motionDepth: 2 } },
+  { label: 'Orbit CCW', values: { motion: 2, motionRate: 0.3, motionDepth: 2 } },
+  { label: 'Frontal', values: { motion: 3, motionRate: 0.35, motionDepth: 2 } },
+  { label: 'Sagittal', values: { motion: 4, motionRate: 0.35, motionDepth: 2 } },
+  { label: 'Spherical', values: { motion: 5, motionRate: 0.3, motionDepth: 2.5 } },
+  { label: 'Ping-Pong', values: { motion: 6, motionRate: 1, motionDepth: 2.5 } },
+  { label: 'Up / Down', values: { motion: 7, motionRate: 0.5, motionDepth: 2 } },
+  { label: 'Figure-8', values: { motion: 8, motionRate: 0.4, motionDepth: 2 } },
+  { label: 'Expand/Collapse', values: { motion: 9, motionRate: 0.25, motionDepth: 3, distance: 2.5 } },
+  { label: 'Teleport', values: { motion: 10, motionDepth: 5 } },
+  { label: 'Autopilot', values: { motion: 11 } },
+];
+
+export const azElToXYZ = (azDeg: number, elDeg: number, dist: number) => {
+  const az = (azDeg * Math.PI) / 180;
+  const el = (elDeg * Math.PI) / 180;
+  return {
+    x: dist * Math.cos(el) * Math.sin(az),
+    y: dist * Math.sin(el),
+    z: -dist * Math.cos(el) * Math.cos(az), // front of the listener is -z
+  };
+};
+
+/** Map a sliced chunk to a teleport position. Azimuth is a golden-angle scatter
+ *  (low-discrepancy, so successive chunks spread evenly around the head), scaled
+ *  by `spread`; brightness lifts elevation (brighter = higher); loudness pulls the
+ *  source in (louder = closer). Deterministic, so live + bounce land identically. */
+export function teleportXYZ(
+  index: number,
+  loudness: number,
+  brightness: number,
+  spread: number,
+): { x: number; y: number; z: number } {
+  const reach = clamp(spread, 0, 8) / 8; // 0..1
+  const az = (((index * 137.508) % 360) - 180) * reach; // golden-angle, scaled toward center at low spread
+  const el = (-25 + clamp(brightness, 0, 1) * 70) * reach; // -25..+45 deg
+  const dist = clamp(3.0 - clamp(loudness, 0, 1) * 1.6, 1.2, 6); // loud ~1.4 (present), quiet ~3.0 (back)
+  return azElToXYZ(az, el, dist);
+}
+
+/** Per-axis LFO frequency + depth + cosine flag, for a motion mode. Pairing a
+ *  sine axis with a cosine axis at the same rate traces a circle, so any plane
+ *  (horizontal XZ, frontal XY, sagittal YZ) can be orbited; the radial
+ *  Expand/Collapse mode drives all three axes in phase along the source direction
+ *  so the image breathes toward and away from the listener (binaural in/out). */
+const motionConfig = (p: Record<string, number>) => {
+  const motion = Math.round(p.motion ?? 0);
+  const rate = clamp(p.motionRate ?? 0.3, 0, 4);
+  const depth = clamp(p.motionDepth ?? 1.5, 0, 8);
+  let fx = rate, fy = rate, fz = rate;
+  let dx = 0, dy = 0, dz = 0;
+  let xCos = false, yCos = false, zCos = false;
+  switch (motion) {
+    case 1: dx = depth; dz = depth; zCos = true; break;              // orbit horizontal CW (XZ)
+    case 2: dx = depth; dz = -depth; zCos = true; break;            // orbit horizontal CCW
+    case 3: dx = depth; dy = depth; yCos = true; break;              // orbit frontal (XY wheel)
+    case 4: dz = depth; dy = depth; yCos = true; break;              // orbit sagittal (YZ, over the top)
+    case 5:                                                          // spherical (orbit + slow vertical precession)
+      dx = depth; dz = depth; zCos = true;
+      dy = depth * 0.7; fy = rate * 0.6; break;
+    case 6: dx = depth; break;                                       // ping-pong (X only)
+    case 7: dy = depth; break;                                       // up / down (Y only)
+    case 8: dx = depth; dz = depth; fz = rate * 2; break;            // figure-8 (Z sine at 2x)
+    case 9: {                                                        // expand / collapse (radial breathing)
+      const u = azElToXYZ(p.azimuth ?? -30, p.elevation ?? 0, 1);    // unit vector toward the source
+      dx = depth * u.x; dy = depth * u.y; dz = depth * u.z; break;
+    }
+    default: break;                                                  // static
+  }
+  return { fx, fy, fz, dx, dy, dz, xCos, yCos, zCos };
+};
+
+const makeSpatializer: RackEffectFactory = (ctx, params) => {
+  const input = ctx.createGain();
+  const output = ctx.createGain();
+  const panner = ctx.createPanner();
+  panner.panningModel = 'HRTF';
+  panner.distanceModel = 'inverse';
+  panner.refDistance = 1.2;    // hold full level a touch farther out before the rolloff bites
+  panner.rolloffFactor = 0.5;  // gentler than the default 1 so distance/depth don't dive in level so fast
+  input.connect(panner).connect(output);
+
+  // Offline contexts expose startRendering and can't run the live Autopilot rAF
+  // loop, so Autopilot falls back to a bake-correct Spherical motion there.
+  const isOffline = 'startRendering' in ctx;
+
+  const pos = azElToXYZ(params.azimuth ?? -30, params.elevation ?? 0, params.distance ?? 1.5);
+  panner.positionX.value = pos.x;
+  panner.positionY.value = pos.y;
+  panner.positionZ.value = pos.z;
+
+  // One LFO per axis adds motion on top of the static position. Each axis can run
+  // as a sine or a 90-degrees-shifted cosine: pairing a sine axis with a cosine
+  // axis at the same rate traces a circle, so any plane (horizontal, frontal,
+  // sagittal) can be orbited, while an in-phase radial triple breathes in and out.
+  const cosWave = ctx.createPeriodicWave(new Float32Array([0, 1]), new Float32Array([0, 0]));
+  const lfoX = ctx.createOscillator(); lfoX.type = 'sine';
+  const lfoY = ctx.createOscillator(); lfoY.type = 'sine';
+  const lfoZ = ctx.createOscillator(); lfoZ.type = 'sine';
+  const setWave = (osc: OscillatorNode, cos: boolean) => {
+    if (cos) osc.setPeriodicWave(cosWave); else osc.type = 'sine';
+  };
+  const depthX = ctx.createGain();
+  const depthY = ctx.createGain();
+  const depthZ = ctx.createGain();
+  lfoX.connect(depthX).connect(panner.positionX);
+  lfoY.connect(depthY).connect(panner.positionY);
+  lfoZ.connect(depthZ).connect(panner.positionZ);
+
+  // Push a motion config onto the LFOs (waveform + frequency + depth).
+  const applyMotion = (cfg: ReturnType<typeof motionConfig>) => {
+    setWave(lfoX, cfg.xCos);
+    setWave(lfoY, cfg.yCos);
+    setWave(lfoZ, cfg.zCos);
+    lfoX.frequency.setValueAtTime(cfg.fx, ctx.currentTime);
+    lfoY.frequency.setValueAtTime(cfg.fy, ctx.currentTime);
+    lfoZ.frequency.setValueAtTime(cfg.fz, ctx.currentTime);
+    ramp(depthX.gain, cfg.dx, ctx);
+    ramp(depthY.gain, cfg.dy, ctx);
+    ramp(depthZ.gain, cfg.dz, ctx);
+  };
+  const applyPosition = (azimuth: number, elevation: number, distance: number) => {
+    const np = azElToXYZ(azimuth, elevation, distance);
+    ramp(panner.positionX, np.x, ctx);
+    ramp(panner.positionY, np.y, ctx);
+    ramp(panner.positionZ, np.z, ctx);
+  };
+
+  // Autopilot — a continuous "spatial choreographer". One AnalyserNode (lazy, live
+  // only) feeds a per-frame MIR feature bus with per-feature AGC (so it reacts to
+  // RELATIVE dynamics on any material), a flux-onset + inter-onset beat clock, a
+  // soft hysteretic mood scorer, and drop/breakdown event detection. Those drive a
+  // beat-aware azimuth orbit with slow elevation (brightness) + distance (bass)
+  // followers, a mood-weighted LFO texture layer, and onset-fired accents that
+  // decay back to the bed. dt-aware + allocation-free per frame; offline = Spherical.
+  let analyser: AnalyserNode | null = null;
+  let rafId = 0;
+  let lastNow = 0;
+  let binHz = 0;
+  const baseAz = () => params.azimuth ?? -30;
+
+  // One place to tune the whole brain.
+  const AP = {
+    onsetK: 1.8, refractoryMs: 120,
+    agcFast: 0.2, agcSlow: 0.0006,
+    elTau: 0.4, distTau: 0.25, distSlew: 0.15, angVelCap: 140,
+    orbitMinHz: 0.05, orbitMaxHz: 1.8, maxRadiusDeg: 70,
+    elMin: -8, elMax: 30, distMin: 1.3, distMax: 3.2, depthMin: 0.4, depthMax: 3.2,
+  };
+
+  // Live-only buffers (allocated in ensureAutopilot so offline never allocates them).
+  let freqBuf: Uint8Array | null = null;
+  let timeBuf: Uint8Array | null = null;
+  let prevFreq: Uint8Array | null = null;
+  let bands: Array<{ lo: number; hi: number }> = [];
+  const agcState: Record<string, { min: number; max: number }> = {};
+  let fastEnergy = 0, slowEnergy = 0, fluxMean = 0, fluxMad = 0;
+  let beatPeriod = 0.5, beatPhase = 0, lastOnset = 0, beatConf = 0;
+  const iois = new Float32Array(8); let ioiIdx = 0, ioiCount = 0;
+  let wCalm = 0.25, wGroove = 0.4, wIntense = 0.2, wEthereal = 0.15;
+  let orbitPhase = 0, azS = 0, elS = 0, distS = 2.2;
+  let accX = 0, accY = 0, accZ = 0, accEnv = 0, accTau = 0.2, accLR = 1;
+  let dropLatch = 0;
+
+  const clamp01 = (x: number) => (x < 0 ? 0 : x > 1 ? 1 : x);
+  const onePole = (cur: number, target: number, tau: number, dt: number) =>
+    cur + (target - cur) * (1 - Math.exp(-dt / Math.max(1e-3, tau)));
+  const agc = (x: number, key: string) => {
+    let s = agcState[key];
+    if (!s) { s = agcState[key] = { min: x, max: x + 1e-3 }; }
+    s.max += (x - s.max) * (x > s.max ? AP.agcFast : AP.agcSlow);
+    s.min += (x - s.min) * (x < s.min ? AP.agcFast : AP.agcSlow);
+    return clamp01((x - s.min) / (s.max - s.min + 1e-6));
+  };
+  const fireAccent = (ax: number, ay: number, az: number, gain: number, tau: number) => {
+    const mag = Math.hypot(ax, ay, az) || 1;
+    accX = (ax / mag) * gain; accY = (ay / mag) * gain; accZ = (az / mag) * gain;
+    accEnv = 1; accTau = tau;
+  };
+
+  const ensureAutopilot = () => {
+    if (analyser) return;
+    const a = ctx.createAnalyser();
+    a.fftSize = 2048;
+    a.smoothingTimeConstant = 0.5; // 0.8 blurs onsets; 0.5 keeps spectral flux alive
+    input.connect(a);
+    analyser = a;
+    freqBuf = new Uint8Array(a.frequencyBinCount); // 1024
+    timeBuf = new Uint8Array(a.fftSize);           // 2048
+    prevFreq = new Uint8Array(a.frequencyBinCount);
+    binHz = ctx.sampleRate / a.fftSize;
+    const edges = [20, 60, 150, 400, 1500, 5000, 16000];
+    bands = [];
+    for (let i = 0; i < edges.length - 1; i += 1) {
+      bands.push({
+        lo: Math.max(1, Math.floor(edges[i] / binHz)),
+        hi: Math.min(freqBuf.length - 1, Math.ceil(edges[i + 1] / binHz)),
+      });
+    }
+    setWave(lfoX, false); setWave(lfoY, false); setWave(lfoZ, false); // plain sines in autopilot
+    azS = baseAz(); elS = 0; distS = 2.2; orbitPhase = 0;
+  };
+
+  const autopilotTick = (now: number) => {
+    if (!rafId || !analyser || !freqBuf || !timeBuf || !prevFreq) return;
+    const dt = lastNow ? Math.min(0.05, Math.max(0.005, (now - lastNow) / 1000)) : 0.016;
+    lastNow = now;
+
+    // time domain -> rms + crest (percussive vs sustained)
+    analyser.getByteTimeDomainData(timeBuf);
+    let sq = 0, peak = 0;
+    for (let i = 0; i < timeBuf.length; i += 1) {
+      const v = (timeBuf[i] - 128) / 128; sq += v * v;
+      const av = v < 0 ? -v : v; if (av > peak) peak = av;
+    }
+    const rms = Math.sqrt(sq / timeBuf.length);
+    const crest = peak / (rms + 1e-6);
+
+    // freq domain -> centroid + spread + flux + per-band flux (one pass)
+    analyser.getByteFrequencyData(freqBuf);
+    const nb = freqBuf.length;
+    let cNum = 0, cNum2 = 0, cDen = 0, flux = 0, bassFlux = 0, highFlux = 0;
+    for (let i = 1; i < nb; i += 1) {
+      const m = freqBuf[i];
+      cNum += i * m; cNum2 += i * i * m; cDen += m;
+      const d = m - prevFreq[i];
+      if (d > 0) { flux += d; if (i < nb * 0.07) bassFlux += d; else if (i > nb * 0.45) highFlux += d; }
+      prevFreq[i] = m;
+    }
+    flux = flux / 255 / nb;
+    // band means (sub+bass, mid) — inline to avoid per-frame closures
+    const b0 = bands[0], b1 = bands[1], bm = bands[3];
+    let s0 = 0; for (let i = b0.lo; i <= b0.hi; i += 1) s0 += freqBuf[i];
+    let s1 = 0; for (let i = b1.lo; i <= b1.hi; i += 1) s1 += freqBuf[i];
+    let sm = 0; for (let i = bm.lo; i <= bm.hi; i += 1) sm += freqBuf[i];
+    const bassRaw = (s0 / Math.max(1, b0.hi - b0.lo + 1) + s1 / Math.max(1, b1.hi - b1.lo + 1)) * 0.5 / 255;
+    const midRaw = sm / Math.max(1, bm.hi - bm.lo + 1) / 255;
+    const cHz = cDen > 0 ? (cNum / cDen) * binHz : 200;
+    const brightness = clamp01(Math.log2(Math.max(200, cHz) / 200) / Math.log2(16000 / 200));
+    const variance = cDen > 0 ? Math.max(0, cNum2 / cDen - (cNum / cDen) ** 2) : 0;
+    const spread01 = clamp01(Math.sqrt(variance) / (nb * 0.3));
+
+    const energyN = agc(rms, 'rms');
+    const bassN = agc(bassRaw, 'bass');
+    const fluxN = agc(flux, 'flux');
+    const arousal = energyN * 0.6 + fluxN * 0.4;
+    fastEnergy = onePole(fastEnergy, energyN, 0.15, dt);
+    slowEnergy = onePole(slowEnergy, energyN, 2.0, dt);
+
+    // onset detection (adaptive flux threshold + refractory) + IOI beat clock
+    fluxMean = onePole(fluxMean, flux, 0.4, dt);
+    fluxMad = onePole(fluxMad, Math.abs(flux - fluxMean), 0.4, dt);
+    const sinceOnset = now - lastOnset;
+    let onset = false;
+    if (flux > fluxMean + AP.onsetK * fluxMad && sinceOnset > AP.refractoryMs) {
+      onset = true;
+      const dtOn = sinceOnset / 1000;
+      if (dtOn >= 0.25 && dtOn <= 1.5) { // 40..240 BPM
+        beatPeriod += (dtOn - beatPeriod) * 0.12;
+        iois[ioiIdx] = dtOn; ioiIdx = (ioiIdx + 1) % iois.length; if (ioiCount < iois.length) ioiCount += 1;
+      }
+      lastOnset = now;
+      beatPhase -= 0.15 * Math.sin(2 * Math.PI * beatPhase); // soft phase pull, no hard reset
+    }
+    beatPhase += dt / Math.max(0.2, beatPeriod);
+    if (beatPhase >= 1) beatPhase -= 1;
+    if (ioiCount >= 3) {
+      let mean = 0; for (let i = 0; i < ioiCount; i += 1) mean += iois[i]; mean /= ioiCount;
+      let mad = 0; for (let i = 0; i < ioiCount; i += 1) mad += Math.abs(iois[i] - mean); mad /= ioiCount;
+      beatConf = clamp01(1 - mad / Math.max(0.1, beatPeriod));
+    } else beatConf = 0;
+
+    // soft mood weights (asymmetric slew: commit fast, linger slow)
+    const sustainN = 1 - clamp01((crest - 1.4) / 3);
+    const sGroove = beatConf * midRaw * (1 - spread01) + 0.3;
+    const sIntense = energyN * fluxN * (0.3 + spread01);
+    const sCalm = (1 - energyN) * (1 - fluxN) * (1 - spread01);
+    const sEthereal = brightness * (1 - arousal) * sustainN;
+    const sTot = sGroove + sIntense + sCalm + sEthereal + 1e-6;
+    const slewW = (w: number, t: number) => onePole(w, t, t > w ? 0.45 : 2.2, dt);
+    wGroove = slewW(wGroove, sGroove / sTot);
+    wIntense = slewW(wIntense, sIntense / sTot);
+    wCalm = slewW(wCalm, sCalm / sTot);
+    wEthereal = slewW(wEthereal, sEthereal / sTot);
+
+    // events: DROP = bass-flux + crest spike + energy jump (collapse-then-bloom)
+    if (dropLatch > 0) dropLatch -= dt * 1000;
+    if (bassFlux > 8 && crest > 3.4 && fastEnergy - slowEnergy > 0.3 && dropLatch <= 0) {
+      dropLatch = 2000;
+      distS = AP.distMin;             // snap in, then ease back out
+      fireAccent(0, -0.3, -1, 1.0, 0.18);
+    }
+    const intenseBias = dropLatch > 0 ? 0.5 : 0;
+
+    // orbit rate: arousal-driven, beat-quantized when confident
+    let orbitHz = AP.orbitMinHz + arousal * (AP.orbitMaxHz - AP.orbitMinHz);
+    if (beatConf > 0.5) {
+      const beatHz = 1 / Math.max(0.2, beatPeriod);
+      orbitHz = beatHz * (energyN > 0.6 ? 0.5 : energyN > 0.3 ? 0.25 : 0.125);
+    }
+    orbitPhase += 2 * Math.PI * orbitHz * dt;
+    if (orbitPhase > Math.PI * 2) orbitPhase -= Math.PI * 2;
+    const widthGate = clamp01(1.2 - spread01 * 0.5 - clamp01(highFlux / 6000) * 0.6);
+    const orbitRadius = Math.min(AP.maxRadiusDeg, (8 + energyN * 62) * Math.max(0.3, widthGate));
+    const breath = 1 + 0.15 * Math.cos(2 * Math.PI * beatPhase) * wGroove;
+
+    accEnv = onePole(accEnv, 0, accTau, dt);
+
+    // targets (azimuth = orbit + lateral accent; el/dist slow followers)
+    const azTarget = baseAz() + orbitRadius * Math.sin(orbitPhase) + accX * accEnv * 40;
+    const elTarget = clamp(AP.elMin + brightness * 38 + wEthereal * 20 - (wIntense + intenseBias) * 8 + accY * accEnv * 15, AP.elMin, AP.elMax);
+    const distTarget = clamp(3.0 - bassN * 1.7 + accZ * accEnv * 0.6, AP.distMin, AP.distMax);
+    elS = onePole(elS, elTarget, AP.elTau, dt);
+    const distNext = onePole(distS, distTarget, AP.distTau, dt);
+    distS += clamp(distNext - distS, -AP.distSlew, AP.distSlew);
+    const maxStep = AP.angVelCap * dt;
+    azS += clamp(azTarget - azS, -maxStep, maxStep); // angular-velocity cap (no seasickness)
+    applyPosition(azS, elS, distS);
+
+    // mood-weighted LFO texture layer (granular shimmer over the orbit bed)
+    const depthCommon = clamp(0.8 + energyN * 1.6 + bassN * 1.0, AP.depthMin, AP.depthMax)
+      * breath * (crest > 3.5 ? 0.7 : crest < 2 ? 1.15 : 1);
+    ramp(depthX.gain, depthCommon * (wIntense * 0.8 + 0.1), ctx);
+    ramp(depthY.gain, depthCommon * (wEthereal * 1.1 + wCalm * 0.5), ctx);
+    ramp(depthZ.gain, depthCommon * (wGroove * 0.6 + wEthereal * 0.5 + (dropLatch > 0 ? 1.2 : 0)), ctx);
+    const lfoHz = Math.max(0.05, orbitHz);
+    lfoX.frequency.setTargetAtTime(lfoHz, ctx.currentTime, 0.3);
+    lfoY.frequency.setTargetAtTime(lfoHz * 0.5, ctx.currentTime, 0.3);
+    lfoZ.frequency.setTargetAtTime(lfoHz * 2, ctx.currentTime, 0.3);
+
+    // onset accents (by band: kick -> in+down, hat -> up, snare -> alternating sides)
+    if (onset && dropLatch <= 0) {
+      if (bassFlux > highFlux) fireAccent(0, -0.3, -1, 0.7 + energyN * 0.4, 0.12 + wEthereal * 0.4);
+      else if (highFlux > bassFlux * 1.5) fireAccent(0, 1, 0, 0.5, 0.15);
+      else { fireAccent(accLR, 0, -0.3, 0.6, 0.15); accLR = -accLR; }
+    }
+
+    rafId = requestAnimationFrame(autopilotTick);
+  };
+  const startAutopilot = () => {
+    if (rafId || isOffline) return;
+    ensureAutopilot();
+    lastNow = 0;
+    rafId = requestAnimationFrame(autopilotTick);
+  };
+  const stopAutopilot = () => {
+    if (rafId) { cancelAnimationFrame(rafId); rafId = 0; }
+  };
+
+  // Build-time motion. Autopilot: live -> start the driver; offline -> Spherical so
+  // the bounce still has motion. Everything else uses its static config.
+  const motion0 = Math.round(params.motion ?? 0);
+  if (motion0 === SPATIAL_AUTOPILOT) {
+    if (isOffline) applyMotion(motionConfig({ ...params, motion: 5, motionRate: 0.3, motionDepth: 2.5 }));
+    else { applyMotion(motionConfig({ motion: 0 })); startAutopilot(); }
+  } else {
+    applyMotion(motionConfig(params));
+  }
+  lfoX.start();
+  lfoY.start();
+  lfoZ.start();
+
+  return {
+    input,
+    output,
+    setParams: (p) => {
+      const motion = Math.round(p.motion ?? 0);
+      if (motion === SPATIAL_AUTOPILOT) {
+        // The driver owns position + motion; nothing static to apply live.
+        if (isOffline) applyMotion(motionConfig({ ...p, motion: 5, motionRate: 0.3, motionDepth: 2.5 }));
+        else startAutopilot();
+        return;
+      }
+      stopAutopilot();
+      // Teleport owns position via its schedule; don't ramp it back to the base.
+      if (motion !== SPATIAL_TELEPORT) applyPosition(p.azimuth ?? -30, p.elevation ?? 0, p.distance ?? 1.5);
+      applyMotion(motionConfig(p));
+    },
+    scheduleTeleport: (events) => {
+      // Jump (hold then step, no ramp) to each scheduled position. The LFO depths
+      // are 0 in Teleport mode, so these setValueAtTime values fully own position.
+      const t0 = ctx.currentTime;
+      try {
+        panner.positionX.cancelScheduledValues(t0);
+        panner.positionY.cancelScheduledValues(t0);
+        panner.positionZ.cancelScheduledValues(t0);
+      } catch { /* no automation scheduled yet */ }
+      for (const ev of events) {
+        const when = Math.max(ev.when, t0);
+        panner.positionX.setValueAtTime(ev.x, when);
+        panner.positionY.setValueAtTime(ev.y, when);
+        panner.positionZ.setValueAtTime(ev.z, when);
+      }
+    },
+    dispose: () => {
+      stopAutopilot();
+      try { lfoX.stop(); lfoY.stop(); lfoZ.stop(); } catch { /* not started */ }
+      try { input.disconnect(); output.disconnect(); analyser?.disconnect(); } catch { /* gone */ }
+    },
+  };
+};
+
+/* ── 6. Loudness Contour (ISO 226 equal-loudness) ──────────────────────────────
+   As monitoring level drops, the ear loses lows and highs relative to mids
+   (Fletcher-Munson). This applies the inverse: low + high shelves whose boost
+   grows as the assumed listening level falls, so the perceived tonal balance
+   holds when you turn it down. A real "night mode" for mixing quietly. */
+const contourGains = (levelPhon: number, amount: number) => {
+  // 80 phon ~ a loud reference where no compensation is needed.
+  const deficit = clamp((80 - levelPhon) / 80, 0, 1) * clamp(amount, 0, 1);
+  return { lowDb: deficit * 12, highDb: deficit * 6 };
+};
+
+const makeLoudnessContour: RackEffectFactory = (ctx, params) => {
+  const input = ctx.createGain();
+  const output = ctx.createGain();
+  const low = ctx.createBiquadFilter();
+  low.type = 'lowshelf';
+  low.frequency.value = 120;
+  const high = ctx.createBiquadFilter();
+  high.type = 'highshelf';
+  high.frequency.value = 8000;
+  const g0 = contourGains(params.level ?? 70, params.amount ?? 0.5);
+  low.gain.value = g0.lowDb;
+  high.gain.value = g0.highDb;
+  input.connect(low).connect(high).connect(output);
+
+  return {
+    input,
+    output,
+    setParams: (p) => {
+      const g = contourGains(p.level ?? 70, p.amount ?? 0.5);
+      low.gain.setTargetAtTime(g.lowDb, ctx.currentTime, 0.03);
+      high.gain.setTargetAtTime(g.highDb, ctx.currentTime, 0.03);
+    },
+    dispose: () => {
+      try { input.disconnect(); output.disconnect(); } catch { /* gone */ }
+    },
+  };
+};
+
+/* ── registry ──────────────────────────────────────────────────────────────── */
+
+export const RACK_EFFECTS: readonly RackEffectDef[] = [
+  {
+    id: 'crossfeed',
+    label: 'Headphone Crossfeed',
+    group: 'Spatial',
+    description: 'Relieves hard-panned headphone "in-head" stereo (Bauer/BS2B).',
+    params: [
+      { key: 'amount', label: 'Amount', min: 0, max: 1, step: 0.01, default: 0.5 },
+      { key: 'cutFreq', label: 'Cut', min: 200, max: 2000, step: 10, default: 700, unit: 'Hz' },
+    ],
+    make: makeCrossfeed,
+  },
+  {
+    id: 'phantom_bass',
+    label: 'Phantom Bass',
+    group: 'Low end',
+    description: 'Implies the missing fundamental via synthesized harmonics.',
+    params: [
+      { key: 'drive', label: 'Drive', min: 1, max: 40, step: 1, default: 6 },
+      { key: 'blend', label: 'Blend', min: 0, max: 1.5, step: 0.01, default: 0.6 },
+      { key: 'crossover', label: 'Crossover', min: 50, max: 160, step: 1, default: 90, unit: 'Hz' },
+    ],
+    make: makePhantomBass,
+  },
+  {
+    id: 'stereo_widener',
+    label: 'Stereo Widener',
+    group: 'Spatial',
+    description: 'True mid/side widening with a mono-safe low end.',
+    params: [
+      { key: 'width', label: 'Width', min: 0, max: 2.5, step: 0.01, default: 1.4 },
+      { key: 'bassMonoFreq', label: 'Bass mono', min: 20, max: 400, step: 5, default: 120, unit: 'Hz' },
+    ],
+    make: makeStereoWidener,
+  },
+  {
+    id: 'exciter',
+    label: 'Aural Exciter',
+    group: 'Tone',
+    description: 'Adds harmonic air/presence the ear reads as detail.',
+    params: [
+      { key: 'frequency', label: 'Freq', min: 1000, max: 9000, step: 50, default: 3500, unit: 'Hz' },
+      { key: 'amount', label: 'Amount', min: 1, max: 40, step: 1, default: 8 },
+      { key: 'mix', label: 'Mix', min: 0, max: 1, step: 0.01, default: 0.4 },
+    ],
+    make: makeExciter,
+  },
+  {
+    id: 'spatializer',
+    label: 'HRTF Spatializer',
+    group: 'Spatial',
+    description: 'Positions the track in 3D around the head, with motion presets.',
+    params: [
+      { key: 'azimuth', label: 'Azimuth', min: -180, max: 180, step: 1, default: -30, unit: 'deg' },
+      { key: 'elevation', label: 'Elevation', min: -90, max: 90, step: 1, default: 0, unit: 'deg' },
+      { key: 'distance', label: 'Distance', min: 0.5, max: 10, step: 0.1, default: 1.5 },
+      { key: 'motion', label: 'Motion', min: 0, max: 11, step: 1, default: 0 },
+      { key: 'motionRate', label: 'Rate', min: 0, max: 4, step: 0.01, default: 0.3, unit: 'Hz' },
+      { key: 'motionDepth', label: 'Depth', min: 0, max: 8, step: 0.1, default: 1.5 },
+    ],
+    make: makeSpatializer,
+  },
+  {
+    id: 'loudness_contour',
+    label: 'Loudness Contour',
+    group: 'Tone',
+    description: 'Equal-loudness tilt so the balance holds at low volume.',
+    params: [
+      { key: 'level', label: 'Level', min: 0, max: 90, step: 1, default: 70, unit: 'phon' },
+      { key: 'amount', label: 'Amount', min: 0, max: 1, step: 0.01, default: 0.5 },
+    ],
+    make: makeLoudnessContour,
+  },
+];
+
+const RACK_BY_ID = new Map<string, RackEffectDef>(RACK_EFFECTS.map((d) => [d.id, d]));
+
+export const getRackEffect = (id: string): RackEffectDef | undefined => RACK_BY_ID.get(id);
+
+/** Default param object for an effect id (used when adding to a chain). */
+export const rackEffectDefaults = (id: string): Record<string, number> => {
+  const def = RACK_BY_ID.get(id);
+  if (!def) return {};
+  const out: Record<string, number> = {};
+  for (const p of def.params) out[p.key] = p.default;
+  return out;
+};
+
+const withDefaults = (id: string, params: Record<string, number>): Record<string, number> => ({
+  ...rackEffectDefaults(id),
+  ...params,
+});
+
+/* ── chain builder ─────────────────────────────────────────────────────────── */
+
+export interface ChainHandle {
+  /** Re-wire the chain to match `entries` (add/remove/reorder/toggle). */
+  rebuild: (entries: ChainEntry[]) => void;
+  /** Push live param values into one running effect without a rebuild. */
+  updateParams: (entryId: string, params: Record<string, number>) => void;
+  /** Live effect instances keyed by ChainEntry.id — lets the caller reach an
+   *  instance for transport-synced scheduling (e.g. the spatializer's teleport). */
+  instances: () => { id: string; effect: string; inst: RackEffectInstance }[];
+  /** Disconnect and dispose everything (leaves input/output untouched). */
+  dispose: () => void;
+}
+
+interface LiveInstance {
+  effect: string;
+  inst: RackEffectInstance;
+}
+
+/**
+ * Wire `entries` in series between caller-owned `input` and `output`. Enabled
+ * effects only; a disabled or absent chain is a clean `input -> output` pass.
+ * Instances persist across rebuilds where the effect id at a slot is unchanged,
+ * so param tweaks stay click-free.
+ */
+export function buildEffectChain(
+  ctx: BaseAudioContext,
+  input: AudioNode,
+  output: AudioNode,
+  entries: ChainEntry[],
+): ChainHandle {
+  const instances = new Map<string, LiveInstance>(); // keyed by ChainEntry.id
+
+  const clearWiring = () => {
+    try { input.disconnect(); } catch { /* nothing wired */ }
+    for (const { inst } of instances.values()) {
+      try { inst.output.disconnect(); } catch { /* gone */ }
+    }
+  };
+
+  const rebuild = (next: ChainEntry[]) => {
+    clearWiring();
+    const enabled = next.filter((e) => e.enabled && RACK_BY_ID.has(e.effect));
+
+    // Dispose instances that are no longer present.
+    const keepIds = new Set(enabled.map((e) => e.id));
+    for (const [id, li] of instances) {
+      if (!keepIds.has(id)) { li.inst.dispose(); instances.delete(id); }
+    }
+
+    if (enabled.length === 0) {
+      input.connect(output);
+      return;
+    }
+
+    let prev: AudioNode = input;
+    for (const e of enabled) {
+      let li = instances.get(e.id);
+      if (!li || li.effect !== e.effect) {
+        if (li) li.inst.dispose();
+        const def = RACK_BY_ID.get(e.effect)!;
+        li = { effect: e.effect, inst: def.make(ctx, withDefaults(e.effect, e.params)) };
+        instances.set(e.id, li);
+      } else {
+        li.inst.setParams(withDefaults(e.effect, e.params));
+      }
+      prev.connect(li.inst.input);
+      prev = li.inst.output;
+    }
+    prev.connect(output);
+  };
+
+  rebuild(entries);
+
+  return {
+    rebuild,
+    updateParams: (entryId, params) => {
+      const li = instances.get(entryId);
+      if (li) li.inst.setParams(withDefaults(li.effect, params));
+    },
+    instances: () =>
+      Array.from(instances.entries()).map(([id, li]) => ({ id, effect: li.effect, inst: li.inst })),
+    dispose: () => {
+      clearWiring();
+      for (const { inst } of instances.values()) inst.dispose();
+      instances.clear();
+    },
+  };
+}

--- a/frontend/src/lib/wavEncode.ts
+++ b/frontend/src/lib/wavEncode.ts
@@ -1,0 +1,41 @@
+/**
+ * encodeWav — interleave an AudioBuffer to a 16-bit PCM WAV Blob.
+ *
+ * Shared by the editor mixdown/bounce paths and the Metamorph "send to editor"
+ * render, so the same encoder produces every clip that lands on the timeline.
+ */
+export function encodeWav(audioBuf: AudioBuffer): Blob {
+  const numCh = audioBuf.numberOfChannels;
+  const sr = audioBuf.sampleRate;
+  const len = audioBuf.length;
+  const buffer = new ArrayBuffer(44 + len * numCh * 2);
+  const view = new DataView(buffer);
+  const writeStr = (off: number, s: string) => {
+    for (let i = 0; i < s.length; i += 1) view.setUint8(off + i, s.charCodeAt(i));
+  };
+  writeStr(0, 'RIFF');
+  view.setUint32(4, 36 + len * numCh * 2, true);
+  writeStr(8, 'WAVE');
+  writeStr(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);          // PCM
+  view.setUint16(22, numCh, true);
+  view.setUint32(24, sr, true);
+  view.setUint32(28, sr * numCh * 2, true);
+  view.setUint16(32, numCh * 2, true);
+  view.setUint16(34, 16, true);
+  writeStr(36, 'data');
+  view.setUint32(40, len * numCh * 2, true);
+  // Interleave + 16-bit PCM.
+  const channels: Float32Array[] = [];
+  for (let c = 0; c < numCh; c += 1) channels.push(audioBuf.getChannelData(c));
+  let offset = 44;
+  for (let i = 0; i < len; i += 1) {
+    for (let c = 0; c < numCh; c += 1) {
+      const sample = Math.max(-1, Math.min(1, channels[c][i]));
+      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+      offset += 2;
+    }
+  }
+  return new Blob([buffer], { type: 'audio/wav' });
+}

--- a/frontend/src/state/editorStore.ts
+++ b/frontend/src/state/editorStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import { logError, logInfo } from './logStore';
 import type { PianoNote } from './pianoRollStore';
+import type { ChainEntry } from './effectChainStore';
+import { rackEffectDefaults } from '../lib/rackEffects';
 
 export type ToolMode = 'move' | 'cut' | 'split';
 export type SnapDivision = 'off' | '1/4' | '1/8' | '1/16';
@@ -62,6 +64,9 @@ export interface EditorTrack {
   color: string;
   /** Default GM program (0-127) for MIDI clips on this track; undefined = global default. */
   instrumentProgram?: number;
+  /** Per-track insert FX chain (real-time psychoacoustic rack), spliced between
+   *  the track fader and its panner during live playback and offline bounce. */
+  fxChain?: ChainEntry[];
 }
 
 interface EditorStoreState {
@@ -76,6 +81,9 @@ interface EditorStoreState {
   snap: SnapDivision;
   bpm: number;              // for snap math
   inpaintSelection: InpaintSelection | null;
+  /** Master-bus insert FX chain (real-time psychoacoustic rack). Session-local —
+   *  liveMixer routes the editor mix through it before the shared engine master. */
+  masterFxChain: ChainEntry[];
 
   // Mutations
   addTrack: (overrides?: Partial<EditorTrack>) => string;
@@ -99,6 +107,20 @@ interface EditorStoreState {
   setBpm: (b: number) => void;
   setInpaintSelection: (sel: InpaintSelection | null) => void;
   clearInpaintSelection: () => void;
+
+  // Master FX rack
+  addMasterEffect: (effectId: string) => void;
+  removeMasterEffect: (entryId: string) => void;
+  reorderMasterEffect: (from: number, to: number) => void;
+  toggleMasterEffect: (entryId: string) => void;
+  updateMasterEffectParams: (entryId: string, params: Record<string, number>) => void;
+
+  // Per-track FX rack
+  addTrackEffect: (trackId: string, effectId: string) => void;
+  removeTrackEffect: (trackId: string, entryId: string) => void;
+  reorderTrackEffect: (trackId: string, from: number, to: number) => void;
+  toggleTrackEffect: (trackId: string, entryId: string) => void;
+  updateTrackEffectParams: (trackId: string, entryId: string, params: Record<string, number>) => void;
 
   // Selectors
   getTotalDurationSec: () => number;
@@ -133,6 +155,7 @@ export const useEditorStore = create<EditorStoreState>()((set, get) => ({
   snap: '1/16',
   bpm: 120,
   inpaintSelection: null,
+  masterFxChain: [],
 
   addTrack: (overrides) => {
     const id = `track-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
@@ -262,6 +285,85 @@ export const useEditorStore = create<EditorStoreState>()((set, get) => ({
   setBpm: (b) => set({ bpm: Math.max(40, Math.min(240, b)) }),
   setInpaintSelection: (sel) => set({ inpaintSelection: sel }),
   clearInpaintSelection: () => set({ inpaintSelection: null }),
+
+  addMasterEffect: (effectId) =>
+    set((s) => ({
+      masterFxChain: [
+        ...s.masterFxChain,
+        { id: uid(), effect: effectId, params: rackEffectDefaults(effectId), enabled: true },
+      ],
+    })),
+
+  removeMasterEffect: (entryId) =>
+    set((s) => ({ masterFxChain: s.masterFxChain.filter((e) => e.id !== entryId) })),
+
+  reorderMasterEffect: (from, to) =>
+    set((s) => {
+      if (from === to || from < 0 || to < 0 || from >= s.masterFxChain.length || to >= s.masterFxChain.length) {
+        return {};
+      }
+      const next = [...s.masterFxChain];
+      const [item] = next.splice(from, 1);
+      next.splice(to, 0, item);
+      return { masterFxChain: next };
+    }),
+
+  toggleMasterEffect: (entryId) =>
+    set((s) => ({
+      masterFxChain: s.masterFxChain.map((e) => (e.id === entryId ? { ...e, enabled: !e.enabled } : e)),
+    })),
+
+  updateMasterEffectParams: (entryId, params) =>
+    set((s) => ({
+      masterFxChain: s.masterFxChain.map((e) => (e.id === entryId ? { ...e, params } : e)),
+    })),
+
+  addTrackEffect: (trackId, effectId) =>
+    set((s) => ({
+      tracks: s.tracks.map((t) =>
+        t.id === trackId
+          ? { ...t, fxChain: [...(t.fxChain ?? []), { id: uid(), effect: effectId, params: rackEffectDefaults(effectId), enabled: true }] }
+          : t,
+      ),
+    })),
+
+  removeTrackEffect: (trackId, entryId) =>
+    set((s) => ({
+      tracks: s.tracks.map((t) =>
+        t.id === trackId ? { ...t, fxChain: (t.fxChain ?? []).filter((e) => e.id !== entryId) } : t,
+      ),
+    })),
+
+  reorderTrackEffect: (trackId, from, to) =>
+    set((s) => ({
+      tracks: s.tracks.map((t) => {
+        if (t.id !== trackId) return t;
+        const chain = t.fxChain ?? [];
+        if (from === to || from < 0 || to < 0 || from >= chain.length || to >= chain.length) return t;
+        const next = [...chain];
+        const [item] = next.splice(from, 1);
+        next.splice(to, 0, item);
+        return { ...t, fxChain: next };
+      }),
+    })),
+
+  toggleTrackEffect: (trackId, entryId) =>
+    set((s) => ({
+      tracks: s.tracks.map((t) =>
+        t.id === trackId
+          ? { ...t, fxChain: (t.fxChain ?? []).map((e) => (e.id === entryId ? { ...e, enabled: !e.enabled } : e)) }
+          : t,
+      ),
+    })),
+
+  updateTrackEffectParams: (trackId, entryId, params) =>
+    set((s) => ({
+      tracks: s.tracks.map((t) =>
+        t.id === trackId
+          ? { ...t, fxChain: (t.fxChain ?? []).map((e) => (e.id === entryId ? { ...e, params } : e)) }
+          : t,
+      ),
+    })),
 
   getTotalDurationSec: () => {
     const { clips } = get();

--- a/frontend/src/state/liveMixer.ts
+++ b/frontend/src/state/liveMixer.ts
@@ -45,6 +45,9 @@ import {
   liveAllNotesOff,
   useSoundfontStore,
 } from '../lib/soundfontEngine';
+import { buildEffectChain, teleportXYZ, SPATIAL_TELEPORT, type ChainHandle } from '../lib/rackEffects';
+import { sliceChunks, type AudioChunk } from '../lib/audioAnalysis';
+import type { ChainEntry } from './effectChainStore';
 
 const DECODE_TIMEOUT_MS = 15000;
 const EDITOR_ENTRY_ID = 'editor-timeline'; // reuse so existing footer/playhead wiring keeps working
@@ -54,9 +57,17 @@ const RAMP_TC = 0.015; // setTargetAtTime time-constant for click-free param mov
 // reclaimed once its Blob is gone, and an edited clip (new Blob) re-decodes.
 const decodeCache = new WeakMap<Blob, AudioBuffer>();
 
+// Onset-sliced chunks cached by Blob identity (for the spatializer Teleport mode),
+// so the (cheap but non-trivial) analysis runs once per clip, not per play/seek.
+const analysisCache = new WeakMap<Blob, AudioChunk[]>();
+
 interface TrackNodes {
   gain: GainNode;
   panner: StereoPannerNode;
+  /** Per-track insert FX, spliced gain -> [fx] -> panner. */
+  fx: ChainHandle;
+  fxFullSig: string; // topology + params (skip no-op reconciles)
+  fxTopoSig: string; // topology only (rebuild trigger)
 }
 
 // ---- live session state (module singletons; one editor timeline at a time) --
@@ -73,6 +84,15 @@ let lastMixSig = '';
 let lastTimePush = 0; // throttle playerStore.currentTime writes
 let midiTimers: number[] = []; // setTimeout handles for scheduled MIDI note on/off
 let liveMidiActive = false; // true while MIDI clips play via the live synth (vs their bounce)
+
+// Session-local master bus + psychoacoustic insert rack. Every track's panner
+// feeds masterBus; masterBus -> masterChain -> the shared engine master, so the
+// EDIT rack processes ONLY the editor mix and never the library/DJ/sequencer
+// audio that also routes through getMasterGain().
+let masterBus: GainNode | null = null;
+let masterChain: ChainHandle | null = null;
+let lastMasterSig = '';     // topology only (rebuild trigger)
+let lastMasterFullSig = ''; // topology + params (skip no-op ticks)
 
 const clamp = (x: number, a: number, b: number) => Math.max(a, Math.min(b, x));
 
@@ -121,10 +141,76 @@ async function ensureDecoded(clips: AudioClip[]): Promise<void> {
   }
 }
 
-/** Build (or rebuild) one shared gain+panner per track that has clips. */
+/** Topology signature of an FX chain (order + effect + enabled), so the store
+ *  subscription rebuilds the node graph only when the topology changes, and
+ *  pushes param-only edits without a rebuild. */
+function chainTopoSig(chain: ChainEntry[]): string {
+  let s = '';
+  for (const e of chain) s += `${e.id}:${e.effect}:${e.enabled ? 1 : 0}|`;
+  return s;
+}
+
+/** (Re)build the session-local master bus + insert rack and route it into the
+ *  shared engine master. Safe to call repeatedly (tears down the prior one). */
+function buildMasterBus(): void {
+  const ctx = getEngineCtx();
+  if (masterChain) { masterChain.dispose(); masterChain = null; }
+  if (masterBus) { try { masterBus.disconnect(); } catch { /* gone */ } masterBus = null; }
+  masterBus = ctx.createGain();
+  const chain = useEditorStore.getState().masterFxChain;
+  masterChain = buildEffectChain(ctx, masterBus, getMasterGain(), chain);
+  lastMasterSig = chainTopoSig(chain);
+  lastMasterFullSig = JSON.stringify(chain);
+}
+
+/** Reconcile the live master rack with the store: rebuild on topology change,
+ *  otherwise push each entry's params live. Cheap no-op when nothing changed
+ *  (this runs on every store tick, including the 60 Hz playhead). */
+function applyMasterChainLive(): void {
+  if (!masterChain) return;
+  const chain = useEditorStore.getState().masterFxChain;
+  const full = JSON.stringify(chain);
+  if (full === lastMasterFullSig) return;
+  lastMasterFullSig = full;
+  const sig = chainTopoSig(chain);
+  if (sig !== lastMasterSig) {
+    lastMasterSig = sig;
+    masterChain.rebuild(chain);
+  } else {
+    for (const e of chain) masterChain.updateParams(e.id, e.params);
+  }
+}
+
+/** Reconcile each track's live insert chain with the store (rebuild on topology
+ *  change, push params otherwise). Runs on every store tick while playing. */
+function applyTrackChainsLive(): void {
+  const tracks = useEditorStore.getState().tracks;
+  const byId = new Map<string, EditorTrack>(tracks.map((t): [string, EditorTrack] => [t.id, t]));
+  for (const [id, n] of trackNodes) {
+    const chain = byId.get(id)?.fxChain ?? [];
+    const full = JSON.stringify(chain);
+    if (full === n.fxFullSig) continue;
+    n.fxFullSig = full;
+    const topo = chainTopoSig(chain);
+    if (topo !== n.fxTopoSig) { n.fxTopoSig = topo; n.fx.rebuild(chain); }
+    else for (const e of chain) n.fx.updateParams(e.id, e.params);
+  }
+}
+
+/** Dispose every track's FX handle + nodes (oscillators in some effects must be
+ *  stopped explicitly). Leaves the trackNodes map for the caller to replace. */
+function disposeTrackNodes(): void {
+  for (const n of trackNodes.values()) {
+    try { n.fx.dispose(); n.gain.disconnect(); n.panner.disconnect(); } catch { /* gone */ }
+  }
+}
+
+/** Build (or rebuild) per track: gain -> [insert FX] -> panner -> master bus.
+ *  Panners feed the session master bus (built first), not the engine master. */
 function buildTrackNodes(tracks: EditorTrack[]): void {
   const ctx = getEngineCtx();
-  const master = getMasterGain();
+  const dest: AudioNode = masterBus ?? getMasterGain();
+  disposeTrackNodes();
   trackNodes = new Map();
   const anySolo = tracks.some((t) => t.solo);
   for (const t of tracks) {
@@ -132,8 +218,16 @@ function buildTrackNodes(tracks: EditorTrack[]): void {
     gain.gain.value = effectiveVol(t, anySolo);
     const panner = ctx.createStereoPanner();
     panner.pan.value = clamp(t.pan, -1, 1);
-    gain.connect(panner).connect(master);
-    trackNodes.set(t.id, { gain, panner });
+    const chain = t.fxChain ?? [];
+    const fx = buildEffectChain(ctx, gain, panner, chain); // wires gain -> [fx] -> panner
+    panner.connect(dest);
+    trackNodes.set(t.id, {
+      gain,
+      panner,
+      fx,
+      fxFullSig: JSON.stringify(chain),
+      fxTopoSig: chainTopoSig(chain),
+    });
   }
 }
 
@@ -200,6 +294,76 @@ function scheduleClips(clips: AudioClip[], fromSec: number): void {
       try { src.disconnect(); clipGain.disconnect(); } catch { /* already gone */ }
     };
     sources.push(src);
+  }
+}
+
+/** Onset-sliced chunks for a clip's decoded buffer (cached by Blob identity). */
+function chunksFor(clip: AudioClip): AudioChunk[] {
+  const buf = decodeCache.get(clip.audioBlob);
+  if (!buf) return [];
+  let chunks = analysisCache.get(clip.audioBlob);
+  if (!chunks) {
+    chunks = sliceChunks(buf);
+    analysisCache.set(clip.audioBlob, chunks);
+  }
+  return chunks;
+}
+
+/**
+ * For every track whose spatializer is in Teleport mode, slice that track's clips
+ * on their onsets and schedule one panner jump per chunk — the position comes from
+ * the chunk's loudness (closer when louder) and brightness (higher when brighter),
+ * spread by the effect's Depth. Runs after scheduleClips, on every (re)start; the
+ * golden-angle index advances across passed chunks too, so a mid-timeline start
+ * lands the same positions a from-zero play would.
+ */
+function scheduleTeleports(clips: AudioClip[], fromSec: number): void {
+  const ctx = getEngineCtx();
+  const now = ctx.currentTime;
+  const tracks = useEditorStore.getState().tracks;
+  for (const t of tracks) {
+    const chain = t.fxChain ?? [];
+    const teleEntries = chain.filter(
+      (e) =>
+        e.enabled &&
+        e.effect === 'spatializer' &&
+        Math.round(e.params?.motion ?? 0) === SPATIAL_TELEPORT,
+    );
+    if (teleEntries.length === 0) continue;
+    const nodes = trackNodes.get(t.id);
+    if (!nodes) continue;
+    const insts = nodes.fx.instances();
+    const trackClips = clips.filter(
+      (c) => c.trackId === t.id && !(liveMidiActive && isMidiClip(c)),
+    );
+
+    for (const entry of teleEntries) {
+      const li = insts.find((x) => x.id === entry.id);
+      if (!li?.inst.scheduleTeleport) continue;
+      const spread = entry.params?.motionDepth ?? 5;
+      const events: { when: number; x: number; y: number; z: number }[] = [];
+      let idx = 0;
+      for (const clip of trackClips) {
+        const buf = decodeCache.get(clip.audioBlob);
+        if (!buf) continue;
+        const offset = Math.min(clip.offsetIntoSource, Math.max(0, buf.duration - 0.01));
+        const dur = Math.min(clip.durationSec, buf.duration - offset);
+        if (dur <= 0) continue;
+        for (const chunk of chunksFor(clip)) {
+          if (chunk.tSec < offset || chunk.tSec >= offset + dur) continue;
+          const timelineSec = clip.startSec + (chunk.tSec - offset);
+          if (timelineSec < fromSec - 0.001) { idx += 1; continue; } // already passed
+          const pos = teleportXYZ(idx, chunk.loudness, chunk.brightness, spread);
+          const whenCtx = startCtxTime + (timelineSec - startOffsetSec);
+          events.push({ when: Math.max(whenCtx, now), x: pos.x, y: pos.y, z: pos.z });
+          idx += 1;
+        }
+      }
+      if (events.length > 0) {
+        events.sort((a, b) => a.when - b.when);
+        li.inst.scheduleTeleport(events);
+      }
+    }
   }
 }
 
@@ -350,12 +514,14 @@ async function start(fromSec: number): Promise<void> {
   // meantime may have cleared it via playerStore.load().
   setLiveTransport({ play, pause, stop, seek });
 
+  buildMasterBus();
   buildTrackNodes(ed.tracks);
   startCtxTime = ctx.currentTime;
   startOffsetSec = begin;
   lastTimePush = 0;
   lastMixSig = mixSignature(ed.tracks);
   scheduleClips(clips, begin);
+  scheduleTeleports(clips, begin);
   if (liveMidiActive) scheduleMidiClips(clips, begin);
 
   playing = true;
@@ -374,9 +540,12 @@ async function start(fromSec: number): Promise<void> {
     unsubEditor = useEditorStore.subscribe(() => {
       if (!playing) return;
       const sig = mixSignature(useEditorStore.getState().tracks);
-      if (sig === lastMixSig) return;
-      lastMixSig = sig;
-      applyMixLive();
+      if (sig !== lastMixSig) {
+        lastMixSig = sig;
+        applyMixLive();
+      }
+      applyMasterChainLive(); // live master rack edits (add/remove/reorder/param)
+      applyTrackChainsLive(); // live per-track rack edits
     });
   }
 
@@ -445,9 +614,11 @@ export function dispose(): void {
   stopClock();
   playing = false;
   if (unsubEditor) { unsubEditor(); unsubEditor = null; }
-  for (const n of trackNodes.values()) {
-    try { n.gain.disconnect(); n.panner.disconnect(); } catch { /* gone */ }
-  }
+  disposeTrackNodes();
   trackNodes = new Map();
+  if (masterChain) { masterChain.dispose(); masterChain = null; }
+  if (masterBus) { try { masterBus.disconnect(); } catch { /* gone */ } masterBus = null; }
+  lastMasterSig = '';
+  lastMasterFullSig = '';
   setLiveTransport(null);
 }

--- a/frontend/src/state/morphEngine.ts
+++ b/frontend/src/state/morphEngine.ts
@@ -1,0 +1,219 @@
+/**
+ * morphEngine — main-thread controller for the granular identity-bleed morph
+ * (Phase M). Holds the AudioWorkletNode, loads donor A + host B from the library,
+ * builds their corpus/target tables (morphCorpus), pushes them and the live params
+ * into the audio thread (granular-morph.worklet.js), and routes the output through
+ * the shared engine master so the HUD/visualizer keep working.
+ *
+ * The panel (MetamorphPanel) is the only consumer; it binds to this Zustand store.
+ * The audio node + decoded buffers live as module singletons (one morph at a time).
+ */
+
+import { create } from 'zustand';
+import { getEngineCtx, getMasterGain } from './playerStore';
+import { logError, logInfo } from './logStore';
+import { buildCorpus, buildTarget, type MorphCorpus, type MorphTarget } from '../lib/morphCorpus';
+import { encodeWav } from '../lib/wavEncode';
+
+export interface MorphParams {
+  bleed: number;     // 0 = dry host, 1 = full A-mosaic
+  grainSize: number; // seconds
+  grainRate: number; // grains / second
+  spray: number;     // 0..1 start + timing jitter
+  match: number;     // 0..1 selection strictness (loose = more of A bleeds through)
+  sync: number;      // 0 = free clock, 1 = lock grains to host B's beat grid
+  favor: number;     // 0..1 bias toward salient (punchy/cool) donor grains
+  gain: number;      // output trim
+}
+
+const DEFAULT_PARAMS: MorphParams = {
+  bleed: 0.6, grainSize: 0.12, grainRate: 24, spray: 0.2, match: 0.7, sync: 0.5, favor: 0.4, gain: 0.9,
+};
+
+// ---- module singletons (audio graph + decoded sources) ----------------------
+let node: AudioWorkletNode | null = null;
+let outGain: GainNode | null = null;
+let moduleP: Promise<void> | null = null;
+let corpus: MorphCorpus | null = null;
+let target: MorphTarget | null = null;
+let loadedAId: string | null = null;
+let loadedBId: string | null = null;
+let sentAId: string | null = null; // which corpus the worklet currently holds
+let sentBId: string | null = null;
+
+function ensureModule(ctx: AudioContext): Promise<void> {
+  if (!moduleP) {
+    moduleP = ctx.audioWorklet.addModule('/granular-morph.worklet.js').catch((e) => {
+      moduleP = null; // allow a later retry
+      throw e;
+    });
+  }
+  return moduleP;
+}
+
+/** A morph source: an audio blob with a stable id + label. The panel resolves
+ *  these from editor clips (blob already in memory) or library entries (fetched),
+ *  so A and B can be sounds that are already on the timeline. */
+export interface MorphSource {
+  id: string;
+  title: string;
+  blob: Blob;
+}
+
+async function decodeBlob(blob: Blob): Promise<AudioBuffer> {
+  const ab = await blob.arrayBuffer();
+  return getEngineCtx().decodeAudioData(ab.slice(0));
+}
+
+function sendParams(p: MorphParams): void {
+  node?.port.postMessage({ type: 'params', ...p });
+}
+
+interface MorphState {
+  aId: string | null; aTitle: string;
+  bId: string | null; bTitle: string;
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  playing: boolean;
+  posSec: number; durSec: number;
+  params: MorphParams;
+  loadA: (source: MorphSource) => Promise<void>;
+  loadB: (source: MorphSource) => Promise<void>;
+  play: () => Promise<void>;
+  stop: () => void;
+  setParam: (k: keyof MorphParams, v: number) => void;
+  /** Offline-render one pass of the current morph to a WAV blob, or null if A/B
+   *  aren't both loaded. The panel drops the result onto the timeline. */
+  renderToBlob: () => Promise<Blob | null>;
+  dispose: () => void;
+}
+
+export const useMorphStore = create<MorphState>()((set, get) => ({
+  aId: null, aTitle: '',
+  bId: null, bTitle: '',
+  status: 'idle',
+  playing: false,
+  posSec: 0, durSec: 0,
+  params: { ...DEFAULT_PARAMS },
+
+  loadA: async (source) => {
+    set({ status: 'loading', aId: source.id, aTitle: source.title });
+    try {
+      const buf = await decodeBlob(source.blob);
+      corpus = buildCorpus(buf);
+      loadedAId = source.id;
+      logInfo('editor', `Metamorph: donor "${source.title}" -> ${corpus.count} grains`);
+      set({ status: corpus && target ? 'ready' : 'idle' });
+    } catch (e) {
+      logError('editor', `Metamorph donor load failed: ${e instanceof Error ? e.message : String(e)}`);
+      set({ status: 'error' });
+    }
+  },
+
+  loadB: async (source) => {
+    set({ status: 'loading', bId: source.id, bTitle: source.title });
+    try {
+      const buf = await decodeBlob(source.blob);
+      target = buildTarget(buf);
+      loadedBId = source.id;
+      set({ status: corpus && target ? 'ready' : 'idle', durSec: buf.duration });
+    } catch (e) {
+      logError('editor', `Metamorph host load failed: ${e instanceof Error ? e.message : String(e)}`);
+      set({ status: 'error' });
+    }
+  },
+
+  play: async () => {
+    if (!corpus || !target) {
+      logError('editor', 'Metamorph: pick a donor (A) and a host (B) first');
+      return;
+    }
+    const ctx = getEngineCtx();
+    if (ctx.state === 'suspended') { try { await ctx.resume(); } catch { /* retry on gesture */ } }
+    try {
+      await ensureModule(ctx);
+    } catch (e) {
+      logError('editor', `Metamorph worklet unavailable: ${e instanceof Error ? e.message : String(e)}`);
+      set({ status: 'error' });
+      return;
+    }
+    if (!node) {
+      node = new AudioWorkletNode(ctx, 'granular-morph', { numberOfInputs: 0, outputChannelCount: [2] });
+      outGain = ctx.createGain();
+      node.connect(outGain).connect(getMasterGain());
+      node.port.onmessage = (e) => { if (e.data?.type === 'pos') set({ posSec: e.data.sec }); };
+      sentAId = null; sentBId = null;
+    }
+    if (corpus && sentAId !== loadedAId) {
+      node.port.postMessage({
+        type: 'loadA', pcm: corpus.pcm, count: corpus.count,
+        gOffset: corpus.gOffset, gLoud: corpus.gLoud, gBright: corpus.gBright, gSal: corpus.gSal,
+      });
+      sentAId = loadedAId;
+    }
+    if (target && sentBId !== loadedBId) {
+      node.port.postMessage({
+        type: 'loadB', pcm: target.pcm, frameHop: target.frameHop,
+        frames: target.frames, fLoud: target.fLoud, fBright: target.fBright, onsets: target.onsets,
+      });
+      sentBId = loadedBId;
+    }
+    sendParams(get().params);
+    node.port.postMessage({ type: 'play', on: true });
+    set({ playing: true, status: 'ready' });
+  },
+
+  stop: () => {
+    node?.port.postMessage({ type: 'play', on: false });
+    set({ playing: false });
+  },
+
+  setParam: (k, v) => {
+    const params = { ...get().params, [k]: v };
+    set({ params });
+    if (node) node.port.postMessage({ type: 'params', [k]: v });
+  },
+
+  renderToBlob: async () => {
+    if (!corpus || !target) { logError('editor', 'Metamorph: load A + B before sending to editor'); return null; }
+    const sr = getEngineCtx().sampleRate; // corpus/target PCM is already at this rate
+    const frames = target.pcm.length;
+    if (frames <= 0) return null;
+    const offline = new OfflineAudioContext(2, frames, sr);
+    try {
+      await offline.audioWorklet.addModule('/granular-morph.worklet.js');
+    } catch (e) {
+      logError('editor', `Metamorph render worklet failed: ${e instanceof Error ? e.message : String(e)}`);
+      return null;
+    }
+    // Seed via processorOptions (reaches the worklet constructor before the first
+    // process() call). Port messages posted before startRendering() race the offline
+    // render and arrive too late — proven live — which rendered a silent/blank clip.
+    const n = new AudioWorkletNode(offline, 'granular-morph', {
+      numberOfInputs: 0,
+      outputChannelCount: [2],
+      processorOptions: {
+        a: {
+          pcm: corpus.pcm, count: corpus.count,
+          gOffset: corpus.gOffset, gLoud: corpus.gLoud, gBright: corpus.gBright, gSal: corpus.gSal,
+        },
+        b: {
+          pcm: target.pcm, frameHop: target.frameHop,
+          frames: target.frames, fLoud: target.fLoud, fBright: target.fBright, onsets: target.onsets,
+        },
+        params: { ...get().params, loop: false }, // one pass, then it ends
+        play: true,
+      },
+    });
+    n.connect(offline.destination);
+    const rendered = await offline.startRendering();
+    return encodeWav(rendered);
+  },
+
+  dispose: () => {
+    if (node) { try { node.port.postMessage({ type: 'play', on: false }); node.disconnect(); } catch { /* gone */ } }
+    if (outGain) { try { outGain.disconnect(); } catch { /* gone */ } }
+    node = null; outGain = null;
+    sentAId = null; sentBId = null;
+    set({ playing: false });
+  },
+}));


### PR DESCRIPTION
feat(edit): real-time psychoacoustic FX rack, granular morph, spatializer

Add a context-agnostic insert-effect engine (rackEffects.ts) that builds the
same node subgraph for live preview and the offline bounce: crossfeed,
missing-fundamental bass, true M/S widening, aural excitation, HRTF
spatialization, and an equal-loudness contour. Master-bus and per-track FX
chains route through liveMixer with a topology-signature reconcile, so param
moves push into the running nodes without a rebuild and only the editor mix is
processed (library/DJ/sequencer audio is untouched).

Add the granular identity-bleed morph (Phase M): donor A is indexed into a
grain corpus and host B's onsets drive grain selection inside
granular-morph.worklet.js, controlled from MetamorphPanel via morphEngine.
Add SpatializerPad with onset-sliced Teleport motion backed by the FFT-free,
time-domain analysis in audioAnalysis.ts. editorStore carries the master and
per-track chain state; wavEncode renders a morph pass back into a timeline clip.

fix(media): build large blobs from arrayBuffer; readable instrument dropdown

fetchRetry now constructs the Blob from an in-memory ArrayBuffer rather than
res.blob(). On a large body Chrome materializes res.blob() into its disk-backed
Blob store, and when the disk is constrained that write fails with
net::ERR_FAILED after a 200, surfacing here as "Failed to fetch". Verified live:
a 66 MB WAV fails every time via res.blob() and succeeds every time via
new Blob([arrayBuffer]).

Also restyle the MIDI InstrumentPicker dropdown for a dark color scheme so the
native option list stays legible.