### PR TITLE
Feat/edit automation

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-21T13:46:59.231Z · Git revision: `5c0f0f7d8ad9` · Repomix tracked: **no**
+> Generated: 2026-06-21T14:15:23.936Z · Git revision: `a580ea8e857b` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-21T14:15:23.936Z · Git revision: `a580ea8e857b` · Repomix tracked: **no**
+> Generated: 2026-06-21T14:40:09.880Z · Git revision: `62edab5b45f3` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-21T14:15:23.936Z",
-  "repoRevision": "a580ea8e857b",
+  "generatedAt": "2026-06-21T14:40:09.880Z",
+  "repoRevision": "62edab5b45f3",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-21T13:46:59.231Z",
-  "repoRevision": "5c0f0f7d8ad9",
+  "generatedAt": "2026-06-21T14:15:23.936Z",
+  "repoRevision": "a580ea8e857b",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T14:17:08.206Z",
+  "generatedAt": "2026-06-21T14:41:45.935Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T13:48:50.581Z",
+  "generatedAt": "2026-06-21T14:17:08.206Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -8,12 +8,12 @@ import { addBlobsToChimera } from '../../lib/chimeraClient';
 import { SlideTrack } from './SlideTrack';
 import { FxRack } from './FxRack';
 import { MetamorphPanel } from './MetamorphPanel';
-import { RACK_EFFECTS, buildEffectChain, ensureChopModule, teleportXYZ, SPATIAL_TELEPORT, type ChainHandle } from '../../lib/rackEffects';
+import { RACK_EFFECTS, getRackEffect, buildEffectChain, ensureChopModule, teleportXYZ, SPATIAL_TELEPORT, type ChainHandle } from '../../lib/rackEffects';
 import { sliceChunks } from '../../lib/audioAnalysis';
 import { encodeWav } from '../../lib/wavEncode';
 import type { AudioDragItem } from '../../lib/audioDnD';
 import { useExternalDragStore } from '../../state/externalDragStore';
-import { useEditorStore, computePeaks, type AudioClip, type EditorTrack, type SnapDivision } from '../../state/editorStore';
+import { useEditorStore, computePeaks, type AudioClip, type EditorTrack, type SnapDivision, type AutomationTarget } from '../../state/editorStore';
 import { useLibraryStore } from '../../state/libraryStore';
 import { usePlaybackStore } from '../../state/playbackStore';
 import { getEngineCtx, getMasterGain, usePlayerStore } from '../../state/playerStore';
@@ -325,6 +325,32 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
       const target = { kind, trackId };
       recordAutomationPoint(target, liveMixer.currentTransportSec(), v);
       liveMixer.automationTouchNative(target, v);
+    }
+  };
+
+  // Apply an FX param change, and while writing + playing, record each param key
+  // that actually changed into its own lane (a KAOSS drag moves x and y at once,
+  // so both are captured). Playback is driven by the FX lookahead writer.
+  const writeFxParams = (
+    scope: { kind: 'master' } | { kind: 'track'; trackId: string },
+    entryId: string,
+    p: Record<string, number>,
+  ) => {
+    const prev =
+      scope.kind === 'master'
+        ? masterFxChain.find((e) => e.id === entryId)?.params
+        : tracks.find((t) => t.id === scope.trackId)?.fxChain?.find((e) => e.id === entryId)?.params;
+    if (scope.kind === 'master') updateMasterEffectParams(entryId, p);
+    else updateTrackEffectParams(scope.trackId, entryId, p);
+    if (!automationWrite || !liveMixer.isPlaying() || !prev) return;
+    const t = liveMixer.currentTransportSec();
+    for (const key of Object.keys(p)) {
+      if (prev[key] === p[key]) continue;
+      const target: AutomationTarget =
+        scope.kind === 'master'
+          ? { kind: 'masterFx', entryId, paramKey: key }
+          : { kind: 'trackFx', trackId: scope.trackId, entryId, paramKey: key };
+      recordAutomationPoint(target, t, p[key]);
     }
   };
   const addMasterEffect = useEditorStore((s) => s.addMasterEffect);
@@ -1698,7 +1724,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
                 onRemove={removeMasterEffect}
                 onReorder={reorderMasterEffect}
                 onToggle={toggleMasterEffect}
-                onUpdateParams={updateMasterEffectParams}
+                onUpdateParams={(id, p) => writeFxParams({ kind: 'master' }, id, p)}
               />
             </section>
           )}
@@ -1748,7 +1774,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               onRemove={(id) => removeTrackEffect(t.id, id)}
               onReorder={(from, to) => reorderTrackEffect(t.id, from, to)}
               onToggle={(id) => toggleTrackEffect(t.id, id)}
-              onUpdateParams={(id, p) => updateTrackEffectParams(t.id, id, p)}
+              onUpdateParams={(id, p) => writeFxParams({ kind: 'track', trackId: t.id }, id, p)}
             />
           </div>
         );
@@ -2070,16 +2096,28 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               );
             })}
 
