### PR TITLE
ci(lint): bump checkout@v5 + setup-python@v6 to Node 24

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,8 +33,8 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install ruff


### PR DESCRIPTION
Clears the Node 20 deprecation warning on the Lint workflow. `actions/setup-python@v5` runs on Node 20 (being sunset on GitHub-hosted runners); v6 runs on Node 24. `actions/checkout` bumped v4 -> v5 (also Node 24). The pinned RUFF_VERSION is unchanged. This PR's own Lint run exercises the new versions.