### PR TITLE
Feat/launch mode toggle

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2072,7 +2072,7 @@ GET  /api/analysis/{entry_id}/prompt
 
 ## 34. Quest and XR Integrations
 
-theDAW drives a Meta Quest headset for live performance without Quest Link (PC tethering) or Meta Quest Developer Hub casting. Each integration rides plain ADB over USB or a wireless pairing, and the backend starts the relay it needs on demand. The headset-side components live in the GANTASMO-MIDI Unity project.
+theDAW drives a Meta Quest headset for live performance without Quest Link (PC tethering) or Meta Quest Developer Hub casting. Each integration rides plain ADB over USB or a wireless pairing, and the backend starts the relay it needs on demand. The headset-side app is theDAW XR, a standalone Quest 3 build (the GANTASMO-MIDI Unity project).
 
 ### 34.1 delinQuest: Quest video into the VJ
 
@@ -2094,7 +2094,7 @@ The headset works as a hands-only controller for theDAW. A floating 3D control s
 
 ### 34.5 Quest colocation
 
-Several headsets in one room can share a single world frame, so the control surface and visuals lock to the same physical spot for everyone and each performer sees the others as lightweight head-and-hands presence. A one-click setup wizard in the GANTASMO-MIDI project installs and wires the pieces: shared spatial anchors, Meta Colocation Discovery for alignment, and Netcode for GameObjects over a LAN-direct transport with no cloud relay. The only manual steps are the Meta platform gates, which are Enhanced Spatial Services on each headset, a verified developer account, and all headsets on the same Wi-Fi.
+Several headsets in one room can share a single world frame, so the control surface and visuals lock to the same physical spot for everyone and each performer sees the others as lightweight head-and-hands presence. A one-click setup wizard in theDAW XR installs and wires the pieces: shared spatial anchors, Meta Colocation Discovery for alignment, and Netcode for GameObjects over a LAN-direct transport with no cloud relay. The only manual steps are the Meta platform gates, which are Enhanced Spatial Services on each headset, a verified developer account, and all headsets on the same Wi-Fi.
 
 ### 34.6 Setup notes
 

