### PR TITLE
feat: media convert, collapse-by-default, XR control bus, Windows installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,4 +257,7 @@ docs/*.pdf
 # Electron desktop shell — build artifacts + runtime logs (deps via node_modules/ above)
 electron-ui/out/
 electron-ui/release/
+# Bundled runtime binaries fetched at build time (uv.exe, ffmpeg.exe) — large,
+# downloaded from official sources by scripts/fetch-runtime-tools.mjs.
+electron-ui/resources/tools/
 logs/

--- a/backend/modules/convert/module.json
+++ b/backend/modules/convert/module.json
@@ -1,0 +1,10 @@
+{
+  "name": "convert",
+  "label": "Convert",
+  "enabled": true,
+  "icon": "Repeat",
+  "sidebar": false,
+  "api_prefix": "/api/convert",
+  "backend": true,
+  "description": "Generic media format conversion via FFmpeg. Converts a library entry or an uploaded file to any compatible target format (audio<->audio, video<->video, video->audio extract, video->gif, image<->image). Powers the right-click 'Convert to...' menu."
+}

--- a/backend/modules/convert/router.py
+++ b/backend/modules/convert/router.py
@@ -1,0 +1,380 @@
+"""Generic media conversion via FFmpeg.
+
+A single "convert anything to anything (sensible)" endpoint set used by the
+right-click "Convert to..." menu in the app and by the Windows Explorer shell
+menu. Reuses the shared FFmpeg helper (``backend/lib/ffmpeg.py``) and the library
+store, so it inherits the bundled ffmpeg binary resolved on PATH by the desktop
+app.
+
+Conversion rules (by source media kind):
+- audio  -> audio
+- video  -> video, audio (extract), gif
+- image  -> image
+Unknown sources are permitted to attempt any target (ffmpeg decides).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+from ...lib import ffmpeg
+from ..library.router import get_store as get_library_store
+
+router = APIRouter(tags=["convert"])
+
+
+# --- format catalog -------------------------------------------------------
+
+# Each target format: the container/extension, its media kind, the mime type for
+# the download, a human label, and the ffmpeg OUTPUT args (codec/quality). Input
+# is auto-decoded by ffmpeg, so only output args are needed. Audio targets carry
+# -vn so converting a video (or art-bearing audio) cleanly extracts the audio.
+FORMATS: dict[str, dict] = {
+    # audio
+    "wav": {
+        "ext": "wav",
+        "kind": "audio",
+        "mime": "audio/wav",
+        "label": "WAV (PCM 16-bit)",
+        "args": ["-vn", "-c:a", "pcm_s16le"],
+    },
+    "wav24": {
+        "ext": "wav",
+        "kind": "audio",
+        "mime": "audio/wav",
+        "label": "WAV (PCM 24-bit)",
+        "args": ["-vn", "-c:a", "pcm_s24le"],
+    },
+    "flac": {
+        "ext": "flac",
+        "kind": "audio",
+        "mime": "audio/flac",
+        "label": "FLAC (lossless)",
+        "args": ["-vn", "-c:a", "flac"],
+    },
+    "mp3": {
+        "ext": "mp3",
+        "kind": "audio",
+        "mime": "audio/mpeg",
+        "label": "MP3 (320k)",
+        "args": ["-vn", "-c:a", "libmp3lame", "-b:a", "320k"],
+    },
+    "ogg": {
+        "ext": "ogg",
+        "kind": "audio",
+        "mime": "audio/ogg",
+        "label": "OGG Vorbis",
+        "args": ["-vn", "-c:a", "libvorbis", "-q:a", "6"],
+    },
+    "opus": {
+        "ext": "opus",
+        "kind": "audio",
+        "mime": "audio/opus",
+        "label": "Opus",
+        "args": ["-vn", "-c:a", "libopus", "-b:a", "192k"],
+    },
+    "m4a": {
+        "ext": "m4a",
+        "kind": "audio",
+        "mime": "audio/mp4",
+        "label": "M4A (AAC 256k)",
+        "args": ["-vn", "-c:a", "aac", "-b:a", "256k"],
+    },
+    "aiff": {
+        "ext": "aiff",
+        "kind": "audio",
+        "mime": "audio/aiff",
+        "label": "AIFF",
+        "args": ["-vn", "-c:a", "pcm_s16be"],
+    },
+    # video
+    "mp4": {
+        "ext": "mp4",
+        "kind": "video",
+        "mime": "video/mp4",
+        "label": "MP4 (H.264)",
+        "args": [
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-crf",
+            "18",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "256k",
+            "-movflags",
+            "+faststart",
+        ],
+    },
+    "mov": {
+        "ext": "mov",
+        "kind": "video",
+        "mime": "video/quicktime",
+        "label": "MOV (H.264)",
+        "args": [
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-crf",
+            "18",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "256k",
+        ],
+    },
+    "mkv": {
+        "ext": "mkv",
+        "kind": "video",
+        "mime": "video/x-matroska",
+        "label": "MKV (H.264)",
+        "args": [
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-crf",
+            "18",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "256k",
+        ],
+    },
+    "webm": {
+        "ext": "webm",
+        "kind": "video",
+        "mime": "video/webm",
+        "label": "WebM (VP9)",
+        "args": [
+            "-c:v",
+            "libvpx-vp9",
+            "-b:v",
+            "0",
+            "-crf",
+            "30",
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "192k",
+        ],
+    },
+    "gif": {
+        "ext": "gif",
+        "kind": "video",
+        "mime": "image/gif",
+        "label": "GIF (animated)",
+        "args": ["-vf", "fps=15,scale=480:-1:flags=lanczos", "-loop", "0"],
+    },
+    # image
+    "png": {
+        "ext": "png",
+        "kind": "image",
+        "mime": "image/png",
+        "label": "PNG",
+        "args": ["-frames:v", "1"],
+    },
+    "jpg": {
+        "ext": "jpg",
+        "kind": "image",
+        "mime": "image/jpeg",
+        "label": "JPEG",
+        "args": ["-frames:v", "1", "-q:v", "2"],
+    },
+    "webp": {
+        "ext": "webp",
+        "kind": "image",
+        "mime": "image/webp",
+        "label": "WebP",
+        "args": ["-frames:v", "1", "-q:v", "85"],
+    },
+    "bmp": {
+        "ext": "bmp",
+        "kind": "image",
+        "mime": "image/bmp",
+        "label": "BMP",
+        "args": ["-frames:v", "1"],
+    },
+    "tiff": {
+        "ext": "tiff",
+        "kind": "image",
+        "mime": "image/tiff",
+        "label": "TIFF",
+        "args": ["-frames:v", "1"],
+    },
+}
+
+# Which target kinds a source kind may produce.
+ALLOWED_TARGETS: dict[str, set[str]] = {
+    "audio": {"audio"},
+    "video": {"video", "audio"},
+    "image": {"image"},
+}
+
+_AUDIO_EXT = {
+    ".wav",
+    ".flac",
+    ".mp3",
+    ".ogg",
+    ".opus",
+    ".m4a",
+    ".aac",
+    ".aiff",
+    ".aif",
+    ".wma",
+}
+_VIDEO_EXT = {".mp4", ".mov", ".mkv", ".webm", ".avi", ".gif", ".m4v", ".flv", ".wmv"}
+_IMAGE_EXT = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tiff", ".tif", ".heic"}
+
+
+def _kind_of(suffix: str) -> str:
+    s = suffix.lower()
+    if s in _AUDIO_EXT:
+        return "audio"
+    if s in _VIDEO_EXT:
+        return "video"
+    if s in _IMAGE_EXT:
+        return "image"
+    return "unknown"
+
+
+def _safe_stem(name: str) -> str:
+    # Strip a trailing file extension only when it really looks like one, so a
+    # title containing a slash (e.g. "AC/DC") is not truncated by Path parsing.
+    head, sep, tail = name.rpartition(".")
+    stem = head if sep and 1 <= len(tail) <= 5 and tail.isalnum() else name
+    stem = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "_", stem).strip(" .")
+    return stem[:120] or "converted"
+
+
+def _ensure_ffmpeg() -> None:
+    if shutil.which("ffmpeg") is None:
+        raise HTTPException(
+            status_code=503,
+            detail="ffmpeg was not found on PATH. The desktop app bundles it; if running the "
+            "backend standalone, install ffmpeg or add it to PATH.",
+        )
+
+
+async def _convert_to_bytes(src: Path, fmt: str, src_kind: str) -> tuple[bytes, dict]:
+    spec = FORMATS.get(fmt)
+    if spec is None:
+        raise HTTPException(status_code=400, detail=f"Unknown target format '{fmt}'.")
+
+    if src_kind != "unknown" and spec["kind"] not in ALLOWED_TARGETS.get(
+        src_kind, set()
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot convert a {src_kind} file to {spec['label']}.",
+        )
+
+    tmp = Path(tempfile.mkdtemp(prefix="convert_"))
+    out = tmp / f"out.{spec['ext']}"
+    try:
+        await ffmpeg.render(src, out, filter_args=[], extra_out_args=spec["args"])
+        data = await asyncio.to_thread(out.read_bytes)
+        return data, spec
+    except ffmpeg.FFmpegError as e:
+        raise HTTPException(
+            status_code=422, detail=f"Conversion failed: {str(e)[-400:]}"
+        )
+    finally:
+        ffmpeg.cleanup(tmp)
+
+
+def _download_headers(stem: str, ext: str) -> dict:
+    return {"Content-Disposition": f'attachment; filename="{stem}.{ext}"'}
+
+
+class ConvertRequest(BaseModel):
+    format: str
+
+
+# --- endpoints ------------------------------------------------------------
+
+
+@router.get("/formats")
+def list_formats() -> dict:
+    """Catalog of target formats plus the source-kind -> target-kind rules so the
+    UI can show only the conversions that make sense for a given item."""
+    return {
+        "formats": [
+            {
+                "id": fid,
+                "ext": v["ext"],
+                "kind": v["kind"],
+                "label": v["label"],
+                "mime": v["mime"],
+            }
+            for fid, v in FORMATS.items()
+        ],
+        "rules": {k: sorted(v) for k, v in ALLOWED_TARGETS.items()},
+    }
+
+
+@router.post("/library/{entry_id}")
+async def convert_library_entry(entry_id: str, body: ConvertRequest) -> Response:
+    """Convert a library entry (audio/video/image) to the requested format and
+    return the converted bytes as a download."""
+    _ensure_ffmpeg()
+    store = get_library_store()
+
+    record = store.get_entry(entry_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Library entry not found.")
+
+    src = store.get_audio_path(entry_id)
+    if src is None or not src.exists():
+        src = store.get_media_path(entry_id)
+    if src is None or not src.exists():
+        raise HTTPException(
+            status_code=404, detail="Source media file not found on disk."
+        )
+
+    src_kind = _kind_of(src.suffix)
+    data, spec = await _convert_to_bytes(src, body.format, src_kind)
+
+    meta = record.to_dict() if hasattr(record, "to_dict") else {}
+    stem = _safe_stem(str(meta.get("title") or src.stem))
+    return Response(
+        content=data,
+        media_type=spec["mime"],
+        headers=_download_headers(stem, spec["ext"]),
+    )
+
+
+@router.post("/file")
+async def convert_upload(
+    file: UploadFile = File(...), format: str = Form(...)
+) -> Response:
+    """Convert an uploaded file to the requested format and return the bytes.
+    Used for arbitrary files that are not library entries."""
+    _ensure_ffmpeg()
+
+    tmp = Path(tempfile.mkdtemp(prefix="convert_up_"))
+    in_suffix = Path(file.filename or "input").suffix or ".bin"
+    src = tmp / f"input{in_suffix}"
+    try:
+        await ffmpeg.stream_upload_to(src, file)
+        src_kind = _kind_of(in_suffix)
+        data, spec = await _convert_to_bytes(src, format, src_kind)
+        stem = _safe_stem(file.filename or "converted")
+        return Response(
+            content=data,
+            media_type=spec["mime"],
+            headers=_download_headers(stem, spec["ext"]),
+        )
+    finally:
+        ffmpeg.cleanup(tmp)

--- a/backend/modules/xrcontrol/module.json
+++ b/backend/modules/xrcontrol/module.json
@@ -1,0 +1,10 @@
+{
+  "name": "xrcontrol",
+  "label": "XR Control Bus",
+  "enabled": true,
+  "icon": "Radio",
+  "sidebar": false,
+  "api_prefix": "/api/xr/control",
+  "backend": true,
+  "description": "Relay between theDAW (the browser, which owns the control manifest and the wired setters) and a theDAW-XR headset (which requests the manifest and sends control changes). Carries the control manifest plus control-set and control-changed messages so hand-tracked spatial controls in XR drive theDAW. Transport only: it holds no control state. Disable to close the bus."
+}

--- a/backend/modules/xrcontrol/router.py
+++ b/backend/modules/xrcontrol/router.py
@@ -1,0 +1,73 @@
+"""FastAPI router for the XR control bus (spatialization P0).
+
+A transport-only relay between theDAW (the browser, which owns the control
+manifest and the wired setters) and a theDAW-XR headset (which requests the
+manifest and sends control changes). The relay holds no manifest and no control
+state: it forwards each JSON frame to every OTHER connected peer, so the browser
+host and the XR controller exchange messages without the backend understanding
+them.
+
+Endpoints (prefix /api/xr/control):
+    GET  /status   connected-peer count
+    WS   /ws       peer relay (browser host <-> XR controller)
+
+Message shapes (defined by the manifest contract in the frontend, not enforced
+here):
+    host -> controller : {"type":"manifest", "version":N, "entries":[...]}
+                         {"type":"control-changed", "id":..., "value":...}
+    controller -> host : {"type":"request-controls"}
+                         {"type":"control-set", "id":..., "value":...}
+                         {"type":"pad"|"jog"|"trigger", ...}
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(tags=["xrcontrol"])
+
+# Every connected peer (browser hosts and XR controllers alike). A frame from
+# any peer is relayed to all the others. Single-host is the intended topology;
+# extra hosts would each apply inbound control-sets, which is idempotent.
+_clients: set[WebSocket] = set()
+
+
+@router.get("/status")
+async def status() -> dict:
+    return {"clients": len(_clients)}
+
+
+async def _relay(origin: WebSocket, msg: object) -> None:
+    """Forward one frame to every peer except its sender."""
+    dead: list[WebSocket] = []
+    for peer in list(_clients):
+        if peer is origin:
+            continue
+        try:
+            await peer.send_json(msg)
+        except Exception:  # noqa: BLE001 — drop peers that went away
+            dead.append(peer)
+    for d in dead:
+        _clients.discard(d)
+
+
+@router.websocket("/ws")
+async def ws(websocket: WebSocket) -> None:
+    await websocket.accept()
+    _clients.add(websocket)
+    log.info("xrcontrol: peer connected (%d total)", len(_clients))
+    try:
+        while True:
+            msg = await websocket.receive_json()
+            await _relay(websocket, msg)
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:  # noqa: BLE001 — peer went away mid-message
+        log.debug("xrcontrol: ws error: %s", e)
+    finally:
+        _clients.discard(websocket)
+        log.info("xrcontrol: peer disconnected (%d total)", len(_clients))

--- a/backend/rag.py
+++ b/backend/rag.py
@@ -20,6 +20,11 @@ RAG_INDEX_DIR = PROJECT_ROOT / "backend" / "rag_index"
 
 DOC_PATHS = [
     PROJECT_ROOT / "CLAUDE.md",
+    # User-facing project overview for the assistant. Lives under docs/ so it is
+    # shipped in the packaged desktop build (which bundles docs/**/*.md but not
+    # the repo-root CLAUDE.md), keeping the assistant's project framing intact
+    # without exposing internal dev guidance to end users.
+    PROJECT_ROOT / "docs" / "guides" / "about-thedaw.md",
     PROJECT_ROOT / "docs" / "SHOWCASE.md",
     PROJECT_ROOT / "docs" / "USER_GUIDE.md",
     PROJECT_ROOT / "docs" / "DESIGN_PRINCIPLES.md",

