### PR TITLE
docs: WHERE-WE-STAND status guide + document VJ sources and Quest/XR integrations

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -51,6 +51,7 @@ The **Docs** button in the top bar opens this guide as a modal with a filterable
 31. [Controller Vision](#31-controller-vision)
 32. [Admin, Module, and Assistant-Key APIs](#32-admin-module-and-assistant-key-apis)
 33. [Notation, Score, Tabs, and Arrangements](#33-notation-score-tabs-and-arrangements)
+34. [Quest and XR Integrations](#34-quest-and-xr-integrations)
 
 ---
 
@@ -591,6 +592,15 @@ The camera input extends past a webcam on the host machine. Any device that open
 
 A master MIDI gate turns Web MIDI on or off for the whole app. When off, the app never requests Web MIDI access, so no browser permission prompt appears.
 
+#### Dedicated in-app sources: delinQuest, STITCH, cymatics, and screen capture
+
+Beyond the browser-camera path above, the VJ source selector offers sources the app drives directly:
+
+- **delinQuest** streams a connected Meta Quest's video into the VJ over ADB (USB or wireless), decoded in the browser, with a choice of 16:9 or side-by-side 3D. It needs neither Quest Link nor Meta Quest Developer Hub. See §34.1.
+- **STITCH** streams only the Quest's clean stitched passthrough (the real-world composite, without the performer's overlay) as a separate source. See §34.2.
+- **Cymatics** renders a procedural, audio-reactive cymatics scene as the source, with plate, orb, landscape, sphere, and plasma modes, mixable against the other sources on the source crossfader.
+- **Screen or window capture** picks a monitor or an application window through the browser's `getDisplayMedia` and feeds it as the source.
+
 ### 10.2 Pop-out and Mobile
 
 - **Pop out** opens the visuals in a separate window. Drag it onto a second monitor for live performance while theDAW keeps running on the main display. **Pop back in** returns it to the tab. Closing the window manually snaps back automatically.
@@ -608,6 +618,14 @@ The tab wires several bridges to the engine through `postMessage`:
 ### 10.4 Export
 
 The visual engine records performances and the backend transcodes the recording to the chosen codec. The saved path is reported back and surfaced in the Processing Log. Exports are written to the local `exports/` folder and are never committed to the repository.
+
+### 10.5 Broadcast and watch-link
+
+A WebRTC signaling module (`/api/broadcast`) backs a live watch-link of the VJ output, so a viewer on the venue LAN can open a URL and watch the visuals peer-to-peer, with no media passing through the server. The GO-LIVE broadcaster front end, a DJ-audio host hop, and a TURN relay for public links are still in progress.
+
+### 10.6 Autopilot visual effects
+
+The VJ engine includes an Autopilot that layers audio-reactive visual effects, such as feedback wash, glitch, and waveform warp, each with its own probability, under a single Autopilot toggle. Turning it on lets the visuals evolve hands-free in time with the audio.
 
 ![VJ tab panel loading state](screenshots/08-vj-tab-loading__vj-panel.png)
 
@@ -2049,6 +2067,34 @@ GET  /api/analysis/{entry_id}/prompt
 ```
 
 `GET /api/notation` reports capabilities (music21 and MuseScore availability, supported formats, tab tunings, arrangement styles). `from-midi` converts a MIDI to MusicXML; `export` takes `{source_artifact_id, format}` with format musicxml/abc/pdf/svg; `tabs` takes `{source_artifact_id | midi_id, instrument, tuning_name, capo, difficulty}` and returns alphaTex; `arrange` takes `{style, source_artifact_id | source_artifact_ids | midi_id}` and returns MusicXML. `GET /api/analysis/{entry_id}/prompt` returns `{prompt_guess, prompt_confidence, semantic_tags}` regenerated from the stored analysis.
+
+---
+
+## 34. Quest and XR Integrations
+
+theDAW drives a Meta Quest headset for live performance without Quest Link (PC tethering) or Meta Quest Developer Hub casting. Each integration rides plain ADB over USB or a wireless pairing, and the backend starts the relay it needs on demand. The headset-side components live in the GANTASMO-MIDI Unity project.
+
+### 34.1 delinQuest: Quest video into the VJ
+
+delinQuest streams the headset's video into the VJ as a live source. The backend `questcast` module starts a Node relay that speaks the scrcpy protocol to the headset over ADB and pushes H.264 over a WebSocket; the VJ decodes it in the browser with WebCodecs and binds it to a camera stream. The VJ source button is labelled **delinQuest** and offers a full side-by-side 3D frame or a single eye cropped to 16:9. Selecting it auto-starts the relay (it verifies ADB and Node, installs the relay's dependency once, then connects), so there is no manual casting step. It requires USB debugging or a wireless ADB pairing on the headset.
+
+This is distinct from pointing the headset's own browser at a tunnel URL (§10.1): delinQuest pulls the headset's rendered video directly over ADB, with no in-headset browser and no public tunnel.
+
+### 34.2 STITCH: clean passthrough into the VJ
+
+queststitch streams only the Quest's stitched passthrough, the clean real-world composite without the performer's overlaid surface, as a separate **STITCH** source. A Unity component on the headset (`GantasmoStitchStreamer`) encodes the stitch render texture to H.264 with Android MediaCodec and sends it over an ADB-reversed TCP socket; the backend `queststitch` bridge re-frames it onto a WebSocket the VJ decodes the same way as delinQuest.
+
+### 34.3 Quest MIDI bridge
+
+QuestMidiBridge carries MIDI both ways between the headset and the DAW over an ADB-reversed TCP socket. The headset sends control and note MIDI, including 14-bit high-resolution CC for hand tracking, into the DAW; the DAW sends MIDI back to the headset through a loopMIDI return port. A hand gesture in-headset can drive the mix, and the mix can drive something in-headset.
+
+### 34.4 GANTASMO Visor
+
+The GANTASMO Visor is a procedural chrome visor rendered in-headset that reacts to the MIDI arriving on the return circuit: control changes drive its glow, hue, and warp, and note velocity flashes it. It mounts to the headset camera and needs no external assets.
+
+### 34.5 Setup notes
+
+Each integration needs USB debugging enabled on the Quest, or a wireless ADB pairing. The backend auto-detects ADB and starts the relay when the source is selected; the relay ports are configurable through environment variables (`theDAW_QUESTCAST_PORT`, `theDAW_QUESTSTITCH_PORT`). No Quest Link session and no Meta Quest Developer Hub are required at any point.
 
 ---
 

--- a/docs/WHERE-WE-STAND.md
+++ b/docs/WHERE-WE-STAND.md
@@ -1,0 +1,172 @@
+# Where We Stand
+
+A working status and roadmap for theDAW, kept for shared reference between Daniel
+and Claude. It is the fast answer to "what is built, what is in flight, what is
+next." For how a shipped feature actually works, use `docs/USER_GUIDE.md`; this
+file tracks state, not behavior.
+
+Last updated: 2026-06-21.
+
+Status tags: **SHIPPED** = merged to `main`. **BUILT** = on a branch, not merged.
+**PENDING** = designed or queued, not built. **OPEN BUG**. **BLOCKED** = waiting
+on an external gate (hardware, a decision, disk).
+
+---
+
+## 1. EDIT tab: performance FX, instruments, automation
+
+The EDIT timeline grew a full performance and automation layer this cycle. All of
+the following is **SHIPPED** (merged via PRs #38-#42):
+
+- **Psychoacoustic insert FX rack**, master bus and per track, baked into COMMIT
+  EDIT through the same node factories used live: Headphone Crossfeed, Phantom
+  Bass, Stereo Widener, Aural Exciter, HRTF Spatializer, Loudness Contour.
+- **Spatializer** with twelve motion modes, including onset-driven **Teleport**
+  and the live **Autopilot** choreographer (analysis-driven 3D motion).
+- **Metamorph** granular identity-bleed morph (donor A rebuilt out of host B's
+  grains), live and render-to-clip.
+- **Performance FX**: KAOSS XY pad, Gater, Bitcrush, Ring Mod, and the MPC-style
+  **Chop** (stutter / beat-repeat / shuffle, AudioWorklet).
+- **Instruments**: per-clip and per-track GM instrument override, live MIDI
+  timeline playback through the SpessaSynth soundfont engine (bundled `gm.sf3`),
+  and the procedural voice banks (psychoacoustic, formant Talk-Box, glitch-hop).
+- **Automation (Phase E, slices 1-2)**: lane model + WRITE mode; recording track
+  volume/pan and any FX param (KAOSS, spatializer, filters) by riding the control
+  while playing; sample-accurate native vol/pan envelope scheduling plus a ~40 Hz
+  FX-param lookahead writer; read-only lane curves drawn over each track.
+
+**PENDING in EDIT:**
+- Automation **E4-full**: draw / drag / delete breakpoints, and the fader/pad
+  visually following automation during playback (today the audio follows, the
+  knob does not move).
+- Automation **E5**: bake lanes into the COMMIT EDIT offline render so exports
+  carry the moves (native params via the offline `AudioParam` timeline, FX params
+  via pre-scheduled `updateParams`).
+- Chop polish: a program dropdown instead of the 0/1/2 slider, and a momentary
+  "hold to chop" trigger. Gater tempo-sync (it is free-running Hz today).
+- Live verification of the chop and glitch worklets by ear is still wanted.
+
+## 2. Library, stems, MIDI, notation
+
+- **SHIPPED**: stems and MIDI as first-class library rows (play, favorite,
+  delete, route) in their own sub-tabs; audio-to-MIDI conversion; the soundfont
+  and GM instrument picker.
+- **SHIPPED notation (phases 1-3, 6, 7)**: the artifact layer, MusicXML / ABC /
+  guitar tabs (alphaTab), arrangements (lead-sheet / piano / simplified /
+  band-score), and prompt inference from a score. Sheet music export is ABC /
+  PDF / SVG (PDF and SVG need MuseScore present).
+- Note on "auto scoring": there is no direct optical-music-recognition path from
+  audio to a score. Audio becomes a score by first converting to MIDI
+  (`basic_pitch` / piano transcription), then rendering the MIDI to MusicXML /
+  tabs / arrangements. Documented in USER_GUIDE section 33.
+- **PENDING notation**: Phase 4 (MT3 transcription), Phase 5 (OMR), Phase 8
+  (notation-reactive visuals).
+
+## 3. DJ tab
+
+- **SHIPPED (D1-D7)**: two decks with beatmatch sync, key-lock, live stems with
+  per-stem faders, FX + limiter, hot cues, cue/headphone via `setSinkId`, DJ
+  MIDI-learn, automix, a sampler bank, a side-list staging lane, and DJ folder ->
+  playlist add.
+- **PENDING**: D7 four-deck mode (a larger refactor), D8, deck persistence, and
+  true real-time stems (today stems are pre-separated). The shipped UI is
+  two-deck only.
+
+## 4. VJ tab
+
+- **SHIPPED**: the VJ app runs as an embedded module with auto-spawn; the
+  Resolume-style clip-grid layout; a native OS folder picker for export; the
+  video/media library backing VJ cues; and several live camera sources
+  (microphone, MIDI, phone on the LAN, device camera, screen/window capture,
+  cymatics, and the Quest sources below).
+- **SHIPPED broadcast signaling**: a WebRTC signaling module for a live
+  watch-link of the VJ output.
+- **PENDING**: the VJ UI punchlist (banks-as-rows, wheel scroll, drag
+  Library->banks, footer play/pause reflecting real playback); a Resolume-modeled
+  visual pass on the media library; the GO-LIVE broadcaster front end plus a
+  DJ-audio host->iframe hop and a TURN relay for public watch-links.
+
+## 5. XR / Quest integrations
+
+These are the headset features. All **SHIPPED** to `main`, with the headset-side
+pieces living in the GANTASMO-MIDI Unity project. The point of the design is that
+none of them need Quest Link (PC tethering) or Meta Quest Developer Hub casting;
+they ride plain ADB (USB or wireless) with auto-started relays.
+
+- **delinQuest**: streams the Quest's video into the VJ as a live source over a
+  scrcpy relay, decoded in the browser with WebCodecs. 16:9 or side-by-side 3D.
+- **queststitch**: streams only the clean stitched passthrough (the real-world
+  composite) into the VJ as a separate "STITCH" source, via a Unity MediaCodec
+  H.264 encoder and a backend TCP-to-WebSocket bridge.
+- **Quest MIDI bridge** (QuestMidiBridge): two-way MIDI between the headset and
+  the DAW over an ADB-reversed TCP socket, with a loopMIDI return circuit.
+- **GANTASMO Visor**: a procedural chrome visor in-headset that reacts to MIDI
+  arriving on the return circuit.
+- Documented in USER_GUIDE section 34.
+
+- **OPEN BUG**: delinQuest is flaky on the main stream.
+- **PENDING / BLOCKED (Quest colocation)**: co-located multiplayer for the
+  QuestMIDI scene is built and wired in the editor but not headset-verified
+  (BLOCKED on charging the second headset; needs Enhanced Spatial Services and a
+  verified dev account). Plan: `docs/plans/2026-06-18-quest-colocation-plan.md`.
+- **PENDING (Quest/Unity)**: MR free-roam (suppress Guardian + scene-mesh
+  collider), hand-pose-to-MIDI (only microgestures exist today), an in-VR
+  "add source" menu, and a scene optimization wizard.
+- **PENDING (two-PC live set)**: two machines, both feeds mixable through the VJ
+  or autoplay; needs the broadcast module's host / multi-input / audio-in rework.
+
+## 6. Generation, models, setup
+
+- **SHIPPED**: the MAKE model dropdown with SA3 <-> Magenta GPU auto-swap; the
+  Settings -> Models panel (local checkpoints, no-download guarantee, Browse to
+  register a checkpoint, generate-config, Locations, HF cache breakdown); and the
+  manual model-placement guide (USER_GUIDE section 21.2: folder tree, download
+  links, where T5Gemma lives, the real `sidecars/magenta-rt2-nvidia/Setup-MRT2.bat`
+  path).
+- **PENDING (Magenta RT2)**: vendor the model as a submodule, extend the sidecar
+  to notes + audio-style conditioning, and finish the full frontend set. The
+  backend module and the Generate-tab text-to-music path are shipped.
+- **OPEN BUG / BLOCKED**: medium-model load can access-violate under commit-limit
+  pressure when both disks are near full. Fix is to free disk + pagefile, or an
+  approved streaming loader. The backend lazy-loads and parks models in RAM as a
+  mitigation.
+
+## 7. Infrastructure and maintenance
+
+- **PENDING**: the 2026-06-10 codebase audit (124 findings) has judge rulings
+  that are not yet applied.
+- **PENDING**: zero-terminal onboarding remainder (an in-app surface for the
+  MRT2 setup beyond the SETUP pill, and setup-script tests).
+- **ONGOING**: RAG / doc maintenance. Doc edits are approval-based; this file and
+  the current doc pass were explicitly requested.
+
+## 8. Documentation and RAG
+
+- The user-facing reference is `docs/USER_GUIDE.md`, indexed into the in-app
+  assistant's RAG (`backend/rag.py` `DOC_PATHS`). The feature-to-doc coverage
+  report lives at `docs/reports/feature-doc-coverage-report.md` and is
+  regenerated by the pre-commit docs hook from `scripts/screenshots/specs.ts`.
+- This pass added: this status file; USER_GUIDE section 34 (Quest / XR); an
+  expanded section 10 (VJ camera sources, broadcast watch-link, autopilot visual
+  effects); and a notation-pipeline clarification in section 33.
+- Recently documented (earlier this cycle): the EDIT FX rack / spatializer /
+  Metamorph (sections 7.7-7.10), first-class stems and MIDI (13.12), the
+  soundfont and voice instrument picker (15.8), and manual model placement (21.2).
+
+## 9. Branch map
+
+`main` holds everything shipped. Recent feature branches (merged): 
+`feat/library-stems-midi-first-class` (#38), `feat/edit-clip-instrument` (#39),
+`feat/edit-kaoss-pad` (#40, #41, the KAOSS / glitch / chop / voices stack), and
+`feat/edit-automation` (#42, automation slices 1-2). Older merged work covers the
+VJ build, the model/storage panel, the MIX overhaul, the playlist suggester, the
+Magenta RT2 integration, the SLIDE controller, and the Quest MIDI bridge.
+
+## 10. Immediate next steps (suggested order)
+
+1. Automation E4-full (lane editing + fader-follows-automation), then E5 (bake
+   into COMMIT EDIT). Finishes Phase E.
+2. Chop and Gater polish (program dropdown, momentary trigger, tempo-sync).
+3. Live-verify the chop / glitch worklets and the full automation pass by ear.
+4. The VJ UI punchlist and the GO-LIVE broadcaster, toward the two-PC live set.
+5. Headset-verify the Quest colocation once the second headset is charged.

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,15 +1,15 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-21T14:40:09.880Z · Git revision: `62edab5b45f3` · Repomix tracked: **no**
+> Generated: 2026-06-22T01:18:50.116Z · Git revision: `50a44d90f570` · Repomix tracked: **no**
 
 ## Audit Dashboard
 
 | Metric | Value |
 |---|---:|
 | Documentation coverage | **100%** |
-| Features inventoried | **29** |
-| Documented features | **29** |
+| Features inventoried | **32** |
+| Documented features | **32** |
 | Missing docs | **0** |
 | Partial docs | **0** |
 | Full screenshot scenes | **9** |
@@ -38,7 +38,7 @@
 | `sequencer-midi-export-render` | Step sequencer Standard MIDI export plus single-track/multi-track render-to-editor flows | daw | implemented | **documented** | #13-7-midi-conversion<br>#14-5-midi-export<br>#15-5-midi-import-and-export | Matched 2/4 guide terms. |
 | `piano-roll-linked-clip-editing` | Piano roll MIDI import/export, render-to-editor, and linked clip re-editing | daw | implemented | **documented** | #15-5-midi-import-and-export<br>#15-7-edit-in-piano-roll<br>#16-6-slide | Matched 4/4 guide terms. |
 | `media-bucket-routing` | Media Bucket send targets for editor, library, init audio, and Chimera stack | daw | implemented | **documented** | #6-3-1-chimera-fusion-stack<br>#8-4-source-output-and-routing<br>#13-4-per-entry-controls<br>#13-12-stems-and-midi-as-first-class-items<br>#16-5-media | Matched 4/4 guide terms. |
-| `vj-sidecar-tab-mobile-share` | VJ tab and mobile share link for iframe/tunnel-backed performance access | vj | experimental | **documented** | #table-of-contents<br>#5-ui-shell<br>#10-vj-tab<br>#purpose<br>#10-3-bridges<br>#10-4-export<br>#13-8-video-and-image-media<br>#19-17-vj | Matched 3/4 guide terms. |
+| `vj-sidecar-tab-mobile-share` | VJ tab and mobile share link for iframe/tunnel-backed performance access | vj | experimental | **documented** | #table-of-contents<br>#5-ui-shell<br>#10-vj-tab<br>#purpose<br>#10-3-bridges<br>#10-6-autopilot-visual-effects<br>#13-8-video-and-image-media<br>#19-17-vj | Matched 3/4 guide terms. |
 | `backend-module-loader-settings` | Backend module loader with module manifests and runtime enable/disable settings | backend-module | implemented | **documented** | #1-repository-anatomy<br>#19-12-module-loader<br>#adding-a-backend-module<br>#zustand-store-architecture<br>#32-admin-module-and-assistant-key-apis | Matched 4/4 guide terms. |
 | `suno-cloud-generation` | Suno cloud generation (Aurora Cloud Console) with simple/custom/cover/mashup, server-side key, and library lineage | create | implemented | **documented** | #table-of-contents<br>#1-repository-anatomy<br>#6-2-generation-parameters<br>#6-3-1-chimera-fusion-stack<br>#12-3-how-the-visualizations-are-rendered<br>#19-14-chimera<br>#21-models<br>#21-1-settings-models-local-checkpoints-and-the-no-download-guarantee<br>#26-cloud-generation-suno<br>#26-1-modes<br>#26-2-flow-and-library-integration<br>#26-3-endpoints<br>#29-catalogue<br>#credits | Matched 5/5 guide terms. |
 | `magenta-rt2-generate` | Magenta RealTime 2 generation (text/notes/audio-style) via the WSL2 NVIDIA sidecar, the first non-Mac MRT2 port | create | experimental | **documented** | #table-of-contents<br>#6-2-generation-parameters<br>#21-models<br>#21-1-settings-models-local-checkpoints-and-the-no-download-guarantee<br>#21-2-manual-model-placement-download-links-and-folder-tree<br>#27-magenta-realtime-2<br>#27-1-the-sidecar-and-conditioning<br>#27-2-first-non-mac-port-of-magenta-realtime-2<br>#33-6-prompt-inference | Matched 5/5 guide terms. |
@@ -47,10 +47,13 @@
 | `controller-vision-detect-identify` | Controller Vision: detect/identify a MIDI controller from a photo (OpenCV + vision-LLM) with LAN phone pairing | daw | implemented | **documented** | #table-of-contents<br>#31-controller-vision | Matched 5/5 guide terms. |
 | `ytimport-youtube-import` | YouTube import: fetch audio from a URL into the Library as a first-class, lineage-tracked entry | library | implemented | **documented** | #table-of-contents<br>#1-repository-anatomy<br>#prerequisites<br>#30-youtube-import | Matched 4/4 guide terms. |
 | `edit-insert-fx-rack` | EDIT real-time psychoacoustic insert-FX rack on the master bus and per track, baked into COMMIT EDIT | edit | implemented | **documented** | #7-6-commit-edit<br>#7-7-insert-fx-rack-psychoacoustic<br>#15-8-instrument-soundfont-and-synth-voices | Matched 6/6 guide terms. |
-| `edit-spatializer-teleport-autopilot` | EDIT HRTF spatializer with 12 motion modes including onset-driven Teleport and the live Autopilot choreographer | edit | implemented | **documented** | #7-6-commit-edit<br>#7-7-insert-fx-rack-psychoacoustic<br>#7-8-spatializer-teleport-and-autopilot | Matched 6/6 guide terms. |
+| `edit-spatializer-teleport-autopilot` | EDIT HRTF spatializer with 12 motion modes including onset-driven Teleport and the live Autopilot choreographer | edit | implemented | **documented** | #7-6-commit-edit<br>#7-7-insert-fx-rack-psychoacoustic<br>#7-8-spatializer-teleport-and-autopilot<br>#10-6-autopilot-visual-effects | Matched 6/6 guide terms. |
 | `edit-metamorph-granular-morph` | Metamorph granular identity-bleed morph: rebuild a host sound out of a donor sound, live and to a clip | edit | implemented | **documented** | #7-9-metamorph-granular-identity-bleed-morph<br>#14-4-send-to-editor<br>#15-6-send-to-editor<br>#16-4-details<br>#16-5-media | Matched 6/6 guide terms. |
 | `edit-timeline-live-midi-soundfont` | Live MIDI timeline playback through the SpessaSynth soundfont engine with a GM and synth-voice instrument picker | daw | implemented | **documented** | #7-10-live-midi-playback-in-the-timeline<br>#15-8-instrument-soundfont-and-synth-voices | Matched 6/6 guide terms. |
 | `library-stems-midi-first-class` | Stems and MIDI as first-class library rows: play, favorite, delete, and route, in their own sub-tabs | library | implemented | **documented** | #1-repository-anatomy<br>#6-4-1-microphone-recorder<br>#purpose<br>#9-4-live-stems-and-fx<br>#12-1-views<br>#13-3-search-filter-sort<br>#13-4-per-entry-controls<br>#13-5-bundle-downloads-and-lineage<br>#13-6-stem-separation<br>#13-7-midi-conversion<br>#13-8-video-and-image-media<br>#13-12-stems-and-midi-as-first-class-items<br>#19-13-disk-backed-library<br>#19-15-stems<br>#19-16-midi<br>#21-1-settings-models-local-checkpoints-and-the-no-download-guarantee<br>#25-3-current-feature-to-screenshot-map | Matched 4/5 guide terms. |
+| `xr-quest-integrations` | Quest / XR integrations: delinQuest video, queststitch passthrough, two-way Quest MIDI bridge, and the GANTASMO Visor, without Quest Link or MQDH | vj | implemented | **documented** | #dedicated-in-app-sources-delinquest-stitch-cymatics-and-screen-capture<br>#34-quest-and-xr-integrations<br>#34-1-delinquest-quest-video-into-the-vj<br>#34-2-stitch-clean-passthrough-into-the-vj<br>#34-3-quest-midi-bridge<br>#34-4-gantasmo-visor<br>#34-5-setup-notes | Matched 6/6 guide terms. |
+| `vj-camera-sources` | VJ dedicated sources: delinQuest, STITCH passthrough, procedural cymatics, and screen/window capture, alongside webcam/phone/Quest-browser inputs | vj | implemented | **documented** | #8-1-layout<br>#dedicated-in-app-sources-delinquest-stitch-cymatics-and-screen-capture<br>#12-3-how-the-visualizations-are-rendered<br>#25-5-promo-video-capture<br>#34-1-delinquest-quest-video-into-the-vj<br>#34-2-stitch-clean-passthrough-into-the-vj<br>#34-5-setup-notes | Matched 5/5 guide terms. |
+| `vj-broadcast-watch-link` | VJ broadcast watch-link: WebRTC signaling for a live peer-to-peer viewer URL of the VJ output | vj | experimental | **documented** | #10-5-broadcast-and-watch-link | Matched 4/4 guide terms. |
 
 ## Screenshot Mapping
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-21T14:40:09.880Z",
-  "repoRevision": "62edab5b45f3",
+  "generatedAt": "2026-06-22T01:18:50.116Z",
+  "repoRevision": "50a44d90f570",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,
@@ -721,6 +721,75 @@
         "favorited",
         "Send to the Piano Roll"
       ]
+    },
+    {
+      "id": "xr-quest-integrations",
+      "name": "Quest / XR integrations: delinQuest video, queststitch passthrough, two-way Quest MIDI bridge, and the GANTASMO Visor, without Quest Link or MQDH",
+      "domain": "vj",
+      "sourcePaths": [
+        "backend/modules/questcast/router.py",
+        "backend/modules/queststitch/bridge.py",
+        "backend/modules/questmidi/router.py"
+      ],
+      "evidence": [
+        "scrcpy relay over ADB (no Quest Link / no MQDH)",
+        "GantasmoStitchStreamer MediaCodec H.264 -> TCP -> WS bridge",
+        "QuestMidiBridge two-way MIDI + loopMIDI return",
+        "GANTASMO Visor reacts to return-circuit MIDI"
+      ],
+      "status": "implemented",
+      "docSearchTerms": [
+        "delinQuest",
+        "queststitch",
+        "Quest MIDI bridge",
+        "GANTASMO Visor",
+        "Quest Link",
+        "Meta Quest Developer Hub"
+      ]
+    },
+    {
+      "id": "vj-camera-sources",
+      "name": "VJ dedicated sources: delinQuest, STITCH passthrough, procedural cymatics, and screen/window capture, alongside webcam/phone/Quest-browser inputs",
+      "domain": "vj",
+      "sourcePaths": [
+        "frontend/src/views/VJView.tsx",
+        "backend/modules/questcast/router.py",
+        "backend/modules/queststitch/bridge.py"
+      ],
+      "evidence": [
+        "delinQuest + STITCH source buttons",
+        "cymatics render-as-source",
+        "getDisplayMedia screen/window capture",
+        "browser-camera path for phone/Quest-browser"
+      ],
+      "status": "implemented",
+      "docSearchTerms": [
+        "delinQuest",
+        "STITCH",
+        "Cymatics",
+        "screen or window capture",
+        "getDisplayMedia"
+      ]
+    },
+    {
+      "id": "vj-broadcast-watch-link",
+      "name": "VJ broadcast watch-link: WebRTC signaling for a live peer-to-peer viewer URL of the VJ output",
+      "domain": "vj",
+      "sourcePaths": [
+        "backend/modules/broadcast/router.py"
+      ],
+      "evidence": [
+        "/api/broadcast WebRTC signaling",
+        "LAN watch-link",
+        "GO-LIVE + TURN still in progress"
+      ],
+      "status": "experimental",
+      "docSearchTerms": [
+        "watch-link",
+        "Broadcast",
+        "WebRTC",
+        "/api/broadcast"
+      ]
     }
   ],
   "coverage": [
@@ -939,7 +1008,7 @@
         "#10-vj-tab",
         "#purpose",
         "#10-3-bridges",
-        "#10-4-export",
+        "#10-6-autopilot-visual-effects",
         "#13-8-video-and-image-media",
         "#19-17-vj"
       ],
@@ -1051,7 +1120,8 @@
       "docAnchors": [
         "#7-6-commit-edit",
         "#7-7-insert-fx-rack-psychoacoustic",
-        "#7-8-spatializer-teleport-and-autopilot"
+        "#7-8-spatializer-teleport-and-autopilot",
+        "#10-6-autopilot-visual-effects"
       ],
       "coverage": "documented",
       "notes": "Matched 6/6 guide terms."
@@ -1100,6 +1170,42 @@
       ],
       "coverage": "documented",
       "notes": "Matched 4/5 guide terms."
+    },
+    {
+      "featureId": "xr-quest-integrations",
+      "docAnchors": [
+        "#dedicated-in-app-sources-delinquest-stitch-cymatics-and-screen-capture",
+        "#34-quest-and-xr-integrations",
+        "#34-1-delinquest-quest-video-into-the-vj",
+        "#34-2-stitch-clean-passthrough-into-the-vj",
+        "#34-3-quest-midi-bridge",
+        "#34-4-gantasmo-visor",
+        "#34-5-setup-notes"
+      ],
+      "coverage": "documented",
+      "notes": "Matched 6/6 guide terms."
+    },
+    {
+      "featureId": "vj-camera-sources",
+      "docAnchors": [
+        "#8-1-layout",
+        "#dedicated-in-app-sources-delinquest-stitch-cymatics-and-screen-capture",
+        "#12-3-how-the-visualizations-are-rendered",
+        "#25-5-promo-video-capture",
+        "#34-1-delinquest-quest-video-into-the-vj",
+        "#34-2-stitch-clean-passthrough-into-the-vj",
+        "#34-5-setup-notes"
+      ],
+      "coverage": "documented",
+      "notes": "Matched 5/5 guide terms."
+    },
+    {
+      "featureId": "vj-broadcast-watch-link",
+      "docAnchors": [
+        "#10-5-broadcast-and-watch-link"
+      ],
+      "coverage": "documented",
+      "notes": "Matched 4/4 guide terms."
     }
   ],
   "missingFeatureIds": [],

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -51,6 +51,7 @@ The **Docs** button in the top bar opens this guide as a modal with a filterable
 31. [Controller Vision](#31-controller-vision)
 32. [Admin, Module, and Assistant-Key APIs](#32-admin-module-and-assistant-key-apis)
 33. [Notation, Score, Tabs, and Arrangements](#33-notation-score-tabs-and-arrangements)
+34. [Quest and XR Integrations](#34-quest-and-xr-integrations)
 
 ---
 
@@ -591,6 +592,15 @@ The camera input extends past a webcam on the host machine. Any device that open
 
 A master MIDI gate turns Web MIDI on or off for the whole app. When off, the app never requests Web MIDI access, so no browser permission prompt appears.
 
+#### Dedicated in-app sources: delinQuest, STITCH, cymatics, and screen capture
+
+Beyond the browser-camera path above, the VJ source selector offers sources the app drives directly:
+
+- **delinQuest** streams a connected Meta Quest's video into the VJ over ADB (USB or wireless), decoded in the browser, with a choice of 16:9 or side-by-side 3D. It needs neither Quest Link nor Meta Quest Developer Hub. See §34.1.
+- **STITCH** streams only the Quest's clean stitched passthrough (the real-world composite, without the performer's overlay) as a separate source. See §34.2.
+- **Cymatics** renders a procedural, audio-reactive cymatics scene as the source, with plate, orb, landscape, sphere, and plasma modes, mixable against the other sources on the source crossfader.
+- **Screen or window capture** picks a monitor or an application window through the browser's `getDisplayMedia` and feeds it as the source.
+
 ### 10.2 Pop-out and Mobile
 
 - **Pop out** opens the visuals in a separate window. Drag it onto a second monitor for live performance while theDAW keeps running on the main display. **Pop back in** returns it to the tab. Closing the window manually snaps back automatically.
@@ -608,6 +618,14 @@ The tab wires several bridges to the engine through `postMessage`:
 ### 10.4 Export
 
 The visual engine records performances and the backend transcodes the recording to the chosen codec. The saved path is reported back and surfaced in the Processing Log. Exports are written to the local `exports/` folder and are never committed to the repository.
+
+### 10.5 Broadcast and watch-link
+
+A WebRTC signaling module (`/api/broadcast`) backs a live watch-link of the VJ output, so a viewer on the venue LAN can open a URL and watch the visuals peer-to-peer, with no media passing through the server. The GO-LIVE broadcaster front end, a DJ-audio host hop, and a TURN relay for public links are still in progress.
+
+### 10.6 Autopilot visual effects
+
+The VJ engine includes an Autopilot that layers audio-reactive visual effects, such as feedback wash, glitch, and waveform warp, each with its own probability, under a single Autopilot toggle. Turning it on lets the visuals evolve hands-free in time with the audio.
 
 ![VJ tab panel loading state](screenshots/08-vj-tab-loading__vj-panel.png)
 
@@ -2049,6 +2067,34 @@ GET  /api/analysis/{entry_id}/prompt
 ```
 
 `GET /api/notation` reports capabilities (music21 and MuseScore availability, supported formats, tab tunings, arrangement styles). `from-midi` converts a MIDI to MusicXML; `export` takes `{source_artifact_id, format}` with format musicxml/abc/pdf/svg; `tabs` takes `{source_artifact_id | midi_id, instrument, tuning_name, capo, difficulty}` and returns alphaTex; `arrange` takes `{style, source_artifact_id | source_artifact_ids | midi_id}` and returns MusicXML. `GET /api/analysis/{entry_id}/prompt` returns `{prompt_guess, prompt_confidence, semantic_tags}` regenerated from the stored analysis.
+
+---
+
+## 34. Quest and XR Integrations
+
+theDAW drives a Meta Quest headset for live performance without Quest Link (PC tethering) or Meta Quest Developer Hub casting. Each integration rides plain ADB over USB or a wireless pairing, and the backend starts the relay it needs on demand. The headset-side components live in the GANTASMO-MIDI Unity project.
+
+### 34.1 delinQuest: Quest video into the VJ
+
+delinQuest streams the headset's video into the VJ as a live source. The backend `questcast` module starts a Node relay that speaks the scrcpy protocol to the headset over ADB and pushes H.264 over a WebSocket; the VJ decodes it in the browser with WebCodecs and binds it to a camera stream. The VJ source button is labelled **delinQuest** and offers a full side-by-side 3D frame or a single eye cropped to 16:9. Selecting it auto-starts the relay (it verifies ADB and Node, installs the relay's dependency once, then connects), so there is no manual casting step. It requires USB debugging or a wireless ADB pairing on the headset.
+
+This is distinct from pointing the headset's own browser at a tunnel URL (§10.1): delinQuest pulls the headset's rendered video directly over ADB, with no in-headset browser and no public tunnel.
+
+### 34.2 STITCH: clean passthrough into the VJ
+
+queststitch streams only the Quest's stitched passthrough, the clean real-world composite without the performer's overlaid surface, as a separate **STITCH** source. A Unity component on the headset (`GantasmoStitchStreamer`) encodes the stitch render texture to H.264 with Android MediaCodec and sends it over an ADB-reversed TCP socket; the backend `queststitch` bridge re-frames it onto a WebSocket the VJ decodes the same way as delinQuest.
+
+### 34.3 Quest MIDI bridge
+
+QuestMidiBridge carries MIDI both ways between the headset and the DAW over an ADB-reversed TCP socket. The headset sends control and note MIDI, including 14-bit high-resolution CC for hand tracking, into the DAW; the DAW sends MIDI back to the headset through a loopMIDI return port. A hand gesture in-headset can drive the mix, and the mix can drive something in-headset.
+
+### 34.4 GANTASMO Visor
+
+The GANTASMO Visor is a procedural chrome visor rendered in-headset that reacts to the MIDI arriving on the return circuit: control changes drive its glow, hue, and warp, and note velocity flashes it. It mounts to the headset camera and needs no external assets.
+
+### 34.5 Setup notes
+
+Each integration needs USB debugging enabled on the Quest, or a wireless ADB pairing. The backend auto-detects ADB and starts the relay when the source is selected; the relay ports are configurable through environment variables (`theDAW_QUESTCAST_PORT`, `theDAW_QUESTSTITCH_PORT`). No Quest Link session and no Meta Quest Developer Hub are required at any point.
 
 ---
 

--- a/scripts/screenshots/specs.ts
+++ b/scripts/screenshots/specs.ts
@@ -339,6 +339,33 @@ export const FEATURE_DESCRIPTORS: FeatureDescriptor[] = [
     status: 'implemented',
     docSearchTerms: ['first-class items', 'Stems', 'sub-tabs', 'favorited', 'Send to the Piano Roll'],
   },
+  {
+    id: 'xr-quest-integrations',
+    name: 'Quest / XR integrations: delinQuest video, queststitch passthrough, two-way Quest MIDI bridge, and the GANTASMO Visor, without Quest Link or MQDH',
+    domain: 'vj',
+    sourcePaths: ['backend/modules/questcast/router.py', 'backend/modules/queststitch/bridge.py', 'backend/modules/questmidi/router.py'],
+    evidence: ['scrcpy relay over ADB (no Quest Link / no MQDH)', 'GantasmoStitchStreamer MediaCodec H.264 -> TCP -> WS bridge', 'QuestMidiBridge two-way MIDI + loopMIDI return', 'GANTASMO Visor reacts to return-circuit MIDI'],
+    status: 'implemented',
+    docSearchTerms: ['delinQuest', 'queststitch', 'Quest MIDI bridge', 'GANTASMO Visor', 'Quest Link', 'Meta Quest Developer Hub'],
+  },
+  {
+    id: 'vj-camera-sources',
+    name: 'VJ dedicated sources: delinQuest, STITCH passthrough, procedural cymatics, and screen/window capture, alongside webcam/phone/Quest-browser inputs',
+    domain: 'vj',
+    sourcePaths: ['frontend/src/views/VJView.tsx', 'backend/modules/questcast/router.py', 'backend/modules/queststitch/bridge.py'],
+    evidence: ['delinQuest + STITCH source buttons', 'cymatics render-as-source', 'getDisplayMedia screen/window capture', 'browser-camera path for phone/Quest-browser'],
+    status: 'implemented',
+    docSearchTerms: ['delinQuest', 'STITCH', 'Cymatics', 'screen or window capture', 'getDisplayMedia'],
+  },
+  {
+    id: 'vj-broadcast-watch-link',
+    name: 'VJ broadcast watch-link: WebRTC signaling for a live peer-to-peer viewer URL of the VJ output',
+    domain: 'vj',
+    sourcePaths: ['backend/modules/broadcast/router.py'],
+    evidence: ['/api/broadcast WebRTC signaling', 'LAN watch-link', 'GO-LIVE + TURN still in progress'],
+    status: 'experimental',
+    docSearchTerms: ['watch-link', 'Broadcast', 'WebRTC', '/api/broadcast'],
+  },
 ];
 
 export const SCREENSHOT_SPECS: ScreenshotSpec[] = [


### PR DESCRIPTION
Add docs/WHERE-WE-STAND.md, a project status and roadmap for shared reference (shipped vs in-flight vs pending across EDIT/automation, DJ, VJ, XR/Quest, generation/models, notation, and infra), with a branch map and next steps.

USER_GUIDE: document the previously-undocumented features the audit surfaced.
- Section 34 "Quest and XR Integrations": delinQuest (Quest video into the VJ over ADB, no Quest Link and no MQDH), queststitch (clean passthrough STITCH source), the two-way Quest MIDI bridge, and the GANTASMO Visor.
- Section 10.1: the dedicated VJ sources (delinQuest, STITCH, cymatics, and screen/window capture) beyond the browser-camera path.
- Sections 10.5 / 10.6: the WebRTC broadcast watch-link and Autopilot visuals.

Register three feature descriptors (xr-quest-integrations, vj-camera-sources, vj-broadcast-watch-link); coverage clean at 32 features, 0 missing.

Notation, auto-scoring, and sheets/tabs are already covered by section 33 (audio -> MIDI -> score); the status guide notes there is no direct OMR path.