--- a/docs/WHERE-WE-STAND.md
+++ b/docs/WHERE-WE-STAND.md
@@ -89,7 +89,7 @@ the following is **SHIPPED** (merged via PRs #38-#42):
 ## 5. XR / Quest integrations
 
 These are the headset features. All **SHIPPED** to `main`, with the headset-side
-pieces living in the GANTASMO-MIDI Unity project. The point of the design is that
+pieces living in theDAW XR (the GANTASMO-MIDI Unity project). The point of the design is that
 none of them need Quest Link (PC tethering) or Meta Quest Developer Hub casting;
 they ride plain ADB (USB or wireless) with auto-started relays.
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-24T00:44:21.357Z · Git revision: `e2bd088a3c80` · Repomix tracked: **no**
+> Generated: 2026-06-24T02:40:16.462Z · Git revision: `7b55e18c801d` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-23T20:58:23.388Z · Git revision: `0004616020e1` · Repomix tracked: **no**
+> Generated: 2026-06-24T00:44:21.357Z · Git revision: `e2bd088a3c80` · Repomix tracked: **no**
 
 ## Audit Dashboard
 
@@ -16,7 +16,7 @@
 | Cropped screenshot assets | **10** |
 
 > [!IMPORTANT]
-> Repomix context: not present; tracked=false. Repomix context was not present for this run.
+> Repomix context: present at `repomix-output.md`; tracked=false. Used as local analysis context only. It is intentionally gitignored and must not be staged.
 
 ## Coverage Matrix
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2026-06-23T20:58:23.388Z",
-  "repoRevision": "0004616020e1",
+  "generatedAt": "2026-06-24T00:44:21.357Z",
+  "repoRevision": "e2bd088a3c80",
   "repomixContext": {
     "path": "repomix-output.md",
-    "present": false,
+    "present": true,
     "tracked": false,
-    "note": "Repomix context was not present for this run."
+    "note": "Used as local analysis context only. It is intentionally gitignored and must not be staged."
   },
   "features": [
     {

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-24T00:44:21.357Z",
-  "repoRevision": "e2bd088a3c80",
+  "generatedAt": "2026-06-24T02:40:16.462Z",
+  "repoRevision": "7b55e18c801d",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-23T15:00:31.918Z",
+  "generatedAt": "2026-06-24T02:43:02.076Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -2072,7 +2072,7 @@ GET  /api/analysis/{entry_id}/prompt
 
 ## 34. Quest and XR Integrations
 
-theDAW drives a Meta Quest headset for live performance without Quest Link (PC tethering) or Meta Quest Developer Hub casting. Each integration rides plain ADB over USB or a wireless pairing, and the backend starts the relay it needs on demand. The headset-side components live in the GANTASMO-MIDI Unity project.
+theDAW drives a Meta Quest headset for live performance without Quest Link (PC tethering) or Meta Quest Developer Hub casting. Each integration rides plain ADB over USB or a wireless pairing, and the backend starts the relay it needs on demand. The headset-side app is theDAW XR, a standalone Quest 3 build (the GANTASMO-MIDI Unity project).
 
 ### 34.1 delinQuest: Quest video into the VJ
 
@@ -2094,7 +2094,7 @@ The headset works as a hands-only controller for theDAW. A floating 3D control s
 
 ### 34.5 Quest colocation
 
-Several headsets in one room can share a single world frame, so the control surface and visuals lock to the same physical spot for everyone and each performer sees the others as lightweight head-and-hands presence. A one-click setup wizard in the GANTASMO-MIDI project installs and wires the pieces: shared spatial anchors, Meta Colocation Discovery for alignment, and Netcode for GameObjects over a LAN-direct transport with no cloud relay. The only manual steps are the Meta platform gates, which are Enhanced Spatial Services on each headset, a verified developer account, and all headsets on the same Wi-Fi.
+Several headsets in one room can share a single world frame, so the control surface and visuals lock to the same physical spot for everyone and each performer sees the others as lightweight head-and-hands presence. A one-click setup wizard in theDAW XR installs and wires the pieces: shared spatial anchors, Meta Colocation Discovery for alignment, and Netcode for GameObjects over a LAN-direct transport with no cloud relay. The only manual steps are the Meta platform gates, which are Enhanced Spatial Services on each headset, a verified developer account, and all headsets on the same Wi-Fi.
 
 ### 34.6 Setup notes
 

--- a/frontend/src/state/questMidiClient.ts
+++ b/frontend/src/state/questMidiClient.ts
@@ -6,7 +6,7 @@
  * separate Node bridge. Inbound Quest MIDI is republished on the global
  * `midiBus`, so every existing consumer (piano synth, VJ forwarder, MidiMapper,
  * the questControlStore) sees it exactly like a hardware controller. Return MIDI
- * (e.g. an audio-reactive feed for the GANTASMO Visor) goes back via
+ * (e.g. an audio-reactive feed for the headset MIDI Reactor) goes back via
  * `sendQuestMidi`.
  *
  * Same-origin URL so it rides the Vite dev proxy (ws:true) in development and is

--- a/theDAW.bat
+++ b/theDAW.bat
@@ -31,8 +31,21 @@ where node >nul 2>&1 || goto :needtools
 where npm  >nul 2>&1 || goto :needtools
 where ffmpeg >nul 2>&1 || echo   [!] ffmpeg not on PATH - audio effects/exports/ingest fail until installed.
 
-:: -- Bootstrap dependencies if this is a fresh / incomplete tree --------
-if not exist ".venv\Scripts\activate" (
+:: -- Bootstrap Python deps if the venv is missing OR incomplete --------
+:: A previous `uv sync` can be interrupted AFTER uv creates the venv but
+:: BEFORE it installs packages, leaving .venv\Scripts\activate present while
+:: uvicorn / fastapi and the other declared deps are absent. The old
+:: "venv exists -> skip sync" check then launched the backend against a
+:: half-built env and crashed on `import uvicorn`. So sync when a core import
+:: fails too, not only when the venv is missing entirely.
+set "NEED_SYNC=0"
+if not exist ".venv\Scripts\activate" set "NEED_SYNC=1"
+if not exist ".venv\Scripts\python.exe" set "NEED_SYNC=1"
+if "%NEED_SYNC%"=="0" (
+    .venv\Scripts\python.exe -c "import uvicorn, fastapi" >nul 2>&1
+    if errorlevel 1 set "NEED_SYNC=1"
+)
+if "%NEED_SYNC%"=="1" (
     echo Bootstrapping Python env: uv sync --group dev
     echo   First run downloads torch + CUDA wheels and can take several minutes...
     call uv sync --group dev


### PR DESCRIPTION
[docs: name the Quest companion "theDAW XR" / "MIDI Reactor" in theDAW add logo

- USER_GUIDE (docs + public mirror) and WHERE-WE-STAND now name the headset
  companion app theDAW XR, keeping the GANTASMO-MIDI repo reference.
- Rename the GANTASMO Visor reference to MIDI Reactor in questMidiClient.
- Add GANTASMO_LOGO.gif.
- Regenerate the feature-doc coverage report (pre-commit hook).

fix(launcher): re-run uv sync when the venv exists but is incomplete

A `uv sync` interrupted after uv creates the venv but before it installs
packages leaves .venv\Scripts\activate present while uvicorn, fastapi, and the
other declared deps are missing. theDAW.bat synced only when the activate
script was absent, so it then launched the backend against a half-built env and
crashed on `import uvicorn`. It now also syncs when a core import (uvicorn,
fastapi) fails, so the deps are always installed before the backend starts.