### PR TITLE
chore: name the Electron desktop app theDAW; drop unused env fallbacks

### DIFF
--- a/backend/modules/analyzer/recommender.py
+++ b/backend/modules/analyzer/recommender.py
@@ -25,10 +25,7 @@ log = logging.getLogger(__name__)
 
 # The theDAW main backend assistant endpoint.
 # Default assumes the main backend runs on localhost:8600.
-_ASSISTANT_BASE = os.environ.get(
-    "THEDAW_BACKEND_URL",
-    os.environ.get("STABLEDAW_BACKEND_URL", "http://127.0.0.1:8600"),
-)
+_ASSISTANT_BASE = os.environ.get("THEDAW_BACKEND_URL", "http://127.0.0.1:8600")
 _ASSISTANT_CHAT_URL = f"{_ASSISTANT_BASE}/api/assistant/chat"
 
 # Provider/model to use for LLM enrichment (configurable via env).

--- a/backend/modules/magenta/sidecar.py
+++ b/backend/modules/magenta/sidecar.py
@@ -14,8 +14,7 @@ Conditioning is combinable per the model: a **text** prompt (default), a list of
 128-pitch state windows), and/or an **audio-style** reference clip (``audio``,
 embedded via the model's style encoder; overrides the prompt). The response
 ``X-Conditioning`` header reports which mode(s) were used. Override the URL with
-``THEDAW_MAGENTA_URL`` (default ``http://localhost:8777``; legacy
-``STABLEDAW_MAGENTA_URL`` is still honored as a fallback).
+``THEDAW_MAGENTA_URL`` (default ``http://localhost:8777``).
 """
 
 from __future__ import annotations
@@ -33,10 +32,7 @@ import httpx
 
 log = logging.getLogger(__name__)
 
-SIDECAR_URL = os.getenv(
-    "THEDAW_MAGENTA_URL",
-    os.getenv("STABLEDAW_MAGENTA_URL", "http://localhost:8777"),
-).rstrip("/")
+SIDECAR_URL = os.getenv("THEDAW_MAGENTA_URL", "http://localhost:8777").rstrip("/")
 
 # The identity the EXTENDED sidecar reports in /health. The bundled Studio server
 # answers ``ready: true`` too but speaks an incompatible JSON protocol and reports
@@ -86,13 +82,8 @@ async def health() -> dict:
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _ENGINE_SCRIPT = _REPO_ROOT / "sidecars" / "magenta" / "server.py"
 _DISTRO_FILE = _REPO_ROOT / "sidecars" / "magenta-rt2-nvidia" / "app" / ".wsl_distro"
-_ENGINE_MODEL = os.getenv(
-    "THEDAW_MAGENTA_MODEL", os.getenv("STABLEDAW_MAGENTA_MODEL", "mrt2_small")
-)
-_WSL_PYTHON = os.getenv(
-    "THEDAW_MAGENTA_WSL_PY",
-    os.getenv("STABLEDAW_MAGENTA_WSL_PY", "~/mrt2/.venv/bin/python"),
-)
+_ENGINE_MODEL = os.getenv("THEDAW_MAGENTA_MODEL", "mrt2_small")
+_WSL_PYTHON = os.getenv("THEDAW_MAGENTA_WSL_PY", "~/mrt2/.venv/bin/python")
 # pkill pattern matching BOTH magenta engines (extended + bundled Studio).
 _ENGINE_PKILL_PATTERN = "sidecars/magenta/server.py|studio_server.py"
 

--- a/electron-ui/electron-builder.yml
+++ b/electron-ui/electron-builder.yml
@@ -1,5 +1,5 @@
-appId: com.gantasmo.stabledaw
-productName: StableDAW
+appId: com.gantasmo.thedaw
+productName: theDAW
 directories:
   output: release
   buildResources: resources

--- a/electron-ui/main/index.ts
+++ b/electron-ui/main/index.ts
@@ -259,7 +259,7 @@ function createWindow(): void {
     height: 900,
     minWidth: 960,
     minHeight: 640,
-    title: 'StableDAW',
+    title: 'theDAW',
     webPreferences: {
       preload: path.join(__dirname, '../preload/index.js'),
       sandbox: true,
@@ -323,7 +323,7 @@ function loadingHTML(): string {
 </head>
 <body>
   <div class="spinner"></div>
-  <h2>StableDAW</h2>
+  <h2>theDAW</h2>
   <p id="status">Starting backend...</p>
   <div id="log"></div>
   <script>
@@ -505,7 +505,7 @@ app.whenReady().then(async () => {
 })
 
 app.on('window-all-closed', () => {
-  // Quit on all platforms — StableDAW is a DAW, not a utility app
+  // Quit on all platforms — theDAW is a DAW, not a utility app
   app.quit()
 })
 

--- a/electron-ui/package.json
+++ b/electron-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stabledaw-desktop",
+  "name": "thedaw-desktop",
   "version": "0.1.0",
   "private": true,
   "main": "./out/main/index.js",


### PR DESCRIPTION
Names the Electron desktop app theDAW (appId, productName, window title, loading heading, package name) and removes unused secondary environment-variable fallbacks (THEDAW_* primaries kept). The key-migration helper and the media-bucket IndexedDB name are left unchanged to avoid orphaning existing user data. ruff passes.