--- a/docs/guides/about-thedaw.md
+++ b/docs/guides/about-thedaw.md
@@ -1,0 +1,47 @@
+# About theDAW
+
+This document gives the in-app assistant a concise, accurate overview of what
+theDAW is and how its main areas fit together. It is a starting point and is
+meant to grow as features land.
+
+## What theDAW is
+
+theDAW is a local music creation workstation built on the Stable Audio 3 model
+family. It runs on the user's own machine, either as a desktop application or in
+a browser, and pairs a React interface with a Python backend that performs both
+generation and audio processing. A text prompt becomes finished 44.1 kHz stereo
+audio.
+
+## How generation works
+
+Generation runs in two stages. A diffusion transformer turns a text prompt and a
+target duration into compressed latents, and the SAME autoencoder decodes those
+latents into stereo audio. Duration is set directly, so a request produces
+exactly the requested length with no wasted padding.
+
+## Models
+
+theDAW ships small and medium model variants. The small model runs on CPU. The
+medium model is faster and higher fidelity on an NVIDIA GPU. The model picker
+switches between them and surfaces local checkpoints when they are present.
+
+## Main areas
+
+- MAKE creates new audio from a text prompt.
+- MIX processes existing audio through the effects and mastering chain. MAKE and
+  MIX are separate stages: MAKE produces material, MIX shapes material that
+  already exists.
+- The Library stores every generation together with its prompt, metadata,
+  lineage, stems, and MIDI.
+- LEARN presents the genealogy of a track as a lineage graph, showing how one
+  result descends from another.
+- SCORE renders notation and book-style sheet music for a track.
+- DJ provides decks, key and tempo control, live stems, cueing, and an effects
+  rack for performance.
+- VJ drives live visuals that react to the audio.
+
+## Where work is saved
+
+Generations, settings, and the library live in the application's data directory
+and persist between sessions. Exports are written on demand to the locations the
+user chooses.

