### PR TITLE
Fix MPS (Apple Silicon) crash in APG guidance: float32 projection on MPS

### DIFF
--- a/stable_audio_3/models/dit.py
+++ b/stable_audio_3/models/dit.py
@@ -319,11 +319,15 @@ class DiffusionTransformer(nn.Module):
                           If provided, only valid positions contribute to the projection.
         """
         dtype = v0.dtype
-        v0, v1 = v0.double(), v1.double()
+        # MPS (Apple Silicon Metal) has no float64 dtype: `.double()` there raises
+        # "Cannot convert a MPS Tensor to float64". Run the projection in float32 on
+        # MPS and keep float64 on CUDA/CPU so existing output is unchanged.
+        proj_dtype = torch.float32 if v0.device.type == "mps" else torch.float64
+        v0, v1 = v0.to(proj_dtype), v1.to(proj_dtype)
 
         if padding_mask is not None:
             # Expand mask to match tensor shape: (B, T) -> (B, 1, T)
-            mask = padding_mask.unsqueeze(1).double()
+            mask = padding_mask.unsqueeze(1).to(proj_dtype)
             # Zero out padding positions for projection computation
             v0_masked = v0 * mask
             v1_masked = v1 * mask


### PR DESCRIPTION
## Problem

On Apple Silicon (MPS), **every generation crashes** at sampling time:

```
RuntimeError: Cannot convert a MPS Tensor to float64 dtype as the MPS
framework doesn't support float64. Please use float32 instead.
```

`DiffusionTransformer.apg_project` (`stable_audio_3/models/dit.py`) casts the guidance projection to float64 via `.double()`. APG is on by default (`apg_scale=1.0`), and the MPS backend has no float64 dtype, so the cast raises before any sampling happens. This hits the Gradio app, the FastAPI backend, and any direct `pipeline.generate()` use on a Mac GPU — the macOS-on-MPS path is effectively unusable.

## Fix

Make the projection dtype **device-conditional**: float32 on MPS, float64 everywhere else.

```python
proj_dtype = torch.float32 if v0.device.type == "mps" else torch.float64
v0, v1 = v0.to(proj_dtype), v1.to(proj_dtype)
...
mask = padding_mask.unsqueeze(1).to(proj_dtype)
```

- **CUDA / CPU behavior is unchanged** — they keep float64 (this is a no-op for them).
- Only MPS switches to float32, which is ample precision for a unit-vector projection of diffusion latents. The function already casts back to the input dtype at the end.
- 3-line change, no new dependencies, no API change.

## Testing

Verified on macOS 26.1 (Apple Silicon), torch 2.7.1, `small` model. A text-to-audio job that previously raised the error above now completes on MPS and produces valid 44.1 kHz stereo WAV, running **entirely on Metal** (no CPU fallback). The same 8-step / 6 s job renders in **~6 s on MPS vs ~20 s on CPU**. CUDA/CPU paths are unaffected by construction.

Found while running StableDAW on macOS via the [Pinokio launcher](https://github.com/cocktailpeanut/stabledaw.pinokio); before this fix the only macOS workaround was forcing the CPU device.
