### PR TITLE
feat(ui): boot logo 2x, MIX framing, convert on video/image media

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-24T14:00:22.714Z · Git revision: `2a48a5b4ed2e` · Repomix tracked: **no**
+> Generated: 2026-06-24T14:58:30.043Z · Git revision: `7981572c43a3` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-24T14:00:22.714Z",
-  "repoRevision": "2a48a5b4ed2e",
+  "generatedAt": "2026-06-24T14:58:30.043Z",
+  "repoRevision": "7981572c43a3",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-24T13:57:38.152Z",
+  "generatedAt": "2026-06-24T15:01:11.829Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/src/components/layout/LiquidChromeTitle.tsx
+++ b/frontend/src/components/layout/LiquidChromeTitle.tsx
@@ -175,8 +175,10 @@ export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, 
       const fbox = new THREE.Box3().setFromObject(dawGroup);
       const size = new THREE.Vector3();
       fbox.getSize(size);
-      // Fill the canvas box, ~20% larger.
-      const scale = 4.0 / Math.max(size.x, 0.001);
+      // 2x size: the theDAW logo is doubled vs the prior fill (was 4.0). The
+      // "by GANTASMO" text/image live outside this canvas (LoadingScreen DOM
+      // siblings), so enlarging the model here does not move them.
+      const scale = 8.0 / Math.max(size.x, 0.001);
       dawGroup.scale.setScalar(scale);
       modelReady = true;
     });

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -1549,6 +1549,10 @@ const MediaGrid: React.FC<{
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const mediaMenu = useContextMenu<LibraryEntry>();
+  const convertMenu = useConvertMenu({
+    onStart: (m) => logInfo('library', m),
+    onError: (m) => logError('library', m),
+  });
 
   const onPick = async (files: FileList | null) => {
     if (!files || files.length === 0) return;
@@ -1589,6 +1593,7 @@ const MediaGrid: React.FC<{
   };
 
   const ctxEntry = mediaMenu.payload;
+  const ctxPos = mediaMenu.position;
   const menuItems: ContextMenuItem[] = ctxEntry
     ? [
         {
@@ -1610,6 +1615,21 @@ const MediaGrid: React.FC<{
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);
+          },
+        },
+        {
+          type: 'item',
+          label: 'Convert to…',
+          icon: <Repeat className="w-3 h-3" />,
+          hint: 'ffmpeg',
+          onSelect: () => {
+            if (ctxPos) {
+              convertMenu.openAt(ctxPos, {
+                entryId: ctxEntry.id,
+                title: ctxEntry.title,
+                kind: ctxEntry.kind ?? 'video',
+              });
+            }
           },
         },
         {
@@ -1689,6 +1709,7 @@ const MediaGrid: React.FC<{
         items={menuItems}
         title={ctxEntry ? ctxEntry.title : ''}
       />
+      {convertMenu.element}
     </div>
   );
 };

--- a/frontend/src/views/MixView.tsx
+++ b/frontend/src/views/MixView.tsx
@@ -118,7 +118,7 @@ function StatRow({ stats }: { stats: AudioStats }) {
      middle — Effects rail · [ Chain over Effect Stage ] · Library
    Version is bumped past any previously-persisted MIX layout so this default
    takes over cleanly. */
-const MIX_LAYOUT_VERSION = 4;
+const MIX_LAYOUT_VERSION = 5;
 const defaultMixLayout: SurfaceLayout = {
   version: MIX_LAYOUT_VERSION,
   root: 'root',
@@ -127,14 +127,14 @@ const defaultMixLayout: SurfaceLayout = {
     topViz: { id: 'topViz', type: 'container', axis: 'column', children: ['inputVizP', 'outputVizP'], fr: { inputVizP: 1, outputVizP: 1 } },
     inputVizP: { id: 'inputVizP', type: 'panel', title: 'Input', flow: 'row', widgets: [], pinned: 'inputViz' },
     outputVizP: { id: 'outputVizP', type: 'panel', title: 'Output', flow: 'row', widgets: [], pinned: 'outputViz' },
-    mid: { id: 'mid', type: 'container', axis: 'row', children: ['railP', 'cont-3-b45ab2a0', 'rackP'], fr: { railP: 0.7625161264148641, 'cont-3-b45ab2a0': 3.652897886323994, rackP: 1.4 } },
+    mid: { id: 'mid', type: 'container', axis: 'row', children: ['railP', 'cont-3-b45ab2a0', 'rackP'], fr: { railP: 0.7625161264148641, 'cont-3-b45ab2a0': 3.652897886323994, rackP: 1.4 }, framed: true },
     railP: { id: 'railP', type: 'panel', title: 'Effects', flow: 'row', widgets: [], pinned: 'effectRail' },
     libraryP: { id: 'libraryP', type: 'panel', title: 'Library', flow: 'row', widgets: [], pinned: 'library' },
     chainP: { id: 'chainP', type: 'panel', title: 'Chain', flow: 'row', widgets: [], pinned: 'chain' },
     stageP: { id: 'stageP', type: 'panel', title: 'Effect Stage', flow: 'row', widgets: [], pinned: 'effectStage' },
     rackP: { id: 'rackP', type: 'panel', title: 'Rack', flow: 'row', widgets: [], pinned: 'mixRack' },
-    'cont-3-b45ab2a0': { id: 'cont-3-b45ab2a0', type: 'container', axis: 'row', children: ['cont-4-4768bad0', 'libraryP'], fr: { libraryP: 0.45836297448789, 'cont-4-4768bad0': 1.5416370255121108 } },
-    'cont-4-4768bad0': { id: 'cont-4-4768bad0', type: 'container', axis: 'column', children: ['chainP', 'stageP'], fr: { chainP: 0.6536796536796542, stageP: 1.3463203463203457 } },
+    'cont-3-b45ab2a0': { id: 'cont-3-b45ab2a0', type: 'container', axis: 'row', children: ['cont-4-4768bad0', 'libraryP'], fr: { libraryP: 0.45836297448789, 'cont-4-4768bad0': 1.5416370255121108 }, framed: true },
+    'cont-4-4768bad0': { id: 'cont-4-4768bad0', type: 'container', axis: 'column', children: ['chainP', 'stageP'], fr: { chainP: 0.6536796536796542, stageP: 1.3463203463203457 }, framed: true },
   },
 };
 


### PR DESCRIPTION
- boot cinematic: theDAW logo rendered 2x (LiquidChromeTitle scale 4.0->8.0); "by GANTASMO" is a separate DOM sibling so it stays put.
- MIX: frame the three work-area containers (reuses MAKE/DJ framing) so the tab is no longer a flat purple field; bumped the layout version to replace the persisted flat layout.
- convert: extend the "Convert to..." menu to the video/image media grid (video -> mp4/gif/audio-extract, image -> image), reusing the same picker.