--- a/docs/plans/2026-06-23-thedaw-xr-spatialization.md
+++ b/docs/plans/2026-06-23-thedaw-xr-spatialization.md
@@ -1,0 +1,341 @@
+# theDAW to theDAW-XR Spatialization Plan
+
+Date: 2026-06-23
+Status: proposed map, pending review
+Scope: spatialize theDAW's MAKE (Chimera), DJ (scratch), VJ (XY pads), and the
+LEARN lineage graph into theDAW-XR's Quest hand-tracked 3D interface, driven from
+data so the port stays low-maintenance.
+
+Repos:
+- theDAW (web app): `d:/StableAudio/JoshOG/stable-audio-3` (`frontend/src` is React/TS)
+- theDAW-XR (Unity): `d:/Dev/Unity/GANTASMO-MIDI/GANTASMO-MIDI`
+- OwlPad3D foundation: already taken into theDAW-XR at `Assets/OwlPad3D`
+
+## 1. The core idea
+
+theDAW already describes its controls in machine-readable registries and already
+dispatches control changes by name. theDAW-XR already builds an entire spatial
+control surface procedurally from a ScriptableObject config. The port connects
+those two facts with a single unified control manifest carried over one
+websocket. A control becomes a data row in a catalogue, and the XR scene
+instantiates a spatial widget for it automatically. Adding a control in theDAW
+surfaces it in XR with no Unity edit, no prefab, and no scene change.
+
+MIDI stays the low-latency carrier for any scalar that already has a CC. The new
+websocket carries the manifest itself plus the toggles, enums, and rich payloads
+that a 7-bit or 14-bit CC cannot express.
+
+## 2. What already exists (the four substrates)
+
+| Substrate | Where | What it gives |
+|---|---|---|
+| DJ control manifest | `frontend/src/state/bindableTargets.ts` (`DJ_TARGETS`, line 35) | An array of `BindableTarget{id,label,group,kind,min,max,step,unit,invoke()}`. `invoke()` is a fully wired setter. This is the exact shape the manifest should take. |
+| VJ two-way control channel | `frontend/src/state/sa3Bridge.ts` + `controlManifest.ts` | The VJ iframe answers `sa3-vj/request-controls` with `sa3-vj/controls-manifest{manifest,values}`, accepts `sa3-vj/control-set{key,value}`, and echoes `sa3-vj/control-changed`. Built procedurally from `MIDI_PARAMS` + `TOGGLE_CONTROLS`. |
+| MAKE action dispatcher | `frontend/src/orb-kit/actionHandlers.ts` (`handletheDAWAction`, line 83) | String-keyed actions: `set_prompt/model/duration/steps/cfg/seed/sampler/shift/init_noise`, `apply_params` (bulk ~25-field patch), `generate/abort`, `get_status`. Every control reads the shared zustand store, so firing an action moves the React UI with zero per-control code. |
+| XR transport | `frontend/src/state/questMidiClient.ts` to backend `/api/questmidi/ws` | A websocket that republishes inbound Quest MIDI onto the global `midiBus` and returns MIDI to the headset (the MIDI Reactor consumes the return path today). |
+
+On the Unity side the procedural surface already exists in
+`Packages/com.gantasmo.questmidi/`:
+- `Runtime/QuestMidiSender.cs` sends 7-bit and 14-bit CC (`SendControlChange14`)
+  and Note On/Off.
+- `Runtime/ControlSurface/MidiControlSurface.cs` routes a surface's controls to
+  the sender on a shared channel.
+- `Runtime/ControlSurface/{MidiSlider,MidiKnob,MidiButton,MicrogestureMidiSource}.cs`
+  are the primitive widgets and the hands-free gesture source (five discrete
+  microgesture events).
+- `Editor/GantasmoSurfaceConfig.cs` plus `GantasmoControlSurfaceBuilder.cs`
+  instantiate the whole surface from a config asset. This already proves that a
+  new control is a new data row rather than new code.
+
+## 3. The new contract: `/api/xr/control` plus a unified manifest
+
+Stand up one backend websocket module, cloning the proven questmidi and
+queststitch socket-plus-module pattern. It serves a manifest on connect and
+relays control changes both ways.
+
+### 3.1 Manifest entry
+
+A flat array of self-describing entries, aggregated host-side from the existing
+registries:
+
+```
+{
+  id:      "dj.eqHi.A" | "make.cfg" | "vj.glitch" | "fx.owlpad.<entryId>.x",
+  area:    "make" | "dj" | "vj" | "fx" | "learn",
+  group:   "deckA.eq" | "chimera.weave" | "distortion",   // spatial bucketing
+  label:   short human string,
+  kind:    "knob"|"fader"|"button"|"toggle"|"select"|"xy"|"xyz"|"jog"|"grid",
+  min, max, step,            // numeric domain (absent for button/toggle/select)
+  options: string[],         // for select/enum
+  default, value,            // value seeds the XR widget on connect
+  unit:    "dB"|"%"|"s"|"BPM",
+  transport: "midi" | "ws",  // midi when a CC/note exists, ws otherwise
+  midi:    { kind:"cc"|"note", number, channel, bits:7|14 },  // when transport=midi
+  worldHint: { anchor, size } // optional placement
+}
+```
+
+This mirrors the shapes three registries already use. `BindableTarget` maps
+field-for-field minus `invoke` (replaced by `transport`/`midi`). The VJ
+`ControlManifestEntry{key,label,kind,group,min,max,step}` forwards almost
+verbatim with `area:"vj"`. MAKE entries are generated from the `SlideRow`/
+`SlideFader` props that already encode `min/max/step` in `AdvancedGenPanel.tsx`,
+each tagged with the `handletheDAWAction` name it fires.
+
+### 3.2 Messages
+
+- Outbound to XR: `{type:"manifest", version, entries:[...]}` on connect and on
+  change; `{type:"control-changed", id, value}` on any host-side move.
+- Inbound from XR, scalar: `{type:"control-set", id, value}`. The host routes it
+  to that id's setter: `DJ_TARGETS.invoke`, the VJ `control-set`, a
+  `handletheDAWAction`, or a new `setRackParam`.
+- Inbound from XR, rich kinds the scalar path cannot express:
+  - `{type:"pad", id, x, y, z?, gate}` for xy and xyz pads,
+  - `{type:"jog", id, velocity, phase:"grab"|"move"|"release"}` for the platter,
+  - `{type:"trigger", id, index}` for grids (clip launch, hotcues, sampler).
+
+A `manifestVersion` integer lets XR re-instantiate only when the manifest
+changes.
+
+### 3.3 Why this is the low-maintenance path
+
+A new theDAW control surfaces in XR the moment it is registered in its area's
+catalogue. There is no Unity edit, no prefab, and no scene change. MIDI remains
+the low-latency value carrier for anything MIDI-mappable, which already works
+through the questmidi websocket. The new websocket carries the manifest, the
+toggles, the enums, and the rich pad and jog payloads.
+
+## 4. Per-area spatialization
+
+### 4.1 MAKE and Chimera
+
+Layout: a shallow arc in front of the performer holds the scalar cluster, and the
+Chimera DNA hero occupies the deep center volume so the stack reads as a
+sculpture rather than a wall of knobs. Scalars summon as a curved panel on gaze.
+Magenta mode swaps the cluster contents in place rather than adding a second
+panel.
+
+Controls: CFG, Steps, and Length port as three large 3D knobs or faders, already
+wired through `set_cfg`/`set_steps`/`set_duration`. Seed becomes a jog dial plus
+a dice button. Model becomes a labeled button cluster, one cube per engine,
+firing `set_model` plus the `patch()` and `swapEngineForModel` side-effects that
+the action must replicate. CREATE and ABORT become one large palm-press launch
+button with a progress halo, driven by `generate`/`abort` and `get_status`.
+
+Hero: the Chimera CRISPR DNA scene (`ChimeraDnaScene.tsx`). It is the single
+highest-leverage reuse in the port. `getRunFraction()` is already exported, the
+real chunk plan lives in `lastMeta.per_clip.placements`, and the helix is already
+depth-sorted under an orthographic camera, so it simulates 3D today. In XR each
+clip becomes a grabbable floating helix lane that stacks and reorders. On CREATE
+the chunks lift, travel to a shared output strand above the stack, and fuse,
+paced by `getRunFraction()` so the DNA and the progress percentage always agree.
+The stack add, remove, reorder, per-clip noise, and base interactions have no
+actions today and reach the engine through `addBlobsToChimera` plus store
+methods, so they need a thin bridge action (`set_chimera_field`).
+
+### 4.2 DJ
+
+Layout: two deck faces angled inward like a booth, the mixer strip (crossfader
+plus the two channel faders) in the centered hero slot, FX pods and pad grids on
+summonable side rails. Waveform ribbons curve along the top and the transport
+sits low, per the design ruleset. Only one deck's deep controls expand at a time.
+
+Controls: nearly the entire DJ surface ports with zero new code by enumerating
+`DJ_TARGETS` and spawning one widget per `target.kind` bound to `target.invoke`:
+EQ hi/mid/lo, filter, gain, channel volume, pitch, crossfade, the FX flanger/
+reverb/wah, keylock, slip, headcue, limiter, play, and cue. Hotcues, sampler, and
+beat loops port as lit button grids calling the directly callable engine
+functions, which need `grid`/`trigger` rows added to the catalogue.
+
+Hero: the jog and scratch platter. It is the priority primitive and the one DJ
+control absent from `DJ_TARGETS`, because its value model is a signed continuous
+angular velocity plus grab and release rather than a scalar. The XR platter
+reuses `JogWheel.tsx` angle-to-velocity math (`VEL_K = SEC_PER_REV / 2PI`) on a
+hand-grabbed disc: grab calls `enterVinyl`, the per-frame hand angular delta
+calls `setVinylVelocity` (clamped to -16..+16), and release calls `exitVinyl`.
+Position read-back flows through `djEngine.subscribe` to drive the emissive ring
+imperatively. This is the jog-binding sibling of the generalized XYZ pad.
+
+### 4.3 VJ
+
+Layout: a large curved video screen shows the live composited output, streamed in
+over the existing delinQuest/queststitch WebCodecs path or a `captureStream`
+texture. The XYZ FX pad floats at hand height center stage. The knob banks
+(color, geometry, look, timecode groups) and the toggle grid arc to the sides,
+auto-instantiated one widget per manifest entry. The Resolume-style clip grid
+sits on a side rail as stacked banks.
+
+Controls: the entire distortion, color, geometry, look, and timecode groups plus
+the crossfader and the toggles spatialize with zero per-control code by consuming
+the existing `sa3-vj/controls-manifest` and emitting `sa3-vj/control-set` per
+widget. Native min and max in the manifest auto-scale the 3D widgets, and
+`control-changed` echoes light toggle state. Range parameters can additionally be
+driven by MIDI CC over questmidi with no new code. Three small additions close
+the gaps: a `sa3-vj/launch-clip{index,bank}` message, an enum/select kind, and a
+host-side relay so an external Unity process can reach the postMessage bridge.
+
+Hero: the XYZ FX pad. The VJ tab has no XY pad of its own today, so the hero is
+the generalized OwlPad3D bound to three chosen manifest keys at once (for
+example X to glitch, Y to feedback, Z to pixelate). The same primitive doubles as
+the OWL-Pad and Spatializer rack pads described in section 5.
+
+### 4.4 LEARN (lineage graph)
+
+Layout: a walk-in volume the performer teleports through. Nodes float as
+clustered constellations tinted by source, edges render as colored tubes. The
+room is the control. A floating inspector summons on point-to-select.
+
+Controls: zero backend work. XR fetches the same `GET /api/library/_graph/all`
+payload and instantiates node meshes reusing the existing `nodeShape` enum, with
+one shared material per source color and edge tubes per edge kind, honoring the
+asset-reuse rule. `flyHome`/`flyForward` map to walk and teleport locomotion. The
+hover-lights-lineage BFS becomes gaze or point highlight of a track's full
+ancestry and descendants. Node selection opens a floating detail panel. This is a
+pure renderer swap riding the new websocket for node-pick and metadata.
+
+Hero: the walk-in derivation graph itself. The force-graph already produces real
+x, y, z node positions and typed edges, so the spatial form is native.
+
+## 5. The XYZ pad, generalized from OwlPad3D
+
+Generalize the demo (now at `Assets/OwlPad3D`) into one reusable `XyzPad`
+primitive, instanced for the VJ FX pad, the OWL audio pad, the Spatializer
+positioner, and the DJ scratch decks. One primitive, configured per instance.
+
+Keep verbatim:
+- `OwlPadController` plane projection and 0..1 normalization (the coordinate
+  engine).
+- The ScriptableObject event-channel decoupling (`OwlPadEventChannel`), the
+  zero-edit seam where a new consumer attaches.
+- The pooled ripple, grid, and indicator visuals, with one shared material per
+  instance.
+- The idempotent `CreateOrLoadAsset` factory from `OwlPad3DAutoSetup` as the
+  spawn-pad-from-descriptor builder.
+
+Promote the Z axis: the controller already computes the signed finger-to-plane
+distance (`distanceToPad` from `padPlane.GetDistanceToPoint`) but only
+threshold-tests it as a binary touch gate. Expose
+`normalizedZ = Clamp01((hoverCeiling - dist) / hoverRange)` and replace the
+hardcoded `pressure = 1.0` with it. The demo becomes a true XYZ surface with no
+new math. Generalize the payload to `Vector3` plus a stable `padId` so one event
+bus serves many pads.
+
+Add the one missing piece, a generic `PadBinding` consumer ScriptableObject that
+replaces the four audio-effect SOs. It reads an axis-to-target assignment from the
+manifest entry (per-axis enable, invert, min, max, curve, plus a touch gate) and
+emits per axis either a 14-bit CC over the questmidi socket or a `control-set`
+over the new websocket, with touch-down and touch-up as a gate. It reuses
+`OwlPadEffect`'s per-axis enable, invert, and `AnimationCurve` range shaping as
+the CC range and curve config.
+
+Bindings:
+- OWL-pad: X and Y to its program-dependent Freq, Reso, Time, and Feedback axes,
+  Z to mix. The HOLD and GATE become a latch toggle beside the pad.
+- Spatializer: the pad plane to azimuth and distance, Z to elevation. The 2D
+  pad's missing third axis becomes free in XR, the cleanest 2D-to-3D promotion in
+  the app.
+- DJ scratch: the jog-binding variant. It emits X velocity (signed dPosition/dt)
+  as a relative jog centered on 64 and gates platter contact on Z, mirroring
+  `JogWheel`'s velocity math, because an absolute-position CC cannot express a
+  scratch.
+
+All four targets bind from descriptor rows, so adding a pad-driven control is a
+manifest edit.
+
+The pad graduates from `Assets/OwlPad3D` into
+`Packages/com.gantasmo.questmidi/Runtime/ControlSurface/` as the `XyzPad`
+primitive once generalized, so package code can instantiate it. The namespace
+moves to the Gantasmo convention at that point.
+
+## 6. Avoiding overcrowding
+
+Treat the manifest `group` field as the spatialization budget and never render
+every control at once.
+
+1. Context-switching per area: only one tab's surface is materialized at a time
+   (MAKE, DJ, VJ, or LEARN), switched by a microgesture shortcut or a wrist menu.
+   The other areas dismiss entirely.
+2. Summon and dismiss on gaze: scalar clusters stay collapsed to a single group
+   anchor and expand into a curved panel only when the performer gazes at or
+   reaches toward it, then auto-collapse on look-away. The always-present
+   elements per tab are the hero and three to five must-have controls.
+3. Single-deck and single-cluster expansion: in DJ only the focused deck expands
+   its loops, hotcues, and stems; in MAKE the expert sub-panels stay hidden until
+   SHIFT mode is engaged.
+4. Proximity layering by depth: heroes occupy the deep center volume, primary
+   controls sit at hand height in the near arc, secondary controls live on side
+   rails reachable by a small lean. The XYZ pad's third axis itself reduces widget
+   count, since one pad replaces two or three knobs.
+5. Group-driven instancing with shared assets: the factory buckets widgets by
+   manifest group into tidy clusters using one shared material per group, so
+   density reads as organized constellations.
+
+LEARN is the model for density without clutter: hundreds of nodes become a
+walk-in constellation with detail summoned only on point-to-select.
+
+## 7. Phased delivery
+
+| Phase | Deliverable | Depends on |
+|---|---|---|
+| P0 Control-bus contract | Define the manifest entry schema and stand up `/api/xr/control` as a backend websocket cloning the questmidi module pattern. Prove the transport end to end with a hand-written three-entry stub manifest. | questmidi router as template; agreement on the entry shape. |
+| P1 Host aggregator, DJ first | A theDAW aggregator that publishes `DJ_TARGETS` verbatim into the manifest and routes inbound `control-set` to `DJ_TARGETS.invoke`, with `control-changed` echoes via `djEngine.subscribe`. The whole DJ scalar surface becomes XR-drivable with no per-control code. | P0; `bindableTargets.ts`. |
+| P2 XR ingester and factory | Replace the hand-authored `GantasmoSurfaceConfig` with a runtime loader that fetches the manifest and feeds the existing builder to instantiate widgets per `entry.kind`. Add the two-way adapter that writes inbound values back onto knob and fader transforms so XR seeds from and follows theDAW. | P1; `GantasmoControlSurfaceBuilder` + `QuestMidiSender` inbound events. |
+| P3 Generalized XYZ pad | Promote OwlPad3D into `XyzPad` (Z axis, `Vector3`+`padId`, `PadBinding` SO, spawn factory). Ship one VJ FX-pad instance and the jog-binding DJ scratch deck on `enterVinyl`/`setVinylVelocity`/`exitVinyl`. | P2; OwlPad3D; `JogWheel`/`djEngine` value model; VJ manifest. |
+| P4 VJ and MAKE aggregators | Forward the VJ `controls-manifest` through the host relay (add the enum kind and the `launch-clip` message). Build the MAKE catalogue from `generateParamsStore` metadata wired to `handletheDAWAction`, including the Chimera bridge actions and the model side-effects, plus CREATE/ABORT with the progress halo and the DNA hero. | P0 to P3; `sa3Bridge.ts`; `actionHandlers.ts`; `ChimeraDnaScene`. |
+| P5 FX-rack hook and walk-in graph | Add a `setRackParam` registry entry so OwlPad and Spatializer params are externally settable, then bind the XyzPad and the positioner. Render the LEARN graph from `/api/library/_graph/all` with shared materials and point-to-highlight. Final overcrowding pass. | P0 to P4; `rackEffects.ts` `ChainEntry.params`; library graph endpoint. |
+
+## 8. Risks and constraints
+
+- The VJ bridge is `window.postMessage` between the theDAW host and the VJ iframe
+  or popout, not a network socket. An external Unity process cannot postMessage
+  in. The `/api/xr/control` relay must bridge it, or VJ control silently never
+  reaches XR.
+- The OWL-pad is two different controls. theDAW's `OwlPad.tsx` is an audio FX-rack
+  XY pad, while the VJ tab has no pad of its own. Both `OwlPad` and `Spatializer`
+  are sealed inside `ChainEntry.params` with no external hook today and need a
+  `setRackParam` entry before any XR pad can drive them.
+- The jog and scratch primitive does not fit the scalar or CC model. It is signed
+  continuous velocity plus grab and release, absent from `DJ_TARGETS`. Forcing it
+  through a 0..1 CC feels wrong. It needs the dedicated jog-binding path and the
+  short stall and wind-down behavior from `JogWheel` to feel like a record.
+- MIDI's 7-bit ceiling makes hand-tracked sweeps steppy, and 127 CCs per channel
+  caps the control count. 14-bit CC (`SendControlChange14`, already present) fixes
+  smoothness, and more than 127 controls forces multi-channel allocation or routes
+  rich and scalar traffic onto the websocket.
+- Several MAKE fields (sigmaMax, apgScale, the schedule-shift faders, the Magenta
+  params, file format and naming, autoplay) are not in `buildParamUpdates` and
+  have no action, and the Chimera stack has no actions at all. They are reachable
+  by extending `buildParamUpdates` and adding store-method bridges in one place,
+  but that work is real and easy to under-scope.
+- Some controls (the hero-tab and compare-layer toggles, DJ Quantize, Auto-gain,
+  Automix, Sync-Lock) are local React `useState`, not in any store, so they are
+  not externally settable until lifted into a store. Low priority, and not free.
+- Two-way value sync requires theDAW to emit value mirrors on every host-side
+  move. `djEngine.subscribe` and the VJ `control-changed` echo cover their areas;
+  MAKE has only `get_status` polling until a push channel is added.
+- The bridge is tethered today: adb reverse over USB-C plus loopMIDI on Windows,
+  single PC. Any wireless or multi-host story is unaddressed, and the queststitch
+  video uplink shares the constraint.
+- The spatial layout and the pad hit-testing must carry the `DESIGN_PRINCIPLES`
+  ruleset (waveforms top, left-to-right flow, symmetric rails with a centered
+  hero, transport at the footer) and the rendered-pixel mapping discipline from
+  the CSS-zoom lesson, or the result drifts into clutter and mis-registered touch
+  points.
+
+## 9. Verified file pointers
+
+theDAW:
+- `frontend/src/state/bindableTargets.ts` (`DJ_TARGETS`)
+- `frontend/src/state/sa3Bridge.ts`, `frontend/src/<vj>/controlManifest.ts`
+- `frontend/src/orb-kit/actionHandlers.ts` (`handletheDAWAction`)
+- `frontend/src/state/questMidiClient.ts`, `frontend/src/state/midiBus.ts`
+- `frontend/src/components/chimera/ChimeraDnaScene.tsx`,
+  `ChimeraControls.tsx`, `ChimeraStack.tsx`
+- `frontend/src/components/audio/{OwlPad,SpatializerPad,JogWheel,SlidePad}.tsx`
+- `frontend/src/views/{AdvancedGenPanel,DJView,VJView}.tsx`
+
+theDAW-XR (`Packages/com.gantasmo.questmidi/`):
+- `Runtime/QuestMidiSender.cs` (`SendControlChange14`)
+- `Runtime/ControlSurface/{MidiControlSurface,MidiSlider,MidiKnob,MidiButton,MicrogestureMidiSource}.cs`
+- `Editor/{GantasmoSurfaceConfig,GantasmoControlSurfaceBuilder}.cs`
+- `Assets/OwlPad3D/` (the XYZ-pad foundation)

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-24T02:40:16.462Z · Git revision: `7b55e18c801d` · Repomix tracked: **no**
+> Generated: 2026-06-24T14:00:22.714Z · Git revision: `2a48a5b4ed2e` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-24T02:40:16.462Z",
-  "repoRevision": "7b55e18c801d",
+  "generatedAt": "2026-06-24T14:00:22.714Z",
+  "repoRevision": "2a48a5b4ed2e",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-24T02:43:02.076Z",
+  "generatedAt": "2026-06-24T13:57:38.152Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/electron-ui/electron-builder.yml
+++ b/electron-ui/electron-builder.yml
@@ -1,14 +1,82 @@
 appId: com.gantasmo.thedaw
 productName: theDAW
