### PR TITLE
feat(mix): psychoacoustics as Studio-style tiles, rack panel removed

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-24T14:58:30.043Z · Git revision: `7981572c43a3` · Repomix tracked: **no**
+> Generated: 2026-06-24T15:25:50.353Z · Git revision: `01731e2d8a54` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-24T14:58:30.043Z",
-  "repoRevision": "7981572c43a3",
+  "generatedAt": "2026-06-24T15:25:50.353Z",
+  "repoRevision": "01731e2d8a54",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-24T15:01:11.829Z",
+  "generatedAt": "2026-06-24T15:28:43.525Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/frontend/src/components/audio/ModuleThumb.tsx
+++ b/frontend/src/components/audio/ModuleThumb.tsx
@@ -107,6 +107,39 @@ const DRAWERS: Record<string, Draw> = {
       ctx.fillText(labels[i], 11, by + 5);
     }
   },
+  // Psychoacoustic effect thumbnails, one per group, in the Studio canvas style.
+  'psy-spatial': (ctx, W, H) => {
+    const cx = W / 2, cy = H / 2;
+    for (let i = 3; i > 0; i--) {
+      ctx.beginPath(); ctx.arc(cx, cy, i * Math.min(W, H) * 0.13, 0, Math.PI * 2);
+      ctx.strokeStyle = `rgba(171,71,188,${0.15 + i * 0.12})`; ctx.lineWidth = 1; ctx.stroke();
+    }
+    ctx.fillStyle = 'rgba(232,121,249,.9)';
+    ctx.beginPath(); ctx.arc(cx + W * 0.18, cy - H * 0.12, 2.5, 0, Math.PI * 2); ctx.fill();
+  },
+  'psy-lowend': (ctx, W, H) => {
+    ctx.strokeStyle = 'rgba(245,158,11,.55)'; ctx.lineWidth = 2; ctx.beginPath();
+    for (let x = 0; x < W; x++) { const v = Math.sin(x * 0.06) * H * 0.3; ctx.lineTo(x, H / 2 - v); }
+    ctx.stroke();
+    ctx.strokeStyle = 'rgba(245,158,11,.2)'; ctx.lineWidth = 1; ctx.beginPath();
+    for (let x = 0; x < W; x++) { const v = Math.sin(x * 0.18) * H * 0.12; ctx.lineTo(x, H / 2 - v); }
+    ctx.stroke();
+  },
+  'psy-tone': (ctx, W, H) => {
+    ctx.strokeStyle = 'rgba(239,83,80,.4)'; ctx.lineWidth = 1;
+    for (let h = 1; h <= 6; h++) { ctx.beginPath(); for (let x = 0; x < W; x++) { const v = Math.sin(x * 0.08 * h) * 3 / h; ctx.lineTo(x, H / 2 + v); } ctx.stroke(); }
+    ctx.strokeStyle = 'rgba(239,83,80,.5)'; ctx.setLineDash([2, 2]);
+    ctx.beginPath(); ctx.moveTo(0, H * 0.72); ctx.lineTo(W, H * 0.25); ctx.stroke(); ctx.setLineDash([]);
+  },
+  'psy-performance': (ctx, W, H) => {
+    const n = 8, bw = W / n;
+    for (let i = 0; i < n; i++) {
+      const on = i % 2 === 0;
+      ctx.fillStyle = on ? 'rgba(139,92,246,.55)' : 'rgba(139,92,246,.12)';
+      const bh = on ? H * 0.7 : H * 0.25;
+      ctx.fillRect(i * bw + 1, H - bh, bw - 2, bh);
+    }
+  },
   codec: (ctx, W, H) => {
     const segW = W / 16;
     for (let i = 0; i < 16; i++) {

--- a/frontend/src/views/MixView.tsx
+++ b/frontend/src/views/MixView.tsx
@@ -19,14 +19,35 @@ import { ModuleThumb } from '../components/audio/ModuleThumb';
 import { ControlSurface } from '../components/surface/ControlSurface';
 import { FxRack } from '../components/audio/FxRack';
 import { useMixRackStore } from '../state/mixRackStore';
-import { buildEffectChain, ensureChopModule } from '../lib/rackEffects';
+import { buildEffectChain, ensureChopModule, RACK_EFFECTS } from '../lib/rackEffects';
 import { encodeWav } from '../lib/wavEncode';
 import type { WidgetRegistry } from '../components/surface/widgetTypes';
 import type { SurfaceLayout } from '../state/surfaceLayoutStore';
 import { EFFECT_CATALOG, PARAM_BOUNDS, CATEGORY_META, fxToCategory } from '../lib/effectCatalog';
 import { STUDIO_MODULES, moduleById, effectToModuleId, type StudioModule } from '../lib/moduleCatalog';
-import { Boxes } from 'lucide-react';
+import { Boxes, Headphones } from 'lucide-react';
 import '../components/layout/track-controls.css';
+
+/* ── Psychoacoustic effects shown as Studio-style tiles ──────────────────────
+   The 11 real-time psychoacoustic rack effects, surfaced in the effects library
+   as tiles (the old standalone "Psychoacoustic Rack" panel is gone). Each tile
+   gets a Studio-matching canvas thumbnail keyed by effect group; selecting one
+   adds it to the rack engine and opens the rack in the Effect Stage. */
+interface PsychoModule { id: string; name: string; color: string; desc: string; preview: string; }
+const PSYCHO_GROUP_STYLE: Record<string, { color: string; preview: string }> = {
+  Spatial: { color: '#ab47bc', preview: 'psy-spatial' },
+  'Low end': { color: '#f59e0b', preview: 'psy-lowend' },
+  Tone: { color: '#ef5350', preview: 'psy-tone' },
+  Performance: { color: '#8b5cf6', preview: 'psy-performance' },
+};
+const PSYCHO_MODULES: PsychoModule[] = RACK_EFFECTS.map((fx) => {
+  const s = PSYCHO_GROUP_STYLE[fx.group] ?? { color: '#a855f7', preview: 'psy-spatial' };
+  return { id: fx.id, name: fx.label, color: s.color, desc: fx.description, preview: s.preview };
+});
+if (import.meta.env.DEV) {
+  const uncovered = [...new Set(RACK_EFFECTS.map((fx) => fx.group))].filter((g) => !(g in PSYCHO_GROUP_STYLE));
+  if (uncovered.length) console.warn('[MixView] psychoacoustic groups with no tile style (fallback used):', uncovered);
+}
 
 /* ═══ MIX (PROCESS) tab — now on the Control-Surface editor ═══════════════════
    Layout (drag-arrangeable in Design Mode, like DJ):
@@ -118,7 +139,7 @@ function StatRow({ stats }: { stats: AudioStats }) {
      middle — Effects rail · [ Chain over Effect Stage ] · Library
    Version is bumped past any previously-persisted MIX layout so this default
    takes over cleanly. */
-const MIX_LAYOUT_VERSION = 5;
+const MIX_LAYOUT_VERSION = 6;
 const defaultMixLayout: SurfaceLayout = {
   version: MIX_LAYOUT_VERSION,
   root: 'root',
@@ -127,12 +148,11 @@ const defaultMixLayout: SurfaceLayout = {
     topViz: { id: 'topViz', type: 'container', axis: 'column', children: ['inputVizP', 'outputVizP'], fr: { inputVizP: 1, outputVizP: 1 } },
     inputVizP: { id: 'inputVizP', type: 'panel', title: 'Input', flow: 'row', widgets: [], pinned: 'inputViz' },
     outputVizP: { id: 'outputVizP', type: 'panel', title: 'Output', flow: 'row', widgets: [], pinned: 'outputViz' },
-    mid: { id: 'mid', type: 'container', axis: 'row', children: ['railP', 'cont-3-b45ab2a0', 'rackP'], fr: { railP: 0.7625161264148641, 'cont-3-b45ab2a0': 3.652897886323994, rackP: 1.4 }, framed: true },
+    mid: { id: 'mid', type: 'container', axis: 'row', children: ['railP', 'cont-3-b45ab2a0'], fr: { railP: 0.7625161264148641, 'cont-3-b45ab2a0': 3.652897886323994 }, framed: true },
     railP: { id: 'railP', type: 'panel', title: 'Effects', flow: 'row', widgets: [], pinned: 'effectRail' },
     libraryP: { id: 'libraryP', type: 'panel', title: 'Library', flow: 'row', widgets: [], pinned: 'library' },
     chainP: { id: 'chainP', type: 'panel', title: 'Chain', flow: 'row', widgets: [], pinned: 'chain' },
     stageP: { id: 'stageP', type: 'panel', title: 'Effect Stage', flow: 'row', widgets: [], pinned: 'effectStage' },
-    rackP: { id: 'rackP', type: 'panel', title: 'Rack', flow: 'row', widgets: [], pinned: 'mixRack' },
     'cont-3-b45ab2a0': { id: 'cont-3-b45ab2a0', type: 'container', axis: 'row', children: ['cont-4-4768bad0', 'libraryP'], fr: { libraryP: 0.45836297448789, 'cont-4-4768bad0': 1.5416370255121108 }, framed: true },
     'cont-4-4768bad0': { id: 'cont-4-4768bad0', type: 'container', axis: 'column', children: ['chainP', 'stageP'], fr: { chainP: 0.6536796536796542, stageP: 1.3463203463203457 }, framed: true },
   },
@@ -163,6 +183,7 @@ interface MixRegArgs {
   setViewMode: (m: 'list' | 'tile') => void; addEffect: (id: string) => void; chainEffectIds: Set<string>;
   // studio modules (exact-GUI instruments)
   onPickModule: (id: string) => void; activeModuleId: string | null; activeModule: StudioModule | null;
+  onPickPsycho: (id: string) => void; activePsychoId: string | null;
   // chain
   chain: ChainEntry[]; selectedId: string | null; setSelectedId: (id: string) => void;
   removeEffect: (id: string) => void; updateParams: (id: string, p: Record<string, number>) => void;
@@ -256,6 +277,13 @@ function buildMixRegistry(p: MixRegArgs): WidgetRegistry {
           <span className="text-[10px] font-semibold flex-1 truncate">All</span>
           <span className="text-[8px] font-mono text-zinc-600 shrink-0">{p.allEffectCount}</span>
         </button>
+        <button onClick={() => p.setActiveCategory('psychoacoustics')}
+          title="Psychoacoustic effects — pick one to open the rack in the Effect Stage"
+          className={`flex items-center gap-1.5 px-1.5 py-1.5 rounded w-full text-left border-l-2 transition-colors ${p.activeCategory === 'psychoacoustics' ? 'border-fuchsia-400 text-fuchsia-200 bg-fuchsia-500/10' : 'border-transparent text-fuchsia-400/80 hover:text-fuchsia-200 hover:bg-fuchsia-500/5'}`}>
+          <Headphones className="w-3.5 h-3.5 shrink-0" />
+          <span className="text-[10px] font-bold flex-1 truncate">Psychoacoustics</span>
+          <span className="text-[8px] font-mono text-fuchsia-600 shrink-0">{PSYCHO_MODULES.length}</span>
+        </button>
         {CATEGORY_META.map((cat) => {
           const Icon = cat.icon;
           const active = p.activeCategory === cat.id;
@@ -288,8 +316,8 @@ function buildMixRegistry(p: MixRegArgs): WidgetRegistry {
   pinned('library', 'Library', (
     <div className="h-full w-full flex flex-col min-h-0 min-w-0 overflow-hidden p-2">
       <div className="flex items-center justify-between mb-2 shrink-0">
-        <span className={sectionTitle}>{p.activeCategory === 'studio' ? 'Studio Modules' : p.activeCategory === 'all' ? 'All Effects' : (CATEGORY_META.find((c) => c.id === p.activeCategory)?.label ?? 'Effects')}</span>
-        {p.activeCategory !== 'studio' && (
+        <span className={sectionTitle}>{p.activeCategory === 'studio' ? 'Studio Modules' : p.activeCategory === 'psychoacoustics' ? 'Psychoacoustics' : p.activeCategory === 'all' ? 'All Effects' : (CATEGORY_META.find((c) => c.id === p.activeCategory)?.label ?? 'Effects')}</span>
+        {p.activeCategory !== 'studio' && p.activeCategory !== 'psychoacoustics' && (
           <div className="flex items-center gap-0.5 bg-black/40 rounded p-0.5">
             <button onClick={() => p.setViewMode('list')} title="List view" className={`p-1 rounded transition-colors ${p.viewMode === 'list' ? 'text-purple-300 bg-purple-500/20' : 'text-zinc-500 hover:text-zinc-300'}`}><LayoutList className="w-3 h-3" /></button>
             <button onClick={() => p.setViewMode('tile')} title="Icon view" className={`p-1 rounded transition-colors ${p.viewMode === 'tile' ? 'text-purple-300 bg-purple-500/20' : 'text-zinc-500 hover:text-zinc-300'}`}><Grid3x3 className="w-3 h-3" /></button>
@@ -307,6 +335,28 @@ function buildMixRegistry(p: MixRegArgs): WidgetRegistry {
                 <div className="flex items-center gap-1.5">
                   <span className="w-2 h-2 rounded-full shrink-0" style={{ background: m.color, boxShadow: `0 0 5px ${m.color}80` }} />
                   <span className="text-[10px] font-bold text-zinc-100 truncate flex-1">{m.name}</span>
+                </div>
+                <div className="relative w-full h-20 rounded bg-[#0a0c14] border border-white/5 overflow-hidden">
+                  <ModuleThumb preview={m.preview} className="w-full h-full" />
+                </div>
+                <span className="text-[8px] font-mono text-zinc-500 leading-tight line-clamp-2">{m.desc}</span>
+              </button>
+            );
+          })}
+        </div></div>
+      ) : p.activeCategory === 'psychoacoustics' ? (
+        <div className="flex-1 overflow-y-auto"><div className="flex flex-wrap gap-3 content-start justify-center p-1.5">
+          {PSYCHO_MODULES.map((m) => {
+            const active = p.activePsychoId === m.id;
+            const inRack = p.rackChain.some((e) => e.effect === m.id);
+            return (
+              <button key={m.id} onClick={() => p.onPickPsycho(m.id)} title={m.desc}
+                className={`group relative flex flex-col gap-1.5 rounded-md border overflow-hidden transition-all p-2 text-left ${active ? 'border-fuchsia-400/60 ring-1 ring-fuchsia-400/40 bg-fuchsia-500/5' : 'border-white/8 bg-black/30 hover:border-white/20 hover:brightness-110'}`}
+                style={{ width: 132 }}>
+                <div className="flex items-center gap-1.5">
+                  <span aria-hidden="true" className="w-2 h-2 rounded-full shrink-0" style={{ background: m.color, boxShadow: `0 0 5px ${m.color}80` }} />
+                  <span className="text-[10px] font-bold text-zinc-100 truncate flex-1">{m.name}</span>
+                  {inRack && <span role="img" aria-label="In rack" className="w-1.5 h-1.5 rounded-full bg-fuchsia-400 shrink-0" />}
                 </div>
                 <div className="relative w-full h-20 rounded bg-[#0a0c14] border border-white/5 overflow-hidden">
                   <ModuleThumb preview={m.preview} className="w-full h-full" />
@@ -414,17 +464,7 @@ function buildMixRegistry(p: MixRegArgs): WidgetRegistry {
      instrument, live Web-Audio preview), falling back to the generic viz for
      chain effects that have no dedicated instrument, and a pick-a-module prompt
      when nothing is focused. ── */
-  pinned('effectStage', 'Effect Stage', (
-    p.activeModule
-      ? <EffectGuiStage module={p.activeModule} sourceFile={p.sourceFile} />
-      : p.selectedEntry
-        ? <EffectsVizPanel effect={p.selectedEntry.effect} params={p.selectedEntry.params} className="h-full! border-purple-500/15!" />
-        : <EffectGuiStage module={null} sourceFile={p.sourceFile} />
-  ));
-
-  /* ── psychoacoustic rack — EDIT's real-time FX engine, applied to the MIX
-     source and baked offline into the output (distinct from the backend chain) ── */
-  pinned('mixRack', 'Rack', (
+  const psychoRackStage = (
     <div className="h-full w-full flex flex-col min-h-0 overflow-hidden p-2 gap-2">
       <div className="flex items-center gap-2 shrink-0">
         <span className={sectionTitle}>Psychoacoustic Rack</span>
@@ -453,6 +493,20 @@ function buildMixRegistry(p: MixRegArgs): WidgetRegistry {
         {p.applyingRack ? 'Rendering…' : 'Apply rack to output'}
       </button>
     </div>
+  );
+  // A focused psycho tile shows the rack; an explicit Studio module or selected
+  // chain entry takes priority; otherwise a populated rack still shows here so it
+  // can never be orphaned (and the Apply button stays reachable).
+  pinned('effectStage', 'Effect Stage', (
+    p.activePsychoId
+      ? psychoRackStage
+      : p.activeModule
+        ? <EffectGuiStage module={p.activeModule} sourceFile={p.sourceFile} />
+        : p.selectedEntry
+          ? <EffectsVizPanel effect={p.selectedEntry.effect} params={p.selectedEntry.params} className="h-full! border-purple-500/15!" />
+          : p.rackChain.length > 0
+            ? psychoRackStage
+            : <EffectGuiStage module={null} sourceFile={p.sourceFile} />
   ));
 
   return reg;
@@ -493,6 +547,8 @@ export const MixView: React.FC = () => {
   const [viewMode, setViewMode] = useState<'list' | 'tile'>('tile');
   const [selectedChainId, setSelectedChainId] = useState<string | null>(null);
   const [activeModuleId, setActiveModuleId] = useState<string | null>(null);
+  // The psychoacoustic effect focused in the Effect Stage (opens the rack there).
+  const [activePsychoId, setActivePsychoId] = useState<string | null>(null);
   const [srcStats, setSrcStats] = useState<AudioStats | null>(null);
   const [outStats, setOutStats] = useState<AudioStats | null>(null);
   const [dragOverSource, setDragOverSource] = useState(false);
@@ -616,9 +672,17 @@ export const MixView: React.FC = () => {
     ?? (mappedModuleId ? moduleById[mappedModuleId] ?? null : null);
 
   // Picking a module from the library toggles its instrument open/closed.
-  const handlePickModule = (id: string) => setActiveModuleId((cur) => (cur === id ? null : id));
+  const handlePickModule = (id: string) => { setActivePsychoId(null); setActiveModuleId((cur) => (cur === id ? null : id)); };
   // Selecting a chain entry hands the stage back to the effect→module mapping.
-  const selectChain = (id: string) => { setSelectedChainId(id); setActiveModuleId(null); };
+  const selectChain = (id: string) => { setActivePsychoId(null); setSelectedChainId(id); setActiveModuleId(null); };
+  // Picking a psychoacoustic tile adds it to the rack engine (once) and opens the
+  // rack in the Effect Stage; clicking the focused one again closes the stage.
+  const handlePickPsycho = (id: string) => {
+    if (activePsychoId === id) { setActivePsychoId(null); return; }
+    if (!rackChain.some((e) => e.effect === id)) rackAdd(id);
+    setActiveModuleId(null);
+    setActivePsychoId(id);
+  };
 
   const registry = buildMixRegistry({
     sourceUrl, outputUrl, srcStats, outStats, sourceFile,
@@ -637,6 +701,7 @@ export const MixView: React.FC = () => {
     quickMaster, setQuickParam, applyQuickMaster, masterEntry: !!masterEntry,
     activeEffects, viewMode, setViewMode, addEffect, chainEffectIds,
     onPickModule: handlePickModule, activeModuleId, activeModule,
+    onPickPsycho: handlePickPsycho, activePsychoId,
     chain, selectedId: selectedChainId, setSelectedId: selectChain,
     removeEffect, updateParams, toggleEnabled, reorder, clearChain,
     outputFormat, setOutputFormat, showHistory, setShowHistory, processHistory,


### PR DESCRIPTION
- new "Psychoacoustics" category in the MIX effects sidebar; the 11 real-time rack effects render as Studio-style tiles with group-matched canvas thumbnails (4 new psy-* drawers in ModuleThumb).
- selecting a tile adds it to the rack engine and opens the rack (FxRack + "Apply to output") in the Effect Stage; a populated rack stays reachable as a stage fallback so it can never be orphaned.
- removed the standalone Psychoacoustic Rack panel + its layout node; bumped the MIX layout version so persisted layouts discard the stale panel cleanly.
- a11y: decorative color dot aria-hidden, "in rack" dot labeled; dev-warn if a rack effect group has no tile style.