-            {/* Automation lanes (read-only curve over each track; volume green, pan blue) */}
+            {/* Automation lanes (read-only curve per track: volume green, pan blue, FX amber).
+                Master-FX lanes still record and play; they are not drawn on a track row. */}
             {automationLanes.map((lane) => {
               if (lane.points.length === 0) return null;
-              if (lane.target.kind !== 'trackVolume' && lane.target.kind !== 'trackPan') return null;
+              const tk = lane.target.kind;
+              if (tk !== 'trackVolume' && tk !== 'trackPan' && tk !== 'trackFx') return null;
               const trackIdx = tracks.findIndex((t) => t.id === lane.target.trackId);
               if (trackIdx < 0) return null;
-              const isPan = lane.target.kind === 'trackPan';
-              const color = isPan ? '#60a5fa' : '#34d399';
-              const norm = (v: number) => (isPan ? (Math.max(-1, Math.min(1, v)) + 1) / 2 : Math.max(0, Math.min(1, v)));
-              const yOf = (v: number) => (1 - norm(v)) * TRACK_HEIGHT;
+              let color = '#34d399';
+              let toNorm = (v: number) => Math.max(0, Math.min(1, v));
+              if (tk === 'trackPan') {
+                color = '#60a5fa';
+                toNorm = (v: number) => (Math.max(-1, Math.min(1, v)) + 1) / 2;
+              } else if (tk === 'trackFx') {
+                const entry = tracks[trackIdx]?.fxChain?.find((e) => e.id === lane.target.entryId);
+                const desc = entry ? getRackEffect(entry.effect)?.params.find((pp) => pp.key === lane.target.paramKey) : undefined;
+                if (!desc) return null;
+                const span = Math.max(1e-6, desc.max - desc.min);
+                color = '#f59e0b';
+                toNorm = (v: number) => Math.max(0, Math.min(1, (v - desc.min) / span));
+              }
+              const yOf = (v: number) => (1 - toNorm(v)) * TRACK_HEIGHT;
               const pts = lane.points.map((p) => `${(p.t * zoom).toFixed(1)},${yOf(p.v).toFixed(1)}`).join(' ');
               return (
                 <svg

--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -311,6 +311,22 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   const setInpaintSelection = useEditorStore((s) => s.setInpaintSelection);
   const clearInpaintSelection = useEditorStore((s) => s.clearInpaintSelection);
   const masterFxChain = useEditorStore((s) => s.masterFxChain);
+  const automationWrite = useEditorStore((s) => s.automationWrite);
+  const setAutomationWrite = useEditorStore((s) => s.setAutomationWrite);
+  const recordAutomationPoint = useEditorStore((s) => s.recordAutomationPoint);
+  const automationLanes = useEditorStore((s) => s.automationLanes);
+
+  // Move a track fader. While automation write is on and the transport is rolling,
+  // the move records a breakpoint (timestamped off the audio clock) and is driven
+  // onto the live param so it is heard as it is recorded.
+  const writeFader = (kind: 'trackVolume' | 'trackPan', trackId: string, v: number) => {
+    updateTrack(trackId, kind === 'trackVolume' ? { volume: v } : { pan: v });
+    if (automationWrite && liveMixer.isPlaying()) {
+      const target = { kind, trackId };
+      recordAutomationPoint(target, liveMixer.currentTransportSec(), v);
+      liveMixer.automationTouchNative(target, v);
+    }
+  };
   const addMasterEffect = useEditorStore((s) => s.addMasterEffect);
   const removeMasterEffect = useEditorStore((s) => s.removeMasterEffect);
   const reorderMasterEffect = useEditorStore((s) => s.reorderMasterEffect);
@@ -1590,6 +1606,17 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
           </button>
 
           <button
+            onClick={() => setAutomationWrite(!automationWrite)}
+            aria-pressed={automationWrite}
+            aria-label="Automation write"
+            title="Automation write: while playing, ride a track's volume or pan fader to record it; turn off to play it back"
+            className={`flex items-center gap-1.5 p-1 px-2 rounded border transition-colors text-[9px] font-mono uppercase tracking-wider
+              ${automationWrite ? 'bg-red-600/20 border-red-500/50 text-red-300' : 'border-white/5 text-zinc-500 hover:text-white hover:bg-white/5'}`}
+          >
+            <span className={`w-2 h-2 rounded-full ${automationWrite ? 'bg-red-500 animate-pulse' : 'bg-zinc-600'}`} /> WRITE
+          </button>
+
+          <button
             onClick={() => setShowMetamorph((v) => !v)}
             aria-pressed={showMetamorph}
             aria-label="Metamorph granular identity-bleed panel"
@@ -1810,12 +1837,12 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
                 <div className="flex items-center gap-1.5">
                   <Volume2 className="w-2.5 h-2.5 text-zinc-600 shrink-0" />
                   <SlideTrack min={0} max={1} step={0.01} value={t.volume}
-                    onChange={(v) => updateTrack(t.id, { volume: v })} className="flex-1" ariaLabel="Track volume" />
+                    onChange={(v) => writeFader('trackVolume', t.id, v)} className="flex-1" ariaLabel="Track volume" />
                 </div>
                 <div className="flex items-center gap-1.5">
                   <span className="text-[7px] font-mono text-zinc-600 uppercase w-3">P</span>
                   <SlideTrack min={-1} max={1} step={0.01} value={t.pan}
-                    onChange={(v) => updateTrack(t.id, { pan: v })} className="flex-1" ariaLabel="Track pan" />
+                    onChange={(v) => writeFader('trackPan', t.id, v)} className="flex-1" ariaLabel="Track pan" />
                   <span className="text-[7px] font-mono text-zinc-600 text-right w-5">
                     {t.pan > 0 ? `R${Math.round(t.pan * 100)}` : t.pan < 0 ? `L${Math.round(-t.pan * 100)}` : 'C'}
                   </span>
@@ -2040,6 +2067,33 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
                     <div className="absolute bottom-2 w-2 h-2 rounded-full bg-white/30 group-hover/fh:bg-white/70 transition-colors border border-white/40" />
                   </div>
                 </div>
+              );
+            })}
+
+            {/* Automation lanes (read-only curve over each track; volume green, pan blue) */}
+            {automationLanes.map((lane) => {
+              if (lane.points.length === 0) return null;
+              if (lane.target.kind !== 'trackVolume' && lane.target.kind !== 'trackPan') return null;
+              const trackIdx = tracks.findIndex((t) => t.id === lane.target.trackId);
+              if (trackIdx < 0) return null;
+              const isPan = lane.target.kind === 'trackPan';
+              const color = isPan ? '#60a5fa' : '#34d399';
+              const norm = (v: number) => (isPan ? (Math.max(-1, Math.min(1, v)) + 1) / 2 : Math.max(0, Math.min(1, v)));
+              const yOf = (v: number) => (1 - norm(v)) * TRACK_HEIGHT;
+              const pts = lane.points.map((p) => `${(p.t * zoom).toFixed(1)},${yOf(p.v).toFixed(1)}`).join(' ');
+              return (
+                <svg
+                  key={lane.id}
+                  className="absolute left-0 pointer-events-none"
+                  style={{ top: trackIdx * TRACK_HEIGHT, width: timelineWidthPx, height: TRACK_HEIGHT }}
+                  width={timelineWidthPx}
+                  height={TRACK_HEIGHT}
+                >
+                  <polyline points={pts} fill="none" stroke={color} strokeOpacity={0.7} strokeWidth={1.5} />
+                  {lane.points.map((p, i) => (
+                    <circle key={`${lane.id}-${i}`} cx={p.t * zoom} cy={yOf(p.v)} r={2} fill={color} fillOpacity={0.85} />
+                  ))}
+                </svg>
               );
             })}
 

