### PR TITLE
feat(models): on-demand model Download Manager with live progress dock

### DIFF
--- a/backend/modules/modeldl/module.json
+++ b/backend/modules/modeldl/module.json
@@ -1,0 +1,10 @@
+{
+  "name": "modeldl",
+  "label": "Model Downloads",
+  "enabled": true,
+  "icon": "Download",
+  "sidebar": false,
+  "api_prefix": "/api/models",
+  "backend": true,
+  "description": "On-demand model weight downloads with a live progress registry behind the Settings download dock."
+}

--- a/backend/modules/modeldl/router.py
+++ b/backend/modules/modeldl/router.py
@@ -1,0 +1,246 @@
+"""FastAPI router for the model-download module (prefix ``/api/models``).
+
+    POST   /{name}/download        start (or rejoin) a download for a catalog model
+    GET    /downloads              every download job this session, with live progress
+    POST   /downloads/clear        drop all finished (done|error) jobs
+
+This is a session-scoped JOB REGISTRY, not a fire-and-forget downloader. Each
+job tracks per-file byte progress and transfer speed so the Settings download
+dock can render a live progress bar. A download fetches BOTH the model config
+JSON and the checkpoint file from the Hugging Face Hub.
+
+Live progress works by passing a custom ``tqdm`` subclass (``_JobTqdm``) to
+``hf_hub_download``. ``huggingface_hub`` drives that tqdm during the transfer;
+each ``update()`` writes the current byte count / total / rate back into the
+job's file entry. The worker thread tags itself with the job id through a
+``contextvars.ContextVar`` so the tqdm instance — created deep inside
+``huggingface_hub`` — knows which job it belongs to.
+
+Downloads run on a DEDICATED two-worker thread pool so they never starve the
+event loop's shared default executor. The in-memory registry and every job
+dict it holds are guarded by a single lock, because jobs are mutated from
+worker threads and read from the request handlers.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import os
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+from fastapi import APIRouter, HTTPException
+from huggingface_hub import hf_hub_download
+from tqdm.auto import tqdm
+
+from stable_audio_3.model_configs import (
+    AutoencoderModelConfig,
+    ModelConfig,
+    all_models,
+)
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# job_id -> job dict. Guarded by _LOCK for every read and write, because worker
+# threads mutate jobs while request handlers read them.
+_REGISTRY: dict[str, dict] = {}
+_LOCK = threading.Lock()
+
+# A dedicated pool keeps long downloads off asyncio's shared default executor.
+_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="modeldl")
+
+# The worker thread stamps its job id here so _JobTqdm (constructed inside
+# huggingface_hub, out of our control) can find the job it is reporting on.
+_CURRENT_JOB: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "modeldl_current_job", default=None
+)
+
+_LIVE_STATUSES = frozenset({"queued", "downloading"})
+_FINISHED_STATUSES = frozenset({"done", "error"})
+
+
+class _JobTqdm(tqdm):
+    """tqdm subclass that mirrors transfer progress into the active job entry.
+
+    Every progress write is wrapped in try/except: a bookkeeping error must
+    never abort an in-flight download.
+    """
+
+    def _publish(self) -> None:
+        job_id = _CURRENT_JOB.get()
+        if not job_id:
+            return
+        try:
+            rate = self.format_dict.get("rate")
+            with _LOCK:
+                job = _REGISTRY.get(job_id)
+                if job is None:
+                    return
+                idx = job["current_file"]
+                if idx < 0 or idx >= len(job["files"]):
+                    return
+                entry = job["files"][idx]
+                entry["bytes_done"] = self.n
+                entry["bytes_total"] = self.total or 0
+                entry["speed"] = float(rate) if rate else 0.0
+        except Exception:  # pragma: no cover - defensive, must never raise
+            log.debug("modeldl: progress publish failed", exc_info=True)
+
+    def update(self, n: int | float = 1) -> bool | None:
+        displayed = super().update(n)
+        self._publish()
+        return displayed
+
+    def close(self) -> None:
+        # Flush a final reading (e.g. the closing 100% tick) before teardown.
+        self._publish()
+        super().close()
+
+
+def _config_files(cfg: ModelConfig | AutoencoderModelConfig) -> list[str]:
+    """The (config, checkpoint) filenames to fetch for a catalog entry, in order."""
+    if isinstance(cfg, AutoencoderModelConfig):
+        return [cfg.ae_config_path, cfg.ae_ckpt_path]
+    return [cfg.config_path, cfg.ckpt_path]
+
+
+def _repo_id(cfg: ModelConfig | AutoencoderModelConfig) -> str:
+    if isinstance(cfg, AutoencoderModelConfig):
+        return cfg.ae_repo_id
+    return cfg.repo_id
+
+
+def _new_job(name: str, cfg: ModelConfig | AutoencoderModelConfig) -> dict:
+    """Build a fresh job dict. Caller must hold _LOCK when inserting it."""
+    return {
+        "id": uuid.uuid4().hex,
+        "name": name,
+        "repo_id": _repo_id(cfg),
+        "label": name.replace("-", " ").title(),
+        "status": "queued",
+        "files": [],
+        "current_file": -1,
+        "dest_dir": "",
+        "error_detail": None,
+        "error_repo_id": None,
+    }
+
+
+def _run_job(job_id: str) -> None:
+    """Worker body: fetch the config file then the checkpoint, tracking progress.
+
+    Runs on the dedicated download pool. All registry/job mutations take _LOCK.
+    Any failure flips the job to ``error`` with the raw exception text so the
+    frontend can classify and surface it; success flips it to ``done``.
+    """
+    _CURRENT_JOB.set(job_id)
+    with _LOCK:
+        job = _REGISTRY.get(job_id)
+        if job is None:
+            return
+        job["status"] = "downloading"
+        repo_id = job["repo_id"]
+        filenames = list(job["_filenames"])
+
+    try:
+        for filename in filenames:
+            with _LOCK:
+                job = _REGISTRY.get(job_id)
+                if job is None:
+                    return
+                job["files"].append(
+                    {
+                        "filename": filename,
+                        "bytes_done": 0,
+                        "bytes_total": 0,
+                        "speed": 0.0,
+                        "done": False,
+                    }
+                )
+                job["current_file"] = len(job["files"]) - 1
+
+            path = hf_hub_download(
+                repo_id=repo_id, filename=filename, tqdm_class=_JobTqdm
+            )
+
+            with _LOCK:
+                job = _REGISTRY.get(job_id)
+                if job is None:
+                    return
+                entry = job["files"][job["current_file"]]
+                entry["done"] = True
+                if entry["bytes_total"]:
+                    entry["bytes_done"] = entry["bytes_total"]
+                if path:
+                    job["dest_dir"] = os.path.dirname(path)
+    except Exception as exc:
+        log.exception("modeldl: download job %s for %r failed", job_id, repo_id)
+        with _LOCK:
+            job = _REGISTRY.get(job_id)
+            if job is not None:
+                job["status"] = "error"
+                job["error_detail"] = str(exc)
+                job["error_repo_id"] = repo_id
+        return
+
+    with _LOCK:
+        job = _REGISTRY.get(job_id)
+        if job is not None:
+            job["status"] = "done"
+
+
+def _public_job(job: dict) -> dict:
+    """A job dict stripped of private keys, safe to serialize. Caller holds _LOCK."""
+    return {k: v for k, v in job.items() if not k.startswith("_")}
+
+
+@router.post("/{name}/download")
+def start_download(name: str) -> dict:
+    cfg = all_models.get(name)
+    if cfg is None:
+        raise HTTPException(404, f"Unknown model {name!r}")
+
+    # Atomic check-and-set: if a live job for this model already exists, rejoin
+    # it instead of starting a duplicate. The existence check and the insert
+    # happen under the SAME lock acquisition so two concurrent POSTs cannot both
+    # decide to enqueue (no TOCTOU).
+    with _LOCK:
+        for existing in _REGISTRY.values():
+            if existing["name"] == name and existing["status"] in _LIVE_STATUSES:
+                return {
+                    "job_id": existing["id"],
+                    "name": existing["name"],
+                    "status": existing["status"],
+                }
+        job = _new_job(name, cfg)
+        job["_filenames"] = _config_files(cfg)
+        _REGISTRY[job["id"]] = job
+        job_id = job["id"]
+        status = job["status"]
+
+    _EXECUTOR.submit(_run_job, job_id)
+    return {"job_id": job_id, "name": name, "status": status}
+
+
+@router.get("/downloads")
+def list_downloads() -> dict:
+    with _LOCK:
+        jobs = [_public_job(job) for job in _REGISTRY.values()]
+    return {"jobs": jobs}
+
+
+@router.post("/downloads/clear")
+def clear_downloads() -> dict:
+    with _LOCK:
+        finished = [
+            job_id
+            for job_id, job in _REGISTRY.items()
+            if job["status"] in _FINISHED_STATUSES
+        ]
+        for job_id in finished:
+            del _REGISTRY[job_id]
+    return {"cleared": len(finished)}

--- a/backend/modules/modeldl/router.py
+++ b/backend/modules/modeldl/router.py
@@ -24,7 +24,7 @@ worker threads and read from the request handlers.
 
 from __future__ import annotations
 
-import contextvars
+import atexit
 import logging
 import os
 import threading
@@ -52,26 +52,31 @@ _LOCK = threading.Lock()
 
 # A dedicated pool keeps long downloads off asyncio's shared default executor.
 _EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="modeldl")
-
-# The worker thread stamps its job id here so _JobTqdm (constructed inside
-# huggingface_hub, out of our control) can find the job it is reporting on.
-_CURRENT_JOB: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "modeldl_current_job", default=None
-)
+# Tear the pool down on process exit / dev-server reload so it isn't leaked.
+atexit.register(lambda: _EXECUTOR.shutdown(wait=False))
 
 _LIVE_STATUSES = frozenset({"queued", "downloading"})
 _FINISHED_STATUSES = frozenset({"done", "error"})
+
+# Cap retained finished/errored jobs so a long session can't grow unbounded.
+_MAX_TERMINAL_JOBS = 25
 
 
 class _JobTqdm(tqdm):
     """tqdm subclass that mirrors transfer progress into the active job entry.
 
