### PR TITLE
feat(library): surface stored analysis + embedded tags on entries

### DIFF
--- a/backend/modules/library/db.py
+++ b/backend/modules/library/db.py
@@ -677,6 +677,23 @@ class LibraryDB:
             cur.close()
             return dict(row) if row else None
 
+    def get_all_analysis(self) -> dict[str, dict[str, Any]]:
+        """Return ``{entry_id: analysis_row}`` for every analyzed entry in a
+        SINGLE query.
+
+        This is the batched sibling of :meth:`get_analysis`. The library list
+        endpoint enriches every entry with its analysis (so the Catalogue
+        inspector + library search can read ``entry.analysis``); doing that
+        with a per-entry ``get_analysis`` call would be an N+1 query storm on a
+        large library. One ``SELECT *`` + a dict keyed by ``entry_id`` keeps the
+        enrichment O(1) queries. Rows are returned verbatim (same shape as
+        ``get_analysis``); callers parse the ``*_json`` columns themselves."""
+        with self._writelock:
+            cur = self._conn.cursor()
+            rows = cur.execute("SELECT * FROM analysis").fetchall()
+            cur.close()
+            return {row["entry_id"]: dict(row) for row in rows}
+
     def add_stem(
         self,
         *,

--- a/backend/modules/library/router.py
+++ b/backend/modules/library/router.py
@@ -65,6 +65,122 @@ def _attach_play_counts(store: LibraryStore, entries: list[dict[str, Any]]) -> N
         e["last_played_at"] = row.get("last_played_at")
 
 
+# Scalar analysis columns that are safe to expose on the entry verbatim. The
+# `*_json` columns (embedded_tags_json / ffprobe_json / semantic_tags_json) are
+# parsed separately below so the frontend never receives raw JSON strings.
+_ANALYSIS_SCALAR_KEYS = (
+    "bpm",
+    "key",
+    "key_confidence",
+    "scale",
+    "pitch_mean_hz",
+    "pitch_std_hz",
+    "loudness_lufs",
+    "rms_db",
+    "bars_estimated",
+    "genre",
+    "genre_confidence",
+    "prompt_guess",
+    "prompt_confidence",
+    "analyzed_at",
+)
+
+# Selected file-technical keys pulled out of the ffprobe `_summary` blob so the
+# inspector can show them as plain rows (sample rate, codec, …) without dumping
+# the whole ffprobe payload.
+_FFPROBE_SUMMARY_KEYS = (
+    "sample_rate",
+    "channels",
+    "bit_depth",
+    "codec",
+    "container",
+    "duration_sec",
+)
+
+
+def _loose_json(text: Optional[str]) -> Any:
+    """Tolerant JSON parse for the stored `*_json` analysis columns. Returns the
+    decoded value for objects/arrays, or ``None`` for empty/invalid input — so a
+    malformed column degrades to "absent" instead of raising mid-request."""
+    if not text:
+        return None
+    try:
+        value = json.loads(text)
+    except (TypeError, ValueError):
+        return None
+    return value if isinstance(value, (dict, list)) else None
+
+
+# WHY THIS ENRICHMENT EXISTS:
+# The frontend was built to read ``entry.analysis`` (the Catalogue inspector's
+# ANALYSIS section + library search by bpm/key/genre) and ``entry.embedded_tags``
+# (the EMBEDDED TAGS section), but the entry payload never carried them — so
+# those sections rendered empty and the stored analytics were effectively
+# invisible. The two helpers below light them up. Both are additive + defensive:
+# an entry with no analysis row is left exactly as-is.
+
+
+def _analysis_payload(row: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Turn one stored analysis row into the ``(analysis, embedded_tags)`` pair
+    the frontend consumes.
+
+    ``analysis`` is a FLAT scalar dict with NULL columns dropped (so the UI only
+    shows real data); ``embedded_tags`` is the parsed ID3/Vorbis/iTunes dict
+    (empty when the file carried none). The stored ``*_json`` columns are parsed
+    here so callers never receive raw JSON strings.
+    """
+    analysis: dict[str, Any] = {
+        k: row[k] for k in _ANALYSIS_SCALAR_KEYS if row.get(k) is not None
+    }
+    semantic = _loose_json(row.get("semantic_tags_json"))
+    if semantic:
+        analysis["semantic_tags"] = semantic
+    # File technicals live inside the ffprobe summary blob; surface a few.
+    summary = _loose_json(row.get("ffprobe_json")) or {}
+    summary = summary.get("_summary") if isinstance(summary, dict) else None
+    if isinstance(summary, dict):
+        for k in _FFPROBE_SUMMARY_KEYS:
+            if summary.get(k) is not None:
+                analysis.setdefault(k, summary[k])
+    embedded = _loose_json(row.get("embedded_tags_json"))
+    if not (isinstance(embedded, dict) and embedded):
+        embedded = {}
+    return analysis, embedded
+
+
+def _apply_analysis(entry: dict[str, Any], row: Optional[dict[str, Any]]) -> None:
+    """Merge one analysis ``row`` onto one ``entry`` dict in place. No-op when
+    ``row`` is ``None`` (entry not analyzed) or yields nothing renderable."""
+    if not row:
+        return
+    analysis, embedded = _analysis_payload(row)
+    if analysis:
+        entry["analysis"] = analysis
+    if embedded:
+        entry["embedded_tags"] = embedded
+
+
+def _attach_analysis(store: LibraryStore, entries: list[dict[str, Any]]) -> None:
+    """Bulk-enrich a LIST of entries with their analysis. One ``get_all_analysis``
+    query for the whole page (no N+1), then an in-memory join by id."""
+    if store.db is None:
+        return
+    rows = store.db.get_all_analysis()
+    if not rows:
+        return
+    for e in entries:
+        _apply_analysis(e, rows.get(e["id"]))
+
+
+def _attach_analysis_one(store: LibraryStore, entry: dict[str, Any]) -> None:
+    """Enrich a SINGLE entry via a targeted ``get_analysis(id)`` lookup — so a
+    single-entry GET never loads the entire analysis table (which the bulk
+    helper would). Used by the per-id endpoint that inspectors hit on select."""
+    if store.db is None:
+        return
+    _apply_analysis(entry, store.db.get_analysis(entry["id"]))
+
+
 _KIND_FILTERS: dict[str, Optional[set[str]]] = {
     "audio": {"audio"},
     "video": {"video"},
@@ -86,6 +202,7 @@ def list_entries(kind: str = "audio") -> dict[str, Any]:
     store = get_store()
     entries = [r.to_dict() for r in store.list_entries(kinds=_KIND_FILTERS[kind])]
     _attach_play_counts(store, entries)
+    _attach_analysis(store, entries)
     return {
         "entries": entries,
         "count": len(entries),
@@ -102,6 +219,7 @@ def get_entry(entry_id: str) -> dict[str, Any]:
         raise HTTPException(404, f"Entry {entry_id!r} not found")
     data = record.to_dict()
     _attach_play_counts(store, [data])
+    _attach_analysis_one(store, data)
     return data
 
 

--- a/frontend/src/catalog/CatalogueInspector.tsx
+++ b/frontend/src/catalog/CatalogueInspector.tsx
@@ -242,6 +242,13 @@ export const CatalogueInspector: React.FC<Props> = ({ entry }) => {
           <Field label="Size" value={formatSize(entry.fileSizeBytes)} />
           <Field label="Source" value={entry.source} />
           <Field label="Created" value={formatDate(entry.timestamp)} />
+          {/* Play analytics — already tracked per entry (persistent counter +
+              last-played stamp), just never surfaced in this inspector. */}
+          <Field label="Plays" value={entry.playCount ?? 0} />
+          <Field
+            label="Last played"
+            value={entry.lastPlayedAt ? formatDate(new Date(entry.lastPlayedAt * 1000).toISOString()) : '—'}
+          />
           <Field label="ID" value={<span className="text-[8px]">{entry.id.slice(0, 16)}…</span>} />
         </div>
 

--- a/frontend/src/lib/backendLocalProvider.ts
+++ b/frontend/src/lib/backendLocalProvider.ts
@@ -41,6 +41,11 @@ interface ServerRecord {
   chimera_sources?: string[];
   play_count?: number;
   last_played_at?: number | null;
+  // Enrichment attached by the backend's `_attach_analysis` (only present once
+  // the entry has been analyzed). Flat scalar analysis dict + parsed embedded
+  // file tags — see LibraryEntry.analysis / .embeddedTags.
+  analysis?: Record<string, unknown>;
+  embedded_tags?: Record<string, unknown>;
 }
 
 const toEntry = (r: ServerRecord): LibraryEntry => ({
@@ -68,6 +73,11 @@ const toEntry = (r: ServerRecord): LibraryEntry => ({
   chimeraSources: r.chimera_sources ?? [],
   playCount: r.play_count ?? 0,
   lastPlayedAt: r.last_played_at ?? null,
+  // Pass the backend analysis enrichment straight through (snake_case →
+  // camelCase only). Left undefined when the entry hasn't been analyzed, which
+  // the inspector + search treat as "no extra data" rather than empty objects.
+  analysis: r.analysis,
+  embeddedTags: r.embedded_tags,
 });
 
 const patchToServerKeys = (patch: LibraryEntryPatch): Record<string, unknown> => {

--- a/frontend/src/state/libraryEntry.ts
+++ b/frontend/src/state/libraryEntry.ts
@@ -48,6 +48,23 @@ export interface LibraryEntry {
   height?: number | null;
   /** True for transparent PNG/WebP or alpha WebM — overlay-capable media. */
   hasAlpha?: boolean;
+  /**
+   * Computed musical analysis attached by the backend list/get endpoints when
+   * the entry has been analyzed: a FLAT scalar dict (bpm, key, scale,
+   * loudness_lufs, rms_db, pitch_*, bars_estimated, genre, semantic_tags, plus
+   * a few ffprobe technicals like sample_rate/codec). Undefined until the
+   * background analyzer has run. The Catalogue inspector renders every key and
+   * `libraryStore.getFiltered` folds the values into its search haystack — both
+   * already read this field; it was simply never populated before.
+   */
+  analysis?: Record<string, unknown>;
+  /**
+   * Tags embedded INSIDE the audio file (ID3 / Vorbis / iTunes), parsed from
+   * the stored analysis row's `embedded_tags_json`. Undefined when the source
+   * file carried none (typical for freshly-generated tracks). Surfaced
+   * key-by-key in the inspector's EMBEDDED TAGS section.
+   */
+  embeddedTags?: Record<string, unknown>;
 }
 
 /** Subset of fields a client is allowed to PATCH. Must match the

--- a/tests/test_library_endpoints.py
+++ b/tests/test_library_endpoints.py
@@ -187,3 +187,67 @@ def test_stream_stem_audio_endpoint_serves_stem_bytes(client_with_root, tmp_path
 def test_stream_stem_audio_endpoint_404_for_unknown_stem(client_with_root):
     r = client_with_root.get("/api/library/stems/does-not-exist/audio")
     assert r.status_code == 404
+
+
+def test_list_entries_attaches_analysis_and_embedded_tags(client_with_root, tmp_path):
+    """Regression for the analytics-surfacing fix: the /entries payload must
+    carry the stored musical analysis + embedded file tags so the Catalogue
+    inspector (which reads ``entry.analysis`` / ``entry.embedded_tags``) and the
+    library search can render/use them. An entry WITHOUT an analysis row must
+    stay untouched — no empty ``analysis`` key."""
+    _seed_generate_entry(tmp_path, "job_anal", 0)
+    _seed_generate_entry(tmp_path, "job_plain", 0)
+
+    # First list registers the on-disk entries into the DB — the FK target the
+    # analysis row references (foreign_keys is ON).
+    client_with_root.get("/api/library/entries")
+
+    store = library_router_module.get_store()
+    assert store.db is not None
+    store.db.upsert_analysis(
+        "job_anal_00",
+        {
+            "bpm": 120.0,
+            "key": "C",
+            "scale": "major",
+            "key_confidence": 0.9,
+            "semantic_tags": ["warm", "ambient"],
+            "embedded_tags": {"artist": "Tester", "play_count": 7},
+            "ffprobe": {"_summary": {"sample_rate": 44100, "codec": "pcm_s16le"}},
+            "version": 2,
+        },
+    )
+
+    body = client_with_root.get("/api/library/entries").json()
+    by_id = {e["id"]: e for e in body["entries"]}
+
+    enriched = by_id["job_anal_00"]
+    assert enriched["analysis"]["bpm"] == 120.0
+    assert enriched["analysis"]["key"] == "C"
+    assert enriched["analysis"]["scale"] == "major"
+    assert enriched["analysis"]["semantic_tags"] == ["warm", "ambient"]
+    # ffprobe `_summary` technicals are flattened onto the analysis dict.
+    assert enriched["analysis"]["sample_rate"] == 44100
+    assert enriched["analysis"]["codec"] == "pcm_s16le"
+    # Embedded ID3/Vorbis tags surface under their own key.
+    assert enriched["embedded_tags"] == {"artist": "Tester", "play_count": 7}
+
+    # The un-analyzed entry must NOT gain empty analysis / embedded_tags keys.
+    plain = by_id["job_plain_00"]
+    assert "analysis" not in plain
+    assert "embedded_tags" not in plain
+
+
+def test_single_entry_endpoint_attaches_analysis(client_with_root, tmp_path):
+    """The per-id endpoint enriches via the targeted single-row lookup
+    (``_attach_analysis_one``), not the whole-table bulk path."""
+    _seed_generate_entry(tmp_path, "job_one", 0)
+    client_with_root.get("/api/library/entries")
+
+    store = library_router_module.get_store()
+    assert store.db is not None
+    store.db.upsert_analysis("job_one_00", {"bpm": 90.0, "key": "A"})
+
+    data = client_with_root.get("/api/library/entries/job_one_00").json()
+    assert data["analysis"]["bpm"] == 90.0
+    assert data["analysis"]["key"] == "A"


### PR DESCRIPTION
## What
The Catalogue inspector (expanded library view) and the library search were already built to read `entry.analysis` / `entry.embeddedTags`, but the `/api/library/entries` payload never carried them — so the inspector's **ANALYSIS** and **EMBEDDED TAGS** sections rendered empty and all the stored per-track analytics (BPM, key, scale, loudness, pitch, bars, ffprobe technicals, semantic tags, embedded ID3/Vorbis tags) were effectively invisible.

This wires the already-built UI to the data that was always there.

## Changes (additive only)
**Backend**
- `LibraryDB.get_all_analysis()` — one batched query for the list path (no N+1).
- `_attach_analysis` (bulk, list endpoint) + `_attach_analysis_one` (targeted single-row lookup, per-id endpoint) merge the analysis row + parsed embedded tags onto each entry dict. Stored `*_json` columns are parsed so the client receives clean dicts.

**Frontend**
- Carry `analysis` / `embeddedTags` through the `LibraryEntry` type and the backend-local mapper.
- Show **Plays** / **Last played** in the Catalogue inspector.

## Tests
- New regression tests for both list and single-entry enrichment (and that un-analyzed entries stay clean).

## Verification
- `ruff check` + `ruff format --check`: clean
- `pytest tests/test_library_endpoints.py`: 15 passed
- `tsc --noEmit`: clean
- Smoke-tested against a live library DB: all audio entries enriched with an 18-key analysis dict.

## Notes
- Purely additive — no existing code paths changed (only insertions).
- Spectrograms in the inspector already worked (on-demand) and are unchanged.