--- a/frontend/src/state/editorStore.ts
+++ b/frontend/src/state/editorStore.ts
@@ -69,6 +69,86 @@ export interface EditorTrack {
   fxChain?: ChainEntry[];
 }
 
+/* ── Automation (Phase E) ─────────────────────────────────────────────────────
+   A lane records a parameter's value over timeline time as breakpoints. Playback
+   schedules them ahead of the playhead: native AudioParam envelope for vol/pan
+   (sample-accurate), a lookahead writer for FX params. */
+export type AutomationTargetKind = 'trackVolume' | 'trackPan' | 'trackFx' | 'masterFx';
+
+export interface AutomationTarget {
+  kind: AutomationTargetKind;
+  /** Set for trackVolume / trackPan / trackFx. */
+  trackId?: string;
+  /** ChainEntry id, set for trackFx / masterFx. */
+  entryId?: string;
+  /** Effect param key, set for trackFx / masterFx. */
+  paramKey?: string;
+}
+
+/** One breakpoint: timeline seconds -> value (in the param's natural units). */
+export interface AutomationPoint {
+  t: number;
+  v: number;
+}
+
+export interface AutomationLane {
+  id: string;
+  target: AutomationTarget;
+  points: AutomationPoint[]; // kept sorted ascending by t
+  enabled: boolean;
+}
+
+/** Stable identity for a target, so a control resolves to its one lane. */
+export const automationTargetKey = (target: AutomationTarget): string =>
+  `${target.kind}|${target.trackId ?? ''}|${target.entryId ?? ''}|${target.paramKey ?? ''}`;
+
+/** Linear-interpolated lane value at time `t`; null when the lane has no points.
+ *  Holds the first/last value outside the breakpoint range. */
+export const sampleLane = (lane: AutomationLane, t: number): number | null => {
+  const pts = lane.points;
+  if (pts.length === 0) return null;
+  if (t <= pts[0].t) return pts[0].v;
+  const last = pts[pts.length - 1];
+  if (t >= last.t) return last.v;
+  let lo = 0;
+  let hi = pts.length - 1;
+  while (lo + 1 < hi) {
+    const mid = (lo + hi) >> 1;
+    if (pts[mid].t <= t) lo = mid;
+    else hi = mid;
+  }
+  const a = pts[lo];
+  const b = pts[hi];
+  const f = (t - a.t) / Math.max(1e-6, b.t - a.t);
+  return a.v + (b.v - a.v) * f;
+};
+
+/** Minimum spacing between recorded breakpoints (thins ~50 Hz gestures). */
+const MIN_POINT_DT = 0.02;
+
+/** Insert (or replace a near neighbor's value) keeping `points` sorted + thinned. */
+const upsertPoint = (points: AutomationPoint[], t: number, v: number): AutomationPoint[] => {
+  let lo = 0;
+  let hi = points.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (points[mid].t < t) lo = mid + 1;
+    else hi = mid;
+  }
+  const idx = lo;
+  const left = idx > 0 ? points[idx - 1] : null;
+  const right = idx < points.length ? points[idx] : null;
+  const next = points.slice();
+  if (left && t - left.t < MIN_POINT_DT) {
+    next[idx - 1] = { t: left.t, v };
+  } else if (right && right.t - t < MIN_POINT_DT) {
+    next[idx] = { t: right.t, v };
+  } else {
+    next.splice(idx, 0, { t, v });
+  }
+  return next;
+};
+
 interface EditorStoreState {
   tracks: EditorTrack[];
   clips: AudioClip[];
@@ -84,6 +164,10 @@ interface EditorStoreState {
   /** Master-bus insert FX chain (real-time psychoacoustic rack). Session-local —
    *  liveMixer routes the editor mix through it before the shared engine master. */
   masterFxChain: ChainEntry[];
+  /** Automation lanes (Phase E): one per automated parameter. */
+  automationLanes: AutomationLane[];
+  /** Write/arm mode: while on, moving an armed control during playback records. */
+  automationWrite: boolean;
 
   // Mutations
   addTrack: (overrides?: Partial<EditorTrack>) => string;
@@ -122,6 +206,17 @@ interface EditorStoreState {
   toggleTrackEffect: (trackId: string, entryId: string) => void;
   updateTrackEffectParams: (trackId: string, entryId: string, params: Record<string, number>) => void;
 
+  // Automation (Phase E)
+  setAutomationWrite: (on: boolean) => void;
+  recordAutomationPoint: (target: AutomationTarget, t: number, v: number) => void;
+  addAutomationPoint: (laneId: string, t: number, v: number) => void;
+  updateAutomationPoint: (laneId: string, index: number, t: number, v: number) => void;
+  removeAutomationPoint: (laneId: string, index: number) => void;
+  toggleAutomationLane: (laneId: string) => void;
+  clearAutomationLane: (laneId: string) => void;
+  removeAutomationLane: (laneId: string) => void;
+  getLaneForTarget: (target: AutomationTarget) => AutomationLane | undefined;
+
   // Selectors
   getTotalDurationSec: () => number;
   snapSec: (s: number) => number;
@@ -156,6 +251,8 @@ export const useEditorStore = create<EditorStoreState>()((set, get) => ({
   bpm: 120,
   inpaintSelection: null,
   masterFxChain: [],
+  automationLanes: [],
+  automationWrite: false,
 
   addTrack: (overrides) => {
     const id = `track-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
@@ -183,6 +280,7 @@ export const useEditorStore = create<EditorStoreState>()((set, get) => ({
     set((s) => ({
       tracks: s.tracks.filter((t) => t.id !== id),
       clips: s.clips.filter((c) => c.trackId !== id),
+      automationLanes: s.automationLanes.filter((l) => l.target.trackId !== id),
       selectedClipId: s.clips.some((c) => c.id === s.selectedClipId && c.trackId === id) ? null : s.selectedClipId,
     }));
     logInfo('editor', `Removed track: ${id}`);
@@ -295,7 +393,10 @@ export const useEditorStore = create<EditorStoreState>()((set, get) => ({
     })),
 
   removeMasterEffect: (entryId) =>
-    set((s) => ({ masterFxChain: s.masterFxChain.filter((e) => e.id !== entryId) })),
+    set((s) => ({
+      masterFxChain: s.masterFxChain.filter((e) => e.id !== entryId),
+      automationLanes: s.automationLanes.filter((l) => l.target.entryId !== entryId),
+    })),
 
   reorderMasterEffect: (from, to) =>
     set((s) => {
@@ -332,6 +433,7 @@ export const useEditorStore = create<EditorStoreState>()((set, get) => ({
       tracks: s.tracks.map((t) =>
         t.id === trackId ? { ...t, fxChain: (t.fxChain ?? []).filter((e) => e.id !== entryId) } : t,
       ),
+      automationLanes: s.automationLanes.filter((l) => l.target.entryId !== entryId),
     })),
 
   reorderTrackEffect: (trackId, from, to) =>
@@ -364,6 +466,72 @@ export const useEditorStore = create<EditorStoreState>()((set, get) => ({
           : t,
       ),
     })),
+
+  setAutomationWrite: (on) => set({ automationWrite: on }),
+
+  recordAutomationPoint: (target, t, v) =>
+    set((s) => {
+      const key = automationTargetKey(target);
+      const existing = s.automationLanes.find((l) => automationTargetKey(l.target) === key);
+      if (existing) {
+        return {
+          automationLanes: s.automationLanes.map((l) =>
+            l.id === existing.id ? { ...l, points: upsertPoint(l.points, t, v) } : l,
+          ),
+        };
+      }
+      return {
+        automationLanes: [
+          ...s.automationLanes,
+          { id: uid(), target, points: [{ t, v }], enabled: true },
+        ],
+      };
+    }),
+
+  addAutomationPoint: (laneId, t, v) =>
+    set((s) => ({
+      automationLanes: s.automationLanes.map((l) =>
+        l.id === laneId ? { ...l, points: upsertPoint(l.points, t, v) } : l,
+      ),
+    })),
+
+  updateAutomationPoint: (laneId, index, t, v) =>
+    set((s) => ({
+      automationLanes: s.automationLanes.map((l) => {
+        if (l.id !== laneId || index < 0 || index >= l.points.length) return l;
+        const without = l.points.filter((_, i) => i !== index);
+        return { ...l, points: upsertPoint(without, t, v) };
+      }),
+    })),
+
+  removeAutomationPoint: (laneId, index) =>
+    set((s) => ({
+      automationLanes: s.automationLanes.map((l) =>
+        l.id === laneId ? { ...l, points: l.points.filter((_, i) => i !== index) } : l,
+      ),
+    })),
+
+  toggleAutomationLane: (laneId) =>
+    set((s) => ({
+      automationLanes: s.automationLanes.map((l) =>
+        l.id === laneId ? { ...l, enabled: !l.enabled } : l,
+      ),
+    })),
+
+  clearAutomationLane: (laneId) =>
+    set((s) => ({
+      automationLanes: s.automationLanes.map((l) =>
+        l.id === laneId ? { ...l, points: [] } : l,
+      ),
+    })),
+
+  removeAutomationLane: (laneId) =>
+    set((s) => ({ automationLanes: s.automationLanes.filter((l) => l.id !== laneId) })),
+
+  getLaneForTarget: (target) => {
+    const key = automationTargetKey(target);
+    return get().automationLanes.find((l) => automationTargetKey(l.target) === key);
+  },
 
   getTotalDurationSec: () => {
     const { clips } = get();

--- a/frontend/src/state/liveMixer.ts
+++ b/frontend/src/state/liveMixer.ts
@@ -448,29 +448,40 @@ function scheduleAutomation(fromSec: number): void {
 }
 
 /** One lookahead frame: write each enabled FX lane's current value into its live
- *  effect param (merged over the entry's static params). */
+ *  effect param. Values are grouped per effect entry first, so a multi-param
+ *  effect (e.g. KAOSS x + y) gets ONE merged update instead of competing
+ *  single-key updates that would each reset the other key to its static value. */
 function applyFxAutomationFrame(): void {
   if (!playing) return;
   const ctx = getEngineCtx();
   const t = clamp(startOffsetSec + (ctx.currentTime - startCtxTime), 0, totalDur);
   const ed = useEditorStore.getState();
+
+  const byEntry = new Map<string, { master: boolean; trackId?: string; entryId: string; values: Record<string, number> }>();
   for (const lane of ed.automationLanes) {
     if (!lane.enabled || lane.points.length === 0) continue;
     const { kind, trackId, entryId, paramKey } = lane.target;
     if ((kind !== 'trackFx' && kind !== 'masterFx') || !entryId || !paramKey) continue;
     const v = sampleLane(lane, t);
     if (v == null) continue;
-    if (kind === 'masterFx') {
+    const mapKey = `${kind}|${trackId ?? ''}|${entryId}`;
+    let acc = byEntry.get(mapKey);
+    if (!acc) { acc = { master: kind === 'masterFx', trackId, entryId, values: {} }; byEntry.set(mapKey, acc); }
+    acc.values[paramKey] = v;
+  }
+
+  for (const acc of byEntry.values()) {
+    if (acc.master) {
       if (!masterChain) continue;
-      const entry = ed.masterFxChain.find((e) => e.id === entryId);
+      const entry = ed.masterFxChain.find((e) => e.id === acc.entryId);
       if (!entry || !entry.enabled) continue;
-      masterChain.updateParams(entryId, { ...entry.params, [paramKey]: v });
+      masterChain.updateParams(acc.entryId, { ...entry.params, ...acc.values });
     } else {
-      if (!trackId) continue;
-      const n = trackNodes.get(trackId);
-      const entry = ed.tracks.find((tr) => tr.id === trackId)?.fxChain?.find((e) => e.id === entryId);
+      if (!acc.trackId) continue;
+      const n = trackNodes.get(acc.trackId);
+      const entry = ed.tracks.find((tr) => tr.id === acc.trackId)?.fxChain?.find((e) => e.id === acc.entryId);
       if (!n || !entry || !entry.enabled) continue;
-      n.fx.updateParams(entryId, { ...entry.params, [paramKey]: v });
+      n.fx.updateParams(acc.entryId, { ...entry.params, ...acc.values });
     }
   }
 }

--- a/frontend/src/state/liveMixer.ts
+++ b/frontend/src/state/liveMixer.ts
@@ -29,7 +29,14 @@
  * Structural clip edits (add/remove/split/move) made WHILE playing take effect
  * on the next play, same as a hardware mixer wouldn't re-cut tape mid-take.
  */
-import { useEditorStore, type AudioClip, type EditorTrack } from './editorStore';
+import {
+  useEditorStore,
+  sampleLane,
+  automationTargetKey,
+  type AudioClip,
+  type EditorTrack,
+  type AutomationTarget,
+} from './editorStore';
 import {
   usePlayerStore,
   getEngineCtx,
@@ -62,9 +69,13 @@ const decodeCache = new WeakMap<Blob, AudioBuffer>();
 const analysisCache = new WeakMap<Blob, AudioChunk[]>();
 
 interface TrackNodes {
+  /** Volume fader (manual OR automated). Split from mute/solo so a volume
+   *  automation lane can own this param while mute/solo stay live. */
   gain: GainNode;
+  /** Mute/solo factor (0 or 1), always driven live (never automated). */
+  muteGain: GainNode;
   panner: StereoPannerNode;
-  /** Per-track insert FX, spliced gain -> [fx] -> panner. */
+  /** Per-track insert FX, spliced gain -> muteGain -> [fx] -> panner. */
   fx: ChainHandle;
   fxFullSig: string; // topology + params (skip no-op reconciles)
   fxTopoSig: string; // topology only (rebuild trigger)
@@ -84,6 +95,7 @@ let lastMixSig = '';
 let lastTimePush = 0; // throttle playerStore.currentTime writes
 let midiTimers: number[] = []; // setTimeout handles for scheduled MIDI note on/off
 let liveMidiActive = false; // true while MIDI clips play via the live synth (vs their bounce)
+let autoFxTimer = 0; // setInterval handle for the FX-param automation lookahead
 
 // Session-local master bus + psychoacoustic insert rack. Every track's panner
 // feeds masterBus; masterBus -> masterChain -> the shared engine master, so the
@@ -96,11 +108,33 @@ let lastMasterFullSig = ''; // topology + params (skip no-op ticks)
 
 const clamp = (x: number, a: number, b: number) => Math.max(a, Math.min(b, x));
 
-/** Effective track gain honoring mute + (exclusive) solo. */
-function effectiveVol(t: EditorTrack, anySolo: boolean): number {
+/** Clamped manual fader value (the volume automation lane overrides this live). */
+function volumeOf(t: EditorTrack): number {
+  return clamp(t.volume, 0, 1);
+}
+
+/** Mute/solo gate: 0 when muted or hidden by an active solo, else 1. */
+function muteSoloFactor(t: EditorTrack, anySolo: boolean): number {
   if (t.mute) return 0;
   if (anySolo && !t.solo) return 0;
-  return clamp(t.volume, 0, 1);
+  return 1;
+}
+
+/** Effective track gain honoring mute + (exclusive) solo (volume x gate). */
+function effectiveVol(t: EditorTrack, anySolo: boolean): number {
+  return volumeOf(t) * muteSoloFactor(t, anySolo);
+}
+
+/** Keys of native (vol/pan) targets that have an enabled automation lane, so the
+ *  manual reconcile leaves those params to the scheduled envelope while playing. */
+function automatedNativeKeys(): Set<string> {
+  const keys = new Set<string>();
+  for (const lane of useEditorStore.getState().automationLanes) {
+    if (!lane.enabled) continue;
+    const k = lane.target.kind;
+    if (k === 'trackVolume' || k === 'trackPan') keys.add(automationTargetKey(lane.target));
+  }
+  return keys;
 }
 
 /** A short signature of just the mixer-relevant fields, so the editorStore
@@ -112,16 +146,22 @@ function mixSignature(tracks: EditorTrack[]): string {
   return s;
 }
 
-/** Push current track volume/pan/mute/solo onto the live nodes (click-free). */
+/** Push current track volume/pan/mute/solo onto the live nodes (click-free).
+ *  Volume and pan are left to their scheduled envelope when an enabled lane owns
+ *  them; the mute/solo gate is always applied live. */
 function applyMixLive(): void {
   const ctx = getEngineCtx();
   const tracks = useEditorStore.getState().tracks;
   const anySolo = tracks.some((t) => t.solo);
+  const automated = automatedNativeKeys();
   for (const t of tracks) {
     const n = trackNodes.get(t.id);
     if (!n) continue;
-    n.gain.gain.setTargetAtTime(effectiveVol(t, anySolo), ctx.currentTime, RAMP_TC);
-    n.panner.pan.setTargetAtTime(clamp(t.pan, -1, 1), ctx.currentTime, RAMP_TC);
+    const volKey = automationTargetKey({ kind: 'trackVolume', trackId: t.id });
+    const panKey = automationTargetKey({ kind: 'trackPan', trackId: t.id });
+    if (!automated.has(volKey)) n.gain.gain.setTargetAtTime(volumeOf(t), ctx.currentTime, RAMP_TC);
+    n.muteGain.gain.setTargetAtTime(muteSoloFactor(t, anySolo), ctx.currentTime, RAMP_TC);
+    if (!automated.has(panKey)) n.panner.pan.setTargetAtTime(clamp(t.pan, -1, 1), ctx.currentTime, RAMP_TC);
   }
 }
 
@@ -201,7 +241,7 @@ function applyTrackChainsLive(): void {
  *  stopped explicitly). Leaves the trackNodes map for the caller to replace. */
 function disposeTrackNodes(): void {
   for (const n of trackNodes.values()) {
-    try { n.fx.dispose(); n.gain.disconnect(); n.panner.disconnect(); } catch { /* gone */ }
+    try { n.fx.dispose(); n.gain.disconnect(); n.muteGain.disconnect(); n.panner.disconnect(); } catch { /* gone */ }
   }
 }
 
@@ -215,14 +255,18 @@ function buildTrackNodes(tracks: EditorTrack[]): void {
   const anySolo = tracks.some((t) => t.solo);
   for (const t of tracks) {
     const gain = ctx.createGain();
-    gain.gain.value = effectiveVol(t, anySolo);
+    gain.gain.value = volumeOf(t);
+    const muteGain = ctx.createGain();
+    muteGain.gain.value = muteSoloFactor(t, anySolo);
     const panner = ctx.createStereoPanner();
     panner.pan.value = clamp(t.pan, -1, 1);
     const chain = t.fxChain ?? [];
-    const fx = buildEffectChain(ctx, gain, panner, chain); // wires gain -> [fx] -> panner
+    gain.connect(muteGain);
+    const fx = buildEffectChain(ctx, muteGain, panner, chain); // gain -> muteGain -> [fx] -> panner
     panner.connect(dest);
     trackNodes.set(t.id, {
       gain,
+      muteGain,
       panner,
       fx,
       fxFullSig: JSON.stringify(chain),
@@ -367,6 +411,101 @@ function scheduleTeleports(clips: AudioClip[], fromSec: number): void {
   }
 }
 
+/* ── Automation (Phase E) ─────────────────────────────────────────────────────
+   Native vol/pan lanes schedule their whole breakpoint envelope onto the real
+   AudioParam at play/seek (sample-accurate, zero ongoing cost). FX-param lanes
+   ride a ~40 Hz lookahead writer because they sit behind the rack's setParams. */
+
+/** Resolve a native (vol/pan) automation target to its live AudioParam. */
+function nativeParamFor(target: AutomationTarget): AudioParam | null {
+  if (!target.trackId) return null;
+  const n = trackNodes.get(target.trackId);
+  if (!n) return null;
+  if (target.kind === 'trackVolume') return n.gain.gain;
+  if (target.kind === 'trackPan') return n.panner.pan;
+  return null;
+}
+
+/** Schedule each enabled native lane's envelope onto its AudioParam from `fromSec`:
+ *  anchor the value at the playhead, then ramp through every later breakpoint. */
+function scheduleAutomation(fromSec: number): void {
+  const ctx = getEngineCtx();
+  const now = ctx.currentTime;
+  for (const lane of useEditorStore.getState().automationLanes) {
+    if (!lane.enabled || lane.points.length === 0) continue;
+    if (lane.target.kind !== 'trackVolume' && lane.target.kind !== 'trackPan') continue;
+    const param = nativeParamFor(lane.target);
+    if (!param) continue;
+    param.cancelScheduledValues(now);
+    param.setValueAtTime(sampleLane(lane, fromSec) ?? param.value, now);
+    for (const p of lane.points) {
+      if (p.t <= fromSec) continue;
+      const whenCtx = startCtxTime + (p.t - startOffsetSec);
+      if (whenCtx <= now) param.setValueAtTime(p.v, now);
+      else param.linearRampToValueAtTime(p.v, whenCtx);
+    }
+  }
+}
+
+/** One lookahead frame: write each enabled FX lane's current value into its live
+ *  effect param (merged over the entry's static params). */
+function applyFxAutomationFrame(): void {
+  if (!playing) return;
+  const ctx = getEngineCtx();
+  const t = clamp(startOffsetSec + (ctx.currentTime - startCtxTime), 0, totalDur);
+  const ed = useEditorStore.getState();
+  for (const lane of ed.automationLanes) {
+    if (!lane.enabled || lane.points.length === 0) continue;
+    const { kind, trackId, entryId, paramKey } = lane.target;
+    if ((kind !== 'trackFx' && kind !== 'masterFx') || !entryId || !paramKey) continue;
+    const v = sampleLane(lane, t);
+    if (v == null) continue;
+    if (kind === 'masterFx') {
+      if (!masterChain) continue;
+      const entry = ed.masterFxChain.find((e) => e.id === entryId);
+      if (!entry || !entry.enabled) continue;
+      masterChain.updateParams(entryId, { ...entry.params, [paramKey]: v });
+    } else {
+      if (!trackId) continue;
+      const n = trackNodes.get(trackId);
+      const entry = ed.tracks.find((tr) => tr.id === trackId)?.fxChain?.find((e) => e.id === entryId);
+      if (!n || !entry || !entry.enabled) continue;
+      n.fx.updateParams(entryId, { ...entry.params, [paramKey]: v });
+    }
+  }
+}
+
+function startFxAutomation(): void {
+  stopFxAutomation();
+  const hasFxLane = useEditorStore.getState().automationLanes.some(
+    (l) => l.enabled && (l.target.kind === 'trackFx' || l.target.kind === 'masterFx'),
+  );
+  if (hasFxLane) autoFxTimer = window.setInterval(applyFxAutomationFrame, 25); // ~40 Hz
+}
+
+function stopFxAutomation(): void {
+  if (autoFxTimer) { clearInterval(autoFxTimer); autoFxTimer = 0; }
+}
+
+/** Current transport position in timeline seconds (for recording timestamps). */
+export function currentTransportSec(): number {
+  if (!playing) return useEditorStore.getState().playheadSec;
+  const ctx = getEngineCtx();
+  return clamp(startOffsetSec + (ctx.currentTime - startCtxTime), 0, totalDur);
+}
+
+/** Drive a native param live while recording, so the move is heard immediately;
+ *  cancels the scheduled envelope for the rest of this pass (latch behavior). The
+ *  caller records the point into the lane, which is re-scheduled on the next play. */
+export function automationTouchNative(target: AutomationTarget, value: number): void {
+  if (!playing) return;
+  const param = nativeParamFor(target);
+  if (!param) return;
+  const ctx = getEngineCtx();
+  param.cancelScheduledValues(ctx.currentTime);
+  param.setTargetAtTime(value, ctx.currentTime, RAMP_TC);
+}
+
 /**
  * Schedule live-synth note on/off for every MIDI clip at or after `fromSec`.
  * Notes fire via timers aligned to the transport (preview-accurate); the offline
@@ -427,6 +566,7 @@ function clearSources(): void {
   }
   sources = [];
   clearMidiTimers();
+  stopFxAutomation();
 }
 
 function stopClock(): void {
@@ -522,6 +662,8 @@ async function start(fromSec: number): Promise<void> {
   lastMixSig = mixSignature(ed.tracks);
   scheduleClips(clips, begin);
   scheduleTeleports(clips, begin);
+  scheduleAutomation(begin); // native vol/pan envelopes onto their AudioParams
+  startFxAutomation();        // ~40 Hz lookahead writer for FX-param lanes
   if (liveMidiActive) scheduleMidiClips(clips, begin);
 
   playing = true;


### PR DESCRIPTION
feat(edit): automation lanes - record + play track volume/pan (Phase E slice 1)

Add the automation foundation and the first, sample-accurate vertical slice.

editorStore: AutomationLane model (target + breakpoints), write/arm state,
record/edit mutators, and a sampleLane interpolation helper; lanes are cleaned
up when their track or effect is removed.

liveMixer: split each track's gain into a volume gain (automatable) and a
mute/solo gate, so volume automation and mute/solo coexist. Native vol/pan lanes
schedule their whole breakpoint envelope onto the AudioParam at play/seek
(sample-accurate, zero ongoing cost); an FX-param lookahead writer (~40 Hz) is
wired for the next slice. The manual reconcile leaves an automated param to its
scheduled envelope.

WaveformEditor: a WRITE toggle in the toolbar; riding a track's volume or pan
fader while playing records a thinned, audio-clock-timestamped lane and is heard
as it is recorded; a read-only curve draws over each track (volume green, pan
blue).

Typecheck clean. Needs live verification (ears + eyes): WRITE on, play, ride a
fader, WRITE off, play again - the move should play back.
@[danieljtrujillo](https://github.com/gantasmo/theDAW/commits?author=danieljtrujillo)
danieljtrujillo committed 9 hours ago
[feat(edit): FX-param automation recording (Phase E slice 2)](https://github.com/gantasmo/theDAW/commit/b9953e58ecf07bf60a7fb0bce800ef822ec9847e) 

Riding a rack param while WRITE is on and the transport rolls now records it, on
the master bus or per track. The FxRack sliders, the KAOSS pad, and the
spatializer pad all flow through one wrapper that diffs the new params and
records each changed key into its own lane, so a KAOSS drag captures x and y at
once. Playback uses the ~40 Hz FX lookahead writer from slice 1.

The lookahead now groups automated values per effect entry and pushes one merged
update per entry, so a multi-param effect does not reset its other keys to their
static value each frame.

The read-only overlay also draws track-FX lanes (amber), normalized by each
param's range; master-FX lanes record and play but are not drawn on a track row.

Typecheck clean. Needs live verification (ears + eyes): add KAOSS to a track,
WRITE on, play, sweep the pad, WRITE off, play - the sweep should play back.