-    Every progress write is wrapped in try/except: a bookkeeping error must
-    never abort an in-flight download.
+    The job id is bound to the (sub)class via ``_bound_tqdm`` rather than a
+    contextvar: huggingface_hub's Xet backend drives ``update()`` from a native
+    worker thread where a contextvar set on our Python thread is invisible.
+    Reading ``self._job_id`` works no matter which thread fires the update.
+    Every write is wrapped in try/except so a bookkeeping error can never abort
+    an in-flight download.
     """
 
+    _job_id: str | None = None
+
     def _publish(self) -> None:
-        job_id = _CURRENT_JOB.get()
+        job_id = self._job_id
         if not job_id:
             return
         try:
@@ -99,6 +104,12 @@ class _JobTqdm(tqdm):
         # Flush a final reading (e.g. the closing 100% tick) before teardown.
         self._publish()
         super().close()
+
+
+def _bound_tqdm(job_id: str) -> type[_JobTqdm]:
+    """A ``_JobTqdm`` subclass pinned to ``job_id`` — used as ``tqdm_class`` so
+    the progress callback finds its job from any thread (incl. Xet's native one)."""
+    return type(f"_JobTqdm_{job_id[:8]}", (_JobTqdm,), {"_job_id": job_id})
 
 
 def _config_files(cfg: ModelConfig | AutoencoderModelConfig) -> list[str]:
@@ -137,7 +148,6 @@ def _run_job(job_id: str) -> None:
     Any failure flips the job to ``error`` with the raw exception text so the
     frontend can classify and surface it; success flips it to ``done``.
     """
-    _CURRENT_JOB.set(job_id)
     with _LOCK:
         job = _REGISTRY.get(job_id)
         if job is None:
@@ -145,6 +155,8 @@ def _run_job(job_id: str) -> None:
         job["status"] = "downloading"
         repo_id = job["repo_id"]
         filenames = list(job["_filenames"])
+
+    bound_tqdm = _bound_tqdm(job_id)
 
     try:
         for filename in filenames:
@@ -164,7 +176,7 @@ def _run_job(job_id: str) -> None:
                 job["current_file"] = len(job["files"]) - 1
 
             path = hf_hub_download(
-                repo_id=repo_id, filename=filename, tqdm_class=_JobTqdm
+                repo_id=repo_id, filename=filename, tqdm_class=bound_tqdm
             )
 
             with _LOCK:
@@ -221,6 +233,13 @@ def start_download(name: str) -> dict:
         _REGISTRY[job["id"]] = job
         job_id = job["id"]
         status = job["status"]
+
+        # Bound growth: evict the oldest terminal jobs beyond the cap.
+        terminal = [
+            jid for jid, j in _REGISTRY.items() if j["status"] in _FINISHED_STATUSES
+        ]
+        for jid in terminal[: max(0, len(terminal) - _MAX_TERMINAL_JOBS)]:
+            del _REGISTRY[jid]
 
     _EXECUTOR.submit(_run_job, job_id)
     return {"job_id": job_id, "name": name, "status": status}

--- a/frontend/src/components/layout/DownloadDock.tsx
+++ b/frontend/src/components/layout/DownloadDock.tsx
@@ -40,11 +40,63 @@ const formatSpeed = (bytesPerSec: number): string => {
 const isActive = (job: DownloadJob): boolean =>
   job.status === 'queued' || job.status === 'downloading';
 
+// Default resting spot: bottom-right, but lifted high enough (bottom-28 = 7rem)
+// to clear the collapsed ShellBottomDock strip so the dock isn't clipped.
+const DEFAULT_POS_CLASS = 'bottom-28 right-4';
+
 export const DownloadDock: React.FC = () => {
   const jobs = useDownloadStore((s) => s.jobs);
   const expanded = useDownloadStore((s) => s.expanded);
   const setExpanded = useDownloadStore((s) => s.setExpanded);
   const clear = useDownloadStore((s) => s.clear);
+
+  // Manual position once the user drags. null = default anchored (bottom-right).
+  const [pos, setPos] = React.useState<{ x: number; y: number } | null>(null);
+  const dragRef = React.useRef<{
+    dx: number;
+    dy: number;
+    startX: number;
+    startY: number;
+    moved: boolean;
+  } | null>(null);
+
+  // Drag from any handle; clamps the dock inside the viewport. A move under
+  // 3px is treated as a click (so the collapsed pill still expands on tap).
+  const startDrag = React.useCallback((e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    const root = (e.currentTarget as HTMLElement).closest('[data-dock-root]') as HTMLElement | null;
+    if (!root) return;
+    const rect = root.getBoundingClientRect();
+    dragRef.current = {
+      dx: e.clientX - rect.left,
+      dy: e.clientY - rect.top,
+      startX: e.clientX,
+      startY: e.clientY,
+      moved: false,
+    };
+    const onMove = (ev: PointerEvent) => {
+      const d = dragRef.current;
+      if (!d) return;
+      if (!d.moved) {
+        if (Math.abs(ev.clientX - d.startX) < 3 && Math.abs(ev.clientY - d.startY) < 3) return;
+        d.moved = true;
+      }
+      const w = root.offsetWidth;
+      const h = root.offsetHeight;
+      const x = Math.max(4, Math.min(ev.clientX - d.dx, window.innerWidth - w - 4));
+      const y = Math.max(4, Math.min(ev.clientY - d.dy, window.innerHeight - h - 4));
+      setPos({ x, y });
+    };
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.setTimeout(() => {
+        dragRef.current = null;
+      }, 0);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  }, []);
 
   if (jobs.length === 0) return null;
 
@@ -54,36 +106,49 @@ export const DownloadDock: React.FC = () => {
     return sum + (file?.speed ?? 0);
   }, 0);
 
-  // ── Collapsed: a single pill. ───────────────────────────────────────────
+  const posClass = pos ? 'fixed z-50' : `fixed z-50 ${DEFAULT_POS_CLASS}`;
+  const posStyle = pos ? { left: pos.x, top: pos.y } : undefined;
+
+  // ── Collapsed: a single draggable pill. ─────────────────────────────────
   if (!expanded) {
     const label =
       activeJobs.length > 0
         ? `${activeJobs.length} downloading · ${formatSpeed(totalSpeed)}`
         : 'Downloads';
     return (
-      <div className="fixed bottom-4 right-4 z-50 w-96 max-w-[92vw] flex justify-end pointer-events-none">
-        <button
-          type="button"
-          onClick={() => setExpanded(true)}
-          aria-label="Expand downloads"
-          className="pointer-events-auto inline-flex items-center gap-1.5 rounded-lg border border-purple-500/40 bg-[#0a080f]/95 px-2.5 py-1.5 text-[10px] font-mono uppercase tracking-widest text-purple-200 shadow-[0_0_16px_rgba(168,85,247,0.35)] backdrop-blur-md hover:bg-purple-500/15 hover:text-white transition-colors"
-        >
-          {activeJobs.length > 0 ? (
-            <Loader2 className="w-3 h-3 animate-spin shrink-0" />
-          ) : (
-            <CheckCircle2 className="w-3 h-3 text-emerald-300 shrink-0" />
-          )}
-          <span className="truncate">{label}</span>
-          {activeJobs.length === 0 && <span className="text-emerald-300">✓</span>}
-        </button>
-      </div>
+      <button
+        type="button"
+        data-dock-root
+        onPointerDown={startDrag}
+        onClick={() => {
+          if (!dragRef.current?.moved) setExpanded(true);
+        }}
+        aria-label="Expand downloads (drag to move)"
+        style={posStyle}
+        className={`${posClass} inline-flex items-center gap-1.5 rounded-lg border border-purple-500/40 bg-[#0a080f]/95 px-2.5 py-1.5 text-[10px] font-mono uppercase tracking-widest text-purple-200 shadow-[0_0_16px_rgba(168,85,247,0.35)] backdrop-blur-md hover:bg-purple-500/15 hover:text-white transition-colors cursor-grab active:cursor-grabbing touch-none select-none`}
+      >
+        {activeJobs.length > 0 ? (
+          <Loader2 className="w-3 h-3 animate-spin shrink-0" />
+        ) : (
+          <CheckCircle2 className="w-3 h-3 text-emerald-300 shrink-0" />
+        )}
+        <span className="truncate">{label}</span>
+        {activeJobs.length === 0 && <span className="text-emerald-300">✓</span>}
+      </button>
     );
   }
 
-  // ── Expanded: header + scrollable job stack. ────────────────────────────
+  // ── Expanded: draggable header + scrollable job stack. ──────────────────
   return (
-    <div className="fixed bottom-4 right-4 z-50 w-96 max-w-[92vw] rounded-lg border border-purple-500/30 bg-[#0a080f]/95 shadow-[0_0_24px_rgba(0,0,0,0.6)] backdrop-blur-md overflow-hidden">
-      <div className="flex items-center gap-2 px-2.5 py-2 border-b border-white/5 bg-linear-to-r from-purple-900/25 to-purple-900/10">
+    <div
+      data-dock-root
+      style={posStyle}
+      className={`${posClass} w-96 max-w-[92vw] rounded-lg border border-purple-500/30 bg-[#0a080f]/95 shadow-[0_0_24px_rgba(0,0,0,0.6)] backdrop-blur-md overflow-hidden`}
+    >
+      <div
+        onPointerDown={startDrag}
+        className="flex items-center gap-2 px-2.5 py-2 border-b border-white/5 bg-linear-to-r from-purple-900/25 to-purple-900/10 cursor-grab active:cursor-grabbing touch-none select-none"
+      >
         <Download className="w-3.5 h-3.5 text-purple-300 shrink-0" />
         <span className="text-[10px] font-black uppercase tracking-widest text-purple-200">Downloads</span>
         <span className="text-[8px] font-mono text-zinc-500">
@@ -92,6 +157,7 @@ export const DownloadDock: React.FC = () => {
         <div className="ml-auto flex items-center gap-1">
           <button
             type="button"
+            onPointerDown={(e) => e.stopPropagation()}
             onClick={() => void clear()}
             aria-label="Clear finished downloads"
             title="Clear finished / errored downloads"
@@ -102,6 +168,7 @@ export const DownloadDock: React.FC = () => {
           </button>
           <button
             type="button"
+            onPointerDown={(e) => e.stopPropagation()}
             onClick={() => setExpanded(false)}
             aria-label="Collapse downloads"
             title="Collapse"

--- a/frontend/src/components/layout/DownloadDock.tsx
+++ b/frontend/src/components/layout/DownloadDock.tsx
@@ -90,12 +90,14 @@ export const DownloadDock: React.FC = () => {
     const onUp = () => {
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
       window.setTimeout(() => {
         dragRef.current = null;
       }, 0);
     };
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
   }, []);
 
   if (jobs.length === 0) return null;

--- a/frontend/src/components/layout/DownloadDock.tsx
+++ b/frontend/src/components/layout/DownloadDock.tsx
@@ -259,15 +259,20 @@ const DownloadError: React.FC<{ detail: string; repoId?: string }> = ({ detail, 
     <div className="rounded border border-rose-500/30 bg-rose-500/5 px-2 py-1.5">
       <div className="text-[9px] font-black uppercase tracking-widest text-rose-300">{info.headline}</div>
       <p className="mt-0.5 text-[8px] leading-relaxed text-rose-200/80">{info.fix}</p>
-      {info.repoUrl && (
-        <a
-          href={info.repoUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="mt-1 inline-flex items-center gap-1 text-[8px] font-mono text-rose-300 hover:text-rose-100 transition-colors"
-        >
-          <ExternalLink className="w-2.5 h-2.5" /> Open model page
-        </a>
+      {info.links && info.links.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+          {info.links.map((link) => (
+            <a
+              key={link.url}
+              href={link.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-[8px] font-mono text-rose-300 hover:text-rose-100 transition-colors"
+            >
+              <ExternalLink className="w-2.5 h-2.5" /> {link.label}
+            </a>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/layout/DownloadDock.tsx
+++ b/frontend/src/components/layout/DownloadDock.tsx
@@ -1,0 +1,207 @@
+/**
+ * DownloadDock — floating bottom-right model download manager.
+ *
+ * Appears only while/after downloads happen (returns null when there are no
+ * jobs). Collapsed it is a compact pill (active count + summed speed, or a
+ * "done" badge). Expanded it shows one row per model with a live progress bar,
+ * speed, size, file counter, and destination, plus an actionable error block
+ * for failed downloads.
+ *
+ * The store owns all state; this component is purely a view + a few buttons.
+ */
+import React from 'react';
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  Download,
+  ExternalLink,
+  Loader2,
+  Trash2,
+} from 'lucide-react';
+import { useDownloadStore } from '../../state/downloadStore';
+import { classifyDownloadError, type DownloadJob } from '../../lib/modelDownloadClient';
+import { formatBytes } from '../../lib/storageClient';
+
+/** Bytes/sec → human rate (B/s · KB/s · MB/s · GB/s). */
+const formatSpeed = (bytesPerSec: number): string => {
+  if (!bytesPerSec || bytesPerSec <= 0) return '0 B/s';
+  if (bytesPerSec < 1024) return `${Math.round(bytesPerSec)} B/s`;
+  const units = ['KB/s', 'MB/s', 'GB/s'];
+  let v = bytesPerSec;
+  let u = -1;
+  do {
+    v /= 1024;
+    u += 1;
+  } while (v >= 1024 && u < units.length - 1);
+  return `${v.toFixed(v >= 100 ? 0 : 1)} ${units[u]}`;
+};
+
+const isActive = (job: DownloadJob): boolean =>
+  job.status === 'queued' || job.status === 'downloading';
+
+export const DownloadDock: React.FC = () => {
+  const jobs = useDownloadStore((s) => s.jobs);
+  const expanded = useDownloadStore((s) => s.expanded);
+  const setExpanded = useDownloadStore((s) => s.setExpanded);
+  const clear = useDownloadStore((s) => s.clear);
+
+  if (jobs.length === 0) return null;
+
+  const activeJobs = jobs.filter(isActive);
+  const totalSpeed = activeJobs.reduce((sum, job) => {
+    const file = job.files[job.current_file];
+    return sum + (file?.speed ?? 0);
+  }, 0);
+
+  // ── Collapsed: a single pill. ───────────────────────────────────────────
+  if (!expanded) {
+    const label =
+      activeJobs.length > 0
+        ? `${activeJobs.length} downloading · ${formatSpeed(totalSpeed)}`
+        : 'Downloads';
+    return (
+      <div className="fixed bottom-4 right-4 z-50 w-96 max-w-[92vw] flex justify-end pointer-events-none">
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          aria-label="Expand downloads"
+          className="pointer-events-auto inline-flex items-center gap-1.5 rounded-lg border border-purple-500/40 bg-[#0a080f]/95 px-2.5 py-1.5 text-[10px] font-mono uppercase tracking-widest text-purple-200 shadow-[0_0_16px_rgba(168,85,247,0.35)] backdrop-blur-md hover:bg-purple-500/15 hover:text-white transition-colors"
+        >
+          {activeJobs.length > 0 ? (
+            <Loader2 className="w-3 h-3 animate-spin shrink-0" />
+          ) : (
+            <CheckCircle2 className="w-3 h-3 text-emerald-300 shrink-0" />
+          )}
+          <span className="truncate">{label}</span>
+          {activeJobs.length === 0 && <span className="text-emerald-300">✓</span>}
+        </button>
+      </div>
+    );
+  }
+
+  // ── Expanded: header + scrollable job stack. ────────────────────────────
+  return (
+    <div className="fixed bottom-4 right-4 z-50 w-96 max-w-[92vw] rounded-lg border border-purple-500/30 bg-[#0a080f]/95 shadow-[0_0_24px_rgba(0,0,0,0.6)] backdrop-blur-md overflow-hidden">
+      <div className="flex items-center gap-2 px-2.5 py-2 border-b border-white/5 bg-linear-to-r from-purple-900/25 to-purple-900/10">
+        <Download className="w-3.5 h-3.5 text-purple-300 shrink-0" />
+        <span className="text-[10px] font-black uppercase tracking-widest text-purple-200">Downloads</span>
+        <span className="text-[8px] font-mono text-zinc-500">
+          {activeJobs.length > 0 ? `${activeJobs.length} active · ${formatSpeed(totalSpeed)}` : `${jobs.length} total`}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => void clear()}
+            aria-label="Clear finished downloads"
+            title="Clear finished / errored downloads"
+            className="inline-flex items-center gap-1 rounded border border-white/10 px-1.5 py-0.5 text-[8px] font-mono uppercase tracking-widest text-zinc-500 hover:bg-white/5 hover:text-zinc-200 transition-colors"
+          >
+            <Trash2 className="w-2.5 h-2.5" />
+            Clear
+          </button>
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            aria-label="Collapse downloads"
+            title="Collapse"
+            className="p-1 rounded text-zinc-500 hover:bg-white/5 hover:text-white transition-colors"
+          >
+            <ChevronDown className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+
+      <div className="max-h-80 overflow-y-auto flex flex-col divide-y divide-white/5">
+        {jobs.map((job) => (
+          <DownloadRow key={job.id} job={job} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const DownloadRow: React.FC<{ job: DownloadJob }> = ({ job }) => {
+  const file = job.files[job.current_file];
+  const fileCount = job.files.length;
+  const bytesDone = file?.bytes_done ?? 0;
+  const bytesTotal = file?.bytes_total ?? 0;
+  const pct = bytesTotal > 0 ? Math.min(100, Math.round((bytesDone / bytesTotal) * 100)) : 0;
+  const isError = job.status === 'error';
+  const isDone = job.status === 'done';
+
+  return (
+    <div className={`px-2.5 py-2 ${isError ? 'bg-rose-500/5' : ''}`}>
+      <div className="flex items-center gap-1.5 mb-1">
+        {job.status === 'downloading' || job.status === 'queued' ? (
+          <Loader2 className="w-3 h-3 text-purple-300 animate-spin shrink-0" />
+        ) : isDone ? (
+          <CheckCircle2 className="w-3 h-3 text-emerald-300 shrink-0" />
+        ) : (
+          <AlertCircle className="w-3 h-3 text-rose-300 shrink-0" />
+        )}
+        <span className="text-[10px] font-bold text-zinc-100 truncate" title={job.label}>{job.label}</span>
+        {fileCount > 0 && (
+          <span className="ml-auto shrink-0 text-[8px] font-mono text-zinc-500 tabular-nums">
+            file {Math.min(job.current_file + 1, fileCount)} of {fileCount}
+          </span>
+        )}
+      </div>
+
+      {isError ? (
+        <DownloadError detail={job.error_detail ?? ''} repoId={job.error_repo_id ?? undefined} />
+      ) : (
+        <>
+          {file?.filename && (
+            <div className="text-[8px] font-mono text-zinc-500 truncate mb-1" title={file.filename}>
+              {file.filename}
+            </div>
+          )}
+          <div
+            role="progressbar"
+            aria-label={`${job.label} download progress`}
+            aria-valuenow={pct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            className="h-1.5 w-full rounded-full bg-white/5 overflow-hidden"
+          >
+            <div
+              className={`h-full rounded-full transition-[width] duration-300 ${isDone ? 'bg-emerald-400' : 'bg-purple-400'}`}
+              style={{ width: `${isDone ? 100 : pct}%` }}
+            />
+          </div>
+          <div className="flex items-center gap-2 mt-1 text-[8px] font-mono text-zinc-500 tabular-nums">
+            <span>{formatBytes(bytesDone)} / {formatBytes(bytesTotal)}</span>
+            {job.status === 'downloading' && <span className="text-purple-300">{formatSpeed(file?.speed ?? 0)}</span>}
+            {isDone && <span className="text-emerald-300">done</span>}
+            {job.dest_dir && (
+              <span className="ml-auto truncate text-zinc-600" title={job.dest_dir}>{job.dest_dir}</span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+const DownloadError: React.FC<{ detail: string; repoId?: string }> = ({ detail, repoId }) => {
+  const info = classifyDownloadError(detail, repoId);
+  return (
+    <div className="rounded border border-rose-500/30 bg-rose-500/5 px-2 py-1.5">
+      <div className="text-[9px] font-black uppercase tracking-widest text-rose-300">{info.headline}</div>
+      <p className="mt-0.5 text-[8px] leading-relaxed text-rose-200/80">{info.fix}</p>
+      {info.repoUrl && (
+        <a
+          href={info.repoUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-1 inline-flex items-center gap-1 text-[8px] font-mono text-rose-300 hover:text-rose-100 transition-colors"
+        >
+          <ExternalLink className="w-2.5 h-2.5" /> Open model page
+        </a>
+      )}
+    </div>
+  );
+};
+
+export default DownloadDock;

--- a/frontend/src/components/layout/SettingsModal.tsx
+++ b/frontend/src/components/layout/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Settings, X, Package, RefreshCw, AlertTriangle, ToggleLeft, ToggleRight, Activity, Scissors, Music, Power, CheckCircle2, AlertCircle, PowerOff, ChevronRight, LayoutGrid, HardDrive, Heart, ExternalLink, Monitor, Globe, UserCircle, Plus, Eye, EyeOff, Loader2 } from 'lucide-react';
+import { Settings, X, Package, RefreshCw, AlertTriangle, ToggleLeft, ToggleRight, Activity, Scissors, Music, Power, CheckCircle2, AlertCircle, PowerOff, ChevronRight, LayoutGrid, HardDrive, Heart, ExternalLink, Monitor, Globe, UserCircle, Plus, Eye, EyeOff, Download, Loader2 } from 'lucide-react';
 import { useFeatureToggleStore } from '../../state/featureToggleStore';
 import {
   addCheckpoint, fetchCheckpoints, fetchHfCache, fetchLocations, fetchModelStatus, formatBytes,
@@ -13,6 +13,7 @@ import { PathInput } from '../ui/PathInput';
 import { InfoTip } from '../ui/Tooltip';
 import { useSunoStore } from '../../suno/sunoStore';
 import { useModuleStore, type ModuleConfig } from '../../state/moduleStore';
+import { useDownloadStore } from '../../state/downloadStore';
 
 /* Shared type scale — kept legible (nothing below 9px) and a touch brighter than
  * the old zinc-600/700 greys, which read as background noise. */
@@ -699,6 +700,11 @@ const ModelProviderCard: React.FC<{ provider: ModelProviderStatus }> = ({ provid
   const ordered = [...models].sort((a, b) => Number(Boolean(b.recommended)) - Number(Boolean(a.recommended)));
   const visible = ordered.slice(0, 3);
   const hidden = Math.max(0, ordered.length - visible.length);
+  // Stable Audio "download" chips become live download triggers. The dock owns
+  // all progress/error state — these chips only fire the request and read job
+  // status for a compact in-place indicator.
+  const downloadJobs = useDownloadStore((s) => s.jobs);
+  const startDownload = useDownloadStore((s) => s.startDownload);
   return (
     <article className={`min-w-0 rounded border border-white/8 bg-white/3 px-1.5 py-1 ${isSuno ? 'col-span-2' : ''}`} title={provider.summary}>
       <div className="flex items-center gap-1.5">
@@ -711,15 +717,36 @@ const ModelProviderCard: React.FC<{ provider: ModelProviderStatus }> = ({ provid
         <div className="mt-1"><SunoKeyInput /></div>
       ) : visible.length > 0 ? (
         <div className="mt-1 flex flex-wrap gap-1">
-          {visible.map((model) => (
-            <span
-              key={model.id}
-              title={modelTooltip(model)}
-              className={`max-w-full truncate rounded border px-1 py-px text-[9px] font-mono ${modelSourceClass(model.source)}`}
-            >
-              {model.recommended ? '★ ' : ''}{model.label}
-            </span>
-          ))}
+          {visible.map((model) => {
+            const isDownloadable = provider.id === 'stable' && model.source === 'download';
+            if (isDownloadable) {
+              const job = downloadJobs.find((j) => j.name === model.id);
+              const downloading = job?.status === 'downloading' || job?.status === 'queued';
+              return (
+                <button
+                  key={model.id}
+                  type="button"
+                  onClick={() => void startDownload(model.id)}
+                  disabled={downloading}
+                  aria-label={`Download ${model.label} model`}
+                  title={modelTooltip(model)}
+                  className={`inline-flex items-center gap-1 max-w-full truncate rounded border px-1 py-px text-[9px] font-mono transition-colors ${modelSourceClass(model.source)} hover:bg-purple-500/15 hover:border-purple-400/50 hover:text-purple-100 disabled:cursor-default disabled:opacity-80`}
+                >
+                  {downloading ? <Loader2 className="w-2 h-2 animate-spin shrink-0" /> : <Download className="w-2 h-2 shrink-0" />}
+                  <span className="truncate">{model.recommended ? '★ ' : ''}{model.label}</span>
+                </button>
+              );
+            }
+            return (
+              <span
+                key={model.id}
+                title={modelTooltip(model)}
+                className={`max-w-full truncate rounded border px-1 py-px text-[9px] font-mono ${modelSourceClass(model.source)}`}
+              >
+                {model.recommended ? '★ ' : ''}{model.label}
+              </span>
+            );
+          })}
           {hidden > 0 && <span className="rounded border border-white/10 px-1 py-px text-[9px] font-mono text-zinc-400">+{hidden}</span>}
         </div>
       ) : null}

--- a/frontend/src/components/layout/Shell.tsx
+++ b/frontend/src/components/layout/Shell.tsx
@@ -9,6 +9,7 @@ import { LogBody, LogActionButton, LogStripCompactInfo } from './ProcessingLog';
 import { BottomMultiTabPanel } from './BottomMultiTabPanel';
 import { DocsModal } from './DocsModal';
 import { SettingsModal } from './SettingsModal';
+import { DownloadDock } from './DownloadDock';
 import { useAppUiStore } from '../../state/appUiStore';
 import { useBottomPanelStore } from '../../state/bottomPanelStore';
 
@@ -316,6 +317,10 @@ export const Shell: React.FC = () => {
         </div>
       )}
       <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      {/* Floating model-download manager — fixed bottom-right, self-hiding when
+          there are no downloads. Mounted once at the app root so it floats over
+          every view. */}
+      <DownloadDock />
     </div>
   );
 };

--- a/frontend/src/lib/modelDownloadClient.ts
+++ b/frontend/src/lib/modelDownloadClient.ts
@@ -1,0 +1,139 @@
+// Model download client — thin fetch wrappers over /api/models for the
+// download manager. Backs the floating DownloadDock and the Settings model
+// chips that trigger a checkpoint download.
+//
+// API contract (backend, snake_case JSON):
+//   POST /api/models/{name}/download   -> { job_id, name, status }
+//   GET  /api/models/downloads         -> { jobs: DownloadJob[] }
+//   POST /api/models/downloads/clear   -> { cleared: number }
+
+export type DownloadJobStatus = 'queued' | 'downloading' | 'done' | 'error';
+
+export interface DownloadFile {
+  filename: string;
+  bytes_done: number;
+  bytes_total: number;
+  speed: number;
+  done: boolean;
+}
+
+export interface DownloadJob {
+  id: string;
+  name: string;
+  repo_id: string;
+  label: string;
+  status: DownloadJobStatus;
+  files: DownloadFile[];
+  current_file: number;
+  dest_dir: string;
+  error_detail: string | null;
+  error_repo_id: string | null;
+}
+
+interface DownloadsResponse {
+  jobs?: DownloadJob[];
+}
+
+/** Read the backend's `detail` field (FastAPI error shape) if present. */
+async function readDetail(res: Response): Promise<string | null> {
+  try {
+    const body = (await res.json()) as { detail?: unknown } | null;
+    const detail = body?.detail;
+    return typeof detail === 'string' ? detail : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Kick off a model download. The dock owns all progress/error state — this
+ * resolves once the backend has accepted (queued) the job; the poll loop
+ * surfaces it on the next tick.
+ */
+export async function startModelDownload(name: string): Promise<void> {
+  const res = await fetch(`/api/models/${encodeURIComponent(name)}/download`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    const detail = await readDetail(res);
+    throw new Error(detail ?? `HTTP ${res.status}`);
+  }
+}
+
+/** Fetch the current download jobs (queued / downloading / done / error). */
+export async function fetchDownloads(): Promise<DownloadJob[]> {
+  const res = await fetch('/api/models/downloads');
+  if (!res.ok) {
+    const detail = await readDetail(res);
+    throw new Error(detail ?? `HTTP ${res.status}`);
+  }
+  const data = (await res.json()) as DownloadsResponse;
+  return data.jobs ?? [];
+}
+
+/** Clear finished/errored jobs from the backend registry. */
+export async function clearDownloads(): Promise<void> {
+  const res = await fetch('/api/models/downloads/clear', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    const detail = await readDetail(res);
+    throw new Error(detail ?? `HTTP ${res.status}`);
+  }
+}
+
+export interface ClassifiedDownloadError {
+  kind: 'network' | 'disk' | 'gated' | 'unknown';
+  headline: string;
+  fix: string;
+  repoUrl?: string;
+}
+
+/**
+ * Map a raw backend error detail to an actionable, human-readable cause + fix.
+ *
+ * ORDER MATTERS: a network failure can contain words that also appear in a
+ * gated-access error (e.g. a "connection" reset while hitting a 403-style
+ * path), so network is tested FIRST and gated LAST so a transient network
+ * error is never misreported as a permissions problem.
+ */
+export function classifyDownloadError(detail: string, repoId?: string): ClassifiedDownloadError {
+  const text = detail ?? '';
+
+  // 1. Network — transient connectivity / DNS / retry exhaustion.
+  if (/timeout|timed out|connection|temporarily|network|getaddrinfo|max retries|connreset/i.test(text)) {
+    return {
+      kind: 'network',
+      headline: 'network error',
+      fix: 'Check your internet connection, then retry.',
+    };
+  }
+
+  // 2. Disk — out of space on the cache drive.
+  if (/no space|enospc|errno 28|disk full/i.test(text)) {
+    return {
+      kind: 'disk',
+      headline: 'not enough disk space',
+      fix: 'Free up space on the Hugging Face cache drive, then retry.',
+    };
+  }
+
+  // 3. Gated — auth / access not granted to the repo.
+  if (/gated|401|403|unauthorized|authenticated|repository not found|restricted|awaiting a review|accept the/i.test(text)) {
+    return {
+      kind: 'gated',
+      headline: 'access not granted (gated model)',
+      fix: 'Open the model page, sign in, click “Agree and access”, then set HF_TOKEN. Retry after access is granted.',
+      repoUrl: repoId ? `https://huggingface.co/${repoId}` : undefined,
+    };
+  }
+
+  // 4. Unknown — surface the raw detail so the user has something to act on.
+  return {
+    kind: 'unknown',
+    headline: 'download failed',
+    fix: text || 'Unknown error — retry, or check the backend log.',
+  };
+}

--- a/frontend/src/lib/modelDownloadClient.ts
+++ b/frontend/src/lib/modelDownloadClient.ts
@@ -84,11 +84,16 @@ export async function clearDownloads(): Promise<void> {
   }
 }
 
+export interface DownloadErrorLink {
+  label: string;
+  url: string;
+}
+
 export interface ClassifiedDownloadError {
   kind: 'network' | 'disk' | 'rate_limit' | 'not_found' | 'gated' | 'unknown';
   headline: string;
   fix: string;
-  repoUrl?: string;
+  links?: DownloadErrorLink[];
 }
 
 /**
@@ -141,7 +146,7 @@ export function classifyDownloadError(detail: string, repoId?: string): Classifi
       kind: 'not_found',
       headline: "That file isn't in this repo",
       fix: 'The checkpoint may be published under a different name or not released yet — open the repo to check its files.',
-      repoUrl,
+      links: repoUrl ? [{ label: 'Open repo', url: repoUrl }] : undefined,
     };
   }
 
@@ -154,8 +159,11 @@ export function classifyDownloadError(detail: string, repoId?: string): Classifi
     return {
       kind: 'gated',
       headline: 'Access not granted (gated model)',
-      fix: 'Sign in to Hugging Face, open the model page and click “Agree and access”, then set an HF_TOKEN for that account and retry. If you already have access, double-check the repo name.',
-      repoUrl,
+      fix: 'You need access first: sign in to Hugging Face, request access on the model page (click "Agree and access"), then create a token and set it as HF_TOKEN. Retry once approved.',
+      links: [
+        ...(repoUrl ? [{ label: 'Request access', url: repoUrl }] : []),
+        { label: 'Create HF token', url: 'https://huggingface.co/settings/tokens' },
+      ],
     };
   }
 
@@ -165,6 +173,6 @@ export function classifyDownloadError(detail: string, repoId?: string): Classifi
     kind: 'unknown',
     headline: 'Download failed',
     fix: firstLine || 'Unknown error — retry, or check the backend log for details.',
-    repoUrl,
+    links: repoUrl ? [{ label: 'Open repo', url: repoUrl }] : undefined,
   };
 }

--- a/frontend/src/lib/modelDownloadClient.ts
+++ b/frontend/src/lib/modelDownloadClient.ts
@@ -85,55 +85,86 @@ export async function clearDownloads(): Promise<void> {
 }
 
 export interface ClassifiedDownloadError {
-  kind: 'network' | 'disk' | 'gated' | 'unknown';
+  kind: 'network' | 'disk' | 'rate_limit' | 'not_found' | 'gated' | 'unknown';
   headline: string;
   fix: string;
   repoUrl?: string;
 }
 
 /**
- * Map a raw backend error detail to an actionable, human-readable cause + fix.
+ * Map a raw backend error into a clean headline + a concrete solution.
  *
- * ORDER MATTERS: a network failure can contain words that also appear in a
- * gated-access error (e.g. a "connection" reset while hitting a 403-style
- * path), so network is tested FIRST and gated LAST so a transient network
- * error is never misreported as a permissions problem.
+ * ORDER MATTERS. Transient causes (network/disk/rate-limit) are tested first so
+ * a blip is never mislabeled as a permissions problem. Critically, Hugging Face
+ * reports BOTH "this file isn't in the repo" (`Entry Not Found`) and "you can't
+ * access this repo" (`Repository Not Found`) as HTTP 404 — so those two are
+ * matched by exact phrase and kept distinct, because the fix differs.
  */
 export function classifyDownloadError(detail: string, repoId?: string): ClassifiedDownloadError {
   const text = detail ?? '';
+  const repoUrl = repoId ? `https://huggingface.co/${repoId}` : undefined;
 
   // 1. Network — transient connectivity / DNS / retry exhaustion.
-  if (/timeout|timed out|connection|temporarily|network|getaddrinfo|max retries|connreset/i.test(text)) {
+  if (
+    /timeout|timed out|connection|temporarily|unreachable|getaddrinfo|max retries|connreset|name (or service )?not known|failed to (establish|resolve)/i.test(
+      text,
+    )
+  ) {
     return {
       kind: 'network',
-      headline: 'network error',
-      fix: 'Check your internet connection, then retry.',
+      headline: "Can't reach Hugging Face",
+      fix: 'Check your internet connection (or VPN/proxy), then click the chip to retry.',
     };
   }
 
   // 2. Disk — out of space on the cache drive.
-  if (/no space|enospc|errno 28|disk full/i.test(text)) {
+  if (/no space|enospc|errno 28|disk (is )?full|not enough space/i.test(text)) {
     return {
       kind: 'disk',
-      headline: 'not enough disk space',
-      fix: 'Free up space on the Hugging Face cache drive, then retry.',
+      headline: 'Not enough disk space',
+      fix: 'Free up room on the Hugging Face cache drive (defaults to your user profile), then retry.',
     };
   }
 
-  // 3. Gated — auth / access not granted to the repo.
-  if (/gated|401|403|unauthorized|authenticated|repository not found|restricted|awaiting a review|accept the/i.test(text)) {
+  // 3. Rate limited by the Hub.
+  if (/\b429\b|too many requests|rate limit/i.test(text)) {
+    return {
+      kind: 'rate_limit',
+      headline: 'Hugging Face is rate-limiting',
+      fix: 'Wait a minute, then retry. Setting an HF_TOKEN raises the download limit.',
+    };
+  }
+
+  // 4. File missing — the repo is reachable but this file is not in it.
+  if (/entry not found|file not found|does not exist/i.test(text)) {
+    return {
+      kind: 'not_found',
+      headline: "That file isn't in this repo",
+      fix: 'The checkpoint may be published under a different name or not released yet — open the repo to check its files.',
+      repoUrl,
+    };
+  }
+
+  // 5. Gated / no access — license not accepted, or no token for a gated repo.
+  if (
+    /gated|\b401\b|\b403\b|unauthorized|not authorized|must be authenticated|authentication|repository not found|restricted|awaiting (a )?review|agree to access|accept the (license|conditions)|access to this/i.test(
+      text,
+    )
+  ) {
     return {
       kind: 'gated',
-      headline: 'access not granted (gated model)',
-      fix: 'Open the model page, sign in, click “Agree and access”, then set HF_TOKEN. Retry after access is granted.',
-      repoUrl: repoId ? `https://huggingface.co/${repoId}` : undefined,
+      headline: 'Access not granted (gated model)',
+      fix: 'Sign in to Hugging Face, open the model page and click “Agree and access”, then set an HF_TOKEN for that account and retry. If you already have access, double-check the repo name.',
+      repoUrl,
     };
   }
 
-  // 4. Unknown — surface the raw detail so the user has something to act on.
+  // 6. Unknown — surface a trimmed first line so there is something to act on.
+  const firstLine = text.trim().split('\n')[0].slice(0, 160);
   return {
     kind: 'unknown',
-    headline: 'download failed',
-    fix: text || 'Unknown error — retry, or check the backend log.',
+    headline: 'Download failed',
+    fix: firstLine || 'Unknown error — retry, or check the backend log for details.',
+    repoUrl,
   };
 }

--- a/frontend/src/state/downloadStore.ts
+++ b/frontend/src/state/downloadStore.ts
@@ -1,0 +1,106 @@
+/**
+ * Model download store — drives the floating DownloadDock.
+ *
+ * The dock is the single owner of download progress/error state. Settings
+ * model chips are thin triggers: they call `startDownload(name)` and read job
+ * status for display, but never poll or hold their own busy/error state.
+ *
+ * Lifecycle:
+ *   - `startDownload` POSTs the job, then ensures the poll loop is running.
+ *   - The poll loop (~1s) calls `refresh()` while ANY job is queued/downloading.
+ *   - When no job is active it STOPS the interval but KEEPS the jobs in state,
+ *     so finished/errored rows persist for the user to read and clear.
+ *   - A page reload naturally drops the store (= a fresh session): the dock is
+ *     empty again until the next download starts.
+ */
+import { create } from 'zustand';
+import {
+  clearDownloads,
+  fetchDownloads,
+  startModelDownload,
+  type DownloadJob,
+} from '../lib/modelDownloadClient';
+
+const POLL_INTERVAL_MS = 1000;
+
+/** True while the job still has work the poll loop should follow. */
+const isActive = (job: DownloadJob): boolean =>
+  job.status === 'queued' || job.status === 'downloading';
+
+interface DownloadStore {
+  jobs: DownloadJob[];
+  expanded: boolean;
+  /** Internal: whether the poll interval is currently running. */
+  _polling: boolean;
+  /** Internal: handle for the active poll interval (guards double-intervals). */
+  _timer: ReturnType<typeof setInterval> | null;
+
+  /** Trigger a download for `name`, then ensure the poll loop is running. */
+  startDownload: (name: string) => Promise<void>;
+  /** Pull the latest jobs from the backend into state. */
+  refresh: () => Promise<void>;
+  /** Clear finished/errored jobs on the backend, then refresh. */
+  clear: () => Promise<void>;
+  setExpanded: (expanded: boolean) => void;
+  /** Internal: start the poll loop if not already running. */
+  _ensurePolling: () => void;
+  /** Internal: stop the poll loop (jobs are kept in state). */
+  _stopPolling: () => void;
+}
+
+export const useDownloadStore = create<DownloadStore>((set, get) => ({
+  jobs: [],
+  expanded: false,
+  _polling: false,
+  _timer: null,
+
+  startDownload: async (name) => {
+    // Open the dock so the user immediately sees the job arrive on next poll.
+    set({ expanded: true });
+    await startModelDownload(name);
+    get()._ensurePolling();
+    // Surface the queued job right away rather than waiting a full tick.
+    void get().refresh();
+  },
+
+  refresh: async () => {
+    try {
+      const jobs = await fetchDownloads();
+      set({ jobs });
+      // Once nothing is active, stop polling but keep the rows on screen.
+      if (!jobs.some(isActive)) get()._stopPolling();
+    } catch {
+      // Transient fetch failure (e.g. backend restarting) — keep the last
+      // known jobs and let the next tick retry. Don't tear down the dock.
+    }
+  },
+
+  clear: async () => {
+    try {
+      await clearDownloads();
+      await get().refresh();
+    } catch {
+      // Fall back to dropping finished/errored rows locally so the UI still
+      // reflects the user's intent even if the backend call failed.
+      set((state) => ({ jobs: state.jobs.filter(isActive) }));
+    }
+    // Nothing left to follow once cleared.
+    if (!get().jobs.some(isActive)) get()._stopPolling();
+  },
+
+  setExpanded: (expanded) => set({ expanded }),
+
+  _ensurePolling: () => {
+    if (get()._polling || get()._timer) return; // guard against double-intervals
+    const timer = setInterval(() => {
+      void get().refresh();
+    }, POLL_INTERVAL_MS);
+    set({ _polling: true, _timer: timer });
+  },
+
+  _stopPolling: () => {
+    const { _timer } = get();
+    if (_timer) clearInterval(_timer);
+    set({ _polling: false, _timer: null });
+  },
+}));

--- a/tests/test_modeldl.py
+++ b/tests/test_modeldl.py
@@ -8,6 +8,7 @@ deterministic without sleeping on a fixed delay.
 
 from __future__ import annotations
 
+import io
 import threading
 import time
 
@@ -68,8 +69,9 @@ def test_download_valid_name_reaches_done(client, monkeypatch):
 
     def fake_download(*, repo_id, filename, **kwargs):
         calls.append((repo_id, filename))
-        # tqdm_class must be forwarded so live progress works in production.
-        assert kwargs.get("tqdm_class") is modeldl._JobTqdm
+        # A job-bound _JobTqdm subclass must be forwarded so live progress works.
+        tqdm_class = kwargs.get("tqdm_class")
+        assert tqdm_class is not None and issubclass(tqdm_class, modeldl._JobTqdm)
         return f"/fake/cache/{repo_id}/{filename}"
 
     monkeypatch.setattr(modeldl, "hf_hub_download", fake_download)
@@ -153,3 +155,47 @@ def test_clear_removes_finished_jobs(client, monkeypatch):
 
     jobs = client.get("/api/models/downloads").json()["jobs"]
     assert all(j["id"] != job_id for j in jobs)
+
+
+def test_jobtqdm_publishes_from_foreign_thread():
+    """Live progress must update even when tqdm.update() runs on a different
+    thread than the worker — as huggingface_hub's Xet backend does. This fails
+    with a contextvar-based binding and passes with the job-bound subclass.
+    """
+    job_id = "foreign-thread-job"
+    with modeldl._LOCK:
+        modeldl._REGISTRY[job_id] = {
+            "id": job_id,
+            "name": "x",
+            "repo_id": "x/x",
+            "label": "X",
+            "status": "downloading",
+            "files": [
+                {
+                    "filename": "f",
+                    "bytes_done": 0,
+                    "bytes_total": 0,
+                    "speed": 0.0,
+                    "done": False,
+                }
+            ],
+            "current_file": 0,
+            "dest_dir": "",
+            "error_detail": None,
+            "error_repo_id": None,
+        }
+    try:
+        bar = modeldl._bound_tqdm(job_id)(total=100, file=io.StringIO())
+        # Drive update() from a foreign thread; a contextvar would not carry here.
+        worker = threading.Thread(target=lambda: bar.update(40))
+        worker.start()
+        worker.join()
+        bar.close()
+
+        with modeldl._LOCK:
+            entry = modeldl._REGISTRY[job_id]["files"][0]
+        assert entry["bytes_done"] == 40
+        assert entry["bytes_total"] == 100
+    finally:
+        with modeldl._LOCK:
+            modeldl._REGISTRY.pop(job_id, None)

--- a/tests/test_modeldl.py
+++ b/tests/test_modeldl.py
@@ -1,0 +1,155 @@
+"""Tests for the model-download job registry (backend.modules.modeldl.router).
+
+``huggingface_hub.hf_hub_download`` is monkeypatched in the router namespace so
+no network call or weight download ever happens. The download pool is real, so
+each test that starts a job polls for the terminal state with a timeout to stay
+deterministic without sleeping on a fixed delay.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.modules.modeldl import router as modeldl
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """A TestClient over an app that mounts only the modeldl router.
+
+    The registry is reset before and after each test so jobs never leak between
+    cases (it is module-global, shared with the live app).
+    """
+    with modeldl._LOCK:
+        modeldl._REGISTRY.clear()
+
+    app = FastAPI()
+    app.include_router(modeldl.router, prefix="/api/models")
+    with TestClient(app) as test_client:
+        yield test_client
+
+    with modeldl._LOCK:
+        modeldl._REGISTRY.clear()
+
+
+def _wait_for_status(
+    client: TestClient, job_id: str, target: str, timeout: float = 5.0
+):
+    """Poll GET /downloads until the job reaches ``target`` or ``timeout`` elapses."""
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        jobs = client.get("/api/models/downloads").json()["jobs"]
+        last = next((j for j in jobs if j["id"] == job_id), None)
+        if last is not None and last["status"] == target:
+            return last
+        time.sleep(0.02)
+    raise AssertionError(
+        f"job {job_id} did not reach {target!r} within {timeout}s; last={last!r}"
+    )
+
+
+def _first_catalog_name() -> str:
+    return next(iter(modeldl.all_models))
+
+
+def test_download_unknown_name_returns_404(client):
+    resp = client.post("/api/models/not-a-real-model/download")
+    assert resp.status_code == 404
+
+
+def test_download_valid_name_reaches_done(client, monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_download(*, repo_id, filename, **kwargs):
+        calls.append((repo_id, filename))
+        # tqdm_class must be forwarded so live progress works in production.
+        assert kwargs.get("tqdm_class") is modeldl._JobTqdm
+        return f"/fake/cache/{repo_id}/{filename}"
+
+    monkeypatch.setattr(modeldl, "hf_hub_download", fake_download)
+
+    name = _first_catalog_name()
+    resp = client.post(f"/api/models/{name}/download")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == name
+    assert body["status"] in {"queued", "downloading", "done"}
+    job_id = body["job_id"]
+    assert job_id
+
+    job = _wait_for_status(client, job_id, "done")
+    # Both the config file and the checkpoint file were fetched, in that order.
+    assert len(calls) == 2
+    assert len(job["files"]) == 2
+    assert all(f["done"] for f in job["files"])
+    assert job["dest_dir"]
+    assert job["error_detail"] is None
+
+
+def test_duplicate_download_while_live_returns_same_job(client, monkeypatch):
+    release = threading.Event()
+    entered = threading.Event()
+
+    def blocking_download(*, repo_id, filename, **kwargs):
+        # Hold the worker inside the first file so the job stays "downloading"
+        # for the duration of the duplicate POST, forcing the dedup path.
+        entered.set()
+        assert release.wait(timeout=5.0), "test never released the blocked download"
+        return f"/fake/cache/{repo_id}/{filename}"
+
+    monkeypatch.setattr(modeldl, "hf_hub_download", blocking_download)
+
+    name = _first_catalog_name()
+    first = client.post(f"/api/models/{name}/download").json()
+    assert entered.wait(timeout=5.0), "worker never started the download"
+
+    second = client.post(f"/api/models/{name}/download").json()
+    assert second["job_id"] == first["job_id"]
+    assert second["status"] in {"queued", "downloading"}
+
+    # Exactly one job exists for this name while it is live.
+    jobs = client.get("/api/models/downloads").json()["jobs"]
+    live = [j for j in jobs if j["name"] == name]
+    assert len(live) == 1
+
+    release.set()
+    _wait_for_status(client, first["job_id"], "done")
+
+
+def test_download_error_path_records_detail(client, monkeypatch):
+    def boom(*, repo_id, filename, **kwargs):
+        raise RuntimeError("network exploded")
+
+    monkeypatch.setattr(modeldl, "hf_hub_download", boom)
+
+    name = _first_catalog_name()
+    job_id = client.post(f"/api/models/{name}/download").json()["job_id"]
+
+    job = _wait_for_status(client, job_id, "error")
+    assert job["status"] == "error"
+    assert job["error_detail"] == "network exploded"
+    assert job["error_repo_id"] == modeldl._repo_id(modeldl.all_models[name])
+
+
+def test_clear_removes_finished_jobs(client, monkeypatch):
+    monkeypatch.setattr(
+        modeldl,
+        "hf_hub_download",
+        lambda *, repo_id, filename, **kwargs: f"/fake/{repo_id}/{filename}",
+    )
+
+    name = _first_catalog_name()
+    job_id = client.post(f"/api/models/{name}/download").json()["job_id"]
+    _wait_for_status(client, job_id, "done")
+
+    cleared = client.post("/api/models/downloads/clear").json()
+    assert cleared["cleared"] == 1
+
+    jobs = client.get("/api/models/downloads").json()["jobs"]
+    assert all(j["id"] != job_id for j in jobs)


### PR DESCRIPTION
## What

Adds an on-demand model **Download Manager** — fetch Stable Audio checkpoints from Settings, with a floating, draggable progress dock. Fully additive: the backend auto-mounts as a module, the frontend hooks into the existing Settings model chips.

## Backend — `backend/modules/modeldl` (auto-mounts at `/api/models`)

- `POST /{name}/download` — race-free check-and-set; rejoins a live job instead of starting a duplicate.
- `GET /downloads` — session job registry with live per-file bytes + transfer speed, captured via a custom `hf_hub_download` `tqdm_class`. The job id is bound to the tqdm subclass (not a contextvar) so progress also works under HuggingFace's **Xet** backend, which drives `update()` from a native thread. Runs on a dedicated 2-worker pool.
- `POST /downloads/clear` — drop finished/errored jobs (registry caps retained terminal jobs at 25; executor torn down via `atexit`).

## Frontend

- Floating **draggable** `DownloadDock` (bottom-right, lifted clear of the bottom dock): collapsed pill ↔ expandable per-model rows with progress bar, speed, size, file counter, destination. Finished rows persist until cleared.
- Download errors are classified into clean, actionable messages — **network / disk / rate-limit / file-not-found / gated** — each with a concrete fix and the right links (request access on the model page, create an HF token).
- Settings model chips with `source=download` become download triggers, kept compatible with the newer compact card / Suno-key layout on `main`.

## Tests / checks

- `tests/test_modeldl.py`: 404, happy-path → done, live dedup, error path, clear, plus a foreign-thread progress test that locks in the Xet fix — **6/6 pass**.
- `ruff check` / `format` clean; `tsc -b` clean (rebased on the latest `main`).

## Notes

- Rebased onto the newest `main`; the single `SettingsModal.tsx` overlap (compact model card + Suno key field) was merged to keep both behaviors.
- The download UI is verified at the data level (endpoints + job/error pipeline); a real non-gated end-to-end download has not been visually QA'd.
