### PR TITLE
feat(akvj/mix/convert): native + monocular point-cloud VJ sources, MIX live rack, Convert menus

### DIFF
--- a/backend/modules/akvj/__init__.py
+++ b/backend/modules/akvj/__init__.py
@@ -1,0 +1,1 @@
+"""AKVJ — generic Unity-desktop -> VJ video bridge (MJPEG over WebSocket)."""

--- a/backend/modules/akvj/kinect_sidecar.py
+++ b/backend/modules/akvj/kinect_sidecar.py
@@ -1,0 +1,279 @@
+"""Headless Azure Kinect (K4A) capture sidecar for the native ``akvj3d`` path.
+
+Opens the Azure Kinect directly with pyk4a, builds a one-time XY unprojection ray
+table, and streams to the akvj relay's ``/ws/source``:
+
+  * a one-time XY table (sent on connect + a slow heartbeat), chunked into
+    row-blocks so each WebSocket message stays under the 1 MB default cap; and
+  * per frame, depth16 (640x576) + the depth-aligned colour as JPEG.
+
+The VJ ``akvj3d`` source unprojects ``position = (rayX, rayY, 1) * depthMeters``
+in a vertex shader and renders the point cloud, so the look lives in the browser.
+
+Wire format (little-endian), matching backend/modules/akvj/router.py and the VJ
+``useAkvj3d`` parser:
+
+  Table chunk:  '<4sBBHHHH' magic="AKV1" type=1 version=1 W H rowStart rowCount
+                + float32[rowCount*W*2]   (rayX, rayY interleaved, row-major)
+  Frame:        '<4sBBHHBBII' magic="AKV1" type=2 version=1 W H
+                depthEnc colorEnc depthLen colorLen
+                + depth bytes (uint16 LE mm) + colour bytes (JPEG RGB)
+
+Speaks structured JSON status lines on stdout for the sidecar manager:
+  {"status": "device", ...} once the camera opens
+  {"status": "streaming", "fps": N, ...} periodically
+  {"status": "error", "message": ...} on any fatal problem
+
+Windows x64 / Linux x64 only. pyk4a-bundle ships the matched k4a/depthengine
+native DLLs, so nothing else has to be installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import os
+import struct
+import sys
+import time
+
+MAGIC = b"AKV1"
+MSG_TABLE = 1
+MSG_FRAME = 2
+VERSION = 1
+DEPTH_ENC_RAW_U16 = 0
+COLOR_ENC_JPEG = 0
+ROWS_PER_CHUNK = 64  # 64 * 640 * 2 * 4 = 327 KB/chunk, safely under the 1 MB cap
+TABLE_HEARTBEAT_SEC = 5.0
+OPEN_ATTEMPTS = 5  # retry device-open so a brief webcam/other-app hold rides out
+OPEN_RETRY_SEC = 1.0
+
+
+def emit(**kw) -> None:
+    """Write one structured status line to stdout for the sidecar manager."""
+    sys.stdout.write(json.dumps(kw) + "\n")
+    sys.stdout.flush()
+
+
+def _fps_enum(fps_int: int):
+    from pyk4a import FPS
+
+    if fps_int <= 5:
+        return FPS.FPS_5, 5
+    if fps_int <= 15:
+        return FPS.FPS_15, 15
+    return FPS.FPS_30, 30
+
+
+def build_xy_table(calibration, width: int, height: int):
+    """Per-pixel ray slopes (rayX, rayY) with position = (rayX, rayY, 1)*depth.
+
+    Built once from k4a's 2d->3d unprojection at a reference depth, so the browser
+    only needs depth per frame. Invalid pixels get (0, 0) and render at the origin
+    (the shader discards zero-depth points anyway). Emits progress because the
+    per-pixel build takes a few seconds and would otherwise look like a hang."""
+    import numpy as np
+    from pyk4a import CalibrationType
+
+    table = np.zeros((height, width, 2), dtype="<f4")
+    ref_mm = 1000.0
+    step = max(1, height // 10)
+    valid = 0
+    for y in range(height):
+        for x in range(width):
+            try:
+                p = calibration.convert_2d_to_3d(
+                    (x, y), ref_mm, CalibrationType.DEPTH, CalibrationType.DEPTH
+                )
+            except Exception:  # noqa: BLE001 — invalid pixel, leave (0,0)
+                continue
+            if p is None:
+                continue
+            z = float(p[2])
+            if z <= 1e-3:
+                continue
+            table[y, x, 0] = float(p[0]) / z
+            table[y, x, 1] = float(p[1]) / z
+            valid += 1
+        if y % step == 0 or y == height - 1:
+            emit(
+                status="building_table",
+                percent=round((y + 1) * 100 / height),
+                rows=y + 1,
+                total=height,
+            )
+    emit(status="table_ready", valid_pixels=valid, total_pixels=width * height)
+    return table
+
+
+def pack_table_chunks(table, width: int, height: int):
+    """Yield one AKV1 table-chunk message per row-block."""
+    for row in range(0, height, ROWS_PER_CHUNK):
+        rows = min(ROWS_PER_CHUNK, height - row)
+        header = struct.pack(
+            "<4sBBHHHH", MAGIC, MSG_TABLE, VERSION, width, height, row, rows
+        )
+        payload = table[row : row + rows].tobytes()
+        yield header + payload
+
+
+def encode_color_jpeg(transformed_color, quality: int) -> bytes:
+    """BGRA (H,W,4) depth-aligned colour -> JPEG (RGB) bytes."""
+    from PIL import Image
+
+    rgb = transformed_color[:, :, :3][:, :, ::-1]  # BGRA -> RGB
+    img = Image.fromarray(rgb, "RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=quality)
+    return buf.getvalue()
+
+
+def pack_frame(width, height, depth_bytes, color_bytes) -> bytes:
+    header = struct.pack(
+        "<4sBBHHBBII",
+        MAGIC,
+        MSG_FRAME,
+        VERSION,
+        width,
+        height,
+        DEPTH_ENC_RAW_U16,
+        COLOR_ENC_JPEG,
+        len(depth_bytes),
+        len(color_bytes),
+    )
+    return header + depth_bytes + color_bytes
+
+
+async def run() -> None:
+    import numpy as np
+    import websockets
+    from pyk4a import ColorResolution, Config, DepthMode, ImageFormat, PyK4A
+
+    ws_url = os.getenv("AKVJ_WS_URL", "ws://127.0.0.1:8600/api/akvj/ws/source")
+    quality = int(os.getenv("AKVJ_COLOR_QUALITY", "70"))
+    fps_req = int(os.getenv("AKVJ_FPS", "30"))
+    fps_enum, fps_n = _fps_enum(fps_req)
+
+    emit(
+        status="opening", ws_url=ws_url, fps=fps_n, color="720p", depth="NFOV_UNBINNED"
+    )
+
+    k4a = PyK4A(
+        Config(
+            color_resolution=ColorResolution.RES_720P,
+            color_format=ImageFormat.COLOR_BGRA32,
+            depth_mode=DepthMode.NFOV_UNBINNED,  # 640x576
+            camera_fps=fps_enum,
+            synchronized_images_only=True,
+        )
+    )
+    opened = False
+    for attempt in range(1, OPEN_ATTEMPTS + 1):
+        try:
+            k4a.start()
+            opened = True
+            emit(status="opened", attempt=attempt)
+            break
+        except Exception as e:  # noqa: BLE001 — device open failed (in use / unplugged)
+            detail = f"{type(e).__name__}: {e}".strip().rstrip(": ")
+            emit(
+                status="opening",
+                attempt=attempt,
+                attempts=OPEN_ATTEMPTS,
+                retrying=attempt < OPEN_ATTEMPTS,
+                note=(
+                    f"open failed ({detail or 'no detail'}); the sensor may still be "
+                    "releasing from the DEVICE/webcam path or held by another app"
+                ),
+            )
+            if attempt < OPEN_ATTEMPTS:
+                time.sleep(OPEN_RETRY_SEC)
+    if not opened:
+        emit(
+            status="error",
+            message=(
+                f"could not open the Azure Kinect after {OPEN_ATTEMPTS} tries. Check it "
+                "is on a USB 3.0 port, powered with its own supply, and not held by the "
+                "DEVICE/webcam source, k4aviewer, Unity Akvj, or another app. A fresh "
+                "sensor may also need a one-time firmware update."
+            ),
+        )
+        return
+
+    width, height = 640, 576
+    emit(
+        status="device",
+        width=width,
+        height=height,
+        depth_mode="NFOV_UNBINNED",
+        fps=fps_n,
+    )
+
+    emit(
+        status="building_table",
+        percent=0,
+        note="one-time XY unprojection table (a few seconds)",
+    )
+    table = build_xy_table(k4a.calibration, width, height)
+    table_msgs = list(pack_table_chunks(table, width, height))
+    emit(status="table_packed", chunks=len(table_msgs))
+
+    loop = asyncio.get_event_loop()
+    frames = 0
+    fps_t0 = time.monotonic()
+    fps_count = 0
+
+    emit(status="connecting", ws_url=ws_url)
+    try:
+        async with websockets.connect(
+            ws_url, max_size=None, ping_interval=20, ping_timeout=20
+        ) as ws:
+            emit(status="relay_connected", ws_url=ws_url)
+            for m in table_msgs:
+                await ws.send(m)
+            last_table = time.monotonic()
+            emit(
+                status="streaming", fps=0, frames=0, note="sending depth+colour frames"
+            )
+
+            while True:
+                capture = await loop.run_in_executor(None, k4a.get_capture)
+                depth = capture.depth
+                color = capture.transformed_color
+                if depth is None or color is None:
+                    continue
+
+                depth_bytes = np.ascontiguousarray(depth, dtype="<u2").tobytes()
+                color_bytes = encode_color_jpeg(color, quality)
+                await ws.send(pack_frame(width, height, depth_bytes, color_bytes))
+
+                frames += 1
+                fps_count += 1
+                now = time.monotonic()
+                if now - fps_t0 >= 2.0:
+                    fps = round(fps_count / (now - fps_t0))
+                    emit(status="streaming", fps=fps, frames=frames)
+                    fps_t0 = now
+                    fps_count = 0
+                if now - last_table >= TABLE_HEARTBEAT_SEC:
+                    for m in table_msgs:
+                        await ws.send(m)
+                    last_table = now
+    except Exception as e:  # noqa: BLE001 — relay closed / device error mid-stream
+        emit(status="error", message=f"stream ended: {e}")
+    finally:
+        try:
+            k4a.stop()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(run())
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:  # noqa: BLE001
+        emit(status="error", message=str(e))
+        sys.exit(1)

--- a/backend/modules/akvj/module.json
+++ b/backend/modules/akvj/module.json
@@ -1,0 +1,10 @@
+{
+  "name": "akvj",
+  "label": "AKVJ Bridge",
+  "enabled": true,
+  "icon": "Camera",
+  "sidebar": false,
+  "api_prefix": "/api/akvj",
+  "backend": true,
+  "description": "Generic Unity-desktop -> VJ video bridge. A Unity app (e.g. Akvj, the Azure-Kinect depth VFX visualizer) JPEG-encodes its camera each frame and pushes the frames over a WebSocket to /api/akvj/ws/source; this module fans them out to every VJ viewer on /api/akvj/ws/view (MJPEG, no native encoder or codec license). The transport is frame-agnostic, so the same bridge serves any Unity desktop visual and could carry H.264 later without backend changes. Disable to skip it."
+}

--- a/backend/modules/akvj/router.py
+++ b/backend/modules/akvj/router.py
@@ -1,0 +1,231 @@
+"""FastAPI router for the AKVJ module — a Unity-desktop / native-Kinect -> VJ bridge.
+
+Two senders feed the same relay, and the relay forwards their binary messages
+verbatim, so it never has to understand the payload:
+
+1. The legacy MJPEG path (Unity Akvj, the maximal-look techie hatch): a Unity
+   desktop app JPEG-encodes its rendered view each frame and pushes the frames to
+   ``/ws/source``. The VJ ``useAkvj`` hook decodes them as a flat video.
+
+2. The native ``akvj3d`` path (the idiotproof default): a headless Python sidecar
+   (pyk4a) opens the Azure Kinect directly and streams a one-time XY unprojection
+   table plus per-frame depth16 + depth-aligned color, framed with a small ``AKV1``
+   header. The VJ ``useAkvj3d`` hook unprojects that into a live three.js point
+   cloud, so the VJ deck owns the look (re-light, point size, noise displacement,
+   audio reactivity) instead of receiving pre-rendered pixels.
+
+The relay only peeks at the 5-byte ``AKV1`` header to tell the two table-chunk
+messages (which a late-joining viewer must be primed with) apart from frames. A
+plain JPEG frame has no ``AKV1`` magic, so the MJPEG path is unaffected.
+
+Endpoints (prefix /api/akvj):
+    GET  /status      source/viewer/frame counters
+    GET  /sidecar     native Kinect sidecar lifecycle state
+    POST /start       lazily spawn the native Kinect sidecar (guarded)
+    POST /stop        stop the native Kinect sidecar
+    WS   /ws/source   the sender: binary messages are JPEG frames or AKV1 frames
+    WS   /ws/view     a VJ viewer: primed with the XY table + latest frame
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Optional
+
+from fastapi import APIRouter, Body, WebSocket, WebSocketDisconnect
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(tags=["akvj"])
+
+# Native-path framing. A message is an AKV1 message when it starts with this
+# magic; byte 4 is the message type. Type 1 = XY unprojection table chunk (the
+# relay caches these so late joiners can rebuild the full table); any other type
+# (2 = depth+color frame) is treated like a plain frame and only the latest is
+# kept. A legacy MJPEG JPEG frame lacks the magic and falls through to "frame".
+_MAGIC = b"AKV1"
+_MSG_TABLE = 1
+
+
+def _is_table_chunk(data: bytes) -> bool:
+    return len(data) >= 5 and data[:4] == _MAGIC and data[4] == _MSG_TABLE
+
+
+def _table_row_start(data: bytes) -> Optional[int]:
+    """rowStart field of an AKV1 table chunk header (uint16 LE at offset 10).
+
+    Header: 4s magic, B type, B version, H width, H height, H rowStart, H rowCount.
+    """
+    if len(data) < 14:
+        return None
+    return int.from_bytes(data[10:12], "little")
+
+
+class _State:
+    viewers: set[WebSocket] = set()
+    source: Optional[WebSocket] = None
+    latest: Optional[bytes] = None  # most recent frame (JPEG or AKV1), for priming
+    # XY table chunks keyed by rowStart, so a late-joining viewer can be primed
+    # with the whole table without waiting for the next heartbeat resend.
+    table_chunks: dict[int, bytes] = {}
+    frames: int = 0
+    last_frame_at: float = 0.0
+
+
+_s = _State()
+
+
+def source_connected() -> bool:
+    """Whether a sender currently holds /ws/source. Used by the sidecar start
+    guard so it never spawns a second process that would fight for the USB
+    device that a running Unity Akvj (or a remote Kinect PC) already owns."""
+    return _s.source is not None
+
+
+async def _broadcast(frame: bytes) -> None:
+    if not _s.viewers:
+        return
+    dead: list[WebSocket] = []
+    for ws in list(_s.viewers):
+        try:
+            await ws.send_bytes(frame)
+        except Exception:  # noqa: BLE001 — viewer went away mid-send
+            dead.append(ws)
+    for d in dead:
+        _s.viewers.discard(d)
+
+
+@router.get("/status")
+async def get_status() -> dict[str, Any]:
+    now = time.monotonic()
+    return {
+        "source_connected": _s.source is not None,
+        "viewers": len(_s.viewers),
+        "frames": _s.frames,
+        "have_frame": _s.latest is not None,
+        "have_table": len(_s.table_chunks) > 0,
+        "table_chunks": len(_s.table_chunks),
+        "stale_ms": int((now - _s.last_frame_at) * 1000) if _s.last_frame_at else None,
+    }
+
+
+@router.get("/sidecar")
+def sidecar_status() -> dict[str, Any]:
+    """Native Kinect sidecar lifecycle state (separate from the relay counters)."""
+    from .sidecar import get_sidecar
+
+    return get_sidecar().status()
+
+
+@router.post("/start")
+def start(payload: dict[str, Any] = Body(default={})) -> dict[str, Any]:
+    """Lazily spawn the native Kinect sidecar.
+
+    Idempotent: if OUR sidecar is already running, reuse it and return its status
+    (selecting the Kinect source again must not respawn or report contention). Only
+    refuse when a FOREIGN source (a running Unity Akvj or a remote Kinect PC) holds
+    the relay, since the local sidecar would fight it for the USB device. The body
+    may carry {ws_url?, fps?} overrides for the techie escape hatch."""
+    from .sidecar import get_sidecar
+
+    sc = get_sidecar()
+    # Our own sidecar is already up -> idempotent reuse. This is the fix for the
+    # "device in use everywhere" report: re-selecting the Kinect source used to see
+    # the sidecar's own relay connection as contention and refuse.
+    if sc.running:
+        st = sc.status()
+        st["ok"] = True
+        st["reused"] = True
+        return st
+    # A foreign source already holds the relay/device; refuse cleanly.
+    if source_connected():
+        return {
+            "ok": False,
+            "error": (
+                "A foreign source is already streaming to this relay (Unity Akvj or "
+                "a remote Kinect feed). Stop it before starting the local Kinect "
+                "sidecar so they do not fight for the device."
+            ),
+            "source_connected": True,
+        }
+    overrides = payload if isinstance(payload, dict) else {}
+    return sc.start(overrides)
+
+
+@router.post("/stop")
+def stop() -> dict[str, Any]:
+    from .sidecar import get_sidecar
+
+    return get_sidecar().stop()
+
+
+@router.websocket("/ws/source")
+async def ws_source(websocket: WebSocket) -> None:
+    """The sender (Unity MJPEG or the native Kinect sidecar). Binary messages are
+    frames; text is ignored (keepalive). Only one source is active at a time — a
+    reconnecting sender supersedes the previous one and resets the cached table."""
+    await websocket.accept()
+    prev = _s.source
+    _s.source = websocket
+    # A fresh source means a fresh (or no) XY table; drop the previous one so a
+    # stale table from an earlier session cannot mis-place the new cloud.
+    _s.table_chunks = {}
+    if prev is not None and prev is not websocket:
+        try:
+            await prev.close()
+        except Exception:  # noqa: BLE001
+            pass
+    log.info("akvj: source connected")
+    try:
+        while True:
+            msg = await websocket.receive()
+            if msg.get("type") == "websocket.disconnect":
+                break
+            data = msg.get("bytes")
+            if data is None:
+                continue  # ignore stray text frames (keepalive, etc.)
+            if _is_table_chunk(data):
+                row = _table_row_start(data)
+                if row is not None:
+                    _s.table_chunks[row] = data
+                await _broadcast(data)
+                continue
+            _s.latest = data
+            _s.frames += 1
+            _s.last_frame_at = time.monotonic()
+            await _broadcast(data)
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:  # noqa: BLE001 — sender went away mid-frame
+        log.debug("akvj: source error: %s", e)
+    finally:
+        if _s.source is websocket:
+            _s.source = None
+        log.info("akvj: source disconnected")
+
+
+@router.websocket("/ws/view")
+async def ws_view(websocket: WebSocket) -> None:
+    """A VJ viewer. Primed with the cached XY table chunks (native path) then the
+    latest frame, so it can rebuild the cloud immediately on a late join."""
+    await websocket.accept()
+    _s.viewers.add(websocket)
+    try:
+        for row in sorted(_s.table_chunks):
+            await websocket.send_bytes(_s.table_chunks[row])
+        if _s.latest is not None:
+            await websocket.send_bytes(_s.latest)
+    except Exception:  # noqa: BLE001 — viewer went away immediately
+        _s.viewers.discard(websocket)
+        return
+    try:
+        # One-way (source -> viewer); await to detect the viewer closing.
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:  # noqa: BLE001
+        log.debug("akvj: viewer error: %s", e)
+    finally:
+        _s.viewers.discard(websocket)

