### PR TITLE
Feat/launch mode toggle

### DIFF
--- a/backend/modules/chimera/router.py
+++ b/backend/modules/chimera/router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -28,6 +29,11 @@ from .weave import (
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Cap on how many ffmpeg / librosa workers run at once during a mashup. ffmpeg
+# is itself multi-threaded, so a small cap parallelizes the per-clip decode /
+# stretch / detect without thrashing the box.
+_MASHUP_CONCURRENCY = 3
 
 
 @router.get("/probe")
@@ -222,44 +228,62 @@ async def chimera_mashup(
     with tempfile.TemporaryDirectory(prefix="chimera_") as tmpdir:
         tmp = Path(tmpdir)
 
-        norm_paths: list[Path] = []
+        n_files = len(files)
+        sem = asyncio.Semaphore(max(1, min(_MASHUP_CONCURRENCY, n_files)))
+
+        # 1) Read each upload to disk (sequential async I/O — fast), then
+        #    decode/normalize them CONCURRENTLY (each ffmpeg call runs in a
+        #    worker thread so they no longer block the event loop one-by-one).
+        raw_info: list[tuple[Path, str]] = []
         for i, upload in enumerate(files):
             suffix = Path(upload.filename or "").suffix or ".bin"
             raw_path = tmp / f"raw_{i}{suffix}"
             with open(raw_path, "wb") as f:
                 while chunk := await upload.read(1 << 20):
                     f.write(chunk)
+            raw_info.append((raw_path, upload.filename or f"clip {i}"))
 
-            norm_path = tmp / f"norm_{i}.wav"
-            try:
-                normalize_to_target(
-                    raw_path, norm_path, target_sr=out_sr, target_channels=2
-                )
-            except RuntimeError as e:
-                raise HTTPException(
-                    400, f"could not decode {upload.filename!r}: {e}"
-                ) from e
-            norm_paths.append(norm_path)
+        norm_paths: list[Path] = [tmp / f"norm_{i}.wav" for i in range(n_files)]
 
-        # Use client-supplied analysis (from analyze-on-add) when present and
-        # only run the detector on clips without it — duration always comes
-        # from the normalized file on disk, never the client.
-        detections = []
-        for i, p in enumerate(norm_paths):
+        async def _normalize(i: int) -> None:
+            async with sem:
+                try:
+                    await asyncio.to_thread(
+                        normalize_to_target,
+                        raw_info[i][0],
+                        norm_paths[i],
+                        target_sr=out_sr,
+                        target_channels=2,
+                    )
+                except RuntimeError as e:
+                    raise HTTPException(
+                        400, f"could not decode {raw_info[i][1]!r}: {e}"
+                    ) from e
+
+        await asyncio.gather(*(_normalize(i) for i in range(n_files)))
+
+        # 2) Use client-supplied analysis (from analyze-on-add) when present and
+        #    only run the detector on clips without it, CONCURRENTLY — duration
+        #    always comes from the normalized file on disk, never the client.
+        detections: list[dict[str, Any]] = [None] * n_files  # type: ignore[list-item]
+
+        async def _detect(i: int) -> None:
+            p = norm_paths[i]
             ka = known_list[i]
             if ka is not None:
                 info = sf.info(str(p))
-                detections.append(
-                    {
-                        "bpm": float(ka["bpm"]),
-                        "beats": [float(b) for b in ka["beats"]],
-                        "confidence": 1.0,
-                        "samplerate": int(info.samplerate),
-                        "duration_sec": float(info.frames) / float(info.samplerate),
-                    }
-                )
+                detections[i] = {
+                    "bpm": float(ka["bpm"]),
+                    "beats": [float(b) for b in ka["beats"]],
+                    "confidence": 1.0,
+                    "samplerate": int(info.samplerate),
+                    "duration_sec": float(info.frames) / float(info.samplerate),
+                }
             else:
-                detections.append(detect_tempo_and_beats(p))
+                async with sem:
+                    detections[i] = await asyncio.to_thread(detect_tempo_and_beats, p)
+
+        await asyncio.gather(*(_detect(i) for i in range(n_files)))
         detected_bpms: list[Optional[float]] = [d["bpm"] for d in detections]
 
         target_bpm_used, target_bpm_source = _resolve_target_bpm(
@@ -268,20 +292,29 @@ async def chimera_mashup(
         if target_bpm_source == "fallback":
             warnings.append("No clip had a detectable BPM; using 120 as fallback.")
 
-        stretched_paths: list[Path] = []
-        stretch_meta: list[dict[str, Any]] = []
-        for i, (norm_path, det) in enumerate(zip(norm_paths, detections)):
+        # 3) Time-stretch every clip to the target BPM, CONCURRENTLY.
+        stretched_paths: list[Path] = [
+            tmp / f"stretched_{i}.wav" for i in range(n_files)
+        ]
+        stretch_meta: list[dict[str, Any]] = [None] * n_files  # type: ignore[list-item]
+
+        async def _stretch(i: int) -> None:
+            det = detections[i]
             if det["bpm"] is None or det["bpm"] <= 0:
                 ratio = 1.0
             else:
                 ratio = target_bpm_used / det["bpm"]
-            out_path = tmp / f"stretched_{i}.wav"
-            try:
-                result = stretch_audio(norm_path, out_path, ratio)
-            except RuntimeError as e:
-                raise HTTPException(500, f"stretch failed for clip {i}: {e}") from e
-            stretched_paths.append(out_path)
-            stretch_meta.append(result)
+            async with sem:
+                try:
+                    stretch_meta[i] = await asyncio.to_thread(
+                        stretch_audio, norm_paths[i], stretched_paths[i], ratio
+                    )
+                except RuntimeError as e:
+                    raise HTTPException(500, f"stretch failed for clip {i}: {e}") from e
+
+        await asyncio.gather(*(_stretch(i) for i in range(n_files)))
+
+        for i, result in enumerate(stretch_meta):
             if result["engine"] == "atempo" and tools["librubberband"]:
                 warnings.append(
                     f"Clip {i}: rubberband unavailable at stretch time; used atempo."

--- a/backend/modules/library/bundle.py
+++ b/backend/modules/library/bundle.py
@@ -31,6 +31,7 @@ def build_bundle_bytes(
     analysis: Optional[dict[str, Any]],
     stems: Iterable[dict[str, Any]] = (),
     midis: Iterable[dict[str, Any]] = (),
+    scores: Iterable[dict[str, Any]] = (),
     lineage_edges: Iterable[dict[str, Any]] = (),
 ) -> bytes:
     """Build the zip and return its bytes. Caller streams these to the
@@ -81,6 +82,15 @@ def build_bundle_bytes(
             mp = Path(midi.get("midi_path") or "")
             if mp.is_file():
                 zf.write(mp, arcname=f"midi/{mp.name}")
+        # Score / notation artifacts (sheets, tabs, arrangements, exports).
+        # Dedup by filename so multiple DB rows pointing at the same file
+        # don't collide in the zip.
+        seen_scores: set[str] = set()
+        for score in scores:
+            sp = Path(score.get("path") or "")
+            if sp.is_file() and sp.name not in seen_scores:
+                seen_scores.add(sp.name)
+                zf.write(sp, arcname=f"scores/{sp.name}")
 
         # README.
         readme_text = _render_readme(
@@ -93,6 +103,7 @@ def build_bundle_bytes(
             midi_count=sum(
                 1 for m in midis if Path(m.get("midi_path") or "").is_file()
             ),
+            scores_count=len(seen_scores),
         )
         zf.writestr("README.txt", readme_text)
 
@@ -107,6 +118,7 @@ def _render_readme(
     analysis: Optional[dict[str, Any]],
     stems_count: int,
     midi_count: int,
+    scores_count: int = 0,
 ) -> str:
     lines: list[str] = []
     lines.append("theDAW Track Bundle")
@@ -139,8 +151,9 @@ def _render_readme(
                 continue
             lines.append(f"  {k}: {v}")
         lines.append("")
-    lines.append(f"Stems: {stems_count}")
-    lines.append(f"MIDI:  {midi_count}")
+    lines.append(f"Stems:  {stems_count}")
+    lines.append(f"MIDI:   {midi_count}")
+    lines.append(f"Scores: {scores_count}")
     lines.append("")
     lines.append("Contents:")
     lines.append("  - <audio file>     the track itself")
@@ -150,4 +163,5 @@ def _render_readme(
     lines.append("  - prompts.txt      positive/negative/embedded prompts")
     lines.append("  - stems/           separated stems (if stems ran)")
     lines.append("  - midi/            MIDI transcriptions (if midi ran)")
+    lines.append("  - scores/          sheet music / tabs / arrangements (if any)")
     return "\n".join(lines) + "\n"

--- a/backend/modules/library/router.py
+++ b/backend/modules/library/router.py
@@ -414,11 +414,18 @@ def download_bundle(entry_id: str) -> Response:
     analysis: Optional[dict[str, Any]] = None
     stems: list[dict[str, Any]] = []
     midis: list[dict[str, Any]] = []
+    scores: list[dict[str, Any]] = []
     edges: list[dict[str, Any]] = []
     if store.db is not None:
         analysis = store.db.get_analysis(entry_id)
         stems = store.db.list_stems(entry_id)
         midis = store.db.list_midis(entry_id)
+        # Notation artifacts minus raw midi (already bundled under midi/).
+        scores = [
+            a
+            for a in store.db.list_notation_artifacts(entry_id)
+            if a.get("kind") != "midi"
+        ]
         # Edges where entry is either parent or child.
         edges = store.db.list_relations(from_id=entry_id) + store.db.list_relations(
             to_id=entry_id
@@ -432,6 +439,7 @@ def download_bundle(entry_id: str) -> Response:
         analysis=analysis,
         stems=stems,
         midis=midis,
+        scores=scores,
         lineage_edges=edges,
     )
 
@@ -543,6 +551,26 @@ def list_all_midi() -> dict[str, Any]:
             midi_payload["parent_id"] = entry["id"]
             out.append(midi_payload)
     return {"midis": out, "count": len(out)}
+
+
+@router.get("/_all/scores")
+def list_all_scores() -> dict[str, Any]:
+    """Return every notation/score artifact across every entry, joined to the
+    parent entry's title. Excludes raw ``midi`` artifacts (those live in the
+    MIDI tab); keeps sheets, tabs, arrangements, and exports."""
+    store = get_store()
+    if store.db is None:
+        raise HTTPException(503, "library DB not available")
+    out: list[dict[str, Any]] = []
+    for entry in store.db.list_entries():
+        for art in store.db.list_notation_artifacts(entry["id"]):
+            if art.get("kind") == "midi":
+                continue
+            payload = dict(art)
+            payload["parent_title"] = entry.get("title")
+            payload["parent_id"] = entry["id"]
+            out.append(payload)
+    return {"scores": out, "count": len(out)}
 
 
 @router.get("/_graph/all")

--- a/backend/modules/library/store.py
+++ b/backend/modules/library/store.py
@@ -567,6 +567,14 @@ class LibraryStore:
         record = self.get_entry(entry_id)
         if record is not None:
             self._sync_record_to_db(record, meta)
+        # Favoriting a track gives it the full treatment — stems, MIDI, and a
+        # score — so a starred track is always fully analyzed and notated. Each
+        # job is idempotent (skipped if the artifact exists) and runs on the
+        # idle-gated, serialized background queue (stems -> midi -> score).
+        if bool(patch.get("favorite")):
+            _maybe_enqueue_stems(self, entry_id, source="favorite", force=True)
+            _maybe_enqueue_midi(self, entry_id, source="favorite", force=True)
+            _maybe_enqueue_score(self, entry_id, source="favorite", force=True)
         return record
 
     def delete_entry(self, entry_id: str) -> bool:
@@ -649,6 +657,7 @@ class LibraryStore:
         _maybe_enqueue_analysis(self, entry_id, source="import")
         _maybe_enqueue_stems(self, entry_id, source="import")
         _maybe_enqueue_midi(self, entry_id, source="import")
+        _maybe_enqueue_score(self, entry_id, source="import")
         return record
 
     def register_reference(
@@ -929,10 +938,13 @@ def _maybe_enqueue_stems(
     entry_id: str,
     *,
     source: str,
+    force: bool = False,
 ) -> None:
     """If feature settings have ``stems.auto_on_<source>`` enabled, queue
     a background stem-separation job. Heavy work — relies on the
-    integration-package sidecar."""
+    integration-package sidecar. ``force`` bypasses the settings gate (used
+    when favoriting a track), but the job is still skipped when the entry
+    already has stems."""
     if store.db is None:
         return
     try:
@@ -944,11 +956,18 @@ def _maybe_enqueue_stems(
     try:
         settings = get_settings_store().get_section("stems")
     except Exception:
-        return
+        settings = {}
 
     key = f"auto_on_{source}"
-    if not settings.get(key, False):
+    if not force and not settings.get(key, False):
         return
+
+    # Idempotent: never re-separate an entry that already has stems.
+    try:
+        if store.db.list_stems(entry_id):
+            return
+    except Exception:
+        pass
 
     audio_path = store.get_audio_path(entry_id)
     entry_dir = store._dir_for(entry_id)
@@ -979,10 +998,13 @@ def _maybe_enqueue_midi(
     entry_id: str,
     *,
     source: str,
+    force: bool = False,
 ) -> None:
     """If feature settings have ``midi.auto_on_<source>`` enabled, queue
     a background MIDI-conversion job. Reads ``midi.from_stems`` to
-    decide whether to also convert each stem."""
+    decide whether to also convert each stem. ``force`` bypasses the settings
+    gate (used when favoriting), but the job is still skipped when the entry
+    already has MIDI."""
     if store.db is None:
         return
     try:
@@ -994,11 +1016,18 @@ def _maybe_enqueue_midi(
     try:
         settings = get_settings_store().get_section("midi")
     except Exception:
-        return
+        settings = {}
 
     key = f"auto_on_{source}"
-    if not settings.get(key, False):
+    if not force and not settings.get(key, False):
         return
+
+    # Idempotent: never re-transcribe an entry that already has MIDI.
+    try:
+        if store.db.list_midis(entry_id):
+            return
+    except Exception:
+        pass
 
     audio_path = store.get_audio_path(entry_id)
     entry_dir = store._dir_for(entry_id)
@@ -1028,3 +1057,90 @@ def _maybe_enqueue_midi(
         get_background_queue().enqueue(f"midi:{entry_id}", _run)
     except Exception as e:
         log.debug("library.store: failed to enqueue midi for %s: %s", entry_id, e)
+
+
+def _generate_score_for_entry(
+    store: "LibraryStore", entry_id: str, entry_dir: Path
+) -> None:
+    """Generate a MusicXML sheet from the entry's first MIDI, stamped with the
+    song title. No-op if the entry already has a sheet or has no MIDI. Runs in
+    a worker thread (music21 parse is CPU-bound)."""
+    if store.db is None:
+        return
+    try:
+        from backend.modules.notation.engine import (
+            midi_to_musicxml,
+            register_existing_midis,
+        )
+    except Exception:
+        return
+    try:
+        register_existing_midis(store.db, entry_id)
+        if store.db.list_notation_artifacts(entry_id, kind="musicxml"):
+            return  # already scored
+        target = None
+        for midi in store.db.list_midis(entry_id):
+            path = midi.get("midi_path") or ""
+            if path and Path(path).is_file():
+                target = midi
+                break
+        if target is None:
+            return  # nothing to score
+        record = store.get_entry(entry_id)
+        title = str(getattr(record, "title", "") or "")
+        midi_id = str(target.get("id") or "")
+        output = entry_dir / "notation" / f"{midi_id}.musicxml"
+        midi_to_musicxml(
+            store.db,
+            entry_id=entry_id,
+            midi_path=Path(target["midi_path"]),
+            output_path=output,
+            source_ref=midi_id,
+            artifact_id=f"{midi_id}__musicxml",
+            title=title,
+        )
+    except Exception as e:  # noqa: BLE001 - best-effort background work
+        log.debug("library.store: auto-score failed for %s: %s", entry_id, e)
+
+
+def _maybe_enqueue_score(
+    store: "LibraryStore",
+    entry_id: str,
+    *,
+    source: str,
+    force: bool = False,
+) -> None:
+    """Queue a background job that turns the entry's MIDI into a titled sheet.
+    Auto-score defaults ON (sheets are cheap music21 work and the job only acts
+    when a MIDI already exists and no sheet does). ``force`` bypasses the
+    settings gate (used when favoriting). Enqueued AFTER any MIDI job so the
+    serial idle queue runs MIDI first, then this finds its output."""
+    if store.db is None:
+        return
+    try:
+        from backend.core.background_workers import get_background_queue
+        from backend.modules.settings.router import get_store as get_settings_store
+    except ImportError:
+        return
+
+    if not force:
+        try:
+            settings = get_settings_store().get_section("notation")
+        except Exception:
+            settings = {}
+        if not settings.get(f"auto_on_{source}", True):
+            return
+
+    entry_dir = store._dir_for(entry_id)
+    if entry_dir is None:
+        return
+
+    async def _run() -> None:
+        import asyncio
+
+        await asyncio.to_thread(_generate_score_for_entry, store, entry_id, entry_dir)
+
+    try:
+        get_background_queue().enqueue(f"score:{entry_id}", _run)
+    except Exception as e:
+        log.debug("library.store: failed to enqueue score for %s: %s", entry_id, e)

--- a/backend/modules/notation/backfill.py
+++ b/backend/modules/notation/backfill.py
@@ -1,0 +1,177 @@
+"""Backfill + repair for notation artifacts.
+
+Idempotent, safe to re-run every launch:
+
+  - Generate a MusicXML sheet for every entry that has MIDI but no sheet.
+  - Repair sheets that are missing the song title (music21 stamps the
+    placeholder "Music21 Fragment" on untitled MIDI) or the artist credit, by
+    regenerating them from the source MIDI so they also pick up the current
+    engraving. When the source MIDI is gone, the title is patched in place.
+
+Runs in a worker thread off the event loop; the caller enqueues it on the
+idle-gated background queue so a large library never blocks a request.
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_PLACEHOLDER = "Music21 Fragment"
+
+
+def _rewrite_titles(path: Path, title: str, composer: str) -> bool:
+    """Patch the printed title (and an existing composer credit) of a MusicXML
+    file in place. Returns True if changed. Best-effort."""
+    if not title and not composer:
+        return False
+    try:
+        tree = ET.parse(str(path))
+    except Exception:
+        return False
+    root = tree.getroot()
+    changed = False
+    for el in root.iter():
+        tag = el.tag.rsplit("}", 1)[-1]  # strip any namespace
+        if title and tag in ("movement-title", "work-title"):
+            if (el.text or "") != title:
+                el.text = title
+                changed = True
+        elif tag == "credit-words" and (el.text or "").strip() == _PLACEHOLDER:
+            el.text = title or composer
+            changed = True
+        elif composer and tag == "creator" and el.get("type") == "composer":
+            if (el.text or "") != composer:
+                el.text = composer
+                changed = True
+    if changed:
+        try:
+            tree.write(str(path), encoding="utf-8", xml_declaration=True)
+        except Exception:
+            return False
+    return changed
+
+
+def _needs_fix(path: Path, title: str, composer: str) -> bool:
+    """Cheap check (no music21 parse): does this sheet still need a title /
+    composer fix?"""
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return False
+    # Only flag the placeholder when we have a real title to replace it with;
+    # otherwise an untitled entry would regenerate to music21's placeholder on
+    # every launch forever.
+    if title and _PLACEHOLDER in text:
+        return True
+    if title and title not in text:
+        return True
+    if composer and composer not in text:
+        return True
+    return False
+
+
+def backfill_scores(store: Any) -> dict[str, int]:
+    res = {"scanned": 0, "generated": 0, "fixed": 0, "skipped": 0, "errors": 0}
+    if store.db is None:
+        return res
+    try:
+        from .engine import (
+            artist_name,
+            clean_title,
+            midi_to_musicxml,
+            register_existing_midis,
+        )
+    except Exception:
+        return res
+
+    composer = artist_name()
+    try:
+        entries = store.db.list_entries()
+    except Exception:
+        return res
+
+    for entry in entries:
+        eid = str(entry.get("id") or "")
+        if not eid:
+            continue
+        res["scanned"] += 1
+        title = clean_title(str(entry.get("title") or ""))
+        try:
+            register_existing_midis(store.db, eid)
+        except Exception:
+            pass
+
+        try:
+            sheets = store.db.list_notation_artifacts(eid, kind="musicxml")
+        except Exception:
+            sheets = []
+
+        # Does this entry need a (re)generation? Missing sheet, or an existing
+        # sheet with the placeholder / wrong title / missing credit.
+        has_sheet = bool(sheets)
+        needs = (not has_sheet) or any(
+            _needs_fix(Path(s.get("path") or ""), title, composer) for s in sheets
+        )
+        if not needs:
+            res["skipped"] += 1
+            continue
+
+        # Prefer regenerating from the source MIDI (fresh engraving + correct
+        # title + composer); fall back to an in-place title patch when the MIDI
+        # is gone.
+        target = None
+        try:
+            midis = store.db.list_midis(eid)
+        except Exception:
+            midis = []
+        for midi in midis:
+            mp = midi.get("midi_path") or ""
+            if mp and Path(mp).is_file():
+                target = midi
+                break
+
+        if target is not None:
+            entry_dir = store._dir_for(eid)  # noqa: SLF001 - module convention
+            if entry_dir is None:
+                res["errors"] += 1
+                continue
+            midi_id = str(target.get("id") or "")
+            out = entry_dir / "notation" / f"{midi_id}.musicxml"
+            try:
+                result = midi_to_musicxml(
+                    store.db,
+                    entry_id=eid,
+                    midi_path=Path(target["midi_path"]),
+                    output_path=out,
+                    source_ref=midi_id,
+                    artifact_id=f"{midi_id}__musicxml",
+                    title=title,
+                )
+                if result.get("ok"):
+                    res["generated" if not has_sheet else "fixed"] += 1
+                else:
+                    res["errors"] += 1
+            except Exception as exc:  # noqa: BLE001 - best-effort
+                log.debug("notation backfill: regen failed for %s: %s", eid, exc)
+                res["errors"] += 1
+        elif has_sheet:
+            fixed_any = False
+            for s in sheets:
+                p = Path(s.get("path") or "")
+                if p.is_file() and _rewrite_titles(p, title, composer):
+                    fixed_any = True
+            res["fixed" if fixed_any else "skipped"] += 1
+        else:
+            res["skipped"] += 1
+
+    log.info(
+        "notation backfill: scanned=%(scanned)d generated=%(generated)d "
+        "fixed=%(fixed)d skipped=%(skipped)d errors=%(errors)d",
+        res,
+    )
+    return res

--- a/backend/modules/notation/engine.py
+++ b/backend/modules/notation/engine.py
@@ -146,13 +146,15 @@ def convert_score(
     output_path: Path,
     source_ref: Optional[str] = None,
     artifact_id: Optional[str] = None,
+    title: str = "",
 ) -> dict[str, Any]:
     """Convert a symbolic source (MIDI or MusicXML) to another notation format
     and register the result as a notation artifact.
 
     ``music21`` handles ``musicxml`` and ``abc`` directly. ``pdf`` and ``svg``
     are engraved by the MuseScore CLI when installed; without it they return
-    ``ok=False`` with an install hint.
+    ``ok=False`` with an install hint. When ``title`` is given it is stamped on
+    the score so the rendered sheet shows the originating song's name.
     """
     fmt = fmt.lower().strip()
     if not source_path.is_file():
@@ -166,6 +168,7 @@ def convert_score(
             output_path=output_path,
             source_ref=source_ref,
             artifact_id=artifact_id,
+            title=title,
         )
     if fmt in _MUSESCORE_FORMATS:
         return _convert_with_musescore(
@@ -189,6 +192,7 @@ def _convert_with_music21(
     output_path: Path,
     source_ref: Optional[str],
     artifact_id: Optional[str],
+    title: str = "",
 ) -> dict[str, Any]:
     try:
         from music21 import converter  # type: ignore[import]
@@ -208,6 +212,18 @@ def _convert_with_music21(
             score = score.quantize((4, 3), inPlace=False, recurse=True)
         except Exception as exc:  # noqa: BLE001 - quantize is best-effort
             log.debug("notation: music21 quantize skipped for %s: %s", source_path, exc)
+        # Stamp the originating song's name so the engraved sheet is titled
+        # (raw MIDI usually carries no title -> blank sheets without this).
+        if title:
+            try:
+                from music21.metadata import Metadata  # type: ignore[import]
+
+                if score.metadata is None:
+                    score.insert(0, Metadata())
+                score.metadata.title = title
+                score.metadata.movementName = title
+            except Exception as exc:  # noqa: BLE001 - titling is best-effort
+                log.debug("notation: could not set title on %s: %s", output_path, exc)
         written = score.write(fmt, fp=str(output_path))
     except Exception as exc:  # noqa: BLE001
         log.warning("notation: %s export failed for %s: %s", fmt, source_path, exc)
@@ -327,6 +343,7 @@ def midi_to_musicxml(
     output_path: Path,
     source_ref: Optional[str] = None,
     artifact_id: Optional[str] = None,
+    title: str = "",
 ) -> dict[str, Any]:
     """Convert a MIDI file to MusicXML and register the artifact.
 
@@ -344,6 +361,7 @@ def midi_to_musicxml(
         output_path=output_path,
         source_ref=source_ref,
         artifact_id=artifact_id,
+        title=title,
     )
 
 

--- a/backend/modules/notation/engine.py
+++ b/backend/modules/notation/engine.py
@@ -27,6 +27,75 @@ from backend.modules.library.db import LibraryDB
 
 log = logging.getLogger(__name__)
 
+# The user is GANTASMO; sheets always carry a composer credit, so this is the
+# floor when no artist is configured (Settings -> notation.artist).
+DEFAULT_ARTIST = "GANTASMO"
+
+# Media file extensions that must never appear in a sheet title (e.g. an
+# imported track called "Foo.wav" should be titled "Foo"). Symbolic source
+# extensions are included too so a MIDI-derived title is never "...mid".
+_MEDIA_EXTENSIONS = (
+    ".wav",
+    ".mp3",
+    ".flac",
+    ".ogg",
+    ".oga",
+    ".m4a",
+    ".aac",
+    ".aif",
+    ".aiff",
+    ".opus",
+    ".wma",
+    ".alac",
+    ".mp4",
+    ".mov",
+    ".webm",
+    ".mkv",
+    ".m4v",
+    ".avi",
+    ".mid",
+    ".midi",
+    ".musicxml",
+    ".xml",
+)
+
+# music21's placeholders for an untitled fragment / unset composer.
+_PLACEHOLDER_TITLES = frozenset({"music21 fragment", "music21"})
+
+
+def clean_title(title: str) -> str:
+    """Sanitize a song title for display + engraving.
+
+    Drops a trailing media file extension (the user never wants ``.wav`` /
+    ``.mp3`` on a sheet) and treats music21's ``Music21 Fragment`` placeholder
+    as empty. Returns ``""`` when nothing meaningful remains.
+    """
+    t = (title or "").strip()
+    if not t:
+        return ""
+    low = t.lower()
+    for ext in _MEDIA_EXTENSIONS:
+        if low.endswith(ext):
+            t = t[: -len(ext)].rstrip()
+            break
+    if t.strip().lower() in _PLACEHOLDER_TITLES:
+        return ""
+    return t.strip()
+
+
+def artist_name() -> str:
+    """The global artist/composer name (Settings -> notation.artist), stamped
+    onto every generated sheet as the composer credit. Falls back to
+    :data:`DEFAULT_ARTIST` so a sheet is never credited to "Music21"."""
+    try:
+        from backend.modules.settings.router import get_store as get_settings_store
+
+        section = get_settings_store().get_section("notation")
+        name = str((section or {}).get("artist", "") or "").strip()
+    except Exception:
+        name = ""
+    return name or DEFAULT_ARTIST
+
 
 # Targets music21 can write directly from a parsed score.
 _MUSIC21_FORMATS = frozenset({"musicxml", "abc"})
@@ -212,18 +281,29 @@ def _convert_with_music21(
             score = score.quantize((4, 3), inPlace=False, recurse=True)
         except Exception as exc:  # noqa: BLE001 - quantize is best-effort
             log.debug("notation: music21 quantize skipped for %s: %s", source_path, exc)
-        # Stamp the originating song's name so the engraved sheet is titled
-        # (raw MIDI usually carries no title -> blank sheets without this).
-        if title:
-            try:
-                from music21.metadata import Metadata  # type: ignore[import]
+        # Stamp the originating song's name (and the artist as composer) so the
+        # engraved sheet is titled + credited — raw MIDI carries neither, which
+        # is why untitled sheets showed music21's "Music21 Fragment" placeholder
+        # and a "Music21" composer. The composer is ALWAYS overwritten (never
+        # left as music21's default); the title drops any media extension.
+        clean = clean_title(title)
+        composer = artist_name()
+        try:
+            from music21.metadata import Metadata  # type: ignore[import]
 
-                if score.metadata is None:
-                    score.insert(0, Metadata())
-                score.metadata.title = title
-                score.metadata.movementName = title
-            except Exception as exc:  # noqa: BLE001 - titling is best-effort
-                log.debug("notation: could not set title on %s: %s", output_path, exc)
+            if score.metadata is None:
+                score.insert(0, Metadata())
+            # Only the work title (song name); deliberately NOT movementName.
+            # music21 writes title -> <work-title> AND movementName ->
+            # <movement-title>; OSMD (and MuseScore) render work-title as the
+            # Title and movement-title as the Subtitle, so setting both to the
+            # song name prints the title twice. The artist is the composer; the
+            # viewer places it under the title via the subtitle slot.
+            if clean:
+                score.metadata.title = clean
+            score.metadata.composer = composer
+        except Exception as exc:  # noqa: BLE001 - titling is best-effort
+            log.debug("notation: could not set title on %s: %s", output_path, exc)
         written = score.write(fmt, fp=str(output_path))
     except Exception as exc:  # noqa: BLE001
         log.warning("notation: %s export failed for %s: %s", fmt, source_path, exc)
@@ -458,6 +538,25 @@ def midi_to_arrangement(
         import music21  # type: ignore[import]
     except ImportError:
         return {"ok": False, "error": "music21 is not installed."}
+
+    # Credit the artist as composer on the arrangement too, and re-stamp a
+    # cleaned title (the arranger sets it from the song name, which may carry a
+    # media extension).
+    clean = clean_title(title)
+    composer = artist_name()
+    try:
+        from music21.metadata import Metadata  # type: ignore[import]
+
+        sc = result["score"]
+        if sc.metadata is None:
+            sc.insert(0, Metadata())
+        # Title only (not movementName) so the song name isn't printed twice; see
+        # the note in _convert_with_music21. Artist is the composer credit.
+        if clean:
+            sc.metadata.title = clean
+        sc.metadata.composer = composer
+    except Exception as exc:  # noqa: BLE001 - crediting is best-effort
+        log.debug("notation: could not set composer on arrangement: %s", exc)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     try:

--- a/backend/modules/notation/router.py
+++ b/backend/modules/notation/router.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import io
 import mimetypes
+import zipfile
 from pathlib import Path
 from typing import Any, Optional
 
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel
 
 from backend.modules.library.router import get_store as get_library_store
@@ -331,6 +333,84 @@ def make_arrangement(entry_id: str, body: ArrangeRequest) -> dict[str, Any]:
     if not result.get("ok"):
         raise HTTPException(501, result)
     return result
+
+
+@router.post("/backfill")
+def backfill() -> dict[str, Any]:
+    """Ensure every entry with MIDI has a titled sheet, and fix the placeholder
+    title on existing sheets. Enqueued on the idle-gated background queue so a
+    large library never blocks; falls back to running inline if the queue is
+    unavailable."""
+    store = get_library_store()
+    if store.db is None:
+        raise HTTPException(503, "library DB not available")
+    from .backfill import backfill_scores
+
+    try:
+        from backend.core.background_workers import get_background_queue
+
+        async def _run() -> None:
+            import asyncio
+
+            await asyncio.to_thread(backfill_scores, store)
+
+        get_background_queue().enqueue("notation:backfill", _run)
+        return {"queued": True}
+    except Exception:
+        # No queue available — run synchronously and return the tallies.
+        return {"queued": False, **backfill_scores(store)}
+
+
+@router.get("/pack/{artifact_id}")
+def download_score_pack(artifact_id: str) -> Response:
+    """Download a score as a zip of the source plus a PDF. The PDF is engraved
+    by the MuseScore CLI when available; without it the zip still carries the
+    MusicXML so the download never fails."""
+    store = get_library_store()
+    if store.db is None:
+        raise HTTPException(503, "library DB not available")
+    artifact = store.db.get_notation_artifact(artifact_id)
+    if artifact is None:
+        raise HTTPException(404, f"artifact {artifact_id!r} not found")
+    src = Path(artifact.get("path") or "")
+    if not src.is_file():
+        raise HTTPException(404, f"artifact file missing on disk: {src}")
+
+    entry_id = str(artifact.get("entry_id") or "")
+    slug = _song_slug(_entry_title(store, entry_id)) or src.stem
+    members: list[tuple[Path, str]] = [(src, f"{slug}{src.suffix}")]
+
+    # Engrave a PDF from a MusicXML sheet when MuseScore is installed.
+    if artifact.get("kind") == "musicxml":
+        entry_dir = store._dir_for(entry_id)  # noqa: SLF001 - module convention
+        if entry_dir is not None:
+            pdf_out = entry_dir / "notation" / f"{src.stem}.pdf"
+            result = convert_score(
+                store.db,
+                entry_id=entry_id,
+                source_path=src,
+                fmt="pdf",
+                output_path=pdf_out,
+                source_ref=artifact_id,
+                artifact_id=f"{artifact_id}__pdf",
+                title=_entry_title(store, entry_id),
+            )
+            if result.get("ok"):
+                pdf_path = Path(result.get("path") or pdf_out)
+                if pdf_path.is_file():
+                    members.append((pdf_path, f"{slug}.pdf"))
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path, arcname in members:
+            if path.is_file():
+                zf.write(path, arcname=arcname)
+    buf.seek(0)
+    return Response(
+        content=buf.read(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{slug}_score.zip"'},
+    )
 
 
 @router.get("/file/{artifact_id}")

--- a/backend/modules/notation/router.py
+++ b/backend/modules/notation/router.py
@@ -34,6 +34,27 @@ _EXT_FOR_FORMAT = {
 }
 
 
+def _song_slug(title: str, fallback: str = "score") -> str:
+    """Filesystem-safe, readable slug of a song title for score filenames."""
+    cleaned = "".join(c if (c.isalnum() or c in " -_") else "_" for c in (title or ""))
+    cleaned = "_".join(cleaned.split())  # collapse whitespace runs to one "_"
+    cleaned = cleaned.strip("_-")
+    return cleaned[:60] or fallback
+
+
+def _entry_title(store: Any, entry_id: str) -> str:
+    entry = store.get_entry(entry_id)
+    return str(getattr(entry, "title", "") or "") if entry is not None else ""
+
+
+def _scored_name(slug: str, base: str) -> str:
+    """Prefix ``base`` with the song slug unless it already leads with it,
+    so the file (and its download name) carries the originating song."""
+    if slug and not base.lower().startswith(slug.lower()):
+        return f"{slug}__{base}"
+    return base
+
+
 class ExportRequest(BaseModel):
     source_artifact_id: str
     format: str
@@ -93,8 +114,11 @@ def convert_midi_artifact(entry_id: str, midi_id: str) -> dict[str, Any]:
     store = get_library_store()
     if store.db is None:
         raise HTTPException(503, "library DB not available")
-    if store.get_entry(entry_id) is None:
+    entry = store.get_entry(entry_id)
+    if entry is None:
         raise HTTPException(404, f"entry {entry_id!r} not found")
+    title = str(getattr(entry, "title", "") or "")
+    slug = _song_slug(title)
     midi_row = None
     for row in store.db.list_midis(entry_id):
         if row.get("id") == midi_id:
@@ -105,7 +129,7 @@ def convert_midi_artifact(entry_id: str, midi_id: str) -> dict[str, Any]:
     entry_dir = store._dir_for(entry_id)  # noqa: SLF001 - existing module convention
     if entry_dir is None:
         raise HTTPException(500, f"entry directory missing for {entry_id!r}")
-    output = entry_dir / "notation" / f"{midi_id}.musicxml"
+    output = entry_dir / "notation" / _scored_name(slug, f"{midi_id}.musicxml")
     result = midi_to_musicxml(
         store.db,
         entry_id=entry_id,
@@ -113,6 +137,7 @@ def convert_midi_artifact(entry_id: str, midi_id: str) -> dict[str, Any]:
         output_path=output,
         source_ref=midi_id,
         artifact_id=f"{midi_id}__musicxml",
+        title=title,
     )
     if not result.get("ok"):
         raise HTTPException(501, result)
@@ -147,7 +172,9 @@ def export_artifact(entry_id: str, body: ExportRequest) -> dict[str, Any]:
     entry_dir = store._dir_for(entry_id)  # noqa: SLF001 - existing module convention
     if entry_dir is None:
         raise HTTPException(500, f"entry directory missing for {entry_id!r}")
-    output = entry_dir / "notation" / f"{source_path.stem}{ext}"
+    title = _entry_title(store, entry_id)
+    slug = _song_slug(title)
+    output = entry_dir / "notation" / _scored_name(slug, f"{source_path.stem}{ext}")
     result = convert_score(
         store.db,
         entry_id=entry_id,
@@ -156,6 +183,7 @@ def export_artifact(entry_id: str, body: ExportRequest) -> dict[str, Any]:
         output_path=output,
         source_ref=body.source_artifact_id,
         artifact_id=f"{body.source_artifact_id}__{fmt}",
+        title=title,
     )
     if not result.get("ok"):
         raise HTTPException(501, result)
@@ -211,7 +239,12 @@ def make_tabs(entry_id: str, body: TabsRequest) -> dict[str, Any]:
     entry_dir = store._dir_for(entry_id)  # noqa: SLF001 - existing module convention
     if entry_dir is None:
         raise HTTPException(500, f"entry directory missing for {entry_id!r}")
-    output = entry_dir / "notation" / f"{stem}__{body.instrument}.alphatex"
+    slug = _song_slug(str(getattr(entry, "title", "") or ""))
+    output = (
+        entry_dir
+        / "notation"
+        / _scored_name(slug, f"{stem}__{body.instrument}.alphatex")
+    )
     result = midi_to_tabs(
         store.db,
         entry_id=entry_id,
@@ -279,7 +312,12 @@ def make_arrangement(entry_id: str, body: ArrangeRequest) -> dict[str, Any]:
     entry_dir = store._dir_for(entry_id)  # noqa: SLF001 - existing module convention
     if entry_dir is None:
         raise HTTPException(500, f"entry directory missing for {entry_id!r}")
-    output = entry_dir / "notation" / f"{sources[0].stem}__{style}.musicxml"
+    slug = _song_slug(str(getattr(entry, "title", "") or ""))
+    output = (
+        entry_dir
+        / "notation"
+        / _scored_name(slug, f"{sources[0].stem}__{style}.musicxml")
+    )
     result = midi_to_arrangement(
         store.db,
         entry_id=entry_id,
@@ -312,8 +350,12 @@ def get_artifact_file(artifact_id: str) -> FileResponse:
         mime = "application/vnd.recordare.musicxml+xml"
     elif kind in ("abc", "alphatex"):
         mime = "text/plain; charset=utf-8"
+    # Name the download after the originating song so saved sheets are
+    # identifiable even for artifacts created before song-prefixed filenames.
+    slug = _song_slug(_entry_title(store, str(artifact.get("entry_id") or "")))
+    download_name = _scored_name(slug, path.name)
     return FileResponse(
         path=str(path),
         media_type=mime or "application/octet-stream",
-        filename=path.name,
+        filename=download_name,
     )

--- a/backend/modules/settings/store.py
+++ b/backend/modules/settings/store.py
@@ -23,7 +23,7 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 
 DEFAULT_SETTINGS: dict[str, Any] = {
@@ -75,6 +75,13 @@ DEFAULT_SETTINGS: dict[str, Any] = {
         # Each take also lands in a per-export subfolder named in the VJ
         # record bar, so the final file is <export_root>/<subfolder>/…
         "export_root": "exports/vj",
+    },
+    "notation": {
+        # Global artist/composer name. Stamped as the composer credit on every
+        # generated sheet (and appended to song titles). Defaults to GANTASMO;
+        # editable in Settings. The engine falls back to GANTASMO even if this
+        # is blanked, so a sheet is never credited to "Music21".
+        "artist": "GANTASMO",
     },
 }
 
@@ -144,6 +151,10 @@ def _merge_defaults(payload: dict[str, Any]) -> dict[str, Any]:
         # section, already filled from DEFAULT_SETTINGS above; this branch
         # re-persists the bumped schema with the field present.
         merged.setdefault("app", deepcopy(DEFAULT_SETTINGS["app"]))
+    if old_version < 7:
+        # Migration v6 → v7: add the `notation` section (artist). New section,
+        # already filled from DEFAULT_SETTINGS above; re-persist the bump.
+        merged.setdefault("notation", deepcopy(DEFAULT_SETTINGS["notation"]))
 
     merged["schema_version"] = SCHEMA_VERSION
     return merged

--- a/backend/modules/settings/store.py
+++ b/backend/modules/settings/store.py
@@ -23,11 +23,17 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 
 DEFAULT_SETTINGS: dict[str, Any] = {
     "schema_version": SCHEMA_VERSION,
+    "app": {
+        # How theDAW opens on the next launch (read by theDAW.bat before it
+        # starts anything): "web" = backend + Vite + browser (current default),
+        # "desktop" = the Electron shell. Both share the same backend + DB.
+        "launch_mode": "web",
+    },
     "analysis": {
         # Analysis is cheap (local librosa + aubio), so it's default-ON
         # — every imported / generated track gets its bpm/key/pitch/bars
@@ -133,6 +139,11 @@ def _merge_defaults(payload: dict[str, Any]) -> dict[str, Any]:
         # section, so it's already filled from DEFAULT_SETTINGS above;
         # this branch only exists to re-persist the bumped schema.
         merged.setdefault("vj", deepcopy(DEFAULT_SETTINGS["vj"]))
+    if old_version < 6:
+        # Migration v5 → v6: add the `app` section (launch_mode). New
+        # section, already filled from DEFAULT_SETTINGS above; this branch
+        # re-persists the bumped schema with the field present.
+        merged.setdefault("app", deepcopy(DEFAULT_SETTINGS["app"]))
 
     merged["schema_version"] = SCHEMA_VERSION
     return merged

--- a/backend/server.py
+++ b/backend/server.py
@@ -843,6 +843,26 @@ async def load_model():
     except Exception as e:
         logger.warning("startup: background worker queue failed to start: %s", e)
 
+    # One idle-gated pass to ensure every entry with MIDI has a titled sheet
+    # (and existing sheets get their "Music21 Fragment" placeholder replaced
+    # with the real song name). Idempotent + serialized, so it's safe to run
+    # every launch — it only does work where a sheet is missing or mistitled.
+    try:
+        from backend.core.background_workers import get_background_queue
+        from backend.modules.library.router import get_store as _get_lib_store
+        from backend.modules.notation.backfill import backfill_scores
+
+        _bf_store = _get_lib_store()
+
+        async def _run_backfill() -> None:
+            import asyncio
+
+            await asyncio.to_thread(backfill_scores, _bf_store)
+
+        get_background_queue().enqueue("notation:backfill", _run_backfill)
+    except Exception as e:
+        logger.debug("startup: notation backfill enqueue skipped: %s", e)
+
 
 @app.on_event("shutdown")
 async def stop_background_workers() -> None:
@@ -1525,6 +1545,7 @@ async def _run_generate_job(
                         from backend.modules.library.store import (
                             _maybe_enqueue_analysis,
                             _maybe_enqueue_midi,
+                            _maybe_enqueue_score,
                             _maybe_enqueue_stems,
                         )
 
@@ -1551,6 +1572,9 @@ async def _run_generate_job(
                                 _lib_store, _entry_id, source="generate"
                             )
                             _maybe_enqueue_midi(
+                                _lib_store, _entry_id, source="generate"
+                            )
+                            _maybe_enqueue_score(
                                 _lib_store, _entry_id, source="generate"
                             )
                     except Exception as _e:

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-23T14:58:26.486Z · Git revision: `8b2cca1fec9f` · Repomix tracked: **no**
+> Generated: 2026-06-23T17:57:11.024Z · Git revision: `cae3caafd94b` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-23T01:58:50.774Z · Git revision: `1854cc784e3a` · Repomix tracked: **no**
+> Generated: 2026-06-23T14:58:26.486Z · Git revision: `8b2cca1fec9f` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-23T01:58:50.774Z",
-  "repoRevision": "1854cc784e3a",
+  "generatedAt": "2026-06-23T14:58:26.486Z",
+  "repoRevision": "8b2cca1fec9f",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-23T14:58:26.486Z",
-  "repoRevision": "8b2cca1fec9f",
+  "generatedAt": "2026-06-23T17:57:11.024Z",
+  "repoRevision": "cae3caafd94b",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": false,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-23T02:00:41.575Z",
+  "generatedAt": "2026-06-23T15:00:31.918Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/electron-ui/electron.vite.config.ts
+++ b/electron-ui/electron.vite.config.ts
@@ -31,6 +31,16 @@ export default defineConfig({
       }
     },
     plugins: [react(), tailwindcss()],
+    // alphaTab resolves its Bravura font + worker via import.meta.url relative
+    // to its own dist/. Vite's dep pre-bundling rewrites that into .vite/deps/
+    // where the worker does NOT exist, which wedges the renderer ("alphaTab.
+    // worker.mjs does not exist in the optimize deps directory"). Excluding it
+    // (matching frontend/vite.config.ts) keeps it served from node_modules so
+    // the worker + font URLs stay valid. Without this, desktop mode hangs on
+    // "loading" and scores never render.
+    optimizeDeps: {
+      exclude: ['@coderline/alphatab'],
+    },
     resolve: {
       alias: { '@': resolve(__dirname, '../frontend') }
     },

--- a/frontend/src/components/audio/ChopControls.tsx
+++ b/frontend/src/components/audio/ChopControls.tsx
@@ -43,7 +43,7 @@ export function ChopControls({ params, onChange, idPrefix }: ChopControlsProps) 
           name={programId}
           value={program}
           onChange={(e) => set('program', Number(e.target.value))}
-          className="flex-1 bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 cursor-pointer"
+          className="flex-1 form-select px-2 py-1 text-[11px] font-mono"
           style={{ colorScheme: 'dark' }}
         >
           {PROGRAMS.map((label, i) => (

--- a/frontend/src/components/audio/FxRack.tsx
+++ b/frontend/src/components/audio/FxRack.tsx
@@ -62,7 +62,7 @@ export function FxRack({
           onChange={(e) => {
             if (e.target.value) onAdd(e.target.value);
           }}
-          className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 transition-colors cursor-pointer"
+          className="form-select px-2 py-1 text-[11px] font-mono"
           style={{ colorScheme: 'dark' }}
           title="Add a psychoacoustic insert effect to this chain"
         >

--- a/frontend/src/components/audio/GaterControls.tsx
+++ b/frontend/src/components/audio/GaterControls.tsx
@@ -65,7 +65,7 @@ export function GaterControls({ params, onChange, idPrefix, projectBpm }: GaterC
               name={divId}
               value={div}
               onChange={(e) => set('div', Number(e.target.value))}
-              className="flex-1 bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 cursor-pointer"
+              className="flex-1 form-select px-2 py-1 text-[11px] font-mono"
               style={{ colorScheme: 'dark' }}
             >
               {GATER_DIVISIONS.map((label, i) => (

--- a/frontend/src/components/audio/InstrumentPicker.tsx
+++ b/frontend/src/components/audio/InstrumentPicker.tsx
@@ -49,7 +49,7 @@ export const InstrumentPicker: React.FC = () => {
         aria-label="MIDI instrument"
         value={value}
         onChange={onChange}
-        className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-xs text-zinc-100 max-w-44 outline-none focus:border-purple-500/60"
+        className="form-select px-2 py-1 text-xs max-w-44"
         style={{ colorScheme: 'dark' }}
       >
         <option value="basic">Basic (sawtooth)</option>

--- a/frontend/src/components/audio/MetamorphPanel.tsx
+++ b/frontend/src/components/audio/MetamorphPanel.tsx
@@ -138,7 +138,7 @@ export function MetamorphPanel() {
             name="morph-donor"
             value={aId ?? ''}
             onChange={pick('a')}
-            className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 cursor-pointer"
+            className="form-select px-2 py-1 text-[11px] font-mono"
             style={{ colorScheme: 'dark' }}
           >
             <SourceOptions />
@@ -151,7 +151,7 @@ export function MetamorphPanel() {
             name="morph-host"
             value={bId ?? ''}
             onChange={pick('b')}
-            className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 cursor-pointer"
+            className="form-select px-2 py-1 text-[11px] font-mono"
             style={{ colorScheme: 'dark' }}
           >
             <SourceOptions />

--- a/frontend/src/components/audio/OwlPad.tsx
+++ b/frontend/src/components/audio/OwlPad.tsx
@@ -113,7 +113,7 @@ export function OwlPad({ params, onChange, idPrefix }: OwlPadProps) {
             name={programId}
             value={program}
             onChange={(e) => set('program', Number(e.target.value))}
-            className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 cursor-pointer"
+            className="form-select px-2 py-1 text-[11px] font-mono"
             style={{ colorScheme: 'dark' }}
           >
             {OWLPAD_PROGRAMS.map((label, i) => (

--- a/frontend/src/components/audio/SpatializerPad.tsx
+++ b/frontend/src/components/audio/SpatializerPad.tsx
@@ -233,7 +233,7 @@ export function SpatializerPad({ params, onChange, idPrefix }: SpatializerPadPro
             name={motionId}
             value={motion}
             onChange={(e) => set('motion', Number(e.target.value))}
-            className="bg-zinc-900 border border-white/20 rounded px-2 py-1 text-[11px] font-mono text-zinc-100 outline-none focus:border-purple-500/60 cursor-pointer"
+            className="form-select px-2 py-1 text-[11px] font-mono"
             style={{ colorScheme: 'dark' }}
           >
             {SPATIAL_MOTIONS.map((label, i) => (

--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -210,7 +210,7 @@ const TrackInstrumentSelect: React.FC<{ track: EditorTrack }> = ({ track }) => {
         aria-label={`Track ${track.name} instrument`}
         value={value}
         onChange={onChange}
-        className="flex-1 min-w-0 bg-zinc-900 border border-white/20 rounded px-1 py-0.5 text-[9px] text-zinc-100 outline-none focus:border-purple-500/60"
+        className="flex-1 min-w-0 form-select px-1 py-0.5 text-[9px]"
         style={{ colorScheme: 'dark' }}
       >
         <option value="default">{defaultLabel}</option>
@@ -256,7 +256,7 @@ const ClipInstrumentSelect: React.FC<{ clip: AudioClip }> = ({ clip }) => {
         aria-label={`Clip ${clip.label} instrument`}
         value={value}
         onChange={onChange}
-        className="flex-1 min-w-0 bg-zinc-900 border border-white/20 rounded px-1.5 py-1 text-[10px] text-zinc-100 outline-none focus:border-purple-500/60"
+        className="flex-1 min-w-0 form-select px-1.5 py-1 text-[10px]"
         style={{ colorScheme: 'dark' }}
       >
         <option value="default">{defaultLabel}</option>

--- a/frontend/src/components/layout/DetailsView.tsx
+++ b/frontend/src/components/layout/DetailsView.tsx
@@ -278,7 +278,7 @@ export const DetailsView: React.FC = () => {
         )}
         {analysis && analysis.embedded_tags_json && analysis.embedded_tags_json !== '{}' && (
           <details className="mt-2">
-            <summary className="text-[8px] font-mono uppercase tracking-widest text-zinc-500 cursor-pointer hover:text-zinc-300">
+            <summary className="text-[8px] font-mono uppercase tracking-widest text-zinc-300 cursor-pointer hover:text-purple-300">
               Embedded tags (ID3 / Vorbis / iTunes)
             </summary>
             <pre className="text-[9px] font-mono text-zinc-400 mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-all">
@@ -288,7 +288,7 @@ export const DetailsView: React.FC = () => {
         )}
         {analysis && analysis.ffprobe_json && analysis.ffprobe_json !== '{}' && (
           <details className="mt-1">
-            <summary className="text-[8px] font-mono uppercase tracking-widest text-zinc-500 cursor-pointer hover:text-zinc-300">
+            <summary className="text-[8px] font-mono uppercase tracking-widest text-zinc-300 cursor-pointer hover:text-purple-300">
               ffprobe summary
             </summary>
             <pre className="text-[9px] font-mono text-zinc-400 mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-all">

--- a/frontend/src/components/layout/ScoreView.tsx
+++ b/frontend/src/components/layout/ScoreView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Download, FileMusic, Guitar, LayoutGrid, Loader2, Maximize2, Minus, Music2, Plus, RefreshCw } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Download, FileMusic, Guitar, LayoutGrid, Loader2, Maximize2, Minus, Music2, Plus, RefreshCw } from 'lucide-react';
 import { useLibraryStore } from '../../state/libraryStore';
 import { logError, logInfo } from '../../state/logStore';
 import {
@@ -10,6 +10,7 @@ import {
   makeArrangement,
   makeTabs,
   notationArtifactUrl,
+  notationPackUrl,
   type NotationArtifact,
   type NotationCapabilities,
 } from '../../lib/notationClient';
@@ -45,6 +46,32 @@ export const ScoreView: React.FC = () => {
   const [tabDifficulty, setTabDifficulty] = useState('medium');
   const [arrangeStyle, setArrangeStyle] = useState('piano-reduction');
   const [arranging, setArranging] = useState(false);
+  // Global artist/composer name — saved to Settings (notation.artist) and
+  // stamped onto every generated sheet as the composer credit.
+  const [artist, setArtist] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch('/api/settings')
+      .then((r) => r.json())
+      .then((s) => {
+        if (!cancelled) setArtist(String(s?.notation?.artist ?? ''));
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  const saveArtist = async (value: string) => {
+    try {
+      await fetch('/api/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notation: { artist: value } }),
+      });
+    } catch (e) {
+      logError('score', `Could not save artist name: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
 
   const selectedArtifact = artifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
   const musicXmlArtifacts = artifacts.filter((artifact) => artifact.kind === 'musicxml');
@@ -201,6 +228,24 @@ export const ScoreView: React.FC = () => {
           >
             {loading ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
           </button>
+        </div>
+
+        <div className="p-2 border-b border-white/5">
+          <label htmlFor="score-artist" className="text-[8px] font-mono uppercase tracking-widest text-zinc-500 block mb-1">
+            Artist
+          </label>
+          <input
+            id="score-artist"
+            name="score-artist"
+            type="text"
+            className="compact-input w-full"
+            placeholder="Your artist name (e.g. GANTASMO)"
+            value={artist}
+            onChange={(e) => setArtist(e.target.value)}
+            onBlur={(e) => void saveArtist(e.target.value.trim())}
+            aria-label="Artist name credited on every sheet"
+            title="Credited as the composer on every generated sheet, and saved with your songs."
+          />
         </div>
 
         <div className="p-2 border-b border-white/5 flex gap-1">
@@ -360,8 +405,17 @@ export const ScoreView: React.FC = () => {
           {selectedArtifact && (
             <a
               className="btn-ghost text-[8px] py-1 flex items-center gap-1"
-              href={notationArtifactUrl(selectedArtifact.id)}
+              href={
+                selectedArtifact.kind === 'musicxml'
+                  ? notationPackUrl(selectedArtifact.id)
+                  : notationArtifactUrl(selectedArtifact.id)
+              }
               download
+              title={
+                selectedArtifact.kind === 'musicxml'
+                  ? 'Download MusicXML + PDF (PDF needs MuseScore)'
+                  : 'Download this artifact'
+              }
             >
               <Download className="w-3 h-3" /> DOWNLOAD
             </a>
@@ -458,28 +512,251 @@ const ZoomControls: React.FC<{
   </div>
 );
 
+const A4_RATIO = 297 / 210; // A4 portrait height / width
+const PAGE_GAP = 24; // px between side-by-side pages (matches gap-6)
+
+// Media + symbolic extensions that must never show up in a sheet title.
+const TITLE_EXT_RE =
+  /\.(wav|mp3|flac|ogg|oga|m4a|aac|aif|aiff|opus|wma|alac|mp4|mov|webm|mkv|m4v|avi|mid|midi|musicxml|xml)$/i;
+
+/** Sanitize a title for engraving: drop a trailing media extension and treat
+ *  music21's "Music21 Fragment" / "Music21" placeholders as empty. */
+const cleanTitleText = (raw: string): string => {
+  const t = (raw || '').trim().replace(TITLE_EXT_RE, '').trim();
+  return /^music21( fragment)?$/i.test(t) ? '' : t;
+};
+
+/** Word-wrap a long title by inserting newlines (OSMD splits labels on \n and
+ *  centers each line) so a long song name lays out across the page instead of
+ *  running off the side. Never truncates; hard-breaks a single oversized word. */
+const wrapTitle = (t: string, budget: number): string => {
+  if (t.length <= budget) return t;
+  const lines: string[] = [];
+  let cur = '';
+  for (const w of t.split(/\s+/)) {
+    let word = w;
+    if (cur && (cur + ' ' + word).length > budget) {
+      lines.push(cur);
+      cur = '';
+    }
+    cur = cur ? cur + ' ' + word : word;
+    while (cur.length > budget) {
+      lines.push(cur.slice(0, budget));
+      cur = cur.slice(budget);
+      word = cur;
+    }
+  }
+  if (cur) lines.push(cur);
+  return lines.join('\n');
+};
+
+/** Pre-process MusicXML before OSMD renders it so the title block reads like a
+ *  real sheet: the SONG name as the centered Title (cleaned of media extensions,
+ *  word-wrapped if long), and the ARTIST centered directly beneath it. OSMD maps
+ *  <work-title> -> Title and <movement-title> -> Subtitle (confirmed in its
+ *  reader), so the song goes in work-title and the artist in movement-title; the
+ *  composer credit is disabled in the options so the artist never floats off to
+ *  the top-right. Returns the cleaned song title for the running page footer. */
+const prepareMusicXml = (
+  xml: string,
+  pageWidthPx: number,
+  artist: string,
+): { xml: string; title: string } => {
+  try {
+    const doc = new DOMParser().parseFromString(xml, 'application/xml');
+    if (doc.querySelector('parsererror')) return { xml, title: '' };
+    const root = doc.documentElement;
+    const budget = Math.max(16, Math.floor(pageWidthPx / 13));
+
+    const song = cleanTitleText(
+      (doc.querySelector('work > work-title')?.textContent ||
+        doc.querySelector('movement-title')?.textContent ||
+        '').trim(),
+    );
+
+    // Title slot (work-title) = wrapped song name.
+    let work = doc.querySelector('work');
+    if (!work) {
+      work = doc.createElement('work');
+      root.insertBefore(work, root.firstChild);
+    }
+    let workTitle = work.querySelector('work-title');
+    if (!workTitle) {
+      workTitle = doc.createElement('work-title');
+      work.appendChild(workTitle);
+    }
+    workTitle.textContent = song ? wrapTitle(song, budget) : '';
+
+    // Subtitle slot (movement-title) = artist, centered under the title.
+    let movement = doc.querySelector('movement-title');
+    if (!movement) {
+      movement = doc.createElement('movement-title');
+      if (work.nextSibling) root.insertBefore(movement, work.nextSibling);
+      else root.appendChild(movement);
+    }
+    movement.textContent = artist || '';
+
+    // Drop music21's placeholder credit-words so they don't print.
+    for (const cw of Array.from(doc.querySelectorAll('credit-words'))) {
+      if (/^music21( fragment)?$/i.test((cw.textContent || '').trim())) cw.textContent = '';
+    }
+
+    return { xml: new XMLSerializer().serializeToString(doc), title: song };
+  } catch {
+    return { xml, title: '' };
+  }
+};
+
+/** Engraving rules that make OSMD output look like sheet music from a book:
+ *  smaller text (the default title/labels are oversized for a fitted A4 page),
+ *  tidy page margins so music never runs off the side, and compact, even
+ *  system spacing. Applied before render; unknown keys on older builds no-op. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const applySheetEngraving = (rules: any): void => {
+  if (!rules) return;
+  try {
+    rules.SheetTitleHeight = 2.2;
+    rules.SheetSubtitleHeight = 1.4;
+    rules.SheetComposerHeight = 1.5;
+    rules.SheetAuthorHeight = 1.4;
+    rules.TitleTopDistance = 5.0;
+    rules.TitleBottomDistance = 1.0;
+    rules.SpacingBetweenTextLines = 1.0;
+    rules.MeasureNumberLabelHeight = 1.0;
+    rules.InstrumentLabelTextHeight = 1.4;
+    rules.LyricsHeight = 1.5;
+    rules.InstantaneousTempoTextHeight = 1.6;
+    rules.ContinuousTempoTextHeight = 1.4;
+    // Generous page margins, especially top + bottom (the bottom margin also
+    // houses the injected running footer + page number).
+    rules.PageLeftMargin = 4.0;
+    rules.PageRightMargin = 4.0;
+    rules.PageTopMargin = 5.5;
+    rules.PageBottomMargin = 7.0;
+    rules.MinimumDistanceBetweenSystems = 4.0;
+    rules.MinSkyBottomDistBetweenSystems = 2.0;
+    rules.StaffDistance = 4.0;
+    rules.BetweenStaffDistance = 4.0;
+    rules.RenderMeasureNumbersOnlyAtSystemStart = true;
+  } catch {
+    /* older OSMD builds: ignore unsupported rules */
+  }
+};
+
+/** Sheet-music preview. Renders the score as real A4 pages laid out left-to-
+ *  right (like an open book), engraved by OpenSheetMusicDisplay with proper
+ *  margins so nothing runs off the edge. OSMD reads the host's offsetWidth to
+ *  size a page, so we feed it a fixed one-page width, render, then flip the
+ *  host into a horizontal strip of the resulting page <svg>s. Zooming re-renders
+ *  (measures reflow + renumber); the footer ◀ ▶ and arrow keys turn pages by
+ *  scrolling one page; the page width tracks the pane height (fit one sheet). */
 const MusicXmlPreview: React.FC<{ artifact: NotationArtifact }> = ({ artifact }) => {
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const hostRef = useRef<HTMLDivElement | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const osmdRef = useRef<any>(null);
   const zoomRef = useRef(1);
+  const pageWRef = useRef(520);
+  const footerTitleRef = useRef('');
+  const footerArtistRef = useRef('');
   const [zoom, setZoom] = useState(1);
   const [status, setStatus] = useState('Loading MusicXML renderer…');
+  const [pageCount, setPageCount] = useState(1);
+  const [page, setPage] = useState(1); // 1-based page currently in view
+
+  const computePageW = (): number => {
+    const availH = (scrollRef.current?.clientHeight ?? 600) - 32;
+    return Math.round(Math.min(1000, Math.max(360, availH / A4_RATIO)));
+  };
+
+  // Add a book-style running footer to each rendered page: "Song - Artist" and
+  // the page number, centered in the bottom margin. OSMD has no footer/page-
+  // number support, so we inject it into each page wrapper after every render
+  // (render() recreates the pages, so this must run each time).
+  const decoratePages = useCallback(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const t = footerTitleRef.current;
+    const a = footerArtistRef.current;
+    const running = a ? (t ? `${t} - ${a}` : a) : t;
+    const pages = Array.from(host.children).filter(
+      (n): n is HTMLElement => n.nodeType === 1,
+    );
+    pages.forEach((node, idx) => {
+      let pageEl = node;
+      if (pageEl.tagName.toLowerCase() === 'svg') {
+        const wrap = document.createElement('div');
+        wrap.style.cssText = 'position:relative;flex:0 0 auto;background:#fff;';
+        pageEl.replaceWith(wrap);
+        wrap.appendChild(pageEl);
+        pageEl = wrap;
+      } else {
+        pageEl.style.position = 'relative';
+      }
+      const w = pageEl.clientWidth || pageWRef.current;
+      const fs = Math.max(8, Math.round(w * 0.019));
+      let f = pageEl.querySelector(':scope > .score-page-footer') as HTMLElement | null;
+      if (!f) {
+        f = document.createElement('div');
+        f.className = 'score-page-footer';
+        pageEl.appendChild(f);
+      }
+      f.style.cssText =
+        `position:absolute;left:0;right:0;bottom:${Math.round(w * 0.022)}px;` +
+        `text-align:center;pointer-events:none;color:#555;line-height:1.35;` +
+        `font-family:Georgia,'Times New Roman',serif;`;
+      f.innerHTML = '';
+      if (running) {
+        const l1 = document.createElement('div');
+        l1.textContent = running;
+        l1.style.cssText = `font-size:${fs}px;font-style:italic;`;
+        f.appendChild(l1);
+      }
+      const l2 = document.createElement('div');
+      l2.textContent = String(idx + 1);
+      l2.style.cssText = `font-size:${fs}px;`;
+      f.appendChild(l2);
+    });
+  }, []);
+
+  // OSMD reads host.offsetWidth at render() to size one page, then we widen the
+  // host into a horizontal strip so the page svgs sit side by side.
+  const doRender = useCallback(() => {
+    const osmd = osmdRef.current;
+    const host = hostRef.current;
+    if (!osmd || !host) return;
+    try {
+      host.style.display = 'block';
+      host.style.width = `${pageWRef.current}px`;
+      osmd.Zoom = zoomRef.current;
+      osmd.render();
+      host.style.display = 'flex';
+      host.style.width = 'max-content';
+      const count =
+        osmd.GraphicSheet?.MusicPages?.length ||
+        host.querySelectorAll('svg').length ||
+        1;
+      setPageCount(count);
+      decoratePages();
+    } catch {
+      /* render races with reload — ignore */
+    }
+  }, [decoratePages]);
 
   const applyZoom = useCallback((next: number) => {
-    const z = clampZoom(next);
-    zoomRef.current = z;
-    setZoom(z);
-    const osmd = osmdRef.current;
-    if (osmd) {
-      try {
-        osmd.Zoom = z;
-        osmd.render();
-      } catch {
-        /* render races with reload — ignore */
-      }
-    }
+    zoomRef.current = clampZoom(next);
+    setZoom(zoomRef.current);
+    doRender();
+  }, [doRender]);
+
+  const goToPage = useCallback((target: number) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const stride = pageWRef.current + PAGE_GAP;
+    const total = Math.max(1, Math.round(el.scrollWidth / stride));
+    const clamped = Math.min(total, Math.max(1, target));
+    el.scrollTo({ left: (clamped - 1) * stride, behavior: 'smooth' });
+    setPage(clamped);
   }, []);
 
   useWheelZoom(scrollRef, (factor) => applyZoom(zoomRef.current * factor));
@@ -487,29 +764,50 @@ const MusicXmlPreview: React.FC<{ artifact: NotationArtifact }> = ({ artifact })
   useEffect(() => {
     let cancelled = false;
     const run = async () => {
-      const container = containerRef.current;
-      if (!container) return;
-      container.innerHTML = '';
+      const host = hostRef.current;
+      if (!host) return;
+      host.innerHTML = '';
       try {
-        const [{ OpenSheetMusicDisplay }, res] = await Promise.all([
+        const [{ OpenSheetMusicDisplay }, res, settingsRes] = await Promise.all([
           import('opensheetmusicdisplay'),
           fetch(notationArtifactUrl(artifact.id)),
+          fetch('/api/settings').catch(() => null),
         ]);
         if (!res.ok) throw new Error(`MusicXML HTTP ${res.status}`);
         const xml = await res.text();
+        let artist = 'GANTASMO';
+        try {
+          if (settingsRes && settingsRes.ok) {
+            const s = await settingsRes.json();
+            artist = String(s?.notation?.artist ?? '').trim() || 'GANTASMO';
+          }
+        } catch {
+          /* settings unavailable — fall back to the GANTASMO floor */
+        }
         if (cancelled) return;
-        const osmd = new OpenSheetMusicDisplay(container, {
+        const osmd = new OpenSheetMusicDisplay(host, {
           backend: 'svg',
-          autoResize: true,
+          autoResize: false, // we drive width + re-render ourselves
           drawTitle: true,
-          drawingParameters: 'compacttight',
+          drawSubtitle: true, // the artist, centered under the title
+          drawComposer: false, // artist is the subtitle; no top-right credit
+          pageFormat: 'A4_P',
+          pageBackgroundColor: '#FFFFFF',
         });
-        await osmd.load(xml);
+        applySheetEngraving(osmd.EngravingRules);
+        // Song as the centered title (wrapped if long), artist as the subtitle
+        // under it; capture the song name for the running page footer.
+        const prepared = prepareMusicXml(xml, computePageW(), artist);
+        footerTitleRef.current = prepared.title;
+        footerArtistRef.current = artist;
+        await osmd.load(prepared.xml);
         if (cancelled) return;
-        osmd.Zoom = zoomRef.current;
-        osmd.render();
         osmdRef.current = osmd;
+        pageWRef.current = computePageW();
+        doRender();
         setStatus('');
+        setPage(1);
+        if (scrollRef.current) scrollRef.current.scrollLeft = 0;
       } catch (e) {
         if (cancelled) return;
         setStatus(`Preview unavailable: ${e instanceof Error ? e.message : String(e)}`);
@@ -520,20 +818,116 @@ const MusicXmlPreview: React.FC<{ artifact: NotationArtifact }> = ({ artifact })
       cancelled = true;
       osmdRef.current = null;
     };
-  }, [artifact.id]);
+  }, [artifact.id, doRender]);
+
+  // Track the page in view on horizontal scroll; re-fit page width to the pane
+  // when it resizes (so one sheet keeps filling the height).
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const stride = pageWRef.current + PAGE_GAP;
+      setPage(Math.max(1, Math.round(el.scrollLeft / stride) + 1));
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    let raf = 0;
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        const w = computePageW();
+        if (Math.abs(w - pageWRef.current) > 4) {
+          pageWRef.current = w;
+          doRender();
+        }
+      });
+    });
+    ro.observe(el);
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      ro.disconnect();
+      cancelAnimationFrame(raf);
+    };
+  }, [doRender]);
+
+  // Keyboard paging (ignored while typing in a field).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT' || t.isContentEditable)) return;
+      if (e.key === 'ArrowRight' || e.key === 'PageDown') {
+        e.preventDefault();
+        goToPage(page + 1);
+      } else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
+        e.preventDefault();
+        goToPage(page - 1);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [page, goToPage]);
+
+  const pageLabel = pageCount <= 1 ? '1 page' : `Page ${page} / ${pageCount}`;
 
   return (
-    <div className="relative h-full">
-      <div ref={scrollRef} className="h-full overflow-auto bg-white text-black">
-        {status && <div className="p-4 text-xs font-mono text-zinc-600">{status}</div>}
-        <div ref={containerRef} className="min-h-full p-4" />
+    <div className="relative h-full flex flex-col bg-[#23222a]">
+      <div ref={scrollRef} className="flex-1 min-h-0 overflow-auto p-4">
+        {status && <div className="p-4 text-xs font-mono text-zinc-300">{status}</div>}
+        {/* display/width are driven imperatively in doRender (block+fixed during
+            OSMD's offsetWidth read, then flex+max-content for the page strip). */}
+        <div
+          ref={hostRef}
+          className="gap-6 items-start [&>div]:shrink-0 [&>div]:bg-white [&>div]:shadow-2xl [&>div]:rounded-sm [&>svg]:shrink-0 [&>svg]:bg-white [&>svg]:shadow-2xl [&>svg]:rounded-sm"
+        />
       </div>
-      <ZoomControls
-        zoom={zoom}
-        onIn={() => applyZoom(zoomRef.current * ZOOM_STEP)}
-        onOut={() => applyZoom(zoomRef.current / ZOOM_STEP)}
-        onReset={() => applyZoom(1)}
-      />
+      {/* Footer: page navigation + zoom. */}
+      <div className="shrink-0 h-8 border-t border-white/10 bg-[#0a080f] flex items-center justify-center gap-1.5 px-2 text-[10px] font-mono text-zinc-300">
+        <button
+          onClick={() => goToPage(page - 1)}
+          disabled={page <= 1}
+          className="p-1 rounded hover:bg-white/10 disabled:opacity-30"
+          title="Previous page (←)"
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="w-3.5 h-3.5" />
+        </button>
+        <span className="min-w-24 text-center tabular-nums">{pageLabel}</span>
+        <button
+          onClick={() => goToPage(page + 1)}
+          disabled={page >= pageCount}
+          className="p-1 rounded hover:bg-white/10 disabled:opacity-30"
+          title="Next page (→)"
+          aria-label="Next page"
+        >
+          <ChevronRight className="w-3.5 h-3.5" />
+        </button>
+        <span className="mx-1 w-px h-4 bg-white/10" />
+        <button
+          onClick={() => applyZoom(zoomRef.current / ZOOM_STEP)}
+          disabled={zoom <= ZOOM_MIN + 0.001}
+          className="p-1 rounded hover:bg-white/10 disabled:opacity-30"
+          title="Zoom out (Ctrl + scroll)"
+          aria-label="Zoom out"
+        >
+          <Minus className="w-3.5 h-3.5" />
+        </button>
+        <button
+          onClick={() => applyZoom(1)}
+          className="min-w-10 text-center hover:text-white"
+          title="Reset zoom"
+          aria-label="Reset zoom"
+        >
+          {Math.round(zoom * 100)}%
+        </button>
+        <button
+          onClick={() => applyZoom(zoomRef.current * ZOOM_STEP)}
+          disabled={zoom >= ZOOM_MAX - 0.001}
+          className="p-1 rounded hover:bg-white/10 disabled:opacity-30"
+          title="Zoom in (Ctrl + scroll)"
+          aria-label="Zoom in"
+        >
+          <Plus className="w-3.5 h-3.5" />
+        </button>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/layout/ScoreView.tsx
+++ b/frontend/src/components/layout/ScoreView.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Download, FileMusic, Guitar, LayoutGrid, Loader2, Music2, RefreshCw } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Download, FileMusic, Guitar, LayoutGrid, Loader2, Maximize2, Minus, Music2, Plus, RefreshCw } from 'lucide-react';
 import { useLibraryStore } from '../../state/libraryStore';
 import { logError, logInfo } from '../../state/logStore';
 import {
@@ -225,7 +225,7 @@ export const ScoreView: React.FC = () => {
               id="score-tab-instrument"
               name="score-tab-instrument"
               aria-label="Tab instrument"
-              className="bg-black/40 border border-white/10 rounded text-[8px] text-zinc-200 px-1 py-1"
+              className="form-select text-[8px] px-1 py-1"
               value={tabInstrument}
               onChange={(e) => onInstrumentChange(e.target.value)}
             >
@@ -236,7 +236,7 @@ export const ScoreView: React.FC = () => {
               id="score-tab-difficulty"
               name="score-tab-difficulty"
               aria-label="Tab difficulty"
-              className="bg-black/40 border border-white/10 rounded text-[8px] text-zinc-200 px-1 py-1"
+              className="form-select text-[8px] px-1 py-1"
               value={tabDifficulty}
               onChange={(e) => setTabDifficulty(e.target.value)}
             >
@@ -250,7 +250,7 @@ export const ScoreView: React.FC = () => {
               id="score-tab-tuning"
               name="score-tab-tuning"
               aria-label="Tab tuning"
-              className="bg-black/40 border border-white/10 rounded text-[8px] text-zinc-200 px-1 py-1"
+              className="form-select text-[8px] px-1 py-1"
               value={tabTuning}
               onChange={(e) => setTabTuning(e.target.value)}
             >
@@ -267,7 +267,7 @@ export const ScoreView: React.FC = () => {
                 min={0}
                 max={12}
                 aria-label="Capo fret"
-                className="w-full bg-black/40 border border-white/10 rounded text-[8px] text-zinc-200 px-1 py-1"
+                className="w-full form-select text-[8px] px-1 py-1"
                 value={tabCapo}
                 onChange={(e) => setTabCapo(Math.max(0, Math.min(12, Number(e.target.value) || 0)))}
               />
@@ -293,7 +293,7 @@ export const ScoreView: React.FC = () => {
             id="score-arrange-style"
             name="score-arrange-style"
             aria-label="Arrangement style"
-            className="w-full bg-black/40 border border-white/10 rounded text-[8px] text-zinc-200 px-1 py-1"
+            className="w-full form-select text-[8px] px-1 py-1"
             value={arrangeStyle}
             onChange={(e) => setArrangeStyle(e.target.value)}
           >
@@ -387,9 +387,102 @@ export const ScoreView: React.FC = () => {
   );
 };
 
+const ZOOM_MIN = 0.4;
+const ZOOM_MAX = 3;
+const ZOOM_STEP = 1.12;
+const clampZoom = (z: number) => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z));
+
+/** Ctrl/Cmd + scrollwheel zoom on the sheet. A native non-passive listener
+ *  is required so the gesture can preventDefault (React's onWheel is passive).
+ *  Plain wheel keeps scrolling the page so long scores stay navigable. */
+function useWheelZoom(
+  scrollRef: React.RefObject<HTMLDivElement | null>,
+  onZoomDelta: (factor: number) => void,
+) {
+  const cb = useRef(onZoomDelta);
+  cb.current = onZoomDelta;
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const handler = (e: WheelEvent) => {
+      if (!(e.ctrlKey || e.metaKey)) return;
+      e.preventDefault();
+      cb.current(e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP);
+    };
+    el.addEventListener('wheel', handler, { passive: false });
+    return () => el.removeEventListener('wheel', handler);
+  }, [scrollRef]);
+}
+
+const ZoomControls: React.FC<{
+  zoom: number;
+  onIn: () => void;
+  onOut: () => void;
+  onReset: () => void;
+}> = ({ zoom, onIn, onOut, onReset }) => (
+  <div className="absolute bottom-2 right-2 z-10 flex items-center gap-0.5 rounded-md border border-purple-500/40 bg-[#0a080f]/95 px-1 py-0.5 shadow-lg backdrop-blur-sm">
+    <button
+      className="p-1 rounded text-purple-200 hover:bg-purple-500/20 disabled:opacity-40"
+      onClick={onOut}
+      disabled={zoom <= ZOOM_MIN + 0.001}
+      title="Zoom out (Ctrl + scroll)"
+      aria-label="Zoom out"
+    >
+      <Minus className="w-3 h-3" />
+    </button>
+    <button
+      className="min-w-9 text-center text-[9px] font-mono text-purple-200 hover:text-white px-0.5"
+      onClick={onReset}
+      title="Reset zoom"
+      aria-label="Reset zoom to 100%"
+    >
+      {Math.round(zoom * 100)}%
+    </button>
+    <button
+      className="p-1 rounded text-purple-200 hover:bg-purple-500/20 disabled:opacity-40"
+      onClick={onIn}
+      disabled={zoom >= ZOOM_MAX - 0.001}
+      title="Zoom in (Ctrl + scroll)"
+      aria-label="Zoom in"
+    >
+      <Plus className="w-3 h-3" />
+    </button>
+    <button
+      className="p-1 rounded text-purple-200 hover:bg-purple-500/20"
+      onClick={onReset}
+      title="Fit / reset zoom"
+      aria-label="Fit to width"
+    >
+      <Maximize2 className="w-3 h-3" />
+    </button>
+  </div>
+);
+
 const MusicXmlPreview: React.FC<{ artifact: NotationArtifact }> = ({ artifact }) => {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const osmdRef = useRef<any>(null);
+  const zoomRef = useRef(1);
+  const [zoom, setZoom] = useState(1);
   const [status, setStatus] = useState('Loading MusicXML renderer…');
+
+  const applyZoom = useCallback((next: number) => {
+    const z = clampZoom(next);
+    zoomRef.current = z;
+    setZoom(z);
+    const osmd = osmdRef.current;
+    if (osmd) {
+      try {
+        osmd.Zoom = z;
+        osmd.render();
+      } catch {
+        /* render races with reload — ignore */
+      }
+    }
+  }, []);
+
+  useWheelZoom(scrollRef, (factor) => applyZoom(zoomRef.current * factor));
 
   useEffect(() => {
     let cancelled = false;
@@ -413,7 +506,9 @@ const MusicXmlPreview: React.FC<{ artifact: NotationArtifact }> = ({ artifact })
         });
         await osmd.load(xml);
         if (cancelled) return;
+        osmd.Zoom = zoomRef.current;
         osmd.render();
+        osmdRef.current = osmd;
         setStatus('');
       } catch (e) {
         if (cancelled) return;
@@ -423,20 +518,51 @@ const MusicXmlPreview: React.FC<{ artifact: NotationArtifact }> = ({ artifact })
     void run();
     return () => {
       cancelled = true;
+      osmdRef.current = null;
     };
   }, [artifact.id]);
 
   return (
-    <div className="h-full overflow-auto bg-white text-black">
-      {status && <div className="p-4 text-xs font-mono text-zinc-600">{status}</div>}
-      <div ref={containerRef} className="min-h-full p-4" />
+    <div className="relative h-full">
+      <div ref={scrollRef} className="h-full overflow-auto bg-white text-black">
+        {status && <div className="p-4 text-xs font-mono text-zinc-600">{status}</div>}
+        <div ref={containerRef} className="min-h-full p-4" />
+      </div>
+      <ZoomControls
+        zoom={zoom}
+        onIn={() => applyZoom(zoomRef.current * ZOOM_STEP)}
+        onOut={() => applyZoom(zoomRef.current / ZOOM_STEP)}
+        onReset={() => applyZoom(1)}
+      />
     </div>
   );
 };
 
 const TabPreview: React.FC<{ artifact: NotationArtifact }> = ({ artifact }) => {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const apiRef = useRef<AlphaTabApi | null>(null);
+  const zoomRef = useRef(1);
+  const [zoom, setZoom] = useState(1);
   const [status, setStatus] = useState('Loading tab renderer…');
+
+  const applyZoom = useCallback((next: number) => {
+    const z = clampZoom(next);
+    zoomRef.current = z;
+    setZoom(z);
+    const api = apiRef.current;
+    if (api) {
+      try {
+        api.settings.display.scale = z;
+        api.updateSettings();
+        api.render();
+      } catch {
+        /* render races with reload — ignore */
+      }
+    }
+  }, []);
+
+  useWheelZoom(scrollRef, (factor) => applyZoom(zoomRef.current * factor));
 
   useEffect(() => {
     let cancelled = false;
@@ -454,7 +580,9 @@ const TabPreview: React.FC<{ artifact: NotationArtifact }> = ({ artifact }) => {
         if (cancelled) return;
         api = new alphaTab.AlphaTabApi(container, {
           player: { enablePlayer: false },
+          display: { scale: zoomRef.current },
         });
+        apiRef.current = api;
         api.error.on((err) => {
           if (!cancelled) setStatus(`Tab render error: ${err instanceof Error ? err.message : String(err)}`);
         });
@@ -470,6 +598,7 @@ const TabPreview: React.FC<{ artifact: NotationArtifact }> = ({ artifact }) => {
     void run();
     return () => {
       cancelled = true;
+      apiRef.current = null;
       try {
         api?.destroy();
       } catch {
@@ -479,9 +608,17 @@ const TabPreview: React.FC<{ artifact: NotationArtifact }> = ({ artifact }) => {
   }, [artifact.id]);
 
   return (
-    <div className="h-full overflow-auto bg-white text-black">
-      {status && <div className="p-4 text-xs font-mono text-zinc-600">{status}</div>}
-      <div ref={containerRef} className="min-h-full" />
+    <div className="relative h-full">
+      <div ref={scrollRef} className="h-full overflow-auto bg-white text-black">
+        {status && <div className="p-4 text-xs font-mono text-zinc-600">{status}</div>}
+        <div ref={containerRef} className="min-h-full" />
+      </div>
+      <ZoomControls
+        zoom={zoom}
+        onIn={() => applyZoom(zoomRef.current * ZOOM_STEP)}
+        onOut={() => applyZoom(zoomRef.current / ZOOM_STEP)}
+        onReset={() => applyZoom(1)}
+      />
     </div>
   );
 };

--- a/frontend/src/components/layout/Shell.tsx
+++ b/frontend/src/components/layout/Shell.tsx
@@ -365,8 +365,15 @@ const ShellBottomDock: React.FC = () => {
   const multiMaximized = useBottomPanelStore((s) => s.multiMaximized);
 
   // Dock-body height — shared by the multi-tab panel (in-flow) and the floating
-  // LOG overlay. Maximized fills the work area.
-  const bodyHeight = multiMaximized ? 'calc(100vh - 7rem)' : `${multiHeight}px`;
+  // LOG overlay. Maximized fills the work area. The height MUST be computed in
+  // the same zoom-aware space as the .dense-layout root (height =
+  // calc((100vh - 5rem) / var(--layout-zoom))); a raw `100vh` calc here ignores
+  // --layout-zoom and, at zoom > 1, overflows the root's overflow-hidden so the
+  // dock's own bottom (e.g. the Score viewer's page/zoom controls) is clipped.
+  // Reserve 5rem inside the root for the header (h-11) + the always-on strip.
+  const bodyHeight = multiMaximized
+    ? 'calc((100vh - 5rem) / var(--layout-zoom) - 5rem)'
+    : `${multiHeight}px`;
   // The LOG strip section auto-fits its content (the telemetry readouts + the
   // fixed action button). Mirror its measured width into logWidth so the LOG
   // body directly below it stays column-aligned (opens to the same left edge).

--- a/frontend/src/components/ui/Section.tsx
+++ b/frontend/src/components/ui/Section.tsx
@@ -21,6 +21,13 @@ interface SectionProps {
    *  rail, which already has the rail-level collapse button — the
    *  inner chevron was a confusing duplicate handle. */
   collapsible?: boolean;
+  /** Fill the parent's remaining height instead of sizing to content.
+   *  The header stays fixed at the top and the body becomes a bounded
+   *  flex column (min-h-0) so a `flex-1 overflow-y-auto` child inside
+   *  scrolls on its own — i.e. a sticky header with a scrolling body.
+   *  Used by the LIBRARY panel. Implies non-resizable, no height
+   *  animation. */
+  fill?: boolean;
 }
 
 export const Section: React.FC<SectionProps> = ({
@@ -33,7 +40,11 @@ export const Section: React.FC<SectionProps> = ({
   minHeight = 80,
   maxContentHeight = 800,
   collapsible = true,
+  fill = false,
 }) => {
+  // Fill mode owns its own height via flex, so the drag-to-resize
+  // handle is disabled.
+  const canResize = fill ? false : resizable;
   // When collapsible=false the Section is locked open. defaultOpen
   // is ignored in that mode.
   const [isOpen, setIsOpen] = useState(collapsible ? defaultOpen : true);
@@ -67,9 +78,9 @@ export const Section: React.FC<SectionProps> = ({
   }, [isResizing, minHeight]);
 
   return (
-    <div className="hardware-card flex flex-col shrink-0 relative mb-1 last:mb-0">
+    <div className={`hardware-card flex flex-col relative mb-1 last:mb-0 ${fill ? 'flex-1 min-h-0' : 'shrink-0'}`}>
        <div
-         className={`flex items-center justify-between px-2 py-1.5 select-none bg-white/2 transition-colors ${
+         className={`flex items-center justify-between px-2 py-1.5 select-none bg-white/2 transition-colors shrink-0 ${
            collapsible ? 'cursor-pointer hover:bg-white/5' : ''
          }`}
          onClick={collapsible ? () => setIsOpen(!isOpen) : undefined}
@@ -88,19 +99,19 @@ export const Section: React.FC<SectionProps> = ({
        <AnimatePresence>
          {isOpen && (
            <motion.div
-             initial={{ height: 0, opacity: 0 }}
-             animate={{ height: height === 'auto' ? 'auto' : height, opacity: 1 }}
-             exit={{ height: 0, opacity: 0 }}
-             className="overflow-hidden flex flex-col"
+             initial={fill ? { opacity: 0 } : { height: 0, opacity: 0 }}
+             animate={fill ? { opacity: 1 } : { height: height === 'auto' ? 'auto' : height, opacity: 1 }}
+             exit={fill ? { opacity: 0 } : { height: 0, opacity: 0 }}
+             className={`overflow-hidden flex flex-col ${fill ? 'flex-1 min-h-0' : ''}`}
              ref={containerRef}
            >
               <div
-                className={`flex flex-col gap-2 pt-2 border-t border-white/5 p-2 flex-1 no-scrollbar overflow-x-hidden ${maxContentHeight !== null ? 'overflow-y-auto' : ''}`}
+                className={`flex flex-col gap-2 pt-2 border-t border-white/5 p-2 no-scrollbar overflow-x-hidden ${fill ? 'flex-1 min-h-0' : 'flex-1'} ${maxContentHeight !== null ? 'overflow-y-auto' : ''}`}
                 style={maxContentHeight !== null ? { maxHeight: `${maxContentHeight}px` } : undefined}
               >
                 {children}
               </div>
-              {resizable && (
+              {canResize && (
                 <div 
                   className="h-1.5 cursor-row-resize hover:bg-purple-500/20 transition-colors flex items-center justify-center group relative mt-1"
                   onMouseDown={(e) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -115,6 +115,24 @@
   .btn-ghost {
     @apply bg-white/5 hover:bg-white/10 text-zinc-300 border border-white/5 py-1 px-2 rounded text-[10px] transition-all;
   }
+
+  /* High-contrast <select> matching .compact-input. Carries no padding /
+     text-size so it composes with each control's own sizing classes
+     (px/py/text-*). color-scheme keeps the native option popup dark. */
+  .form-select {
+    @apply bg-black/40 border border-(--panel-border) rounded text-white outline-none focus:border-purple-500 cursor-pointer transition-colors;
+    color-scheme: dark;
+  }
+}
+
+/* Native <select> popups render dark + legible everywhere (the browser
+   default is a white option list that clashes with theDAW's dark panels);
+   option rows take the panel palette so the open list matches the app. */
+select { color-scheme: dark; }
+select option,
+select optgroup {
+  background-color: var(--panel);
+  color: var(--text-primary);
 }
 
 @theme {

--- a/frontend/src/lib/notationClient.ts
+++ b/frontend/src/lib/notationClient.ts
@@ -132,3 +132,9 @@ export async function makeArrangement(
 export function notationArtifactUrl(artifactId: string): string {
   return `/api/notation/file/${encodeURIComponent(artifactId)}`;
 }
+
+/** Download a score as a zip of the source + a PDF (PDF when MuseScore is
+ *  installed; the MusicXML is always included). Use for musicxml sheets. */
+export function notationPackUrl(artifactId: string): string {
+  return `/api/notation/pack/${encodeURIComponent(artifactId)}`;
+}

--- a/frontend/src/suno/SunoGenPanel.tsx
+++ b/frontend/src/suno/SunoGenPanel.tsx
@@ -346,9 +346,11 @@ export const SunoGenPanel: React.FC = () => {
           </div>
         </div>
 
-        {/* Render queue */}
-        <motion.div {...fade(0.12)} className="w-80 shrink-0 flex flex-col bg-[#08060c]/60 backdrop-blur-sm">
-          <div className="flex items-center justify-between px-3 py-2.5 border-b border-white/8">
+        {/* Render queue — min-h-0 lets the column bound its height so ONLY
+            the job list scrolls; the header stays pinned (shrink-0) instead
+            of the whole column compressing when the pane is short. */}
+        <motion.div {...fade(0.12)} className="w-80 shrink-0 min-h-0 flex flex-col bg-[#08060c]/60 backdrop-blur-sm">
+          <div className="shrink-0 flex items-center justify-between px-3 py-2.5 border-b border-white/8">
             <span className="mono-label text-[10px]! flex items-center gap-1.5">
               <ListMusic className="w-3.5 h-3.5 text-purple-400" />
               Render Queue

--- a/frontend/src/suno/SunoJobList.tsx
+++ b/frontend/src/suno/SunoJobList.tsx
@@ -81,14 +81,14 @@ export const SunoJobList: React.FC = () => {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto no-scrollbar p-2 flex flex-col gap-2">
+    <div className="flex-1 min-h-0 overflow-y-auto no-scrollbar p-2 flex flex-col gap-2">
       {jobs.map((job) => {
         const cfg = STATUS[job.status] ?? STATUS.submitted;
         const hasAudio = (job.status === 'complete' || job.status === 'streaming') && !!job.audio_url;
         const isCurrent = engineEntryId === job.id;
         const open = expanded === job.id;
         return (
-          <div key={job.id} className={`hardware-card p-2 ${isCurrent ? 'ring-1 ring-purple-500/50' : ''}`}>
+          <div key={job.id} className={`hardware-card shrink-0 p-2 ${isCurrent ? 'ring-1 ring-purple-500/50' : ''}`}>
             <div className="flex items-start gap-2">
               <HoverTip text={hasAudio ? 'Play or pause this track in the shared player.' : 'Audio is not ready yet — the job is still generating.'}>
                 <button

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -5,7 +5,7 @@ import {
   LayoutGrid, List as ListIcon, Activity, Scissors, Layers, Wand2, PenLine,
   Package, Network, FileMusic, Loader2, Mic, Piano, ListOrdered,
   CheckSquare, Square, MoreHorizontal, Combine, Paintbrush, FileText, ChevronDown, Maximize2,
-  Film, Image as ImageIcon, Upload,
+  Film, Image as ImageIcon, Upload, RefreshCw, Tv2,
 } from 'lucide-react';
 import { ContextMenu, useContextMenu, type ContextMenuItem } from '../components/ui/ContextMenu';
 import { LineageModal } from '../components/library/LineageModal';
@@ -26,6 +26,8 @@ import { listMedia, importMedia, deleteMedia, MEDIA_ACCEPT } from '../lib/mediaL
 import { setAudioDragData } from '../lib/audioDnD';
 import { renderMidiBufferToBlob } from '../lib/midiSynth';
 import { fetchMidiBytesWithRetry, fetchBlobWithRetry } from '../lib/fetchRetry';
+import { notationArtifactUrl } from '../lib/notationClient';
+import { sendTrackToVj } from '../state/vjSetBus';
 import {
   loadMidiIntoPianoRoll,
   midiIdToSendable,
@@ -71,7 +73,7 @@ const downloadEntry = (entry: LibraryEntry, url: string) => {
 
 export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpand?: () => void }> = ({ onSwitchTab, onExpand }) => {
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('list');
-  const [subTab, setSubTab] = useState<'tracks' | 'stems' | 'midi' | 'video'>('tracks');
+  const [subTab, setSubTab] = useState<'tracks' | 'stems' | 'midi' | 'video' | 'score'>('tracks');
   const [lineageOpen, setLineageOpen] = useState<string | null>(null);
   const [suggestOpen, setSuggestOpen] = useState(false);
   const [selectedEntryIds, setSelectedEntryIds] = useState<string[]>([]);
@@ -83,6 +85,11 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
   const entryMenu = useContextMenu<{ entryId: string }>();
   const [allStems, setAllStems] = useState<Array<Record<string, unknown>> | null>(null);
   const [allMidis, setAllMidis] = useState<Array<Record<string, unknown>> | null>(null);
+  // SCORE library tab: every notation/sheet artifact across all entries,
+  // joined to its parent track's title. Fetched lazily when the SCORE tab
+  // opens (notation is per-entry server-side, so this uses the aggregate
+  // /_all/scores route, mirroring stems/midi).
+  const [allScores, setAllScores] = useState<Array<Record<string, unknown>> | null>(null);
   // VJ video library: video + image entries live outside the audio store
   // (the default /entries list is audio-only). Fetched lazily when the
   // VIDEO tab opens and re-fetched after an import / delete.
@@ -301,7 +308,13 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
           setMediaEntries([]);
         });
     }
-  }, [subTab, allStems, allMidis, mediaEntries]);
+    if (subTab === 'score' && allScores === null) {
+      void fetch('/api/library/_all/scores')
+        .then((r) => r.json())
+        .then((j) => setAllScores(j.scores || []))
+        .catch(() => setAllScores([]));
+    }
+  }, [subTab, allStems, allMidis, mediaEntries, allScores]);
 
   const refreshMedia = React.useCallback(async () => {
     try {
@@ -332,6 +345,15 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
     }
   }, []);
 
+  const refreshScores = React.useCallback(async () => {
+    try {
+      const j = await fetch('/api/library/_all/scores').then((r) => r.json());
+      setAllScores(j.scores || []);
+    } catch (e) {
+      logError('library', `Failed to refresh scores: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }, []);
+
   const stemsByParent = useMemo(() => {
     const map: Record<string, Array<Record<string, unknown>>> = {};
     (allStems || []).forEach((s) => {
@@ -351,6 +373,16 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
     });
     return map;
   }, [allMidis]);
+
+  const scoresByParent = useMemo(() => {
+    const map: Record<string, Array<Record<string, unknown>>> = {};
+    (allScores || []).forEach((s) => {
+      const pid = String(s.parent_id ?? '');
+      if (!map[pid]) map[pid] = [];
+      map[pid].push(s);
+    });
+    return map;
+  }, [allScores]);
 
   const entries = useLibraryStore((s) => s.entries);
   const loaded = useLibraryStore((s) => s.loaded);
@@ -661,15 +693,16 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
   const favCount = entries.filter((e) => e.favorite).length;
 
   return (
-    // h-full + overflow-y-auto on the outer scroll container ensures
-    // the Library is ALWAYS fully scrollable inside the right rail —
-    // never clipped behind the always-on Log section that pins to the
-    // rail's bottom. min-h-0 lets the flex parent collapse properly.
-    <div className="flex flex-col gap-2 h-full min-h-0 overflow-y-auto text-[11px] pb-2 px-2 pt-2">
+    // The panel itself does NOT scroll (overflow-hidden); the upper region
+    // (stats + LIBRARY header + search + filters + sub-tabs) stays pinned and
+    // ONLY the per-tab list region scrolls (see the scroll wrapper below).
+    // h-full + min-h-0 let the flex parent collapse so the fill chain works
+    // inside the right rail without clipping the always-on Log section.
+    <div className="flex flex-col gap-2 h-full min-h-0 overflow-hidden text-[11px] pb-2 px-2 pt-2">
 
       {/* Top stats strip — compact "features" version of the old
           LIBRARY ANALYSIS section. */}
-      <div className="flex items-center gap-1 flex-wrap text-[8px] font-mono uppercase tracking-widest text-zinc-500 pb-1 border-b border-white/5">
+      <div className="shrink-0 flex items-center gap-1 flex-wrap text-[8px] font-mono uppercase tracking-widest text-zinc-500 pb-1 border-b border-white/5">
         <span className="px-1.5 py-0.5 rounded bg-white/5 border border-white/10">
           <span className="text-zinc-300">{entries.length}</span> entries
         </span>
@@ -741,7 +774,7 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
         }}
       />
 
-      <Section title="LIBRARY" icon={Database} defaultOpen={true} resizable={false} collapsible={false} maxContentHeight={null} rightNode={
+      <Section title="LIBRARY" icon={Database} defaultOpen={true} resizable={false} collapsible={false} fill maxContentHeight={null} rightNode={
         <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
           <span className="text-[8px] font-mono text-zinc-600">{entries.length} TRACKS</span>
           {/* Mic-in toggle removed per spec — the MicRecorder lives
@@ -778,7 +811,7 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
           </div>
         )}
 
-        <div className="flex flex-col gap-2 mb-2">
+        <div className="shrink-0 flex flex-col gap-2 mb-2">
           <div className="relative">
             <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-zinc-600" />
             <input
@@ -818,10 +851,11 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
           </div>
         </div>
 
-        {/* Sub-tabs: Tracks / Stems / MIDI — text-only per spec, no
-            icons; GRAPH button removed (use the LEARN tab for the
-            lineage graph instead). */}
-        <div className="flex items-center gap-1 mb-2 border-b border-white/5 pb-1">
+        {/* Sub-tabs: Tracks / Stems / MIDI / Video / Score — text-only per
+            spec, no icons; GRAPH button removed (use the LEARN tab for the
+            lineage graph instead). overflow-x-auto so the row never wraps and
+            stays a single sticky strip above the scrolling lists. */}
+        <div className="shrink-0 flex items-center gap-1 mb-2 border-b border-white/5 pb-1 overflow-x-auto no-scrollbar">
           <SubTabButton active={subTab === 'tracks'} onClick={() => setSubTab('tracks')}>
             Tracks ({entries.length})
           </SubTabButton>
@@ -834,7 +868,14 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
           <SubTabButton active={subTab === 'video'} onClick={() => setSubTab('video')}>
             Video ({mediaEntries?.length ?? '…'})
           </SubTabButton>
+          <SubTabButton active={subTab === 'score'} onClick={() => setSubTab('score')}>
+            Score ({allScores?.length ?? '…'})
+          </SubTabButton>
         </div>
+
+        {/* THE scroll region: only the per-tab lists scroll; everything
+            above (stats / search / filters / sub-tab strip) stays pinned. */}
+        <div className="flex-1 min-h-0 overflow-y-auto no-scrollbar flex flex-col">
 
         {subTab === 'tracks' && (<>
         {/* Icon-only top-level actions toolbar (user request 2026-05-28).
@@ -1068,6 +1109,18 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
             onChanged={refreshMedia}
           />
         )}
+        {subTab === 'score' && (
+          <ScoreList
+            byParent={scoresByParent}
+            parentTitles={Object.fromEntries(entries.map((e) => [e.id, e.title]))}
+            placeholder={allScores === null
+              ? 'Loading scores…'
+              : 'No scores yet. Open a track → Score and use MAKE SHEET / MAKE TABS / ARRANGE.'}
+            onOpen={openScoreForEntry}
+            onRefresh={refreshScores}
+          />
+        )}
+        </div>
       </Section>
 
       {(() => {
@@ -1128,9 +1181,24 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
           { type: 'separator' },
           {
             type: 'item',
+            label: 'Download audio',
+            icon: <Download className="w-3 h-3" />,
+            hint: 'file',
+            onSelect: () => {
+              const title = entries.find((e) => e.id === ctxEntryId)?.title ?? ctxEntryId;
+              const a = document.createElement('a');
+              a.href = `/api/library/${ctxEntryId}/audio`;
+              a.download = title;
+              document.body.appendChild(a);
+              a.click();
+              document.body.removeChild(a);
+            },
+          },
+          {
+            type: 'item',
             label: 'Download bundle',
             icon: <Package className="w-3 h-3" />,
-            hint: '.zip',
+            hint: '.zip+scores',
             onSelect: () => {
               const a = document.createElement('a');
               a.href = `/api/library/${ctxEntryId}/bundle`;
@@ -1458,6 +1526,7 @@ const MediaGrid: React.FC<{
 }> = ({ entries, onChanged }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
+  const mediaMenu = useContextMenu<LibraryEntry>();
 
   const onPick = async (files: FileList | null) => {
     if (!files || files.length === 0) return;
@@ -1486,6 +1555,61 @@ const MediaGrid: React.FC<{
       logError('library', `Media delete failed: ${e instanceof Error ? e.message : String(e)}`);
     }
   };
+
+  const sendToVj = (entry: LibraryEntry) => {
+    sendTrackToVj({
+      entryId: entry.id,
+      label: entry.title,
+      url: entry.mediaUrl ?? entry.audioUrl,
+      kind: entry.kind === 'image' ? 'image' : 'video',
+    });
+    logInfo('library', `Sent "${entry.title}" to the VJ.`);
+  };
+
+  const ctxEntry = mediaMenu.payload;
+  const menuItems: ContextMenuItem[] = ctxEntry
+    ? [
+        {
+          type: 'item',
+          label: 'Send to VJ',
+          icon: <Film className="w-3 h-3" />,
+          hint: 'live visuals',
+          onSelect: () => sendToVj(ctxEntry),
+        },
+        { type: 'separator' },
+        {
+          type: 'item',
+          label: 'Download',
+          icon: <Download className="w-3 h-3" />,
+          onSelect: () => {
+            const a = document.createElement('a');
+            a.href = ctxEntry.mediaUrl ?? ctxEntry.audioUrl;
+            a.download = ctxEntry.title;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+          },
+        },
+        {
+          type: 'item',
+          label: 'Copy media link',
+          icon: <FileText className="w-3 h-3" />,
+          onSelect: () => {
+            void navigator.clipboard?.writeText(
+              new URL(ctxEntry.mediaUrl ?? ctxEntry.audioUrl, window.location.origin).toString(),
+            );
+          },
+        },
+        { type: 'separator' },
+        {
+          type: 'item',
+          label: 'Delete',
+          icon: <Trash2 className="w-3 h-3" />,
+          danger: true,
+          onSelect: () => { void onRemove(ctxEntry); },
+        },
+      ]
+    : [];
 
   return (
     <div className="px-1">
@@ -1526,24 +1650,45 @@ const MediaGrid: React.FC<{
       ) : (
         <div className="grid grid-cols-2 gap-2">
           {entries.map((entry) => (
-            <MediaCard key={entry.id} entry={entry} onRemove={() => onRemove(entry)} />
+            <MediaCard
+              key={entry.id}
+              entry={entry}
+              onRemove={() => onRemove(entry)}
+              onSendToVj={() => sendToVj(entry)}
+              onContextMenu={(e) => mediaMenu.open(e, entry)}
+            />
           ))}
         </div>
       )}
+
+      <ContextMenu
+        position={mediaMenu.position}
+        onClose={mediaMenu.close}
+        items={menuItems}
+        title={ctxEntry ? ctxEntry.title : ''}
+      />
     </div>
   );
 };
 
-const MediaCard: React.FC<{ entry: LibraryEntry; onRemove: () => void }> = ({ entry, onRemove }) => {
+const MediaCard: React.FC<{
+  entry: LibraryEntry;
+  onRemove: () => void;
+  onSendToVj: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+}> = ({ entry, onRemove, onSendToVj, onContextMenu }) => {
   const isVideo = entry.kind === 'video';
   const mediaUrl = entry.mediaUrl ?? entry.audioUrl;
   return (
     <div
       className="group relative rounded-lg overflow-hidden border border-white/8 bg-black/40"
       draggable
+      onContextMenu={onContextMenu}
+      title="Drag onto the VJ tab to add it · right-click for actions"
       onDragStart={(e) => {
-        // Stable URL so a drop target (VJ bridge in B3, or any consumer)
-        // can reference the persisted file rather than a session blob.
+        // Stable URL so a drop target (the VJ tab's drop zone, or any
+        // consumer) can reference the persisted file rather than a session blob.
+        e.dataTransfer.effectAllowed = 'copy';
         e.dataTransfer.setData('text/uri-list', mediaUrl);
         e.dataTransfer.setData(
           'application/x-thedaw-media',
@@ -1587,23 +1732,49 @@ const MediaCard: React.FC<{ entry: LibraryEntry; onRemove: () => void }> = ({ en
           </span>
         )}
       </div>
+
+      {/* Action buttons — top-right corner so they never sit under the
+          duration badge (bottom-right). Hover-revealed; dark pill so the
+          icons read over any thumbnail. */}
+      <div className="absolute top-1 right-1 flex items-center gap-0.5 rounded bg-black/70 px-0.5 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onSendToVj(); }}
+          aria-label={`Send ${entry.title} to the VJ`}
+          title="Send to VJ"
+          className="p-0.5 rounded text-fuchsia-300 hover:text-fuchsia-100 hover:bg-white/10"
+        >
+          <Tv2 size={12} />
+        </button>
+        <a
+          href={mediaUrl}
+          download={entry.title}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`Download ${entry.title}`}
+          title="Download"
+          className="p-0.5 rounded text-zinc-300 hover:text-white hover:bg-white/10"
+        >
+          <Download size={12} />
+        </a>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onRemove(); }}
+          aria-label={`Remove ${entry.title} from the media library`}
+          className="p-0.5 rounded text-zinc-300 hover:text-red-400 hover:bg-white/10"
+        >
+          <Trash2 size={12} />
+        </button>
+      </div>
+
       {isVideo && entry.duration > 0 && (
         <span className="absolute bottom-1 right-1 px-1 py-0.5 rounded bg-black/70 text-[8px] font-mono text-zinc-300">
           {formatDuration(entry.duration)}
         </span>
       )}
 
-      {/* Footer: title + remove */}
-      <div className="flex items-center justify-between gap-1 px-1.5 py-1">
-        <span className="text-[9px] text-zinc-300 truncate" title={entry.title}>{entry.title}</span>
-        <button
-          type="button"
-          onClick={onRemove}
-          aria-label={`Remove ${entry.title} from the media library`}
-          className="shrink-0 text-zinc-600 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
-        >
-          <Trash2 size={12} />
-        </button>
+      {/* Footer: title */}
+      <div className="px-1.5 py-1">
+        <span className="text-[9px] text-zinc-300 truncate block" title={entry.title}>{entry.title}</span>
       </div>
     </div>
   );
@@ -1945,6 +2116,107 @@ const SubTabList: React.FC<SubTabListProps> = ({ byParent, parentTitles, kind, p
         items={menuItems}
         title={menuTitle}
       />
+    </div>
+  );
+};
+
+
+/* ═══════════════════════════════ ScoreList ═══════════════════════════════ */
+
+const SCORE_KIND_LABEL: Record<string, string> = {
+  musicxml: 'Sheet',
+  alphatex: 'Tab',
+  abc: 'ABC',
+  pdf: 'PDF',
+  svg: 'SVG',
+  guitarpro: 'GP',
+};
+
+/** SCORE library tab: every sheet / tab / arrangement across the library,
+ *  grouped by parent track. A row opens the Score viewer for that track and
+ *  downloads the artifact (the backend names the file after the originating
+ *  song). Scores are created elsewhere (the bottom Score panel), so a manual
+ *  refresh is offered since this list is cached on first open. */
+const ScoreList: React.FC<{
+  byParent: Record<string, Array<Record<string, unknown>>>;
+  parentTitles: Record<string, string>;
+  placeholder: string;
+  onOpen: (entryId: string) => void;
+  onRefresh: () => void | Promise<void>;
+}> = ({ byParent, parentTitles, placeholder, onOpen, onRefresh }) => {
+  const parentIds = Object.keys(byParent);
+
+  const downloadScore = (id: string) => {
+    const a = document.createElement('a');
+    a.href = notationArtifactUrl(id);
+    a.download = '';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
+  const refreshBtn = (
+    <div className="flex justify-end">
+      <button
+        onClick={() => void onRefresh()}
+        className="p-1 rounded text-zinc-500 hover:text-purple-300"
+        title="Refresh scores"
+        aria-label="Refresh scores"
+      >
+        <RefreshCw className="w-3 h-3" />
+      </button>
+    </div>
+  );
+
+  if (parentIds.length === 0) {
+    return (
+      <div className="flex flex-col gap-2">
+        {refreshBtn}
+        <p className="text-[10px] text-zinc-500 italic py-4 text-center">{placeholder}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {refreshBtn}
+      {parentIds.map((pid) => (
+        <div key={pid} className="border border-white/5 rounded p-2 bg-white/3">
+          <div className="text-[9px] font-black uppercase tracking-widest text-emerald-300 mb-1 truncate">
+            {parentTitles[pid] ?? pid}
+          </div>
+          <div className="flex flex-col gap-0.5">
+            {byParent[pid].map((row, idx) => {
+              const id = String(row.id ?? '');
+              const kind = String(row.kind ?? '');
+              const label = SCORE_KIND_LABEL[kind] ?? kind.toUpperCase();
+              const engine = String(row.engine ?? '');
+              return (
+                <div
+                  key={id || idx}
+                  className="group flex items-center gap-1 text-[10px] font-mono text-zinc-300 px-1 py-0.5 hover:bg-white/5 rounded cursor-pointer"
+                  onClick={() => onOpen(pid)}
+                  title="Open in the Score viewer"
+                >
+                  <span className="shrink-0 px-1 py-0.5 rounded bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 text-[8px] font-black uppercase tracking-widest">
+                    {label}
+                  </span>
+                  <span className="truncate flex-1 min-w-0">{engine || kind}</span>
+                  <button
+                    type="button"
+                    className="shrink-0 p-0.5 rounded hover:bg-white/10 opacity-0 group-hover:opacity-100 transition-opacity"
+                    onClick={(e) => { e.stopPropagation(); downloadScore(id); }}
+                    title="Download score"
+                    aria-label={`Download ${label} score`}
+                  >
+                    <Download className="w-2.5 h-2.5 text-zinc-500 hover:text-white" />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
     </div>
   );
 };

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -26,7 +26,7 @@ import { listMedia, importMedia, deleteMedia, MEDIA_ACCEPT } from '../lib/mediaL
 import { setAudioDragData } from '../lib/audioDnD';
 import { renderMidiBufferToBlob } from '../lib/midiSynth';
 import { fetchMidiBytesWithRetry, fetchBlobWithRetry } from '../lib/fetchRetry';
-import { notationArtifactUrl } from '../lib/notationClient';
+import { notationArtifactUrl, notationPackUrl } from '../lib/notationClient';
 import { sendTrackToVj } from '../state/vjSetBus';
 import {
   loadMidiIntoPianoRoll,
@@ -2146,9 +2146,10 @@ const ScoreList: React.FC<{
 }> = ({ byParent, parentTitles, placeholder, onOpen, onRefresh }) => {
   const parentIds = Object.keys(byParent);
 
-  const downloadScore = (id: string) => {
+  const downloadScore = (id: string, kind: string) => {
     const a = document.createElement('a');
-    a.href = notationArtifactUrl(id);
+    // Sheets come down as a MusicXML + PDF zip; tabs/others as the raw file.
+    a.href = kind === 'musicxml' ? notationPackUrl(id) : notationArtifactUrl(id);
     a.download = '';
     document.body.appendChild(a);
     a.click();
@@ -2205,8 +2206,8 @@ const ScoreList: React.FC<{
                   <button
                     type="button"
                     className="shrink-0 p-0.5 rounded hover:bg-white/10 opacity-0 group-hover:opacity-100 transition-opacity"
-                    onClick={(e) => { e.stopPropagation(); downloadScore(id); }}
-                    title="Download score"
+                    onClick={(e) => { e.stopPropagation(); downloadScore(id, kind); }}
+                    title={kind === 'musicxml' ? 'Download MusicXML + PDF' : 'Download score'}
                     aria-label={`Download ${label} score`}
                   >
                     <Download className="w-2.5 h-2.5 text-zinc-500 hover:text-white" />

--- a/frontend/src/views/VJView.tsx
+++ b/frontend/src/views/VJView.tsx
@@ -22,7 +22,7 @@ import { useLibraryStore } from '../state/libraryStore';
 import { subscribeToMidi } from '../state/midiBus';
 import { useMidiTriggerStore } from '../state/midiTriggerStore';
 import { getVjPlaybackState, registerVjPlaybackHandler, reportVjPlaybackState } from '../state/vjPlaybackBus';
-import { registerVjSetHandler } from '../state/vjSetBus';
+import { registerVjSetHandler, sendTrackToVj } from '../state/vjSetBus';
 import { ingestManifest, applyFromVj, registerControlSink } from '../state/controlSyncBus';
 import type { VisualControl } from '../state/slideStore';
 import { useAppUiStore } from '../state/appUiStore';
@@ -88,6 +88,11 @@ export const VJView: React.FC = () => {
   // when the source is changed from inside the VJ app.
   const [cameraOn, setCameraOn] = useState(false);
   const [cameraError, setCameraError] = useState<string | null>(null);
+  // True while a library media card is being dragged anywhere in the app. We
+  // flip a transparent drop layer over the iframe so the drop lands on US (the
+  // iframe would otherwise swallow the drag). Detected on the parent window
+  // while the cursor is still over parent content, before it reaches the iframe.
+  const [mediaDragActive, setMediaDragActive] = useState(false);
   const [questStatus, setQuestStatus] = useState<QuestCastStatus | null>(null);
   const [questBusy, setQuestBusy] = useState(false);
   const [questDetail, setQuestDetail] = useState('delinQuest status not loaded yet.');
@@ -222,6 +227,43 @@ export const VJView: React.FC = () => {
     document.addEventListener('visibilitychange', onVis);
     return () => document.removeEventListener('visibilitychange', onVis);
   }, []);
+
+  // Detect a library media drag anywhere in the app so we can raise a drop
+  // layer over the iframe BEFORE the cursor reaches it (the iframe would
+  // otherwise swallow the drag and the parent never sees the drop).
+  useEffect(() => {
+    const hasMedia = (e: DragEvent) =>
+      Array.from(e.dataTransfer?.types ?? []).includes('application/x-thedaw-media');
+    const onDragOver = (e: DragEvent) => { if (hasMedia(e)) setMediaDragActive(true); };
+    const clear = () => setMediaDragActive(false);
+    window.addEventListener('dragover', onDragOver);
+    window.addEventListener('drop', clear);
+    window.addEventListener('dragend', clear);
+    return () => {
+      window.removeEventListener('dragover', onDragOver);
+      window.removeEventListener('drop', clear);
+      window.removeEventListener('dragend', clear);
+    };
+  }, []);
+
+  const handleMediaDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setMediaDragActive(false);
+    const raw = e.dataTransfer.getData('application/x-thedaw-media');
+    if (!raw) return;
+    try {
+      const m = JSON.parse(raw) as { id?: string; url?: string; kind?: string; name?: string };
+      sendTrackToVj({
+        entryId: m.id ?? null,
+        label: m.name ?? 'media',
+        url: m.url,
+        kind: m.kind === 'image' ? 'image' : 'video',
+      });
+      logInfo('vj', `Added "${m.name ?? 'media'}" to the VJ from a drag-and-drop.`);
+    } catch {
+      logError('vj', 'Could not read the dropped media.');
+    }
+  };
 
   // Fetch the VJ URL on mount. The backend will spawn the dev server
   // if it isn't already running — this can take ~30s on first launch
@@ -952,6 +994,23 @@ export const VJView: React.FC = () => {
             reusing the in-VJ decoded stream — so we no longer decode a second
             copy here (kills the double HW-decode of the 60fps feed). The host
             toolbar still controls the relay (start/stop/refresh). */}
+
+        {/* Media drop zone — appears while a library media card is being
+            dragged, so the user can drop a clip/image straight onto the VJ to
+            add it to the performance bucket (sendTrackToVj). It sits above the
+            iframe so the drop lands here instead of being swallowed. */}
+        {mediaDragActive && (
+          <div
+            className="absolute inset-0 z-30 flex items-center justify-center bg-fuchsia-500/10 border-2 border-dashed border-fuchsia-400/60 backdrop-blur-[1px]"
+            onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; }}
+            onDrop={handleMediaDrop}
+            onDragLeave={(e) => { if (e.currentTarget === e.target) setMediaDragActive(false); }}
+          >
+            <div className="px-4 py-2 rounded-lg border border-fuchsia-400/60 bg-[#0a080f]/90 text-fuchsia-100 text-[11px] font-black uppercase tracking-widest flex items-center gap-2 pointer-events-none">
+              <Tv2 className="w-4 h-4" /> Drop to add to the VJ
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
feat(score+library): SCORE library tab, song-titled sheets, sticky panels, hi-contrast dropdowns

notation:
- stamp the originating song title onto every generated sheet (plain
  MAKE SHEET previously had no title)
- song-named score filenames; downloads named after the song even for
  older artifacts
library:
- new SCORE sub-tab listing every sheet/tab/arrangement (aggregate
  /api/library/_all/scores)
- sticky upper region: only the track/midi/video/stem/score lists scroll
  (new Section fill mode)
- bundle download now includes a scores/ folder; README lists scores
- per-item right-click downloads for tracks (audio) and video; download
  buttons on score + video rows
suno:
- pin the Render Queue header and bound the column so only the job list
  scrolls
score viewer:
- scrollwheel (Ctrl/Cmd) zoom with on-screen zoom controls
ui:
- .form-select utility + dark native option popups; convert washed-out
  bg-zinc-900 selects across the FX rack, OWL-Pad, gater, chop,
  spatializer, instrument pickers and waveform editor; brighten faint
  details headers
video cards:
- move actions to the top-right corner, add a right-click menu, and a
  Send-to-VJ action; drag a card onto the VJ tab to load it

feat(score): book-style sheet engraving + notation auto-pipeline

Score viewer (OSMD):
- song as the centered title, artist as the subtitle directly beneath it
  (was a duplicated title with the composer floated top-right); long titles
  word-wrap and are never truncated
- smaller fonts, wider top/bottom margins, even system spacing
- per-page running footer ("Song - Artist") + centered page number
- strip media extensions and drop the "Music21" stamp; clean XML at display

Notation backend:
- engine clean_title() + always-stamped composer (GANTASMO floor); stop
  writing movement-title so the title prints once
- idle backfill regenerates each entry's sheet once to fix title/credit
- auto-score on import/generate/favorite; score in bundle + MusicXML/PDF pack

Other:
- chimera first leg parallelized (normalize/bpm/stretch via to_thread+gather)
- Suno render queue: sticky header + scrolling list
- Shell: maximized bottom dock height is zoom-aware so the score controls
  are no longer clipped in fullscreen
- electron: exclude @coderline/alphatab from optimizeDeps (desktop score)