### PR TITLE
feat(edit): MPC chop effect (stutter / beat-repeat / shuffle)

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-21T12:25:39.805Z · Git revision: `b39522426797` · Repomix tracked: **no**
+> Generated: 2026-06-21T13:46:59.231Z · Git revision: `5c0f0f7d8ad9` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-21T12:25:39.805Z",
-  "repoRevision": "b39522426797",
+  "generatedAt": "2026-06-21T13:46:59.231Z",
+  "repoRevision": "5c0f0f7d8ad9",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T12:27:24.066Z",
+  "generatedAt": "2026-06-21T13:48:50.581Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/public/chop.worklet.js
+++ b/frontend/public/chop.worklet.js
@@ -1,0 +1,102 @@
+/**
+ * chop.worklet.js - an MPC-style buffer chop processor for the EDIT FX rack.
+ *
+ * Keeps a rolling ring buffer of recent stereo input. On each trigger (rate per
+ * second) it captures a slice and loops it for the period, so the output is the
+ * input re-chopped in real time:
+ *   program 0 = stutter      : re-capture the most recent slice every trigger.
+ *   program 1 = beat-repeat  : capture once, repeat the held slice for 4 triggers.
+ *   program 2 = shuffle      : jump to a random earlier slice every trigger.
+ * `slice` sets the slice length as a fraction of the trigger period; `mix`
+ * crossfades dry against the chopped signal.
+ *
+ * Parameters are AudioParams (k-rate), so they are set from rackEffects via
+ * setValueAtTime / setTargetAtTime and apply deterministically in both the live
+ * context and the offline bounce (no port-message race).
+ */
+
+class ChopProcessor extends AudioWorkletProcessor {
+  static get parameterDescriptors() {
+    return [
+      { name: 'program', defaultValue: 0, minValue: 0, maxValue: 2, automationRate: 'k-rate' },
+      { name: 'rate', defaultValue: 8, minValue: 0.5, maxValue: 32, automationRate: 'k-rate' },
+      { name: 'slice', defaultValue: 0.5, minValue: 0.05, maxValue: 1, automationRate: 'k-rate' },
+      { name: 'mix', defaultValue: 1, minValue: 0, maxValue: 1, automationRate: 'k-rate' },
+    ];
+  }
+
+  constructor() {
+    super();
+    this.bufLen = Math.ceil(sampleRate * 2); // 2 seconds of history
+    this.bufL = new Float32Array(this.bufLen);
+    this.bufR = new Float32Array(this.bufLen);
+    this.writePos = 0;
+    this.phase = 0; // samples remaining until the next trigger
+    this.sliceStart = 0; // ring index where the current slice begins
+    this.sliceLen = 1; // current slice length in samples
+    this.readOff = 0; // playback offset within the slice
+    this.trig = 0; // trigger counter (for beat-repeat hold)
+    this.seed = 22222; // deterministic PRNG so the bounce matches the preview
+  }
+
+  rng() {
+    this.seed = (this.seed * 1664525 + 1013904223) >>> 0;
+    return this.seed / 4294967296;
+  }
+
+  process(inputs, outputs, params) {
+    const output = outputs[0];
+    if (!output || output.length === 0) return true;
+    const input = inputs[0];
+    const inL = input && input[0] ? input[0] : null;
+    const inR = input && input[1] ? input[1] : inL;
+    const outL = output[0];
+    const outR = output[1] || output[0];
+    const n = outL.length;
+
+    const program = Math.round(params.program[0]);
+    const rate = params.rate[0];
+    const sliceFrac = params.slice[0];
+    const mix = params.mix[0];
+    const period = Math.max(64, Math.floor(sampleRate / Math.max(0.5, rate)));
+
+    for (let i = 0; i < n; i += 1) {
+      const xl = inL ? inL[i] : 0;
+      const xr = inR ? inR[i] : xl;
+
+      this.bufL[this.writePos] = xl;
+      this.bufR[this.writePos] = xr;
+
+      if (this.phase <= 0) {
+        this.phase = period;
+        this.sliceLen = Math.max(32, Math.min(this.bufLen - 1, Math.floor(period * Math.max(0.05, Math.min(1, sliceFrac)))));
+        const recapture = program !== 1 || this.trig % 4 === 0;
+        if (recapture) {
+          if (program === 2) {
+            const back = Math.floor((0.1 + 0.85 * this.rng()) * (this.bufLen - this.sliceLen));
+            this.sliceStart = (this.writePos - back + this.bufLen) % this.bufLen;
+          } else {
+            this.sliceStart = (this.writePos - this.sliceLen + this.bufLen) % this.bufLen;
+          }
+        }
+        this.readOff = 0; // restart the slice each period for a clean rhythmic repeat
+        this.trig += 1;
+      }
+
+      const rp = (this.sliceStart + (this.readOff % this.sliceLen) + this.bufLen) % this.bufLen;
+      const wl = this.bufL[rp];
+      const wr = this.bufR[rp];
+
+      outL[i] = xl * (1 - mix) + wl * mix;
+      if (outR) outR[i] = xr * (1 - mix) + wr * mix;
+
+      this.readOff += 1;
+      this.phase -= 1;
+      this.writePos = (this.writePos + 1) % this.bufLen;
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('chop-processor', ChopProcessor);

--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -8,7 +8,7 @@ import { addBlobsToChimera } from '../../lib/chimeraClient';
 import { SlideTrack } from './SlideTrack';
 import { FxRack } from './FxRack';
 import { MetamorphPanel } from './MetamorphPanel';
-import { RACK_EFFECTS, buildEffectChain, teleportXYZ, SPATIAL_TELEPORT, type ChainHandle } from '../../lib/rackEffects';
+import { RACK_EFFECTS, buildEffectChain, ensureChopModule, teleportXYZ, SPATIAL_TELEPORT, type ChainHandle } from '../../lib/rackEffects';
 import { sliceChunks } from '../../lib/audioAnalysis';
 import { encodeWav } from '../../lib/wavEncode';
 import type { AudioDragItem } from '../../lib/audioDnD';
@@ -387,6 +387,13 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   const [inpaintPrompt, setInpaintPrompt] = useState('');
   const [inpaintSteps, setInpaintSteps] = useState(8);
   const [inpaintSeed, setInpaintSeed] = useState(-1);
+
+  // Preload the chop worklet on the live engine context so a Chop insert builds
+  // its real worklet node the first time playback starts (instead of one silent
+  // passthrough play while the module loads).
+  useEffect(() => {
+    void ensureChopModule(getEngineCtx()).catch(() => {});
+  }, []);
 
   // Revoke the object URL when the review phase ends or the panel closes.
   useEffect(() => {
@@ -928,6 +935,15 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
       } finally {
         decodeCtx.close().catch(() => {});
       }
+      // If any enabled insert chain uses the chop worklet, register it on the
+      // offline context first so the bounce builds the real node (the factory
+      // would otherwise fall back to passthrough and the chop would not bake in).
+      const usesChop = [masterFxChain, ...tracks.map((t) => t.fxChain ?? [])]
+        .some((ch) => ch.some((e) => e.effect === 'chop' && e.enabled));
+      if (usesChop) {
+        try { await ensureChopModule(offline); } catch { /* falls back to passthrough */ }
+      }
+
       // Master bus + insert rack -> destination, mirroring liveMixer's routing so
       // the bounce carries the SAME psychoacoustic FX the user hears in preview.
       const masterBus = offline.createGain();

--- a/frontend/src/lib/rackEffects.ts
+++ b/frontend/src/lib/rackEffects.ts
@@ -978,6 +978,76 @@ const makeRingMod: RackEffectFactory = (ctx, params) => {
   };
 };
 
+/* ── 11. Chop (MPC-style buffer chop, worklet) ─────────────────────────────────
+   Stutter / beat-repeat / shuffle by re-looping a rolling buffer. The DSP lives
+   in a worklet (public/chop.worklet.js), so the module must be registered on the
+   context before the node is built; ensureChopModule caches that per context
+   (the editor preloads it on the live context, and commitEdit awaits it on the
+   offline context). If the module is not ready yet, the factory degrades to a
+   clean passthrough and kicks off the load so the next build gets the real node. */
+const chopModuleByCtx = new WeakMap<BaseAudioContext, Promise<void>>();
+export const ensureChopModule = (ctx: BaseAudioContext): Promise<void> => {
+  let p = chopModuleByCtx.get(ctx);
+  if (!p) {
+    p = ctx.audioWorklet.addModule('/chop.worklet.js').catch((e) => {
+      chopModuleByCtx.delete(ctx);
+      throw e;
+    });
+    chopModuleByCtx.set(ctx, p);
+  }
+  return p;
+};
+
+const makeChop: RackEffectFactory = (ctx, params) => {
+  const input = ctx.createGain();
+  const output = ctx.createGain();
+  let node: AudioWorkletNode | null = null;
+  try {
+    node = new AudioWorkletNode(ctx, 'chop-processor', {
+      numberOfInputs: 1,
+      numberOfOutputs: 1,
+      outputChannelCount: [2],
+    });
+  } catch {
+    node = null; // module not registered on this context yet
+  }
+
+  if (!node) {
+    input.connect(output); // passthrough; load the module for the next build
+    void ensureChopModule(ctx).catch(() => {});
+    return {
+      input,
+      output,
+      setParams: () => {},
+      dispose: () => { try { input.disconnect(); output.disconnect(); } catch { /* gone */ } },
+    };
+  }
+
+  const chop = node;
+  input.connect(chop).connect(output);
+  const apply = (p: Record<string, number>) => {
+    const prog = chop.parameters.get('program');
+    if (prog) prog.setValueAtTime(Math.round(clamp(p.program ?? 0, 0, 2)), ctx.currentTime);
+    const set = (key: string, v: number) => {
+      const ap = chop.parameters.get(key);
+      if (ap) ap.setTargetAtTime(v, ctx.currentTime, 0.01);
+    };
+    set('rate', clamp(p.rate ?? 8, 0.5, 32));
+    set('slice', clamp(p.slice ?? 0.5, 0.05, 1));
+    set('mix', clamp(p.mix ?? 1, 0, 1));
+  };
+  apply(params);
+
+  return {
+    input,
+    output,
+    setParams: (p) => apply(p),
+    dispose: () => {
+      try { input.disconnect(); output.disconnect(); chop.disconnect(); } catch { /* gone */ }
+    },
+  };
+};
+
 /* ── registry ──────────────────────────────────────────────────────────────── */
 
 export const RACK_EFFECTS: readonly RackEffectDef[] = [
@@ -1101,6 +1171,19 @@ export const RACK_EFFECTS: readonly RackEffectDef[] = [
       { key: 'mix', label: 'Mix', min: 0, max: 1, step: 0.01, default: 1 },
     ],
     make: makeRingMod,
+  },
+  {
+    id: 'chop',
+    label: 'Chop',
+    group: 'Performance',
+    description: 'MPC-style buffer chop: stutter (0), beat-repeat (1), shuffle (2).',
+    params: [
+      { key: 'program', label: 'Program', min: 0, max: 2, step: 1, default: 0 },
+      { key: 'rate', label: 'Rate', min: 0.5, max: 32, step: 0.5, default: 8, unit: 'Hz' },
+      { key: 'slice', label: 'Slice', min: 0.05, max: 1, step: 0.01, default: 0.5 },
+      { key: 'mix', label: 'Mix', min: 0, max: 1, step: 0.01, default: 1 },
+    ],
+    make: makeChop,
   },
 ];
 


### PR DESCRIPTION
Add a buffer-chop insert backed by an AudioWorklet (public/chop.worklet.js): a rolling 2-second ring buffer re-loops captured slices in real time. Programs: stutter (re-capture each trigger), beat-repeat (hold a slice for four triggers), shuffle (jump to a random earlier slice). Rate, slice length, and mix are AudioParams, so they apply deterministically in both the live context and the offline bounce (no port-message race).

The worklet module is registered per context: the editor preloads it on the live engine context at mount, and COMMIT EDIT awaits it on the offline context when a chop is in use, so the effect bakes into the export. If the module is not ready, the factory degrades to a clean passthrough and loads it for the next build.