--- a/backend/modules/akvj/sidecar.py
+++ b/backend/modules/akvj/sidecar.py
@@ -1,0 +1,268 @@
+"""Native Kinect sidecar manager for the akvj module.
+
+Owns the lifecycle of ``kinect_sidecar.py`` — a headless pyk4a capture process
+that opens the Azure Kinect directly and streams a one-time XY unprojection table
+plus per-frame depth16 + depth-aligned color to the akvj relay's ``/ws/source``.
+The VJ ``akvj3d`` source then renders the point cloud natively in three.js, so no
+Unity is needed in the default path.
+
+This module is just process lifecycle + diagnostics, mirroring the questcast
+sidecar: it bootstraps the capture deps on first run (pyk4a-bundle ships its own
+matched k4a/depthengine DLLs, so nothing else has to be installed), spawns the
+script with ``sys.executable``, and parses its structured stdout so the API can
+report device/streaming/error state and a rolling log.
+
+Windows x64 and Linux x64 only (the Azure Kinect SDK native stack; pyk4a-bundle
+publishes no macOS wheel).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+LOG_RING_SIZE = 400
+SCRIPT = Path(__file__).resolve().parent / "kinect_sidecar.py"
+BOOTSTRAP_TIMEOUT_SEC = 600.0
+READY_TIMEOUT_SEC = 30.0
+
+# Capture deps. pyk4a-bundle carries its OWN matched k4a.dll + depthengine, so the
+# user installs nothing else. numpy/websockets ship with the backend already;
+# pillow encodes the colour frames to JPEG.
+PIP_PACKAGES = ["pyk4a-bundle", "websockets", "numpy", "pillow"]
+IMPORT_PROBE = "import pyk4a, numpy, websockets, PIL"
+
+# Sidecar stdout status values that describe its lifecycle; the manager mirrors
+# each one into its reported state so the UI can show the real progression rather
+# than a single opaque "starting".
+LIFECYCLE_STATES = {
+    "opening",
+    "opened",
+    "device",
+    "building_table",
+    "table_packed",
+    "table_ready",
+    "connecting",
+    "relay_connected",
+    "streaming",
+    "error",
+}
+
+
+def _default_ws_url() -> str:
+    explicit = os.getenv("theDAW_AKVJ_WS_URL")
+    if explicit:
+        return explicit
+    port = os.getenv("theDAW_PORT") or os.getenv("PORT") or "8600"
+    return f"ws://127.0.0.1:{port}/api/akvj/ws/source"
+
+
+class AkvjSidecar:
+    """One instance per process. ``start()`` is idempotent."""
+
+    def __init__(self) -> None:
+        self._proc: Optional[subprocess.Popen] = None
+        self._reader: Optional[threading.Thread] = None
+        self._lock = threading.RLock()
+        self._status: dict[str, Any] = {"state": "stopped"}
+        self._log: deque[str] = deque(maxlen=LOG_RING_SIZE)
+
+    def _record(self, line: str) -> None:
+        stamp = time.strftime("%H:%M:%S")
+        self._log.append(f"{stamp} {line}")
+        log.info("akvj-sidecar: %s", line)
+
+    # ---- diagnostics --------------------------------------------------------
+
+    @property
+    def running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "running": self.running,
+                "platform": sys.platform,
+                "supported": sys.platform in ("win32", "linux"),
+                "python": sys.executable,
+                "script": str(SCRIPT),
+                "script_present": SCRIPT.is_file(),
+                "deps_installed": self._deps_present(),
+                "log": list(self._log),
+                **self._status,
+            }
+
+    # ---- bootstrap ----------------------------------------------------------
+
+    def _deps_present(self) -> bool:
+        try:
+            r = subprocess.run(
+                [sys.executable, "-c", IMPORT_PROBE],
+                capture_output=True,
+                timeout=30,
+            )
+            return r.returncode == 0
+        except (subprocess.TimeoutExpired, OSError):
+            return False
+
+    def _ensure_deps(self) -> Optional[str]:
+        if self._deps_present():
+            return None
+        self._record("installing Kinect capture deps (one-time)...")
+        # Prefer uv (the project's resolver); fall back to pip in the venv.
+        attempts = [
+            ["uv", "pip", "install", *PIP_PACKAGES],
+            [sys.executable, "-m", "pip", "install", *PIP_PACKAGES],
+        ]
+        last_err = ""
+        for cmd in attempts:
+            try:
+                r = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=BOOTSTRAP_TIMEOUT_SEC,
+                )
+            except (subprocess.TimeoutExpired, OSError) as e:
+                last_err = f"{cmd[0]}: {e}"
+                continue
+            if r.returncode == 0 and self._deps_present():
+                self._record(f"deps installed via {cmd[0]}")
+                return None
+            last_err = (r.stderr or r.stdout or "")[-400:]
+            self._record(f"{cmd[0]} install failed: {last_err}")
+        return f"could not install Kinect capture deps: {last_err}"
+
+    # ---- lifecycle ----------------------------------------------------------
+
+    def _read_stdout(self, proc: subprocess.Popen) -> None:
+        assert proc.stdout is not None
+        for raw in proc.stdout:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except ValueError:
+                with self._lock:
+                    self._record(f"[sidecar raw] {line}")
+                continue
+            status = msg.get("status")
+            with self._lock:
+                detail = {k: v for k, v in msg.items() if k != "status"}
+                self._record(
+                    f"[sidecar] {status}"
+                    + (f" {json.dumps(detail, default=str)}" if detail else "")
+                )
+                if status in LIFECYCLE_STATES:
+                    self._status = {"state": status, **msg}
+        with self._lock:
+            rc = proc.poll()
+            self._record(f"[sidecar] process exited (rc={rc})")
+            if self._status.get("state") not in ("error", "stopped"):
+                self._status = {"state": "stopped", "reason": f"exited (rc={rc})"}
+
+    def start(self, overrides: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+        overrides = overrides or {}
+        with self._lock:
+            if self.running:
+                self._record("start() ignored, sidecar already running")
+                return self.status()
+
+            if sys.platform not in ("win32", "linux"):
+                msg = (
+                    f"the native Kinect sidecar needs Windows or Linux x64 "
+                    f"(this is {sys.platform}). Run the Unity Akvj path instead, "
+                    f"or point at a remote Kinect PC."
+                )
+                self._status = {"state": "error", "message": msg}
+                self._record(f"ABORT: {msg}")
+                return {"ok": False, "error": msg}
+
+            if not SCRIPT.is_file():
+                msg = f"capture script missing: {SCRIPT}"
+                self._status = {"state": "error", "message": msg}
+                self._record(f"ABORT: {msg}")
+                return {"ok": False, "error": msg}
+
+            self._record("ensuring capture deps...")
+            err = self._ensure_deps()
+            if err:
+                self._status = {"state": "error", "message": err}
+                self._record(f"ABORT: {err}")
+                return {"ok": False, "error": err}
+
+            env = dict(os.environ)
+            env["AKVJ_WS_URL"] = str(overrides.get("ws_url") or _default_ws_url())
+            if overrides.get("fps"):
+                env["AKVJ_FPS"] = str(overrides["fps"])
+            if overrides.get("color_quality"):
+                env["AKVJ_COLOR_QUALITY"] = str(overrides["color_quality"])
+
+            self._status = {"state": "starting"}
+            self._record(f"spawning sidecar: {SCRIPT.name} -> {env['AKVJ_WS_URL']}")
+            try:
+                self._proc = subprocess.Popen(
+                    [sys.executable, "-u", str(SCRIPT)],
+                    cwd=str(SCRIPT.parent),
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,
+                )
+            except OSError as e:
+                self._status = {"state": "error", "message": str(e)}
+                self._record(f"ABORT: spawn failed: {e}")
+                return {"ok": False, "error": str(e)}
+
+            self._record(f"sidecar process started (pid={self._proc.pid})")
+            self._reader = threading.Thread(
+                target=self._read_stdout, args=(self._proc,), daemon=True
+            )
+            self._reader.start()
+
+        deadline = time.monotonic() + READY_TIMEOUT_SEC
+        while time.monotonic() < deadline:
+            if not self.running:
+                break
+            with self._lock:
+                state = self._status.get("state")
+            if state in ("streaming", "error"):
+                break
+            time.sleep(0.25)
+        return self.status()
+
+    def stop(self) -> dict[str, Any]:
+        with self._lock:
+            proc = self._proc
+            self._proc = None
+            self._status = {"state": "stopped"}
+            self._record("stop() requested, terminating sidecar")
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        return {"ok": True, "state": "stopped"}
+
+
+_sidecar: Optional[AkvjSidecar] = None
+
+
+def get_sidecar() -> AkvjSidecar:
+    global _sidecar
+    if _sidecar is None:
+        _sidecar = AkvjSidecar()
+    return _sidecar

--- a/docs/plans/2026-06-24-akvj-volcap-roadmap.md
+++ b/docs/plans/2026-06-24-akvj-volcap-roadmap.md
@@ -1,0 +1,125 @@
+# akvj3d -> general volumetric-video engine: roadmap
+
+Status: living plan. Created 2026-06-24 from a multi-agent brainstorm. Not in RAG.
+
+## The thesis
+
+`AkvjCloudRenderer` (the VJ app, `src/akvj/AkvjCloudRenderer.ts`) does not care where
+`rayX / rayY / depth / color` come from. It unprojects `pos = (rayX, -rayY, 1) * depth`
+in a vertex shader, then applies the style behaviours (drift / evaporate / swirl /
+scatter / wireframe) with `bass/mid/high/volume` already wired in. So the move is to
+**stop treating depth as a sensor feature and start treating it as a texture any source
+can produce**. Decouple the renderer from the Kinect and every video, webcam, screen
+capture, or phone frame can drive it.
+
+## What already shipped (this session)
+
+- Native Kinect path: pyk4a sidecar (depth16 + depth-aligned colour over the AKV1
+  WebSocket) -> `AkvjCloudRenderer` point cloud. Backend relay table-chunk aware,
+  idempotent `/start`, verbose sidecar status, viewer connects direct to the backend
+  (the dev proxy drops `/api` WS upgrades).
+- Style system + behaviours: POINTS, DUST, FLOW, SWIRL (vortex), SCATTER (beat
+  explosion), NEONVOX (voxel evaporation), WIRE (Battlezone green wireframe via
+  `LineSegments`, gap-collapsed), ELECTRIC, FERRO, CHROME (fixed, controlled metal),
+  CONFETTI. Camera spin slider (0 = frozen face-on). Audio reactivity through all of it.
+
+## The headline next unlock: depth-ify any video (no depth camera)
+
+Run a monocular depth model (Depth-Anything-V2) in the browser via transformers.js +
+WebGPU, in a Web Worker, on ANY source frame, synthesize a depth texture, build a
+one-time pinhole ray-table (`rayX = (u-0.5)*tanHalfFov*aspect`, `rayY = (v-0.5)*tanHalfFov`),
+and feed the EXISTING renderer. Every clip in the library becomes a live, re-shadeable,
+audio-reactive point cloud with zero new shader code.
+
+Hard requirements (non-negotiable):
+- Inference runs OFF the main thread (Web Worker) at reduced resolution (256-384px) and
+  ~10-15fps, DECOUPLED from the 60fps render loop (GPU-upscale the depth texture), or the
+  deck stutters.
+- Temporally smooth the depth (EMA) because Depth-Anything output is RELATIVE/affine and
+  flickers frame-to-frame. It is a stylized look, never a measurement.
+- Pin the model id + transformers.js API from the LIVE HuggingFace / library source of
+  truth, never from memory (CLAUDE.md hard rule).
+
+Reuse: `useDepthCloud.ts` builds a synthesized pinhole ray-table once, then per frame maps
+the model's normalized depth into the pseudo-mm range and calls the SAME
+`AkvjCloudRenderer.setXYTable` / `pushFrame`. Add `cameraSource='depthcloud'` to the VJ
+`types.ts` union + `useMedia`. The same STYLE selector + spin slider apply for free.
+
+## Volcap transport on web/mobile
+
+1. ENCODE: backend export bakes an akvj3d capture into ONE ordinary `.mp4` with Depthkit
+   "Combined Per Pixel" layout (colour one half, HUE-encoded depth the other) + a sidecar
+   JSON carrying the ray-table / intrinsics + near/far. Use the UCL/Hwang periodic
+   triangle/sawtooth hue depth encoding (NOT naive hi/lo byte split, which H.264 DCT +
+   4:2:0 chroma subsampling destroys); clamp near/far tight.
+2. PLAY: replace the per-frame `createImageBitmap` + CPU `mm->m` DataTexture rebuild with a
+   WebCodecs `VideoDecoder` feeding `VideoFrame` straight to a GPU texture (demux via
+   mp4box.js). Hardware-decoded H.264/HEVC/AV1, near-zero CPU, 30-60fps at 1080p. Vertex
+   shader unchanged. This is the single biggest "lower video overhead" win.
+3. SPLAT tier: load `.splat/.ply/.ksplat` via a FOSS WebGL viewer (antimatter15/splat,
+   mkkellogg GaussianSplats3D) now; WebGPU/TSL radix-sort compute upgrade later. Baked
+   photoreal captures into the same VJ rack via `captureStream()`.
+
+Budgets: live clouds 100-150k points mobile / 300-600k desktop; baked splats <3M mobile /
+<5M desktop. WebGPU on iOS 26 / Chrome Android 12+; keep a WebGL2 + decimation fallback.
+Remote viewers via the existing WebRTC broadcast module (depth+color mp4 as a normal track,
+reconstructed on-device).
+
+## ASCILINE (D:\StableAudio\ASCILINE)
+
+Luminance-to-glyph video engine (FastAPI + OpenCV + Canvas2D). NOT line-art (gap to close).
+Genuinely reusable piece: its adaptive frame codec (`codec.py`/`codec.js`: RAW/ZLIB/DELTA
+conditional-replenishment, keyframe every 48, ~375x on static content; char plane exact,
+colour plane lossy). License: MIT + anti-advertisement clause -> vendor with attribution,
+port only the algorithm/palette/codec, never the slow Canvas2D `fillText` path.
+
+Folds in three ways:
+1. GPU ASCII source/effect: port `AsciiMapper.convert` to a GLSL pass with the 93-char ramp
+   as a glyph-atlas texture; add `cameraSource='asciiline'` + an `asciiMode` token mirroring
+   `akvjMode`. Re-renders any upstream texture as live typography at full framerate.
+2. Depth-aware ASCII: pick the glyph by `depthMeters` instead of luminance (near = dense
+   `@#%`, far = sparse `.` space) for a self-shading volumetric ASCII portrait; drive glyph
+   font-size from depth + bass (the "dynamic font-size" idea). LOD: fall back to dots when
+   glyph quads go sub-pixel.
+3. Transport: adopt the codec for VJ thumbnails, watch-link/questcast feeds, weak devices.
+
+## Audio-reactivity (depth-native, mostly 2-3 uniform tweaks)
+
+Already: `gl_PointSize *= 0.7+bass*0.6`, displacement `*= 0.15+volume*0.85`, ferro spike
+scales with bass, frag brightness `*= 0.85+high*0.6`. Extend with: bass depth-push
+(breathing cloud, scale depth by `1+bass*k`), beat-triggered scatter/evaporate (bass-onset
+derivative spikes displacement ~200ms), spectral color (bass->R mid->G high->B), beat-synced
+decimation (drop/restore density on transients), high-band glyph jitter (ASCII), mid->hue
+rotation.
+
+## Recommended roadmap (each shippable, smallest valuable first)
+
+- P0 Audio-reactivity pack (shader-only). MOSTLY DONE this session (scatter/evaporate/
+  wireframe-flicker + reactivity); remaining: bass depth-push + spectral RGB mode + per-style
+  intensity control.
+- P1 Depth-ify any clip (monocular depth). THE HEADLINE, no hardware. `useDepthCloud.ts` +
+  reuse `AkvjCloudRenderer`; Depth-Anything-V2-small via transformers.js WebGPU worker,
+  EMA-smoothed, synth pinhole ray-table, `cameraSource='depthcloud'`.
+- P2 Wireframe (DONE) + depth-edge line-art (Sobel/DoG on the DEPTH buffer -> contour glyphs).
+- P3 WebCodecs depth+color playback + backend depth-in-video `.mp4` export.
+- P4 ASCILINE GPU source + dynamic-font-size; adopt its codec as a low-overhead transport.
+- P5 Mobile + remote volcap: stream depth+color mp4 to phones over WebRTC; accept phone-as-
+  source over AKV1 (ARKit/ARCore or on-device monocular) with intrinsics added to the header.
+- P6 Splat fidelity tier + WebGPU/TSL compute port of `AkvjCloudRenderer` (toward ~1M points).
+
+## Risks (honest)
+
+- Monocular depth is relative/affine + flickery; needs EMA + near/far remap; stylized look only.
+- GPU contention: transformers.js inference + three.js cloud + the effect rack share one GPU;
+  inference MUST be a reduced-res worker decoupled from the render loop.
+- Depth-in-video accuracy: chroma subsampling + DCT quantize hue-encoded depth; needs the UCL
+  periodic encoding + tight near/far; HEVC 4:4:4/10-bit helps but Chromium HEVC decode is
+  platform-gated; validate decoded depth error empirically.
+- "Lower overhead" is true ONLY for the stylized point-cloud/ASCII looks; for flat playback,
+  depth+color+reconstruction costs MORE than good H.264. Frame the UI as a "stylized
+  low-overhead source", not "compress all video".
+- ASCILINE is third-party MIT + anti-ad clause: attribute, do not silently absorb, do not
+  copy the Canvas2D renderer.
+- Do NOT pin transformers.js / ORT-Web / three.js / the Depth-Anything model id from memory;
+  fetch the live source of truth first. Every new VJ control needs valid labels/ARIA. None of
+  this is verified until the user sees it live (headless build/tsc do not count).

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-24T15:25:50.353Z · Git revision: `01731e2d8a54` · Repomix tracked: **no**
+> Generated: 2026-06-25T01:57:35.311Z · Git revision: `9cf384cc8384` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-24T15:25:50.353Z",
-  "repoRevision": "01731e2d8a54",
+  "generatedAt": "2026-06-25T01:57:35.311Z",
+  "repoRevision": "9cf384cc8384",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/electron-ui/electron-builder.yml
+++ b/electron-ui/electron-builder.yml
@@ -51,6 +51,11 @@ extraResources:
     to: tools
     filter:
       - "**/*"
+  # Explorer right-click "Convert with theDAW" helper (registered by
+  # resources/installer.nsh). Lands at <install>\resources\convert-with-thedaw.ps1
+  # and resolves the bundled ffmpeg at .\tools\ffmpeg.exe.
+  - from: resources/convert-with-thedaw.ps1
+    to: convert-with-thedaw.ps1
 
 win:
   target:

--- a/electron-ui/resources/convert-with-thedaw.ps1
+++ b/electron-ui/resources/convert-with-thedaw.ps1
@@ -1,0 +1,65 @@
+# theDAW — Explorer right-click convert helper.
+#
+# Invoked by the per-user "Convert with theDAW" context menu (registered in
+# installer.nsh). Converts a single file to the chosen format using the ffmpeg
+# bundled beside this script (resources\tools\ffmpeg.exe), writes the result next
+# to the source, and reveals it in Explorer. Mirrors the in-app /api/convert args.
+param(
+    [Parameter(Mandatory = $true)][string]$Format,
+    [Parameter(Mandatory = $true)][string]$Source
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Show-Error([string]$message) {
+    try {
+        Add-Type -AssemblyName System.Windows.Forms | Out-Null
+        [System.Windows.Forms.MessageBox]::Show($message, 'theDAW Convert', 'OK', 'Error') | Out-Null
+    } catch {
+        Write-Host $message
+    }
+    exit 1
+}
+
+$ffmpeg = Join-Path $PSScriptRoot 'tools\ffmpeg.exe'
+if (-not (Test-Path -LiteralPath $ffmpeg)) { Show-Error "ffmpeg was not found at $ffmpeg" }
+if (-not (Test-Path -LiteralPath $Source)) { Show-Error "Source file not found: $Source" }
+
+$ext = $Format.ToLowerInvariant()
+$dir = Split-Path -Parent $Source
+$base = [System.IO.Path]::GetFileNameWithoutExtension($Source)
+$out = Join-Path $dir "$base.$ext"
+$n = 1
+while (Test-Path -LiteralPath $out) { $out = Join-Path $dir "$base ($n).$ext"; $n++ }
+
+# Format-specific encoder args (kept in step with backend/modules/convert/router.py).
+$ffArgs = @('-hide_banner', '-loglevel', 'error', '-y', '-i', $Source)
+switch ($ext) {
+    'wav'  { $ffArgs += @('-c:a', 'pcm_s16le') }
+    'mp3'  { $ffArgs += @('-c:a', 'libmp3lame', '-q:a', '2', '-vn') }
+    'flac' { $ffArgs += @('-c:a', 'flac', '-vn') }
+    'ogg'  { $ffArgs += @('-c:a', 'libvorbis', '-q:a', '5', '-vn') }
+    'm4a'  { $ffArgs += @('-c:a', 'aac', '-b:a', '256k', '-vn') }
+    'mp4'  { $ffArgs += @('-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-crf', '20', '-c:a', 'aac', '-b:a', '192k') }
+    'mov'  { $ffArgs += @('-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-crf', '20', '-c:a', 'aac', '-b:a', '192k') }
+    'webm' { $ffArgs += @('-c:v', 'libvpx-vp9', '-b:v', '0', '-crf', '32', '-c:a', 'libopus') }
+    'gif'  { $ffArgs += @('-vf', 'fps=12,scale=480:-1:flags=lanczos') }
+    'png'  { $ffArgs += @('-frames:v', '1') }
+    'jpg'  { $ffArgs += @('-frames:v', '1', '-q:v', '3') }
+    'webp' { $ffArgs += @('-frames:v', '1') }
+    default { Show-Error "Unsupported target format: $ext" }
+}
+$ffArgs += $out
+
+try {
+    $proc = Start-Process -FilePath $ffmpeg -ArgumentList $ffArgs -NoNewWindow -Wait -PassThru
+} catch {
+    Show-Error "Could not run ffmpeg: $($_.Exception.Message)"
+}
+
+if ($proc.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $out)) {
+    Show-Error "Conversion to $ext failed (ffmpeg exit $($proc.ExitCode))."
+}
+
+# Reveal the converted file in Explorer.
+Start-Process explorer.exe "/select,`"$out`""

--- a/electron-ui/resources/installer.nsh
+++ b/electron-ui/resources/installer.nsh
@@ -1,0 +1,51 @@
+; theDAW custom NSIS include.
+;
+; electron-builder auto-includes ${buildResources}/installer.nsh (buildResources is
+; "resources" here) and invokes the customInstall / customUnInstall macros. We use
+; them to register a per-user (HKCU, no elevation) "Convert with theDAW" cascading
+; context menu on audio / video / image files. Each sub-item runs the bundled ffmpeg
+; through resources\convert-with-thedaw.ps1.
+
+; Parent cascading entry for a Windows perceived type (audio / video / image).
+; SubCommands "" enables the nested shell\ cascade (the modern submenu pattern).
+!macro ConvParent KIND
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\${KIND}\shell\theDAWConvert" "MUIVerb" "Convert with theDAW"
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\${KIND}\shell\theDAWConvert" "Icon" "$INSTDIR\theDAW.exe,0"
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\${KIND}\shell\theDAWConvert" "SubCommands" ""
+!macroend
+
+; One target-format sub-item under a parent.
+!macro ConvSub KIND ID LABEL FMT
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\${KIND}\shell\theDAWConvert\shell\${ID}" "MUIVerb" "${LABEL}"
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\${KIND}\shell\theDAWConvert\shell\${ID}\command" "" 'powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "$INSTDIR\resources\convert-with-thedaw.ps1" -Format ${FMT} -Source "%1"'
+!macroend
+
+!macro customInstall
+  ; AUDIO files
+  !insertmacro ConvParent "audio"
+  !insertmacro ConvSub "audio" "wav"  "To WAV"  "wav"
+  !insertmacro ConvSub "audio" "mp3"  "To MP3"  "mp3"
+  !insertmacro ConvSub "audio" "flac" "To FLAC" "flac"
+  !insertmacro ConvSub "audio" "ogg"  "To OGG"  "ogg"
+  !insertmacro ConvSub "audio" "m4a"  "To M4A"  "m4a"
+
+  ; VIDEO files
+  !insertmacro ConvParent "video"
+  !insertmacro ConvSub "video" "mp4"  "To MP4"            "mp4"
+  !insertmacro ConvSub "video" "mov"  "To MOV"            "mov"
+  !insertmacro ConvSub "video" "webm" "To WebM"           "webm"
+  !insertmacro ConvSub "video" "gif"  "To GIF"            "gif"
+  !insertmacro ConvSub "video" "mp3"  "Extract audio (MP3)" "mp3"
+
+  ; IMAGE files
+  !insertmacro ConvParent "image"
+  !insertmacro ConvSub "image" "png"  "To PNG"  "png"
+  !insertmacro ConvSub "image" "jpg"  "To JPG"  "jpg"
+  !insertmacro ConvSub "image" "webp" "To WebP" "webp"
+!macroend
+
+!macro customUnInstall
+  DeleteRegKey HKCU "Software\Classes\SystemFileAssociations\audio\shell\theDAWConvert"
+  DeleteRegKey HKCU "Software\Classes\SystemFileAssociations\video\shell\theDAWConvert"
+  DeleteRegKey HKCU "Software\Classes\SystemFileAssociations\image\shell\theDAWConvert"
+!macroend

--- a/frontend/src/catalog/CatalogueContextMenu.tsx
+++ b/frontend/src/catalog/CatalogueContextMenu.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
-  Play, Scissors, Layers, Wand2, PenLine, Download, Trash2, Star, Shuffle, Cloud,
+  Play, Scissors, Layers, Wand2, PenLine, Download, Trash2, Star, Shuffle, Cloud, Repeat, ChevronLeft,
 } from 'lucide-react';
 import type { LibraryEntry } from '../state/libraryEntry';
 import { useLibraryStore } from '../state/libraryStore';
@@ -13,6 +13,8 @@ import {
 import { sunoActions } from '../suno/sunoActions';
 import { HoverTip } from '../components/ui/Tooltip';
 import { playCatalogueEntry } from './CatalogueList';
+import { loadConvertFormats, formatsForKind, convertLibraryEntry } from '../convert/convertClient';
+import type { ConvertFormat } from '../convert/convertClient';
 
 export interface CatalogueContextMenuState {
   x: number;
@@ -59,6 +61,29 @@ export const CatalogueContextMenu: React.FC<Props> = ({ menu, onClose }) => {
   const toggleFavorite = useLibraryStore((s) => s.toggleFavorite);
   const getAudioUrl = useLibraryStore((s) => s.getAudioUrl);
   const fetchAudioBlob = useLibraryStore((s) => s.fetchAudioBlob);
+
+  // Two-stage "Convert to…" — stays inside this menu (the root div stops click
+  // propagation, so switching to the format list doesn't dismiss the menu).
+  const [view, setView] = useState<'root' | 'convert'>('root');
+  const [formats, setFormats] = useState<ConvertFormat[] | null>(null);
+  const [convertMsg, setConvertMsg] = useState<string | null>(null);
+
+  const openConvert = () => {
+    setView('convert');
+    if (formats === null) {
+      // Catalogue entries are audio tracks; offer the audio source-kind targets.
+      loadConvertFormats()
+        .then((cat) => setFormats(formatsForKind(cat, 'audio')))
+        .catch(() => setFormats([]));
+    }
+  };
+
+  const doConvert = (f: ConvertFormat) => {
+    setConvertMsg(`Converting to ${f.label}…`);
+    convertLibraryEntry(entry.id, f, entry.title)
+      .then(() => onClose())
+      .catch((e) => setConvertMsg(`Convert failed: ${e instanceof Error ? e.message : String(e)}`));
+  };
 
   // Dismiss on outside click / Esc / blur.
   useEffect(() => {
@@ -108,9 +133,39 @@ export const CatalogueContextMenu: React.FC<Props> = ({ menu, onClose }) => {
       onContextMenu={(e) => e.preventDefault()}
     >
       <div className="px-3 py-1.5 text-[8px] uppercase tracking-widest text-zinc-600 border-b border-white/5 mb-0.5 truncate">
-        {entry.title}
+        {view === 'convert' ? `Convert · ${entry.title}` : entry.title}
       </div>
 
+      {view === 'convert' ? (
+        <>
+          <button
+            className="w-full text-left px-3 py-1.5 flex items-center gap-1.5 text-zinc-400 hover:bg-purple-500/15 hover:text-zinc-100"
+            onClick={() => { setView('root'); setConvertMsg(null); }}
+          >
+            <ChevronLeft className="w-3 h-3" /> Back
+          </button>
+          <div className="border-t border-white/5 my-0.5" />
+          {formats === null ? (
+            <div className="px-3 py-1.5 text-zinc-500">Loading formats…</div>
+          ) : formats.length === 0 ? (
+            <div className="px-3 py-1.5 text-zinc-500">No conversions available</div>
+          ) : (
+            formats.map((f) => (
+              <button
+                key={f.id}
+                className="w-full text-left px-3 py-1.5 flex items-center gap-1.5 text-zinc-200 hover:bg-purple-500/15"
+                onClick={() => doConvert(f)}
+              >
+                <Repeat className="w-3 h-3" /> {f.label}
+              </button>
+            ))
+          )}
+          {convertMsg && (
+            <div className="px-3 py-1 text-[9px] text-amber-300/90 border-t border-white/5 mt-0.5">{convertMsg}</div>
+          )}
+        </>
+      ) : (
+      <>
       <Item icon={Play} label="Play" tip="Play this track through the global player." onClick={run(() => playCatalogueEntry(entry))} />
       <Item icon={Scissors} label="Send to Editor (append)" tip="Append this audio to the tail of the first editor track." onClick={run(() => sendAudioToEditor(sendable, 'editor-first-track'))} />
       <Item icon={Layers} label="Send to Editor (new track)" tip="Add this audio as a brand-new track in the editor." onClick={run(() => sendAudioToEditor(sendable, 'editor-new-track'))} />
@@ -129,8 +184,11 @@ export const CatalogueContextMenu: React.FC<Props> = ({ menu, onClose }) => {
       <div className="border-t border-white/5 my-0.5" />
       <Item icon={Star} label={entry.favorite ? 'Unfavorite' : 'Favorite'} tip={entry.favorite ? 'Remove from favorites.' : 'Mark as a favorite (star).'} onClick={run(() => toggleFavorite(entry.id))} />
       <Item icon={Download} label="Download" tip="Download the original audio file to your computer." onClick={run(download)} />
+      <Item icon={Repeat} label="Convert to…" tip="Convert this track to another format (WAV, MP3, FLAC, OGG…) via FFmpeg and download it." onClick={openConvert} />
       <div className="border-t border-white/5 my-0.5" />
       <Item icon={Trash2} label="Delete" tip="Permanently delete this entry from the library. Cannot be undone." onClick={run(del)} danger />
+      </>
+      )}
     </div>
   );
 };

--- a/frontend/src/state/mixLiveRack.ts
+++ b/frontend/src/state/mixLiveRack.ts
@@ -1,0 +1,93 @@
+/**
+ * mixLiveRack — routes the MIX tab's psychoacoustic rack (mixRackStore) onto the
+ * global player's master-output insert, so the rack is heard LIVE on the footer
+ * transport (whatever the footer is playing) instead of only via an offline bounce.
+ *
+ * The rack lives on the master insert independently of the loaded source, so
+ * swapping the source / applying a new clip does NOT rebuild it. Effects never
+ * restart, click, or re-initialise (oscillators, autopilot, etc.) when a new clip
+ * is applied. Param tweaks are pushed live and click-free; only an
+ * add/remove/reorder/toggle rebuilds, and unchanged instances are kept across the
+ * rebuild so even that stays click-free.
+ *
+ * Attached once (idempotent) on the first MIX mount and kept for the session — an
+ * empty rack is a clean passthrough, so leaving it attached colours nothing and
+ * costs nothing.
+ */
+import { useMixRackStore } from './mixRackStore';
+import { getEngineCtx, getMasterInsert } from './playerStore';
+import { buildEffectChain, ensureChopModule, type ChainHandle } from '../lib/rackEffects';
+import type { ChainEntry } from './effectChainStore';
+
+let handle: ChainHandle | null = null;
+let unsub: (() => void) | null = null;
+let lastTopo = '';
+let lastFull = '';
+
+/** Topology signature (order + effect + enabled) — a change here forces a rebuild;
+ *  everything else is a click-free param push. */
+const topoSig = (chain: ChainEntry[]): string => {
+  let s = '';
+  for (const e of chain) s += `${e.id}:${e.effect}:${e.enabled ? 1 : 0}|`;
+  return s;
+};
+
+const hasLiveChop = (chain: ChainEntry[]): boolean =>
+  chain.some((e) => e.effect === 'chop' && e.enabled);
+
+/** Rebuild the live chain. If a chop effect is present, preregister its worklet on
+ *  the live context first, then rebuild again so it builds as the real node rather
+ *  than the one-shot passthrough the factory falls back to before the module loads. */
+const rebuild = (chain: ChainEntry[]): void => {
+  if (!handle) return;
+  handle.rebuild(chain);
+  if (hasLiveChop(chain)) {
+    void ensureChopModule(getEngineCtx())
+      .then(() => handle?.rebuild(useMixRackStore.getState().chain))
+      .catch(() => { /* falls back to a clean passthrough */ });
+  }
+};
+
+/** Reconcile the live rack with the store: rebuild on a topology change, otherwise
+ *  push each entry's params live. Cheap no-op when nothing relevant changed. */
+const reconcile = (chain: ChainEntry[]): void => {
+  if (!handle) return;
+  const full = JSON.stringify(chain);
+  if (full === lastFull) return;
+  lastFull = full;
+  const topo = topoSig(chain);
+  if (topo !== lastTopo) {
+    lastTopo = topo;
+    rebuild(chain);
+  } else {
+    for (const e of chain) handle.updateParams(e.id, e.params);
+  }
+};
+
+/** Wire the MIX rack onto the master insert + subscribe to the store. Idempotent,
+ *  so it is safe to call on every MIX mount. Never detaches on its own (the rack is
+ *  a global master insert that should persist across tab switches). */
+export function attachMixLiveRack(): void {
+  if (handle) return;
+  const { ctx, input, output } = getMasterInsert();
+  const chain = useMixRackStore.getState().chain;
+  handle = buildEffectChain(ctx, input, output, chain);
+  lastTopo = topoSig(chain);
+  lastFull = JSON.stringify(chain);
+  if (hasLiveChop(chain)) rebuild(chain);
+  unsub = useMixRackStore.subscribe((s) => reconcile(s.chain));
+}
+
+/** Tear the live rack down and restore the clean insert passthrough. Rarely needed
+ *  (the rack normally persists for the session); provided for completeness/tests. */
+export function detachMixLiveRack(): void {
+  if (unsub) { unsub(); unsub = null; }
+  if (handle) {
+    const { input, output } = getMasterInsert();
+    handle.dispose();
+    handle = null;
+    try { input.connect(output); } catch { /* restore the default passthrough */ }
+  }
+  lastTopo = '';
+  lastFull = '';
+}

--- a/frontend/src/state/playerStore.ts
+++ b/frontend/src/state/playerStore.ts
@@ -8,14 +8,22 @@ import { logError, logInfo } from './logStore';
  * always reflect whatever's audible.
  *
  *   HTMLAudioElement ──┐
- *                      ├──▶ master gain ──▶ analyser ──▶ destination
+ *                      ├──▶ master gain ──▶ [master insert] ──▶ analyser ──▶ destination
  *   editor preview  ───┤
  *   sequencer voices ──┘
+ *
+ * The [master insert] is a passthrough bus (insertIn ─▶ insertOut) sitting on
+ * the summed output. A live effect rack (the MIX psychoacoustic rack) splices
+ * itself between insertIn and insertOut so it processes everything audible on
+ * the footer transport without rebuilding when the source/clip changes.
  */
 
 let _ctx: AudioContext | null = null;
 let _master: GainNode | null = null;
 let _analyser: AnalyserNode | null = null;
+// Master-output insert bus: master -> insertIn -> [rack] -> insertOut -> analyser.
+let _insertIn: GainNode | null = null;
+let _insertOut: GainNode | null = null;
 let _audioEl: HTMLAudioElement | null = null;
 let _mediaSrc: MediaElementAudioSourceNode | null = null;
 let _objectUrl: string | null = null;
@@ -64,7 +72,15 @@ export const ensureEngine = (): EngineHandles => {
   const analyser = ctx.createAnalyser();
   analyser.fftSize = 2048;
   analyser.smoothingTimeConstant = 0.7;
-  master.connect(analyser);
+  // Master-output insert bus: master -> insertIn -> insertOut -> analyser. A live
+  // rack (the MIX psychoacoustic rack) splices itself between insertIn/insertOut
+  // so it processes the full mixed output on the footer transport; the default is
+  // a clean passthrough so audio flows with no rack and with no rack overhead.
+  const insertIn = ctx.createGain();
+  const insertOut = ctx.createGain();
+  master.connect(insertIn);
+  insertIn.connect(insertOut);
+  insertOut.connect(analyser);
   analyser.connect(ctx.destination);
 
   const audioEl = new Audio();
@@ -106,6 +122,8 @@ export const ensureEngine = (): EngineHandles => {
   _ctx = ctx;
   _master = master;
   _analyser = analyser;
+  _insertIn = insertIn;
+  _insertOut = insertOut;
   _audioEl = audioEl;
   _mediaSrc = mediaSrc;
   return { ctx, master, analyser, audioEl };
@@ -115,6 +133,19 @@ export const ensureEngine = (): EngineHandles => {
 export const getMasterGain = (): GainNode => ensureEngine().master;
 export const getAnalyser = (): AnalyserNode => ensureEngine().analyser;
 export const getEngineCtx = (): AudioContext => ensureEngine().ctx;
+
+/**
+ * The master-output insert bus. A live effect rack wires itself between `input`
+ * and `output` — master -> input -> [rack] -> output -> analyser — so it
+ * processes everything audible on the footer transport. The default wiring is a
+ * clean `input -> output` passthrough, so an empty rack colours nothing. The rack
+ * lives on this bus independently of the loaded source, so loading a new clip
+ * never tears it down (see mixLiveRack).
+ */
+export const getMasterInsert = (): { ctx: AudioContext; input: GainNode; output: GainNode } => {
+  ensureEngine();
+  return { ctx: _ctx!, input: _insertIn!, output: _insertOut! };
+};
 
 /**
  * Live transport override. When the EDIT timeline plays through the real-time

--- a/frontend/src/views/MixView.tsx
+++ b/frontend/src/views/MixView.tsx
@@ -19,6 +19,7 @@ import { ModuleThumb } from '../components/audio/ModuleThumb';
 import { ControlSurface } from '../components/surface/ControlSurface';
 import { FxRack } from '../components/audio/FxRack';
 import { useMixRackStore } from '../state/mixRackStore';
+import { attachMixLiveRack } from '../state/mixLiveRack';
 import { buildEffectChain, ensureChopModule, RACK_EFFECTS } from '../lib/rackEffects';
 import { encodeWav } from '../lib/wavEncode';
 import type { WidgetRegistry } from '../components/surface/widgetTypes';
@@ -564,6 +565,11 @@ export const MixView: React.FC = () => {
   const sourceUrl = useMemo(() => (sourceFile ? URL.createObjectURL(sourceFile) : null), [sourceFile]);
   useEffect(() => () => { if (sourceUrl) URL.revokeObjectURL(sourceUrl); }, [sourceUrl]);
 
+  // Wire the psychoacoustic rack onto the footer's master insert so it is heard
+  // LIVE on the transport and is never rebuilt when a new clip is applied. Attached
+  // once for the session; an empty rack is a clean passthrough (see mixLiveRack).
+  useEffect(() => { attachMixLiveRack(); }, []);
+
   useEffect(() => {
     if (!sourceFile) { setSrcStats(null); return; }
     analyzeAudio(sourceFile).then(setSrcStats).catch(() => setSrcStats(null));
@@ -576,6 +582,10 @@ export const MixView: React.FC = () => {
   const setSourceBoth = (file: File | null) => {
     setSource(file);
     useStudioStore.getState().setSourceFile(file);
+    // Bind the MIX working file to the footer transport so pressing Play auditions
+    // it LIVE through the master rack. The rack stays put across source swaps, so a
+    // new clip starts cleanly without tearing down or restarting the effects.
+    if (file) void usePlayerStore.getState().load(file, { label: file.name });
   };
   const handleDrop = async (e: React.DragEvent) => {
     e.preventDefault(); setDragOverSource(false);

--- a/frontend/src/views/VJView.tsx
+++ b/frontend/src/views/VJView.tsx
@@ -14,6 +14,8 @@ import {
   Check,
   Camera,
   CameraOff,
+  Sliders,
+  Glasses,
 } from 'lucide-react';
 
 import { getAnalyser } from '../state/playerStore';
@@ -692,8 +694,8 @@ export const VJView: React.FC = () => {
           <InputChip
             active={vjInputs.mic}
             onToggle={() => toggleVjInput('mic')}
-            label="Mic"
-            icon={<Mic className="w-2.5 h-2.5" />}
+            name="Microphone input"
+            icon={<Mic className="w-3 h-3" />}
             activeLabel="Microphone capture is enabled — VJ iframe will request browser permission on first use."
             inactiveLabel="Microphone input is muted. Click to enable."
             disabled={vjInputs.mic && !vjInputs.audio && !vjInputs.midi}
@@ -701,8 +703,8 @@ export const VJView: React.FC = () => {
           <InputChip
             active={vjInputs.audio}
             onToggle={() => toggleVjInput('audio')}
-            label={bridgeFps > 0 ? `Audio ${bridgeFps}` : 'Audio'}
-            icon={<MusicIcon className="w-2.5 h-2.5" />}
+            name="Audio bridge"
+            icon={<MusicIcon className="w-3 h-3" />}
             activeLabel={
               bridgeFps > 0
                 ? `Audio bridge live — forwarding SA3 player levels @ ${bridgeFps}fps`
@@ -715,8 +717,8 @@ export const VJView: React.FC = () => {
           <InputChip
             active={vjInputs.midi}
             onToggle={() => toggleVjInput('midi')}
-            label="MIDI"
-            icon={<Piano className="w-2.5 h-2.5" />}
+            name="MIDI forwarding"
+            icon={<Piano className="w-3 h-3" />}
             activeLabel="MIDI events from your controller are forwarded into the VJ iframe."
             inactiveLabel="MIDI forwarding is off. Click to enable."
             disabled={vjInputs.midi && !vjInputs.mic && !vjInputs.audio}
@@ -743,9 +745,9 @@ export const VJView: React.FC = () => {
                 : 'Camera OFF — click to use the live webcam as the VJ source.'
             }
             aria-pressed={cameraOn}
+            aria-label="Camera source"
           >
-            {cameraOn ? <Camera className="w-2.5 h-2.5" /> : <CameraOff className="w-2.5 h-2.5" />}
-            Cam
+            {cameraOn ? <Camera className="w-3 h-3" /> : <CameraOff className="w-3 h-3" />}
           </button>
           <div className="flex items-center gap-0.5">
             <button
@@ -761,20 +763,17 @@ export const VJView: React.FC = () => {
                   ? 'border-sky-500/50 bg-sky-500/10 text-sky-200 hover:bg-sky-500/20'
                   : 'border-white/10 text-zinc-500 hover:text-zinc-200 hover:border-white/20 hover:bg-white/5'
               }`}
-              title={`${questRunning ? 'Click to stop' : 'Click to start'} direct delinQuest ADB/scrcpy relay. This does not use the browser window picker. ${questDetail}`}
-              aria-label="Toggle delinQuest ADB video relay"
+              title={`delinQuest (Quest video relay) — ${questLabel}. ${questRunning ? 'Click to stop' : 'Click to start'} the direct ADB/scrcpy relay (no browser window picker). ${questDetail}`}
+              aria-label={`delinQuest Quest video relay — ${questLabel}`}
               aria-pressed={questRunning}
             >
               {questBusy ? (
-                <Loader2 className="w-2.5 h-2.5 animate-spin" />
+                <Loader2 className="w-3 h-3 animate-spin" />
               ) : questErrored ? (
-                <AlertCircle className="w-2.5 h-2.5" />
-              ) : questReady ? (
-                <Check className="w-2.5 h-2.5" />
+                <AlertCircle className="w-3 h-3" />
               ) : (
-                <Tv2 className="w-2.5 h-2.5" />
+                <Glasses className="w-3 h-3" />
               )}
-              delinQuest {questLabel}
             </button>
             <button
               type="button"
@@ -809,6 +808,19 @@ export const VJView: React.FC = () => {
           >
             <Piano className="w-2.5 h-2.5" />
             MIDI
+          </button>
+          {/* MIDI MAP — opens the VJ engine's controller-mapping panel (MIDI map
+              + audio-react routing) right inside the iframe. The mapper used to
+              live as a floating pill on the VJ canvas; it now opens from here. */}
+          <button
+            type="button"
+            onClick={() => postToIframe({ type: 'sa3-vj/open-midi-map' })}
+            disabled={status !== 'ready'}
+            className="p-1.5 rounded border border-white/5 hover:bg-white/5 text-zinc-400 hover:text-zinc-100 disabled:opacity-40 disabled:pointer-events-none"
+            title="Open the VJ MIDI mapping + audio-react panel"
+            aria-label="Open VJ MIDI mapping panel"
+          >
+            <Sliders className="w-3.5 h-3.5" />
           </button>
           {/* Mobile link — exposes the LAN-reachable URL so a phone on
               the same Wi-Fi can open the VJ output. The Vite server is
@@ -1017,26 +1029,29 @@ export const VJView: React.FC = () => {
 };
 
 /**
- * Tiny toggle chip for the VJ input row (Mic / Audio / MIDI). Lit
- * emerald when active; faded zinc when disabled. `disabled` true
- * means the chip can't be turned off because it's the last
- * remaining active input (min-1 invariant).
+ * Tiny icon-only toggle for the VJ input row (Mic / Audio / MIDI). Lit emerald /
+ * cyan when active; faded zinc when off. `disabled` true means the chip can't be
+ * turned off because it's the last remaining active input (min-1 invariant). The
+ * label moved to `aria-label` + `title`; a live dot rides the Audio chip when the
+ * bridge is streaming.
  */
 const InputChip: React.FC<{
   active: boolean;
   onToggle: () => void;
-  label: string;
+  name: string;
   icon: React.ReactNode;
   activeLabel: string;
   inactiveLabel: string;
   disabled?: boolean;
   indicator?: 'live' | null;
-}> = ({ active, onToggle, label, icon, activeLabel, inactiveLabel, disabled, indicator }) => (
+}> = ({ active, onToggle, name, icon, activeLabel, inactiveLabel, disabled, indicator }) => (
   <button
     type="button"
     onClick={onToggle}
     disabled={!!disabled && active}
-    className={`px-1.5 py-0.5 rounded border text-[8px] font-mono uppercase tracking-widest flex items-center gap-1 transition-colors ${
+    aria-pressed={active}
+    aria-label={name}
+    className={`relative px-1.5 py-1 rounded border flex items-center justify-center transition-colors ${
       active
         ? indicator === 'live'
           ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/20'
@@ -1045,13 +1060,19 @@ const InputChip: React.FC<{
     } disabled:cursor-not-allowed disabled:opacity-100`}
     title={
       disabled && active
-        ? `${activeLabel} — at least one input must stay enabled.`
+        ? `${name}: ${activeLabel} — at least one input must stay enabled.`
         : active
-        ? `${activeLabel} (click to mute)`
-        : inactiveLabel
+        ? `${name}: ${activeLabel} (click to mute)`
+        : `${name}: ${inactiveLabel}`
     }
   >
-    {icon} {label}
+    {icon}
+    {indicator === 'live' && active && (
+      <span
+        className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-emerald-400 shadow-[0_0_4px_rgba(52,211,153,0.9)]"
+        aria-hidden="true"
+      />
+    )}
   </button>
 );
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,13 @@ dependencies = [
     # and updated often as site extractors change; keep a generous floor and let
     # `uv sync` pull the newest so YouTube/SoundCloud keep working.
     "yt-dlp>=2025.1.1",
+    # akvj native Kinect point cloud (backend/modules/akvj/kinect_sidecar.py).
+    # pyk4a-bundle ships its OWN matched k4a.dll + depthengine, so no separate
+    # Azure Kinect SDK install is needed; the sidecar just works. Windows x64 +
+    # Linux x64 only (no macOS wheel), gated so `uv sync` skips it elsewhere.
+    # websockets is the sidecar's WebSocket client to the relay.
+    "pyk4a-bundle ; (sys_platform == 'win32') or (sys_platform == 'linux' and platform_machine == 'x86_64')",
+    "websockets>=12.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -4418,6 +4418,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pyk4a-bundle"
+version = "1.5.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/db/8fe45be023dfe1345529df1b439fe57193f2b9c382c06e97762c198bc216/pyk4a_bundle-1.5.0.1-cp310-cp310-manylinux_2_38_x86_64.manylinux_2_39_x86_64.whl", hash = "sha256:b9271f840b18e73d73e82e75dde5ecf4e6d3af92e3e4b976417d3d93e8631d06", size = 7555800, upload-time = "2026-01-31T18:31:19.037Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2b/870862d41956847460451b435ce4996fe72de50fb7df40286d39a1dce20c/pyk4a_bundle-1.5.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:899d68c67a1853bd912ef9c413899805d18a23f46e1cfc396622ae09dfb569ad", size = 933808, upload-time = "2026-01-31T18:31:20.904Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/55/baeedf94f2819aca3d56152e579726d4a21a3d95d84817cde0ef7175bee5/pyk4a_bundle-1.5.0.1-cp311-cp311-manylinux_2_38_x86_64.manylinux_2_39_x86_64.whl", hash = "sha256:e50097cd2cec55147001aa6f2063bc907071b1b7ed5a48417e217f2f25d95f47", size = 7556959, upload-time = "2026-01-31T18:31:22.749Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6b/de4ae0492332048a516e53ebcc06acc69ee277ac6fd65268dcb76e694087/pyk4a_bundle-1.5.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:ad4a19aa1a3a28f397644d8b5f633a1750efb515c88334f9e16b7ae05c1f8b90", size = 933806, upload-time = "2026-01-31T18:31:24.48Z" },
+    { url = "https://files.pythonhosted.org/packages/81/80/7256cb094307fd34ec03ba0e7647af2a5d93da0d309e090524629eac68c9/pyk4a_bundle-1.5.0.1-cp312-cp312-manylinux_2_38_x86_64.manylinux_2_39_x86_64.whl", hash = "sha256:133d24971a3e5527e16a449a18da70210ac47fd68a9ca1ab38c7f1a7ab973047", size = 7557030, upload-time = "2026-01-31T18:31:26.294Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/20/1684a995eaefb8364d288a1ba86e0081dccc18745966f34699118730b57b/pyk4a_bundle-1.5.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:8a1550a752d4858657ef0f68f06f4cb25edcd39380f837077157ad335962b0ec", size = 933842, upload-time = "2026-01-31T18:31:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/89/62c4e870567eb002c839b65334f82b735954651fe24e1b532e608bd26f50/pyk4a_bundle-1.5.0.1-cp313-cp313-manylinux_2_38_x86_64.manylinux_2_39_x86_64.whl", hash = "sha256:a52eb710af27549916b48602830a5b1f494c531ade49d470588769eef8bb6aeb", size = 7559638, upload-time = "2026-01-31T18:31:29.048Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/75/28dc00ba3a11d61d805470cbf3c639610dee643c9ee58e8a4d8eb29d1879/pyk4a_bundle-1.5.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cbc2b809b5b52cb17ff1e6801873db438868de21984927bb7d6bd0a5cb93f14e", size = 933835, upload-time = "2026-01-31T18:31:30.579Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/41/f541806114b47da31c2edf099da1e5839989a80c181a7ecf0c8be246dd87/pyk4a_bundle-1.5.0.1-cp313-cp313t-manylinux_2_38_x86_64.manylinux_2_39_x86_64.whl", hash = "sha256:2d745b5646e26c5973bf2488e76f80516aff78a0f2859dfad1d632658e6f7cd7", size = 7561068, upload-time = "2026-01-31T18:31:32.409Z" },
+    { url = "https://files.pythonhosted.org/packages/34/98/a30baab9fac8129ccd9c3fa8b990646768c44c4b35655839ba8a54240304/pyk4a_bundle-1.5.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:8e4c777669325a95971dd976daa0c2406babfa1c985278fc68205056d0740263", size = 934146, upload-time = "2026-01-31T18:31:34.122Z" },
+    { url = "https://files.pythonhosted.org/packages/31/47/81ca7e8f7e1f16203f6325460ffb0d8e02ff3b0d4f91ea1fc18c7df1e5f9/pyk4a_bundle-1.5.0.1-cp314-cp314-manylinux_2_38_x86_64.manylinux_2_39_x86_64.whl", hash = "sha256:858f6a68b191bb90968fa839577bf9fa85ab2de693cd0e3d80fa090eaf333222", size = 7559762, upload-time = "2026-01-31T18:31:35.396Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a2/dcbc054574f5206d4bd6cb31c66d6176435fdf9f138e3ab2e96dc4ceacb0/pyk4a_bundle-1.5.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:e76929e2b6787da216145e8aba182fd6827013b753021fc3803b58578a57f718", size = 970903, upload-time = "2026-01-31T18:31:36.677Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/59/535a5327f4e4c2bfbdcac38fa9575f81d655a65726b220bc1786152d6472/pyk4a_bundle-1.5.0.1-cp314-cp314t-manylinux_2_38_x86_64.manylinux_2_39_x86_64.whl", hash = "sha256:ee0fe097e5c2f86df79846faadafd878f1dca9a9fb3392b11f194a35e29fe8db", size = 7561179, upload-time = "2026-01-31T18:31:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/43/cc950e621bfdf772b5e8b5750bf4e5109465fd29bae82270848b208a5e64/pyk4a_bundle-1.5.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6a4c2b86f5202ba7cd6a98ece5564539fcdc1bd727bf834004bd847c77d172db", size = 971130, upload-time = "2026-01-31T18:31:39.654Z" },
+]
+
+[[package]]
 name = "pyloudnorm"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5367,6 +5392,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pretty-midi" },
     { name = "psutil" },
+    { name = "pyk4a-bundle", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
     { name = "pyloudnorm" },
     { name = "python-multipart" },
     { name = "safetensors" },
@@ -5384,6 +5410,7 @@ dependencies = [
     { name = "tqdm" },
     { name = "transformers" },
     { name = "uvicorn" },
+    { name = "websockets" },
     { name = "yt-dlp" },
 ]
 
@@ -5437,6 +5464,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pretty-midi", specifier = ">=0.2.11" },
     { name = "psutil", specifier = ">=5.9.0" },
+    { name = "pyk4a-bundle", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
     { name = "pyloudnorm", specifier = ">=0.1.1" },
     { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.20" },
@@ -5456,6 +5484,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=5.8.0" },
     { name = "uvicorn", specifier = ">=0.42.0" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.34.0" },
+    { name = "websockets", specifier = ">=12.0" },
     { name = "yt-dlp", specifier = ">=2025.1.1" },
 ]
 provides-extras = ["ui", "lora", "server"]


### PR DESCRIPTION
Session checkpoint.

akvj backend module: relay made AKV1 table-chunk aware (caches XY-table chunks + latest frame, primes late joiners), idempotent POST /start with a foreign-source guard, pyk4a kinect_sidecar capture + questcast-style lifecycle manager with verbose status. pyk4a-bundle + websockets added to pyproject. docs/plans: akvj -> volumetric -video roadmap.

MIX: live FX/rack on the footer master insert (mixLiveRack.ts) so effects no longer restart per clip.

Convert: catalogue right-click "Convert to" + Windows Explorer "Convert with theDAW" shell menu (installer.nsh + ffmpeg helper). electron-builder + VJView updates.