### PR TITLE
fix(electron): disable HW accel + open windowed (black screen / forced fullscreen)

### DIFF
--- a/electron-ui/main/index.ts
+++ b/electron-ui/main/index.ts
@@ -515,12 +515,6 @@ protocol.registerSchemesAsPrivileged([
   },
 ])
 
-// Some Windows GPU drivers crash Electron's GPU process (exit_code=34), which
-// leaves the window unable to composite — a black screen. Disabling hardware
-// acceleration forces software compositing so the renderer always paints.
-// Must be called before the app is ready.
-app.disableHardwareAcceleration()
-
 app.whenReady().then(async () => {
   registerIpcHandlers()
 

--- a/electron-ui/main/index.ts
+++ b/electron-ui/main/index.ts
@@ -367,8 +367,8 @@ function createWindow(): void {
     minWidth: 960,
     minHeight: 640,
     title: 'theDAW',
-    // Open full screen, per spec.
-    fullscreen: true,
+    // Open windowed at the default size (reverted from forced fullscreen).
+    fullscreen: false,
     // Paint solid black immediately so there's no white window flash before
     // content loads — one continuous black background from the first frame to
     // the app (matches index.html's <body> + the boot splash).
@@ -514,6 +514,12 @@ protocol.registerSchemesAsPrivileged([
     },
   },
 ])
+
+// Some Windows GPU drivers crash Electron's GPU process (exit_code=34), which
+// leaves the window unable to composite — a black screen. Disabling hardware
+// acceleration forces software compositing so the renderer always paints.
+// Must be called before the app is ready.
+app.disableHardwareAcceleration()
 
 app.whenReady().then(async () => {
   registerIpcHandlers()


### PR DESCRIPTION
## What & why

Two desktop-shell fixes in `electron-ui/main/index.ts`:

1. **`app.disableHardwareAcceleration()`** — on this Windows GPU setup the Electron GPU process crashed repeatedly (`gpu_process_host … exit_code=34`), leaving the window unable to composite — a **black screen**. Forcing software compositing makes the renderer paint.
2. **`fullscreen: false`** — revert the forced fullscreen added in `ec5c459` ("electron fullscreen"); the window opens windowed at the default 1400×900 as before.

## Tradeoff to weigh

Disabling hardware acceleration is the *guaranteed* black-screen fix, but it makes **all** GPU compositing software — the VJ tab's WebGL will run slower. If preserving the GPU matters, a narrower switch (`--disable-gpu-sandbox` or `--use-angle=gl`) may fix `exit_code=34` while keeping acceleration, but those are driver-dependent and need testing. Led with the reliable fix.

## Scope

Separate from the Magenta tools PR (#64) by request.