+copyright: Copyright (c) 2026 GANTASMO
 directories:
   output: release
   buildResources: resources
-win:
-  target: nsis
-mac:
-  target: dmg
-linux:
-  target: AppImage
+
+# The Electron shell itself ships only the built renderer + main/preload bundles.
+# Everything Python lives beside the app under resources/ (see extraResources)
+# and is installed on first launch by the bundled uv. Keeping the Python source
+# out of the asar keeps it on a real filesystem path that uv + the spawned
+# backend can read and write (the venv is created next to pyproject.toml).
 files:
   - out/**/*
-  - "!node_modules"
+
+# Thin-bootstrap payload. None of this is a virtualenv or model weights; it is
+# the source tree plus the two native binaries the first-run bootstrap needs.
+# uv pulls a managed CPython 3.10 and every dependency itself, so the target
+# machine needs nothing pre-installed.
+extraResources:
+  - from: ../backend
+    to: python/backend
+    filter:
+      - "**/*"
+      - "!**/__pycache__/**"
+      - "!**/*.py[cod]"
+      - "!rag_index/**"
+  - from: ../stable_audio_3
+    to: python/stable_audio_3
+    filter:
+      - "**/*"
+      - "!**/__pycache__/**"
+      - "!**/*.py[cod]"
+  - from: ../pyproject.toml
+    to: python/pyproject.toml
+  - from: ../uv.lock
+    to: python/uv.lock
+  - from: ../.python-version
+    to: python/.python-version
+  - from: ../README.md
+    to: python/README.md
+  - from: ../docs
+    to: python/docs
+    filter:
+      - "**/*.md"
+  - from: ../frontend/public/USER_GUIDE.md
+    to: python/frontend/public/USER_GUIDE.md
+  # uv.exe + ffmpeg.exe, downloaded by scripts/fetch-runtime-tools.mjs before
+  # the build. Prepended to the spawned backend's PATH at runtime.
+  - from: resources/tools
+    to: tools
+    filter:
+      - "**/*"
+
+win:
+  target:
+    - nsis
+  # artifactName keeps the installer name stable for release uploads.
+  artifactName: theDAW-Setup-${version}.${ext}
+
+nsis:
+  # Per-user install (no elevation). Lands under %LOCALAPPDATA%\Programs\theDAW,
+  # which is writable, so uv can build the venv there and the backend can write
+  # its data/ tree without admin rights.
+  oneClick: false
+  perMachine: false
+  allowToChangeInstallationDirectory: true
+  createDesktopShortcut: true
+  createStartMenuShortcut: true
+  # The first launch downloads ~3-5 GB of Python + CUDA wheels and the model
+  # weights, so the uninstaller leaves user data in place unless asked.
+  deleteAppDataOnUninstall: false
+
+mac:
+  target:
+    - dmg
+  category: public.app-category.music
+
+linux:
+  target:
+    - AppImage
+  category: Audio

--- a/electron-ui/main/index.ts
+++ b/electron-ui/main/index.ts
@@ -58,6 +58,123 @@ const BACKEND_BASE = 'http://localhost:8600'
 const HEALTH_URL = `${BACKEND_BASE}/api/health`
 const SHUTDOWN_URL = `${BACKEND_BASE}/api/admin/shutdown`
 
+// ---------------------------------------------------------------------------
+// Packaged-app paths + first-run bootstrap
+//
+// In a packaged build the Python project, a bundled uv.exe, and ffmpeg.exe ship
+// under process.resourcesPath (see electron-builder.yml -> extraResources). The
+// per-user install directory is writable, so uv creates the venv next to the
+// bundled pyproject.toml on first launch and the backend writes its data/ tree
+// there. In dev none of this applies: the backend runs from the repo via uv on
+// PATH exactly as before.
+// ---------------------------------------------------------------------------
+
+function getPythonDir(): string {
+  return app.isPackaged ? path.join(process.resourcesPath, 'python') : repoRoot
+}
+
+function getToolsDir(): string {
+  return path.join(process.resourcesPath, 'tools')
+}
+
+function getUvCommand(): string {
+  return app.isPackaged ? path.join(getToolsDir(), 'uv.exe') : 'uv'
+}
+
+function venvPython(pyDir: string): string {
+  return process.platform === 'win32'
+    ? path.join(pyDir, '.venv', 'Scripts', 'python.exe')
+    : path.join(pyDir, '.venv', 'bin', 'python')
+}
+
+// Environment for the backend + the uv sync step. Packaged builds prepend the
+// bundled tools dir (uv.exe, ffmpeg.exe, ffprobe.exe) to PATH so the backend's
+// audio I/O resolves ffmpeg without a system install. The PATH key is matched
+// case-insensitively because Windows exposes it as "Path".
+function buildBackendEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, SA3_SUPERVISOR_PRESENT: '1' }
+  if (app.isPackaged) {
+    const toolsDir = getToolsDir()
+    const key = Object.keys(env).find((k) => k.toLowerCase() === 'path') ?? 'PATH'
+    env[key] = `${toolsDir}${path.delimiter}${env[key] ?? ''}`
+  }
+  return env
+}
+
+function coreImportsOk(py: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const proc = spawn(py, ['-c', 'import uvicorn, fastapi'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      })
+      proc.on('exit', (code) => resolve(code === 0))
+      proc.on('error', () => resolve(false))
+    } catch {
+      resolve(false)
+    }
+  })
+}
+
+function runUvSync(uvCmd: string, cwd: string): Promise<void> {
+  return new Promise((resolve) => {
+    log(`Running ${uvCmd} sync --group dev in ${cwd}`)
+    const proc = spawn(uvCmd, ['sync', '--group', 'dev'], {
+      cwd,
+      env: buildBackendEnv(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    })
+    const emit = (data: Buffer): void => {
+      for (const raw of data.toString().split('\n')) {
+        const text = raw.replace(/\r$/, '').trimEnd()
+        if (!text.trim()) continue
+        log(`[uv] ${text}`)
+        sendLoadingLog(text, '')
+      }
+    }
+    proc.stdout?.on('data', emit)
+    proc.stderr?.on('data', emit)
+    proc.on('exit', (code) => {
+      if (code === 0) {
+        sendLoadingLog('Dependencies installed.', 'load')
+      } else {
+        sendLoadingLog(
+          `Setup step exited with code ${code}. The app may not start until this is resolved.`,
+          'err',
+        )
+      }
+      resolve()
+    })
+    proc.on('error', (err) => {
+      sendLoadingLog(`Setup failed to start: ${err.message}`, 'err')
+      resolve()
+    })
+  })
+}
+
+// First-run bootstrap: build the venv when it is missing or a core import fails
+// (a uv sync interrupted after the venv is created but before packages install
+// leaves a half-built env). Streams progress into the boot cinematic. No-op in
+// dev, where the repo venv is managed by theDAW.bat / uv on PATH.
+async function ensurePythonEnv(): Promise<void> {
+  if (!app.isPackaged) return
+  const pyDir = getPythonDir()
+  const py = venvPython(pyDir)
+  let ok = fs.existsSync(py)
+  if (ok) ok = await coreImportsOk(py)
+  if (ok) {
+    log('Python env present and complete — skipping sync.')
+    return
+  }
+  sendLoadingStatus('First run: setting up the audio engine')
+  sendLoadingLog(
+    'Installing the Python runtime and dependencies. The first run downloads several GB and can take several minutes.',
+    'load',
+  )
+  await runUvSync(getUvCommand(), pyDir)
+}
+
 async function isBackendRunning(): Promise<boolean> {
   try {
     const res = await globalThis.fetch(HEALTH_URL, {
@@ -73,10 +190,23 @@ function spawnBackend(): void {
   log('Spawning backend process...')
 
   const isWindows = process.platform === 'win32'
-  const cwd = repoRoot
-  const env = { ...process.env, SA3_SUPERVISOR_PRESENT: '1' }
+  const cwd = getPythonDir()
+  const env = buildBackendEnv()
 
-  if (isWindows) {
+  if (app.isPackaged) {
+    // The bundled uv is an absolute path, so it is invoked directly (no shell).
+    backendProcess = spawn(
+      getUvCommand(),
+      ['run', 'python', '-m', 'backend._supervisor'],
+      {
+        cwd,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+        detached: !isWindows,
+      },
+    )
+  } else if (isWindows) {
     backendProcess = spawn(
       'cmd',
       ['/c', 'uv run python -m backend._supervisor'],
@@ -401,6 +531,9 @@ app.whenReady().then(async () => {
   // up, the app surfaces its "continue without backend" escape — same as web.
   const alreadyRunning = await isBackendRunning()
   if (!alreadyRunning) {
+    // Packaged builds bootstrap the Python env on first launch before the
+    // backend can start; dev builds no-op here.
+    await ensurePythonEnv()
     spawnBackend()
   } else {
     log('Backend already running — skipping spawn.')

--- a/electron-ui/package.json
+++ b/electron-ui/package.json
@@ -2,12 +2,16 @@
   "name": "thedaw-desktop",
   "version": "0.1.0",
   "private": true,
+  "description": "theDAW desktop shell: an Electron front end that bootstraps and supervises the Python audio backend.",
+  "author": "GANTASMO",
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
-    "package": "electron-vite build && electron-builder"
+    "fetch:tools": "node scripts/fetch-runtime-tools.mjs",
+    "package": "electron-vite build && electron-builder",
+    "dist:win": "npm run fetch:tools && electron-vite build && electron-builder --win"
   },
   "dependencies": {},
   "devDependencies": {

--- a/electron-ui/scripts/fetch-runtime-tools.mjs
+++ b/electron-ui/scripts/fetch-runtime-tools.mjs
@@ -1,0 +1,135 @@
+// Fetch the two native binaries the packaged Windows app bootstraps with:
+//   - uv.exe     (Astral) builds the Python venv and pulls a managed CPython 3.10
+//   - ffmpeg.exe (gyan.dev) backs every audio I/O path in the backend
+//
+// Both land in electron-ui/resources/tools/ so electron-builder copies them into
+// the installer under resources/tools/ (see electron-builder.yml -> extraResources).
+// The directory is gitignored; this script repopulates it before each packaged
+// build. It is idempotent: an existing, non-empty binary is left untouched.
+//
+// Sources match install/setup.ps1 (astral.sh for uv, gyan.dev for FFmpeg) so the
+// installer trusts the same upstreams the manual setup path already does.
+//
+// Run:  node scripts/fetch-runtime-tools.mjs
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, existsSync, statSync, rmSync, readdirSync, copyFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tmpdir } from 'node:os'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const toolsDir = resolve(__dirname, '..', 'resources', 'tools')
+
+const UV_URL =
+  'https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-pc-windows-msvc.zip'
+const FFMPEG_URL = 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip'
+
+function log(msg) {
+  process.stdout.write(`[fetch-tools] ${msg}\n`)
+}
+
+// A zero-byte or missing file means we still need to fetch it.
+function present(p) {
+  try {
+    return existsSync(p) && statSync(p).size > 0
+  } catch {
+    return false
+  }
+}
+
+async function download(url, dest) {
+  log(`downloading ${url}`)
+  const res = await fetch(url, { redirect: 'follow' })
+  if (!res.ok) {
+    throw new Error(`download failed (${res.status} ${res.statusText}) for ${url}`)
+  }
+  const buf = Buffer.from(await res.arrayBuffer())
+  const { writeFileSync } = await import('node:fs')
+  writeFileSync(dest, buf)
+  log(`saved ${(buf.length / 1e6).toFixed(1)} MB -> ${dest}`)
+}
+
+// Extract with PowerShell Expand-Archive. This script only runs on the Windows
+// build host (it fetches .exe binaries), and Windows tar.exe misparses a drive
+// path like C:\... as an [user@]host:path remote, so Expand-Archive is the
+// reliable choice here.
+function unzip(zipPath, outDir) {
+  mkdirSync(outDir, { recursive: true })
+  execFileSync(
+    'powershell',
+    [
+      '-NoProfile',
+      '-Command',
+      `Expand-Archive -Path '${zipPath}' -DestinationPath '${outDir}' -Force`,
+    ],
+    { stdio: 'inherit' },
+  )
+}
+
+// Depth-first search for the first file named `name` under `root`.
+function findFile(root, name) {
+  const stack = [root]
+  while (stack.length) {
+    const dir = stack.pop()
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) stack.push(full)
+      else if (entry.name.toLowerCase() === name.toLowerCase()) return full
+    }
+  }
+  return null
+}
+
+async function fetchUv() {
+  const dest = join(toolsDir, 'uv.exe')
+  if (present(dest)) {
+    log('uv.exe already present, skipping')
+    return
+  }
+  const work = join(tmpdir(), 'thedaw-fetch-uv')
+  rmSync(work, { recursive: true, force: true })
+  mkdirSync(work, { recursive: true })
+  const zip = join(work, 'uv.zip')
+  await download(UV_URL, zip)
+  unzip(zip, work)
+  const found = findFile(work, 'uv.exe')
+  if (!found) throw new Error('uv.exe not found in the downloaded archive')
+  copyFileSync(found, dest)
+  log(`installed uv.exe -> ${dest}`)
+  rmSync(work, { recursive: true, force: true })
+}
+
+async function fetchFfmpeg() {
+  const ffmpeg = join(toolsDir, 'ffmpeg.exe')
+  const ffprobe = join(toolsDir, 'ffprobe.exe')
+  if (present(ffmpeg) && present(ffprobe)) {
+    log('ffmpeg.exe + ffprobe.exe already present, skipping')
+    return
+  }
+  const work = join(tmpdir(), 'thedaw-fetch-ffmpeg')
+  rmSync(work, { recursive: true, force: true })
+  mkdirSync(work, { recursive: true })
+  const zip = join(work, 'ffmpeg.zip')
+  await download(FFMPEG_URL, zip)
+  unzip(zip, work)
+  for (const exe of ['ffmpeg.exe', 'ffprobe.exe']) {
+    const found = findFile(work, exe)
+    if (!found) throw new Error(`${exe} not found in the downloaded archive`)
+    copyFileSync(found, join(toolsDir, exe))
+    log(`installed ${exe} -> ${join(toolsDir, exe)}`)
+  }
+  rmSync(work, { recursive: true, force: true })
+}
+
+async function main() {
+  mkdirSync(toolsDir, { recursive: true })
+  await fetchUv()
+  await fetchFfmpeg()
+  log('done')
+}
+
+main().catch((err) => {
+  process.stderr.write(`[fetch-tools] ERROR: ${err.message}\n`)
+  process.exit(1)
+})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,10 @@ import { useLayoutPrefs } from './state/layoutPrefsStore';
 import { triggerPianoNoteFromMidi } from './components/audio/PianoRoll';
 import { publishMidi } from './state/midiBus';
 import { startQuestMidi, stopQuestMidi } from './state/questMidiClient';
+import { startXrControl, stopXrControl, registerXrControlSource } from './state/xrControlClient';
+import { djControlSource } from './state/xrControlDjSource';
+import { startXrViz, stopXrViz } from './state/xrViz';
+import { XrBusTester } from './components/dev/XrBusTester';
 import { useMidiDevicesStore } from './state/midiDevicesStore';
 import { isMidiAudioMuted, useMidiTriggerStore } from './state/midiTriggerStore';
 
@@ -213,7 +217,20 @@ export default function App() {
   useEffect(() => {
     if (!midiEnabled) return;
     startQuestMidi();
-    return () => stopQuestMidi();
+    // XR control bus (spatialization P0/P1): publish theDAW's control manifest
+    // to a theDAW-XR headset and apply inbound control-sets. The DJ source maps
+    // DJ_TARGETS to spatial controls with no per-control wiring; it lazy-loads
+    // the DJ engine so registering it here does not pull djEngine into boot.
+    registerXrControlSource(djControlSource);
+    startXrControl();
+    // Stream the visualization feed (waveform pack) over the same bridge so a
+    // theDAW-XR headset can render theDAW's live audio natively.
+    startXrViz();
+    return () => {
+      stopQuestMidi();
+      stopXrControl();
+      stopXrViz();
+    };
   }, [midiEnabled]);
 
   const handleAssistantAction = useCallback((action: { type: string; payload?: any }) => {
@@ -246,6 +263,10 @@ export default function App() {
         onExecuteAction={handleAssistantAction}
         orbPosition={orbPosition}
       />
+
+      {/* Dev-only: simulated XR controller to drive the control bus without a
+          headset. Stripped from production builds. */}
+      {import.meta.env.DEV && <XrBusTester />}
 
       {/* Loading screen overlays everything until backend is ready */}
       <AnimatePresence>

--- a/frontend/src/components/dev/XrBusTester.tsx
+++ b/frontend/src/components/dev/XrBusTester.tsx
@@ -1,0 +1,279 @@
+/**
+ * XR control-bus tester (dev only).
+ *
+ * A simulated theDAW-XR controller in the browser: it opens its OWN WebSocket
+ * peer to the `xrcontrol` relay (`/api/xr/control/ws`), asks for the live
+ * control manifest, and renders one real control per entry that sends
+ * `control-set` back over the bus. That exercises the full P0 + P1 loop
+ * (controller -> relay -> theDAW host -> the wired setter) with no headset and
+ * no console snippet.
+ *
+ * Mounted only under import.meta.env.DEV (see App.tsx), so it never ships in a
+ * production build. The theDAW host peer (xrControlClient, started when MIDI is
+ * enabled) must be connected for control-sets to take effect; until it is, this
+ * panel connects but receives no manifest.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Radio, X } from 'lucide-react';
+import type { XrManifestEntry, XrControlValue } from '../../state/xrControlClient';
+
+function wsUrl(): string {
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${window.location.host}/api/xr/control/ws`;
+}
+
+const RANGE_KINDS = new Set(['knob', 'fader', 'crossfader', 'xy', 'xyz', 'jog']);
+
+export function XrBusTester(): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const [connected, setConnected] = useState(false);
+  const [entries, setEntries] = useState<XrManifestEntry[]>([]);
+  const [values, setValues] = useState<Record<string, XrControlValue>>({});
+  const [lastEcho, setLastEcho] = useState('');
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const disconnect = useCallback(() => {
+    const sock = wsRef.current;
+    wsRef.current = null;
+    if (sock) {
+      try { sock.close(); } catch { /* already closing */ }
+    }
+    setConnected(false);
+    setEntries([]);
+  }, []);
+
+  const connect = useCallback(() => {
+    if (wsRef.current) return;
+    let sock: WebSocket;
+    try {
+      sock = new WebSocket(wsUrl());
+    } catch {
+      return;
+    }
+    wsRef.current = sock;
+    sock.onopen = () => {
+      setConnected(true);
+      sock.send(JSON.stringify({ type: 'request-controls' }));
+    };
+    sock.onmessage = (e) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(typeof e.data === 'string' ? e.data : '');
+      } catch {
+        return;
+      }
+      if (!parsed || typeof parsed !== 'object') return;
+      const m = parsed as { type?: unknown; id?: unknown; value?: unknown; entries?: unknown };
+      if (m.type === 'manifest' && Array.isArray(m.entries)) {
+        setEntries(m.entries as XrManifestEntry[]);
+      } else if (m.type === 'control-changed' && typeof m.id === 'string') {
+        const id = m.id;
+        const value = m.value as XrControlValue;
+        setValues((v) => ({ ...v, [id]: value }));
+        setLastEcho(`${id} = ${String(value)}`);
+      }
+    };
+    sock.onerror = () => {
+      try { sock.close(); } catch { /* already closing */ }
+    };
+    sock.onclose = () => {
+      if (wsRef.current === sock) wsRef.current = null;
+      setConnected(false);
+    };
+  }, []);
+
+  // Close the peer when the panel unmounts.
+  useEffect(() => () => disconnect(), [disconnect]);
+
+  const send = useCallback((id: string, value: XrControlValue) => {
+    const sock = wsRef.current;
+    if (sock && sock.readyState === WebSocket.OPEN) {
+      sock.send(JSON.stringify({ type: 'control-set', id, value }));
+    }
+    setValues((v) => ({ ...v, [id]: value }));
+  }, []);
+
+  const toggleConnect = useCallback(() => {
+    if (connected || wsRef.current) disconnect();
+    else connect();
+  }, [connected, connect, disconnect]);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Open the XR control-bus tester"
+        title="XR control-bus tester (dev)"
+        className="fixed bottom-3 right-3 z-200 flex items-center gap-1.5 rounded-full border border-cyan-400/50 bg-cyan-500/15 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest text-cyan-100 shadow-[0_0_14px_rgba(34,211,238,0.4)] hover:bg-cyan-500/30"
+      >
+        <Radio className="h-3.5 w-3.5" />
+        XR bus
+      </button>
+    );
+  }
+
+  // Group entries by their manifest group for tidy clusters.
+  const groups: Record<string, XrManifestEntry[]> = {};
+  for (const en of entries) {
+    (groups[en.group] ??= []).push(en);
+  }
+
+  return (
+    <section
+      aria-label="XR control-bus tester"
+      className="fixed bottom-3 right-3 z-200 flex max-h-[70vh] w-80 flex-col rounded-lg border border-cyan-400/40 bg-zinc-950/95 text-zinc-200 shadow-[0_0_24px_rgba(34,211,238,0.35)] backdrop-blur"
+    >
+      <header className="flex items-center justify-between gap-2 border-b border-white/10 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <Radio className="h-4 w-4 text-cyan-300" />
+          <span className="text-[11px] font-black uppercase tracking-widest text-cyan-100">
+            XR control bus
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          aria-label="Close the XR control-bus tester"
+          className="rounded p-1 text-zinc-400 hover:bg-white/10 hover:text-white"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </header>
+
+      <div className="flex items-center justify-between gap-2 px-3 py-2">
+        <button
+          type="button"
+          onClick={toggleConnect}
+          aria-pressed={connected}
+          aria-label={connected ? 'Disconnect the simulated XR controller' : 'Connect the simulated XR controller'}
+          className={
+            connected
+              ? 'flex items-center gap-2 rounded border border-emerald-400/60 bg-emerald-500/20 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest text-emerald-100'
+              : 'flex items-center gap-2 rounded border border-white/15 bg-white/5 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest text-zinc-300 hover:bg-white/10'
+          }
+        >
+          <span
+            className={`h-2 w-2 rounded-full ${connected ? 'bg-emerald-400' : 'bg-zinc-500'}`}
+            aria-hidden="true"
+          />
+          {connected ? 'Connected' : 'Connect'}
+        </button>
+        <span className="text-[10px] tabular-nums text-zinc-400">
+          {entries.length} control{entries.length === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      {connected && entries.length === 0 && (
+        <p className="px-3 pb-2 text-[10px] leading-snug text-amber-300/90">
+          Connected, but theDAW sent no manifest yet. Enable MIDI in Settings so the
+          control host attaches, then reconnect.
+        </p>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+        {Object.entries(groups).map(([group, items]) => (
+          <fieldset key={group} className="mb-3 border-0 p-0">
+            <legend className="mb-1 text-[9px] font-black uppercase tracking-widest text-cyan-300/80">
+              {group}
+            </legend>
+            <div className="flex flex-col gap-1.5">
+              {items.map((en) => (
+                <ControlRow
+                  key={en.id}
+                  entry={en}
+                  value={values[en.id]}
+                  onSend={send}
+                />
+              ))}
+            </div>
+          </fieldset>
+        ))}
+      </div>
+
+      {lastEcho && (
+        <footer className="border-t border-white/10 px-3 py-1.5 text-[9px] text-zinc-500">
+          last echo: <span className="text-zinc-300">{lastEcho}</span>
+        </footer>
+      )}
+    </section>
+  );
+}
+
+function ControlRow({
+  entry,
+  value,
+  onSend,
+}: {
+  entry: XrManifestEntry;
+  value: XrControlValue | undefined;
+  onSend: (id: string, value: XrControlValue) => void;
+}): React.ReactElement {
+  const fieldId = `xr-${entry.id}`;
+
+  if (RANGE_KINDS.has(entry.kind)) {
+    const min = entry.min ?? 0;
+    const max = entry.max ?? 1;
+    const step = entry.step ?? 0.01;
+    const current = typeof value === 'number' ? value : min;
+    return (
+      <label htmlFor={fieldId} className="flex items-center gap-2 text-[10px]">
+        <span className="w-28 shrink-0 truncate text-zinc-300" title={entry.label}>
+          {entry.label}
+        </span>
+        <input
+          id={fieldId}
+          name={fieldId}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={current}
+          onChange={(e) => onSend(entry.id, Number(e.target.value))}
+          className="h-1 flex-1 cursor-pointer accent-cyan-400"
+        />
+        <span className="w-10 shrink-0 text-right tabular-nums text-zinc-400">
+          {current}
+          {entry.unit ? <span className="text-zinc-600">{entry.unit}</span> : null}
+        </span>
+      </label>
+    );
+  }
+
+  if (entry.kind === 'toggle') {
+    const on = Boolean(value);
+    return (
+      <button
+        type="button"
+        onClick={() => onSend(entry.id, !on)}
+        aria-pressed={on}
+        aria-label={`${entry.label} toggle`}
+        className={
+          on
+            ? 'flex items-center justify-between rounded border border-emerald-400/50 bg-emerald-500/15 px-2 py-1 text-[10px] text-emerald-100'
+            : 'flex items-center justify-between rounded border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-zinc-300 hover:bg-white/10'
+        }
+      >
+        <span className="truncate" title={entry.label}>{entry.label}</span>
+        <span className="ml-2 shrink-0 text-[9px] font-black uppercase tracking-widest">
+          {on ? 'On' : 'Off'}
+        </span>
+      </button>
+    );
+  }
+
+  // button / pad / grid: momentary trigger.
+  return (
+    <button
+      type="button"
+      onClick={() => onSend(entry.id, true)}
+      aria-label={`Trigger ${entry.label}`}
+      className="flex items-center justify-between rounded border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-zinc-300 hover:border-cyan-400/40 hover:bg-cyan-500/10"
+    >
+      <span className="truncate" title={entry.label}>{entry.label}</span>
+      <span className="ml-2 shrink-0 text-[9px] font-black uppercase tracking-widest text-cyan-300/70">
+        Tap
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/convert/ConvertMenu.tsx
+++ b/frontend/src/convert/ConvertMenu.tsx
@@ -1,0 +1,89 @@
+/**
+ * Two-stage "Convert to..." menu.
+ *
+ * The ContextMenu primitive has no nested submenus, so a parent menu's
+ * "Convert to..." item calls `openAt(position, target)` and this hook renders a
+ * SECOND ContextMenu at the same spot listing the valid target formats for that
+ * item's media kind (filtered by the backend's source-kind -> target-kind
+ * rules), grouped by kind. Selecting one runs the conversion and downloads it.
+ */
+import { useEffect, useState } from 'react';
+import { ContextMenu } from '../components/ui/ContextMenu';
+import type { ContextMenuItem, ContextMenuPosition } from '../components/ui/ContextMenu';
+import { convertLibraryEntry, formatsForKind, loadConvertFormats } from './convertClient';
+import type { ConvertCatalog, ConvertFormat } from './convertClient';
+
+export interface ConvertTarget {
+  entryId: string;
+  title: string;
+  /** 'audio' | 'video' | 'image' (or 'unknown' to offer everything). */
+  kind: string;
+}
+
+interface UseConvertMenuOptions {
+  /** Called when a conversion starts (e.g. to show a toast / log line). */
+  onStart?: (message: string) => void;
+  /** Called when a conversion fails. */
+  onError?: (message: string) => void;
+}
+
+export function useConvertMenu(opts: UseConvertMenuOptions = {}) {
+  const [state, setState] = useState<{ pos: ContextMenuPosition; target: ConvertTarget } | null>(
+    null,
+  );
+  const [catalog, setCatalog] = useState<ConvertCatalog | null>(null);
+
+  useEffect(() => {
+    loadConvertFormats()
+      .then(setCatalog)
+      .catch(() => {
+        /* formats fetched lazily; failure just yields an empty menu */
+      });
+  }, []);
+
+  const openAt = (pos: ContextMenuPosition, target: ConvertTarget) => setState({ pos, target });
+  const close = () => setState(null);
+
+  let element: React.ReactNode = null;
+  if (state && catalog) {
+    const formats = formatsForKind(catalog, state.target.kind);
+    const byKind: Record<string, ConvertFormat[]> = {};
+    for (const f of formats) (byKind[f.kind] ??= []).push(f);
+
+    const items: ContextMenuItem[] = [];
+    for (const kind of ['audio', 'video', 'image']) {
+      const list = byKind[kind];
+      if (!list?.length) continue;
+      if (Object.keys(byKind).length > 1) items.push({ type: 'header', label: kind });
+      for (const f of list) {
+        items.push({
+          type: 'item',
+          label: f.label,
+          onSelect: () => {
+            opts.onStart?.(`Converting "${state.target.title}" to ${f.label}...`);
+            convertLibraryEntry(state.target.entryId, f, state.target.title).catch((e) => {
+              opts.onError?.(
+                `Convert to ${f.label} failed: ${e instanceof Error ? e.message : String(e)}`,
+              );
+            });
+          },
+        });
+      }
+    }
+
+    if (items.length === 0) {
+      items.push({ type: 'header', label: 'No conversions available' });
+    }
+
+    element = (
+      <ContextMenu
+        position={state.pos}
+        onClose={close}
+        items={items}
+        title={`Convert · ${state.target.title}`}
+      />
+    );
+  }
+
+  return { openAt, close, element };
+}

--- a/frontend/src/convert/convertClient.ts
+++ b/frontend/src/convert/convertClient.ts
@@ -1,0 +1,87 @@
+/**
+ * Client for the backend generic FFmpeg convert module (`/api/convert`).
+ *
+ * The catalog (target formats + source-kind -> target-kind rules) is fetched
+ * once and cached. Converting a library entry streams the result back as bytes
+ * and triggers a download. Large media is read via arrayBuffer() rather than
+ * blob() (the latter spills to a disk-backed store that fails under disk
+ * pressure — see fetchRetry.ts).
+ */
+
+export interface ConvertFormat {
+  id: string;
+  ext: string;
+  kind: 'audio' | 'video' | 'image';
+  label: string;
+  mime: string;
+}
+
+export interface ConvertCatalog {
+  formats: ConvertFormat[];
+  rules: Record<string, string[]>;
+}
+
+let _catalog: ConvertCatalog | null = null;
+let _inflight: Promise<ConvertCatalog> | null = null;
+
+export async function loadConvertFormats(): Promise<ConvertCatalog> {
+  if (_catalog) return _catalog;
+  if (_inflight) return _inflight;
+  _inflight = (async () => {
+    const res = await fetch('/api/convert/formats');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const catalog = (await res.json()) as ConvertCatalog;
+    _catalog = catalog;
+    _inflight = null;
+    return catalog;
+  })().catch((e) => {
+    _inflight = null;
+    throw e;
+  });
+  return _inflight;
+}
+
+/** The target formats that make sense for a given source media kind. */
+export function formatsForKind(catalog: ConvertCatalog, kind: string): ConvertFormat[] {
+  const allowed = new Set(catalog.rules[kind] ?? ['audio', 'video', 'image']);
+  return catalog.formats.filter((f) => allowed.has(f.kind));
+}
+
+/**
+ * Convert a library entry to the given format and download the result.
+ * Resolves when the download has been triggered; rejects with a readable
+ * message on failure.
+ */
+export async function convertLibraryEntry(
+  entryId: string,
+  format: ConvertFormat,
+  title: string,
+): Promise<void> {
+  const res = await fetch(`/api/convert/library/${encodeURIComponent(entryId)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ format: format.id }),
+  });
+  if (!res.ok) {
+    let detail = `HTTP ${res.status}`;
+    try {
+      const j = await res.json();
+      if (j?.detail) detail = String(j.detail);
+    } catch {
+      /* response had no JSON body */
+    }
+    throw new Error(detail);
+  }
+
+  const buf = await res.arrayBuffer();
+  const blob = new Blob([buf], { type: res.headers.get('content-type') ?? format.mime });
+  const url = URL.createObjectURL(blob);
+  const safeTitle = (title || 'converted').replace(/[<>:"/\\|?*\x00-\x1f]/g, '_').slice(0, 120);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${safeTitle}.${format.ext}`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/frontend/src/state/appUiStore.ts
+++ b/frontend/src/state/appUiStore.ts
@@ -103,12 +103,12 @@ export const useAppUiStore = create<AppUiState>()(
       setDocsOpen: (open) => set({ docsOpen: open }),
     }),
     {
-      name: 'thedaw-app-ui',
+      name: 'thedaw-app-ui-v2',
+      // Panel open/expand state is intentionally NOT persisted: every app open
+      // starts with the shell chrome collapsed (left panel, right library rail).
+      // Only the active center tab and the rail width are remembered.
       partialize: (s) => ({
         centerTab: s.centerTab,
-        isLeftPanelOpen: s.isLeftPanelOpen,
-        isRightPanelOpen: s.isRightPanelOpen,
-        isLibraryExpanded: s.isLibraryExpanded,
         rightPanelWidth: s.rightPanelWidth,
       }),
     },

--- a/frontend/src/state/bottomPanelStore.ts
+++ b/frontend/src/state/bottomPanelStore.ts
@@ -68,14 +68,14 @@ export const useBottomPanelStore = create<BottomPanelState>()(
         })),
     }),
     {
-      name: 'thedaw-bottom-panel-v4',
+      name: 'thedaw-bottom-panel-v5',
+      // Open/maximized state is intentionally NOT persisted so the bottom dock
+      // and the log start collapsed on every app open. The active tab and the
+      // sizes are remembered.
       partialize: (s) => ({
         activeTab: s.activeTab,
-        isOpen: s.isOpen,
-        isLogOpen: s.isLogOpen,
         multiHeight: s.multiHeight,
         logWidth: s.logWidth,
-        multiMaximized: s.multiMaximized,
       }),
     },
   ),

--- a/frontend/src/state/xrControlClient.ts
+++ b/frontend/src/state/xrControlClient.ts
@@ -1,0 +1,181 @@
+/**
+ * XR control client (spatialization P0/P1).
+ *
+ * Holds a WebSocket to the backend `xrcontrol` relay (`/api/xr/control/ws`), the
+ * transport between theDAW (this browser, which owns the control manifest and
+ * the wired setters) and a theDAW-XR headset. This browser is the HOST peer: it
+ * publishes a control manifest aggregated from registered sources and applies
+ * inbound `control-set` messages by routing them to the source that owns the id.
+ * A new control surfaces in XR the moment its source contributes a manifest
+ * entry, with no Unity edit.
+ *
+ * Same-origin URL so it rides the Vite dev proxy in development and is direct in
+ * production. Auto-reconnects while running.
+ */
+import { logInfo, logWarn } from './logStore';
+
+export type XrControlValue = number | boolean;
+
+/** One self-describing control in the manifest XR consumes. Mirrors the shape
+ *  theDAW's own registries already use (DJ_TARGETS, the VJ control manifest). */
+export interface XrManifestEntry {
+  id: string;
+  area: string;
+  group: string;
+  label: string;
+  /** knob | fader | button | toggle | crossfader | select | xy | xyz | jog | grid */
+  kind: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  options?: string[];
+  unit?: string;
+  /** Current value, when the source can read one (seeds the XR widget). */
+  value?: XrControlValue;
+}
+
+/** A contributor of controls for one namespace (e.g. "dj", "vj", "make"). */
+export interface XrControlSource {
+  /** Namespace that owns this source's ids, e.g. "dj" for "dj.eqHi.A". */
+  area: string;
+  /** Contribute this source's manifest entries (async so it can lazy-load). */
+  buildEntries: () => Promise<XrManifestEntry[]> | XrManifestEntry[];
+  /** Apply an inbound control value. Returns true when the id was handled. */
+  apply: (id: string, value: XrControlValue) => boolean | Promise<boolean>;
+}
+
+const sources = new Map<string, XrControlSource>();
+let manifestVersion = 0;
+
+/**
+ * Register a control source (DJ, then VJ / MAKE in later phases). Bumps the
+ * manifest version and re-publishes when connected. Idempotent and safe to call
+ * before or after {@link startXrControl}.
+ */
+export function registerXrControlSource(source: XrControlSource): void {
+  sources.set(source.area, source);
+  manifestVersion += 1;
+  void publishManifest();
+}
+
+let ws: WebSocket | null = null;
+let reconnectTimer = 0;
+let running = false;
+let everConnected = false;
+
+function wsUrl(): string {
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${window.location.host}/api/xr/control/ws`;
+}
+
+async function buildManifest(): Promise<XrManifestEntry[]> {
+  const all: XrManifestEntry[] = [];
+  for (const s of sources.values()) {
+    try {
+      const entries = await s.buildEntries();
+      all.push(...entries);
+    } catch {
+      /* a source that cannot build right now is skipped, never fatal */
+    }
+  }
+  return all;
+}
+
+async function publishManifest(): Promise<void> {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  const entries = await buildManifest();
+  ws.send(JSON.stringify({ type: 'manifest', version: manifestVersion, entries }));
+}
+
+/** Mirror a host-side value move to XR so its widget follows theDAW state. */
+export function publishControlChanged(id: string, value: XrControlValue): void {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: 'control-changed', id, value }));
+  }
+}
+
+async function applyControlSet(id: string, value: XrControlValue): Promise<void> {
+  const area = id.split('.')[0];
+  const source = sources.get(area);
+  if (!source) return;
+  try {
+    await source.apply(id, value);
+  } catch {
+    /* a setter that throws (e.g. engine not started yet) is non-fatal */
+  }
+}
+
+function scheduleReconnect(): void {
+  if (!running || reconnectTimer) return;
+  reconnectTimer = window.setTimeout(() => {
+    reconnectTimer = 0;
+    connect();
+  }, 2000);
+}
+
+function connect(): void {
+  if (!running || ws) return;
+  let sock: WebSocket;
+  try {
+    sock = new WebSocket(wsUrl());
+  } catch {
+    scheduleReconnect();
+    return;
+  }
+  ws = sock;
+  sock.onopen = () => {
+    everConnected = true;
+    logInfo('xrcontrol', 'XR control bus connected.');
+    // Seed any controller already waiting on the relay.
+    void publishManifest();
+  };
+  sock.onmessage = (e) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(typeof e.data === 'string' ? e.data : '');
+    } catch {
+      return; /* ignore malformed frame */
+    }
+    if (!parsed || typeof parsed !== 'object') return;
+    const m = parsed as { type?: unknown; id?: unknown; value?: unknown };
+    if (typeof m.type !== 'string') return;
+    if (m.type === 'request-controls') {
+      void publishManifest();
+    } else if (m.type === 'control-set' && typeof m.id === 'string') {
+      void applyControlSet(m.id, m.value as XrControlValue);
+    }
+  };
+  sock.onerror = () => {
+    try { sock.close(); } catch { /* already closing */ }
+  };
+  sock.onclose = () => {
+    if (ws === sock) ws = null;
+    if (running && everConnected) logWarn('xrcontrol', 'XR control bus disconnected — retrying…');
+    scheduleReconnect();
+  };
+}
+
+/** Open (and keep open) the XR control bus. Safe to call repeatedly. */
+export function startXrControl(): void {
+  if (running) return;
+  running = true;
+  everConnected = false;
+  connect();
+}
+
+/** Close the bus and stop reconnecting. */
+export function stopXrControl(): void {
+  running = false;
+  if (reconnectTimer) {
+    window.clearTimeout(reconnectTimer);
+    reconnectTimer = 0;
+  }
+  if (ws) {
+    try { ws.close(); } catch { /* already closing */ }
+    ws = null;
+  }
+}
+
+export function isXrControlConnected(): boolean {
+  return !!ws && ws.readyState === WebSocket.OPEN;
+}

--- a/frontend/src/state/xrControlDjSource.ts
+++ b/frontend/src/state/xrControlDjSource.ts
@@ -1,0 +1,63 @@
+/**
+ * DJ control source for the XR control bus (spatialization P1).
+ *
+ * Publishes theDAW's DJ surface to XR by reusing DJ_TARGETS verbatim: each
+ * BindableTarget becomes one manifest entry, and an inbound control-set is
+ * routed straight to that target's wired `invoke`. There is no per-control code,
+ * so the DJ surface stays in sync as DJ_TARGETS grows. bindableTargets (and
+ * through it djEngine) is imported lazily so it stays in the DJ chunk and never
+ * loads at app boot.
+ */
+import type {
+  XrControlSource,
+  XrManifestEntry,
+  XrControlValue,
+} from './xrControlClient';
+import type { BindableTarget } from '../components/surface/widgetTypes';
+
+let cache: BindableTarget[] | null = null;
+
+async function targets(): Promise<BindableTarget[]> {
+  if (!cache) {
+    const mod = await import('./bindableTargets');
+    cache = mod.DJ_TARGETS;
+  }
+  return cache;
+}
+
+// theDAW's BindableTarget.kind -> manifest kind. A momentary "pad" maps to a
+// button; the crossfader is a horizontal fader.
+function toKind(k: BindableTarget['kind']): string {
+  if (k === 'pad') return 'button';
+  if (k === 'crossfader') return 'fader';
+  return k; // knob | fader | toggle
+}
+
+export const djControlSource: XrControlSource = {
+  area: 'dj',
+
+  async buildEntries(): Promise<XrManifestEntry[]> {
+    const list = await targets();
+    return list.map((t) => ({
+      id: t.id,
+      area: 'dj',
+      group: t.group,
+      label: t.label,
+      kind: toKind(t.kind),
+      min: t.min,
+      max: t.max,
+      step: t.step,
+      unit: t.unit,
+    }));
+  },
+
+  async apply(id: string, value: XrControlValue): Promise<boolean> {
+    const t = (await targets()).find((x) => x.id === id);
+    if (!t) return false;
+    // Toggles want a boolean; ranges want a number; pads trigger (arg ignored).
+    if (t.kind === 'toggle') t.invoke(Boolean(value));
+    else if (t.kind === 'pad') t.invoke(true);
+    else t.invoke(Number(value));
+    return true;
+  },
+};

--- a/frontend/src/state/xrViz.ts
+++ b/frontend/src/state/xrViz.ts
@@ -1,0 +1,79 @@
+/**
+ * XR visualization feed (waveform pack).
+ *
+ * Streams compact visual data to a theDAW-XR headset over the SAME questmidi
+ * return channel the MIDI Reactor uses (`QuestMidiSender`'s inbound path), so
+ * there is no new transport. Each frame is a valid MIDI SysEx message,
+ * `[0xF0, 0x7D, type, ...7-bit payload, 0xF7]` (<= 255 bytes), which passes
+ * cleanly whether the bridge is the loopMIDI-free relay or a loopMIDI port.
+ *
+ * Frame types:
+ *   0x01 waveform  — WAVE_POINTS time-domain samples, each 0..127 (64 = silence)
+ *
+ * The audio source is the shared player-engine master AnalyserNode
+ * (`getAnalyser`), the same tap the in-app visualizers use. The Quest renders
+ * these natively (XrVizReceiver + XrWaveformRibbon).
+ */
+import { getAnalyser } from './playerStore';
+import { sendQuestMidi, isQuestMidiConnected } from './questMidiClient';
+
+const SYSEX_START = 0xf0;
+const MFG = 0x7d; // SysEx "non-commercial / experimental" id
+const SYSEX_END = 0xf7;
+const T_WAVE = 0x01;
+
+const WAVE_POINTS = 128;
+const SEND_INTERVAL_MS = 33; // ~30 Hz
+
+let running = false;
+let rafId = 0;
+let lastSend = 0;
+let timeBuf: Uint8Array | null = null;
+
+function sendWaveform(): void {
+  let analyser: AnalyserNode;
+  try {
+    analyser = getAnalyser();
+  } catch {
+    return; // audio engine not up yet
+  }
+  const fft = analyser.fftSize;
+  if (!timeBuf || timeBuf.length !== fft) timeBuf = new Uint8Array(fft);
+  analyser.getByteTimeDomainData(timeBuf);
+
+  const payload: number[] = [SYSEX_START, MFG, T_WAVE];
+  const step = fft / WAVE_POINTS;
+  for (let i = 0; i < WAVE_POINTS; i++) {
+    // time-domain 0..255 (128 = silence) -> 7-bit 0..127
+    payload.push(timeBuf[Math.floor(i * step)] >> 1);
+  }
+  payload.push(SYSEX_END);
+  sendQuestMidi(payload);
+}
+
+function tick(now: number): void {
+  if (!running) return;
+  if (isQuestMidiConnected() && now - lastSend >= SEND_INTERVAL_MS) {
+    lastSend = now;
+    sendWaveform();
+  }
+  rafId = requestAnimationFrame(tick);
+}
+
+/** Start streaming the viz feed. Safe to call repeatedly; only sends while the
+ *  Quest bridge is connected. */
+export function startXrViz(): void {
+  if (running) return;
+  running = true;
+  lastSend = 0;
+  rafId = requestAnimationFrame(tick);
+}
+
+/** Stop the viz feed. */
+export function stopXrViz(): void {
+  running = false;
+  if (rafId) {
+    cancelAnimationFrame(rafId);
+    rafId = 0;
+  }
+}

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -5,9 +5,10 @@ import {
   LayoutGrid, List as ListIcon, Activity, Scissors, Layers, Wand2, PenLine,
   Package, Network, FileMusic, Loader2, Mic, Piano, ListOrdered,
   CheckSquare, Square, MoreHorizontal, Combine, Paintbrush, FileText, ChevronDown, Maximize2,
-  Film, Image as ImageIcon, Upload, RefreshCw, Tv2,
+  Film, Image as ImageIcon, Upload, RefreshCw, Tv2, Repeat,
 } from 'lucide-react';
 import { ContextMenu, useContextMenu, type ContextMenuItem } from '../components/ui/ContextMenu';
+import { useConvertMenu } from '../convert/ConvertMenu';
 import { LineageModal } from '../components/library/LineageModal';
 import { SuggestPlaylistModal } from '../components/library/SuggestPlaylistModal';
 import { StemsRunModal, type StemsRunOptions } from '../components/library/StemsRunModal';
@@ -83,6 +84,12 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
   // automatically). Payload carries the entryId of the right-clicked
   // row so the menu's items can read it without re-finding the row.
   const entryMenu = useContextMenu<{ entryId: string }>();
+  // Second-stage "Convert to..." format picker (FFmpeg). Shared by the audio
+  // context menu below; opened at the same spot the parent menu was.
+  const convertMenu = useConvertMenu({
+    onStart: (m) => logInfo('library', m),
+    onError: (m) => logError('library', m),
+  });
   const [allStems, setAllStems] = useState<Array<Record<string, unknown>> | null>(null);
   const [allMidis, setAllMidis] = useState<Array<Record<string, unknown>> | null>(null);
   // SCORE library tab: every notation/sheet artifact across all entries,
@@ -1126,6 +1133,9 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
       {(() => {
         const ctxEntryId = entryMenu.payload?.entryId;
         if (!ctxEntryId) return null;
+        // Captured while the parent menu is open; the convert picker reopens here
+        // (onSelect runs after the parent menu has already closed itself).
+        const ctxPos = entryMenu.position;
         const isRunning = (k: 'analysis' | 'stems' | 'midi') =>
           runningKind?.id === ctxEntryId && runningKind?.kind === k;
         const items: ContextMenuItem[] = [
@@ -1196,6 +1206,16 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
           },
           {
             type: 'item',
+            label: 'Convert to…',
+            icon: <Repeat className="w-3 h-3" />,
+            hint: 'ffmpeg',
+            onSelect: () => {
+              const title = entries.find((e) => e.id === ctxEntryId)?.title ?? ctxEntryId;
+              if (ctxPos) convertMenu.openAt(ctxPos, { entryId: ctxEntryId, title, kind: 'audio' });
+            },
+          },
+          {
+            type: 'item',
             label: 'Download bundle',
             icon: <Package className="w-3 h-3" />,
             hint: '.zip+scores',
@@ -1226,6 +1246,8 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
           />
         );
       })()}
+
+      {convertMenu.element}
 
       <LineageModal
         open={lineageOpen !== null}


### PR DESCRIPTION
Convert (in-app FFmpeg "Convert to..."):
- backend/modules/convert: /api/convert formats catalog + convert-by-library-id
  + convert-by-upload; audio<->audio, video->video/audio/gif, image<->image with source-kind rules. Verified end-to-end against real ffmpeg.
- frontend: right-click a library track -> Convert to... -> kind-filtered format picker -> downloads (reuses the ContextMenu primitive; arrayBuffer not blob).

Layout:
- shell starts with all panels/rails/dock collapsed on every app open (stop persisting the open flags; sizes + active tab still remembered; storage keys bumped so existing installs reset cleanly).

XR spatialization (P0/P1):
- backend/modules/xrcontrol websocket relay /api/xr/control (transport-only).
- frontend xrControlClient + DJ source aggregator (reuses DJ_TARGETS); dev-only XrBusTester; xrViz master-analyser waveform sender over the questmidi channel.
- docs: about-thedaw assistant doc (in rag.py DOC_PATHS) + XR spatialization plan.

Desktop:
- Windows thin-bootstrap installer (electron-builder NSIS, per-user): bundles backend source + uv.exe + ffmpeg; first-run uv sync; fetch-runtime-tools.mjs.