### PR TITLE
feat(sway+pose): 6-dim Sway controller bus + camera-pose control bridge

### DIFF
--- a/docs/guides/theDAW_SoulX_Singer_Integration_Guide.md
+++ b/docs/guides/theDAW_SoulX_Singer_Integration_Guide.md
@@ -1,0 +1,1093 @@
+# theDAW × SoulX-Singer — Focused Integration Guide for Agents
+
+**Scope:** This document covers **SoulX-Singer only**. It specifies how to integrate SoulX-Singer and SoulX-Singer-SVC into the existing theDAW application as a local, Library-aware, timeline-aligned singing-vocal renderer.
+
+**Do not expand scope in this implementation.**
+- Do not add unrelated vocal engines.
+- Do not add unrelated voice-conversion providers.
+- Do not build a separate user-facing Gradio application.
+- Do not create a parallel media library, timeline, or project store.
+- Do not replace or alter the instrumental when rendering a vocal layer.
+
+---
+
+## 0. Source-of-truth links
+
+Read these before writing the adapter. They are the official current implementation surfaces.
+
+| Purpose | Link |
+|---|---|
+| SoulX-Singer repository | https://github.com/Soul-AILab/SoulX-Singer |
+| Official README | https://github.com/Soul-AILab/SoulX-Singer/blob/main/README.md |
+| Official preprocessing guide | https://github.com/Soul-AILab/SoulX-Singer/blob/main/preprocess/README.md |
+| SVS CLI inference source | https://github.com/Soul-AILab/SoulX-Singer/blob/main/cli/inference.py |
+| SVC CLI inference source | https://github.com/Soul-AILab/SoulX-Singer/blob/main/cli/inference_svc.py |
+| SVS shell example | https://github.com/Soul-AILab/SoulX-Singer/blob/main/example/infer.sh |
+| SVC shell example | https://github.com/Soul-AILab/SoulX-Singer/blob/main/example/infer_svc.sh |
+| Preprocessing shell example | https://github.com/Soul-AILab/SoulX-Singer/blob/main/example/preprocess.sh |
+| SoulX-Singer model files | https://huggingface.co/Soul-AILab/SoulX-Singer |
+| SoulX preprocessing model files | https://huggingface.co/Soul-AILab/SoulX-Singer-Preprocess |
+| Official demo page | https://soul-ailab.github.io/soulx-singer/ |
+| Online demo | https://huggingface.co/spaces/Soul-AILab/SoulX-Singer |
+| MIDI Editor | https://huggingface.co/spaces/Soul-AILab/SoulX-Singer-Midi-Editor |
+| Technical report | https://arxiv.org/abs/2602.07803 |
+
+**License noted by upstream:** Apache 2.0 for SoulX-Singer code/model weights. Agents must still inspect current upstream license/model-card files at implementation time.
+
+---
+
+## 1. What SoulX actually provides
+
+SoulX has two separate inference products. They must appear as separate modes in theDAW because their inputs and jobs are different.
+
+### A. SoulX-Singer SVS — generate a singing performance
+
+Use this when theDAW has:
+- a **target singer reference** (prompt audio),
+- a target vocal plan represented as either:
+  - **score control:** lyrics + aligned MIDI-note metadata, or
+  - **melody control:** lyrics + aligned melody/F0 metadata.
+
+This is the correct SoulX route for:
+```text
+Lyrics + a new editable MIDI line
+→ a new sung vocal layer
+
+Lyrics + a guide-derived F0 / melodic contour
+→ a new sung vocal layer matching the intended melody
+```
+
+Upstream SVS command entry point:
+```text
+python -m cli.inference
+```
+
+The upstream CLI requires:
+```text
+--model_path
+--config
+--prompt_wav_path
+--prompt_metadata_path
+--target_metadata_path
+--phoneset_path
+--save_dir
+--control melody|score
+```
+
+Optional:
+```text
+--auto_shift
+--pitch_shift <semitones>
+--fp16
+```
+
+### B. SoulX-Singer-SVC — convert an existing singing performance
+
+Use this when theDAW already has:
+- a **prompt/reference singer audio file**,
+- a **target singing performance**,
+- F0 contours for both.
+
+This is the correct SoulX route for:
+```text
+Existing sung guide/performance
++ reference singer/timbre
+→ converted singing performance
+```
+
+It is audio-to-audio. It preserves the target’s existing melody, rhythm, and lyric content. It does **not** create a new lyric performance from text.
+
+Upstream SVC command entry point:
+```text
+python -m cli.inference_svc
+```
+
+The upstream CLI requires:
+```text
+--model_path
+--config
+--prompt_wav_path
+--target_wav_path
+--prompt_f0_path
+--target_f0_path
+--save_dir
+```
+
+Optional:
+```text
+--auto_shift
+--pitch_shift <semitones>
+--n_steps <int>
+--cfg <float>
+--fp16
+```
+
+---
+
+## 2. Product behavior inside theDAW
+
+### 2.1 New SoulX workspace/panel
+
+Create a focused panel inside the existing theDAW flow:
+
+```text
+MAKE / EDIT
+  → VOCALS
+     → SOULX-SINGER
+```
+
+Do not create an independent app.
+
+The panel has exactly two mode cards:
+
+```text
+[ CREATE SINGING PERFORMANCE ]
+SoulX-Singer SVS
+Inputs:
+- Singer reference
+- Lyrics + MIDI or melody guide
+- Timeline placement
+Output:
+- New lead vocal stem
+
+[ CONVERT EXISTING SINGING ]
+SoulX-Singer-SVC
+Inputs:
+- Singer reference
+- Existing singing target
+- Timeline placement
+Output:
+- Converted singing stem
+```
+
+### 2.2 Required shared inputs
+
+```text
+Singer reference
+- choose a Library audio asset
+- or import/record one through existing theDAW paths
+- must be a clean usable vocal reference, ideally dry
+
+Destination
+- selected EDIT timeline range
+- start time / bar range
+- target track
+- insert result into EDIT toggle
+
+Output
+- default WAV
+- preserve source artifact
+- import result to Library
+- create lineage edge
+```
+
+### 2.3 SVS inputs
+
+```text
+Target representation:
+( ) MIDI score control
+( ) Melody/F0 control
+
+Target metadata source:
+( ) SoulX preprocessing pipeline
+( ) existing theDAW Piano Roll → exported SoulX metadata
+( ) guide audio → SoulX preprocessing → editable metadata
+
+Lyrics:
+- editable text field / structured lyric editor
+
+Target range:
+- requested start/end time in project timeline
+```
+
+### 2.4 SVC inputs
+
+```text
+Prompt singer reference:
+- Library audio asset
+
+Target singing performance:
+- Library asset / selected EDIT clip / imported audio / recorded take
+
+Prepare target:
+- extract F0 automatically
+- preserve existing source
+- optionally inspect generated F0 curve
+
+Target range:
+- optional crop range before rendering
+```
+
+---
+
+## 3. Integration boundary
+
+Create one focused module.
+
+```text
+backend/modules/soulx_singer/
+├── module.json
+├── router.py
+├── schemas.py
+├── service.py
+├── jobs.py
+├── paths.py
+├── worker_client.py
+├── preprocess.py
+├── metadata.py
+├── timeline.py
+├── adapters/
+│   ├── svs.py
+│   └── svc.py
+└── workers/
+    ├── protocol.py
+    └── soulx_worker.py
+```
+
+### Required design rules
+
+1. **Lazy load only.** SoulX must not initialize at normal theDAW startup.
+2. **Dedicated environment/worker.** Do not force its dependency graph into the main theDAW Python environment.
+3. **Use Library IDs at the API boundary.** Resolve physical paths internally.
+4. **Keep every source.** Prompt reference, target guide, metadata JSON, MIDI edit, and final waveform remain Library-linked artifacts.
+5. **Never overwrite the original guide or source vocal.**
+6. **All output must return to the existing Library and EDIT timeline.**
+7. **The SoulX metadata must be stored as a first-class artifact.**
+8. **Do not expose upstream shell scripts directly to the browser.** Wrap model execution in the theDAW worker contract.
+
+---
+
+## 4. Environment and model installation
+
+### 4.1 Isolate SoulX
+
+Upstream recommends Python 3.10 and Conda.
+
+Suggested managed environment:
+```text
+<theDAW root>/
+└── sidecars/
+    └── soulx-singer/
+        ├── repo/
+        ├── conda-env-name.txt
+        ├── models/
+        ├── jobs/
+        └── outputs/
+```
+
+Suggested environment:
+```bash
+conda create -n thedaw-soulx python=3.10 -y
+conda activate thedaw-soulx
+pip install -r requirements.txt
+```
+
+Clone:
+```bash
+git clone https://github.com/Soul-AILab/SoulX-Singer.git
+cd SoulX-Singer
+```
+
+Model downloads:
+```bash
+pip install -U huggingface_hub
+
+hf download Soul-AILab/SoulX-Singer \
+  --local-dir pretrained_models/SoulX-Singer
+
+hf download Soul-AILab/SoulX-Singer-Preprocess \
+  --local-dir pretrained_models/SoulX-Singer-Preprocess
+```
+
+### 4.2 Model readiness contract
+
+Add a SoulX card in the existing Settings → Models system.
+
+```json
+{
+  "id": "soulx_singer",
+  "display_name": "SoulX-Singer",
+  "status": "not_installed | installing | ready | busy | error",
+  "environment": "thedaw-soulx",
+  "device": "cuda",
+  "svs_checkpoint_found": false,
+  "svc_checkpoint_found": false,
+  "preprocess_models_found": false,
+  "last_error": null
+}
+```
+
+The SVS and SVC checkpoints are separate:
+```text
+pretrained_models/SoulX-Singer/model.pt
+pretrained_models/SoulX-Singer/model-svc.pt
+```
+
+---
+
+## 5. SoulX preprocessing: do not skip the metadata requirement
+
+### 5.1 What SVS requires
+
+SoulX-Singer SVS does not accept arbitrary raw text + arbitrary MIDI as its published CLI input.
+
+It requires:
+```text
+Prompt singer audio
++ prompt metadata JSON
++ target metadata JSON
+```
+
+The target metadata represents:
+```text
+- segment timing
+- lyrics/words
+- note information
+- durations
+- F0-related information
+- language
+```
+
+Upstream preprocessing produces the required format.
+
+### 5.2 SoulX preprocessing pipeline
+
+Official preprocess command:
+```bash
+python -m preprocess.pipeline \
+  --audio_path <input_audio> \
+  --save_dir <output_dir> \
+  --language <language> \
+  --device cuda \
+  --vocal_sep <true|false> \
+  --max_merge_duration <milliseconds> \
+  --midi_transcribe <true|false>
+```
+
+Processing stages:
+```text
+1. Vocal separation and dereverberation — optional
+2. F0 extraction
+3. Voice activity / segment detection
+4. Lyrics transcription
+5. Note transcription
+6. Metadata JSON construction
+```
+
+Important output behavior:
+```text
+<input>.wav / .mp3 / .flac
+→ matching <input>.json copied beside the source
+→ metadata.json inside save_dir
+→ cut vocal wavs
+→ F0 .npy files
+→ intermediate separated vocal/accompaniment assets when separation is enabled
+```
+
+### 5.3 Mapping to existing theDAW tools
+
+Reuse theDAW where safe:
+
+```text
+theDAW stem separation
+→ optional clean guide/reference prep
+
+theDAW Library asset
+→ resolved source file passed into SoulX preprocess
+
+theDAW MIDI/Piano Roll
+→ can become the editor surface for score data
+
+SoulX native preprocess
+→ still required to create/maintain SoulX-compatible JSON
+```
+
+Do not assume theDAW’s existing Basic Pitch/MIDI object is already equivalent to SoulX metadata. Build an explicit converter and validate against SoulX’s editor/import path.
+
+### 5.4 Preprocess options by mode
+
+#### SVS
+```text
+midi_transcribe=True
+```
+
+Use:
+- on prompt singer reference when metadata is not already available,
+- on target guide or target-score seed audio when creating metadata,
+- before score/melody SVS inference.
+
+#### SVC
+```text
+midi_transcribe=False
+```
+
+Use:
+- for prompt singer audio,
+- for target singing audio,
+- when only waveform + F0 are needed.
+
+### 5.5 Metadata correction is mandatory UI work
+
+Upstream explicitly warns that automatic lyric/note alignment can materially harm quality.
+
+Implement a review stage:
+
+```text
+Prepare
+→ generated metadata
+→ review / correct
+→ render
+```
+
+At minimum expose:
+```text
+- text/lyric words
+- phrase boundaries
+- note pitch
+- note duration
+- line start/end
+- project timeline offset
+```
+
+Do not silently render unreviewed metadata as the only workflow.
+
+---
+
+## 6. The critical timing bridge: SoulX metadata ↔ theDAW timeline
+
+SoulX SVS reads target metadata segment timing in milliseconds and creates a rendered output buffer based on the end of the final target segment.
+
+theDAW operates in project timeline seconds/bars.
+
+### Required strategy
+
+When a user targets a project range:
+
+```text
+Project:
+bar 17 through bar 25
+timeline: 32.000 sec through 47.500 sec
+
+SoulX job:
+render a local vocal region with metadata from 0.000 sec through 15.500 sec
+
+Result:
+generated.wav
+→ import as Library child artifact
+→ insert clip in EDIT at 32.000 sec
+```
+
+Never give SoulX project-global timestamps unless the worker intentionally wants a leading silent region.
+
+### Conversion rules
+
+```text
+project_relative_sec = absolute_project_sec - requested_region_start_sec
+
+SoulX metadata time:
+milliseconds = round(project_relative_sec * 1000)
+```
+
+After render:
+```text
+EDIT clip startSec = requested_region_start_sec
+source offset = 0
+duration = rendered audio duration
+```
+
+### Padding correction
+
+Model/render pipelines may return leading or trailing silence.
+
+Implement:
+```text
+1. Measure leading silence.
+2. Save measured offset in output metadata.
+3. Shift only when it is a known model-produced pad.
+4. Never shift a musical pickup or intentional rest without user confirmation.
+5. Preserve the untrimmed raw render in Library.
+6. Make cleaned/timeline-aligned clip a child artifact.
+```
+
+---
+
+## 7. SVS adapter
+
+### 7.1 Required request schema
+
+```python
+class SoulXSvsRequest(BaseModel):
+    instrumental_entry_id: str
+    prompt_entry_id: str
+    target_metadata_entry_id: str
+    timeline_start_sec: float
+    timeline_end_sec: float
+    control: Literal["melody", "score"]
+    auto_shift: bool = True
+    pitch_shift: int = 0
+    use_fp16: bool = True
+    insert_into_edit: bool = True
+    edit_track_name: str = "VOCAL — SoulX Lead"
+```
+
+### 7.2 Worker invocation
+
+Use a structured job file, not string-concatenated shell code.
+
+Example job payload:
+```json
+{
+  "job_id": "job_soulx_svs_001",
+  "mode": "svs",
+  "model_path": "pretrained_models/SoulX-Singer/model.pt",
+  "config": "soulxsinger/config/soulxsinger.yaml",
+  "prompt_wav_path": "resolved/prompt.wav",
+  "prompt_metadata_path": "resolved/prompt.json",
+  "target_metadata_path": "resolved/target.json",
+  "phoneset_path": "soulxsinger/utils/phoneme/phone_set.json",
+  "save_dir": "sidecars/soulx-singer/outputs/job_soulx_svs_001",
+  "control": "score",
+  "auto_shift": true,
+  "pitch_shift": 0,
+  "fp16": true
+}
+```
+
+Worker command:
+```bash
+python -m cli.inference \
+  --device cuda \
+  --model_path <model_path> \
+  --config <config_path> \
+  --prompt_wav_path <prompt_wav_path> \
+  --prompt_metadata_path <prompt_metadata_path> \
+  --target_metadata_path <target_metadata_path> \
+  --phoneset_path <phoneset_path> \
+  --save_dir <save_dir> \
+  --control <melody|score> \
+  --auto_shift \
+  --pitch_shift <int> \
+  --fp16
+```
+
+### 7.3 Important upstream example bug to avoid
+
+The official `example/infer.sh` defines:
+```text
+control=score
+```
+
+but its shown command does not pass:
+```text
+--control $control
+```
+
+The actual Python CLI defaults to `melody`.
+
+**The theDAW adapter must always explicitly pass `--control score` or `--control melody`. Never depend on the upstream script default.**
+
+### 7.4 Output handling
+
+Upstream SVS code writes:
+```text
+generated.wav
+```
+
+The published inference source writes that output at **24 kHz**.
+
+theDAW project audio is generally 44.1 kHz. Therefore:
+
+```text
+SoulX raw output (24 kHz)
+→ preserve as raw Library artifact
+→ high-quality resample to 44.1 kHz
+→ create a timeline-ready child artifact
+→ insert child into EDIT
+```
+
+Persist:
+```json
+{
+  "source_sample_rate": 24000,
+  "project_sample_rate": 44100,
+  "resampled": true,
+  "resample_method": "ffmpeg high-quality resampler",
+  "soulx_mode": "svs",
+  "soulx_control": "score"
+}
+```
+
+---
+
+## 8. SVC adapter
+
+### 8.1 Required request schema
+
+```python
+class SoulXSvcRequest(BaseModel):
+    prompt_entry_id: str
+    target_entry_id: str
+    timeline_start_sec: float
+    timeline_end_sec: float
+    prompt_f0_entry_id: str | None = None
+    target_f0_entry_id: str | None = None
+    auto_shift: bool = True
+    pitch_shift: int = 0
+    n_steps: int = 32
+    cfg: float = 3.0
+    use_fp16: bool = True
+    insert_into_edit: bool = True
+    edit_track_name: str = "VOCAL — SoulX SVC"
+```
+
+### 8.2 Worker invocation
+
+```bash
+python -m cli.inference_svc \
+  --device cuda \
+  --model_path pretrained_models/SoulX-Singer/model-svc.pt \
+  --config soulxsinger/config/soulxsinger.yaml \
+  --prompt_wav_path <prompt_wav_path> \
+  --target_wav_path <target_wav_path> \
+  --prompt_f0_path <prompt_f0.npy> \
+  --target_f0_path <target_f0.npy> \
+  --save_dir <save_dir> \
+  --auto_shift \
+  --pitch_shift <int> \
+  --n_steps 32 \
+  --cfg 3.0 \
+  --fp16
+```
+
+### 8.3 F0 requirements
+
+SoulX SVC consumes NumPy `.npy` F0 arrays for:
+```text
+prompt/reference singer audio
+target singing audio
+```
+
+Preferred workflow:
+```text
+Prompt Library asset
+→ SoulX preprocess with midi_transcribe=False
+→ prompt vocal.wav + prompt vocal_f0.npy
+
+Target singing asset
+→ SoulX preprocess with midi_transcribe=False
+→ target vocal.wav + target vocal_f0.npy
+
+Prompt + target + F0 arrays
+→ SoulX SVC worker
+```
+
+### 8.4 Do not misuse SVC
+
+SVC can:
+```text
+Preserve target performance
+→ change target singer/timbre/style
+```
+
+SVC cannot replace the need for:
+```text
+Lyrics + melody plan
+→ newly authored vocal performance
+```
+
+Do not put a lyrics input on the SVC panel unless it is explicitly marked as non-operative metadata for the project. The upstream SVC inference path does not accept lyrics or MIDI inputs.
+
+---
+
+## 9. API surface
+
+```text
+POST /api/soulx/prepare
+POST /api/soulx/metadata/import-midi
+POST /api/soulx/metadata/export-midi
+GET  /api/soulx/metadata/{asset_id}
+
+POST /api/soulx/render/svs
+POST /api/soulx/render/svc
+
+GET  /api/soulx/jobs/{job_id}
+POST /api/soulx/jobs/{job_id}/cancel
+
+GET  /api/soulx/health
+GET  /api/soulx/models
+```
+
+### 9.1 `POST /api/soulx/prepare`
+
+```json
+{
+  "library_entry_id": "lib_guide_012",
+  "language": "English",
+  "vocal_separation": true,
+  "midi_transcription": true,
+  "max_merge_duration_ms": 60000,
+  "purpose": "svs_target"
+}
+```
+
+Rules:
+```text
+purpose = svs_prompt | svs_target | svc_prompt | svc_target
+
+svs_prompt:
+midi_transcription=true
+
+svs_target:
+midi_transcription=true
+
+svc_prompt:
+midi_transcription=false
+
+svc_target:
+midi_transcription=false
+```
+
+Expected result:
+```json
+{
+  "job_id": "job_soulx_prepare_012",
+  "status": "queued"
+}
+```
+
+### 9.2 `POST /api/soulx/render/svs`
+
+```json
+{
+  "prompt_entry_id": "lib_singer_reference",
+  "prompt_metadata_entry_id": "lib_singer_reference_soulx_metadata",
+  "target_metadata_entry_id": "lib_target_plan_soulx_metadata",
+  "instrumental_entry_id": "lib_instrumental",
+  "timeline_start_sec": 32.0,
+  "timeline_end_sec": 47.5,
+  "control": "score",
+  "auto_shift": true,
+  "pitch_shift": 0,
+  "use_fp16": true,
+  "insert_into_edit": true,
+  "edit_track_name": "VOCAL — SoulX Lead"
+}
+```
+
+### 9.3 `POST /api/soulx/render/svc`
+
+```json
+{
+  "prompt_entry_id": "lib_target_singer_reference",
+  "target_entry_id": "lib_existing_singing_performance",
+  "instrumental_entry_id": "lib_instrumental",
+  "timeline_start_sec": 32.0,
+  "timeline_end_sec": 47.5,
+  "auto_shift": true,
+  "pitch_shift": 0,
+  "n_steps": 32,
+  "cfg": 3.0,
+  "use_fp16": true,
+  "insert_into_edit": true,
+  "edit_track_name": "VOCAL — SoulX SVC"
+}
+```
+
+---
+
+## 10. Metadata as an editable artifact
+
+### 10.1 Persist SoulX metadata
+
+Store a JSON child artifact in the Library:
+
+```json
+{
+  "asset_type": "soulx_metadata",
+  "source_audio_entry_id": "lib_guide_012",
+  "mode": "svs_target",
+  "language": "English",
+  "metadata_path": "library/.../metadata.json",
+  "midi_path": "library/.../vocal.mid",
+  "f0_artifacts": [".../vocal_f0.npy"],
+  "created_by": "soulx.prepare.v1"
+}
+```
+
+### 10.2 MIDI round-trip
+
+SoulX’s official preprocessing supports:
+
+```text
+Metadata JSON
+→ MIDI
+→ edit note pitch/duration/lyrics
+→ MIDI
+→ SoulX metadata JSON
+```
+
+Upstream commands:
+
+```bash
+python -m preprocess.tools.midi_parser \
+  --meta2midi \
+  --meta <metadata.json> \
+  --midi <vocal.mid>
+```
+
+```bash
+python -m preprocess.tools.midi_parser \
+  --midi2meta \
+  --midi <vocal_edited.mid> \
+  --meta <edit_metadata.json> \
+  --vocal <vocal.wav>
+```
+
+### 10.3 theDAW implementation requirement
+
+Connect the round trip to the existing Piano Roll where possible:
+
+```text
+SoulX metadata
+→ exported MIDI artifact
+→ Piano Roll edit
+→ edited MIDI export
+→ SoulX metadata converter
+→ SVS render
+```
+
+Do not claim the existing Piano Roll directly edits SoulX metadata until the converter preserves:
+```text
+- exact note timing
+- pitch
+- lyric/phoneme association
+- voice segment timing
+```
+
+---
+
+## 11. Worker protocol
+
+### 11.1 Job file
+
+Backend writes:
+```text
+sidecars/soulx-singer/jobs/<job_id>.json
+```
+
+Worker writes:
+```text
+sidecars/soulx-singer/jobs/<job_id>.status.json
+sidecars/soulx-singer/outputs/<job_id>/generated.wav
+sidecars/soulx-singer/outputs/<job_id>/result.json
+```
+
+### 11.2 Status contract
+
+```json
+{
+  "job_id": "job_soulx_svs_001",
+  "state": "queued | preparing | loading_model | inferencing | postprocessing | completed | failed | cancelled",
+  "progress": 0.0,
+  "message": "Loading SoulX-Singer checkpoint",
+  "error": null
+}
+```
+
+### 11.3 Pseudocode
+
+```python
+def render_svs(job: SoulXSvsRequest) -> RenderResult:
+    paths = resolve_library_assets(job)
+
+    assert_model_ready("soulx_singer")
+    assert_soulx_metadata(paths.prompt_metadata)
+    assert_soulx_metadata(paths.target_metadata)
+
+    local_region = make_region_relative_metadata(
+        metadata=paths.target_metadata,
+        project_start_sec=job.timeline_start_sec,
+    )
+
+    result = soulx_worker.run_svs(
+        prompt_wav=paths.prompt_wav,
+        prompt_metadata=paths.prompt_metadata,
+        target_metadata=local_region,
+        control=job.control,
+        auto_shift=job.auto_shift,
+        pitch_shift=job.pitch_shift,
+        fp16=job.use_fp16,
+    )
+
+    raw_asset = library.import_asset(
+        result.generated_wav,
+        kind="vocal_soulx_raw",
+        parent_ids=[job.prompt_entry_id, job.target_metadata_entry_id],
+    )
+
+    timeline_asset = resample_and_align_for_thedaw(
+        raw_asset,
+        target_sample_rate=44100,
+        clip_start_sec=job.timeline_start_sec,
+    )
+
+    library.add_lineage(raw_asset, timeline_asset)
+    edit.insert_clip(
+        asset_id=timeline_asset.id,
+        track_name=job.edit_track_name,
+        start_sec=job.timeline_start_sec,
+    )
+
+    return timeline_asset
+```
+
+---
+
+## 12. UI/UX acceptance criteria
+
+### SVS mode
+
+1. User selects a singer reference from Library.
+2. User selects or creates a target metadata asset.
+3. User selects `Score (MIDI)` or `Melody (F0)`.
+4. User sees an editable timing/note/lyric review state.
+5. User selects a project timeline range.
+6. User clicks render.
+7. Job shows actual preparation/model/render progress.
+8. Completed output is:
+   - saved as raw SoulX output,
+   - resampled/aligned as a child asset,
+   - inserted onto the intended EDIT track,
+   - independently auditionable against the instrumental.
+
+### SVC mode
+
+1. User chooses reference singer and target singing performance.
+2. System prepares/reuses F0 artifacts.
+3. User selects range and render settings.
+4. Result is imported as a distinct child stem.
+5. Original target remains untouched and independently available.
+
+---
+
+## 13. Test plan
+
+| Test | Expected result |
+|---|---|
+| SVS: existing target metadata + score control | `--control score` is actually passed; output has no accidental melody-mode default |
+| SVS: melody control | `--control melody` is explicitly passed |
+| SVS: missing prompt metadata | job blocks with actionable requirement; no inference starts |
+| SVS: target metadata uses project-global times | adapter converts to region-relative times before inference |
+| SVS: 24 kHz output | raw result preserved; timeline child is 44.1 kHz |
+| SVC: target audio with no F0 | prepare job creates/reuses target F0 before render |
+| SVC: user submits lyrics | UI does not imply lyrics change SVC output |
+| Prepared metadata has bad note/lyric alignment | review/edit step is visible before final render |
+| Worker is unavailable | backend remains alive; model state shows error/offline |
+| Rerender | creates a new Library child and lineage edge; does not overwrite prior output |
+| Insert into EDIT | result begins at exact intended project timeline start |
+| Model output begins with artificial silence | raw output kept; optional aligned child records measured adjustment |
+
+---
+
+## 14. Explicit non-goals for this SoulX implementation
+
+Do not build these during the SoulX-only pass:
+
+```text
+- a generic lyrics-to-rap planner
+- broad instrumental-aware vocal composition logic
+- unrelated singing engines
+- generic TTS
+- another voice-conversion provider
+- autonomous lyric writing
+- a second DAW UI
+- user-facing model shell scripting
+- permanent model loading at app startup
+- destructive replacement of source vocals
+```
+
+SoulX integration ends at:
+```text
+Prepared SoulX-compatible target metadata
+→ SVS or SVC render
+→ Library artifact
+→ exact EDIT timeline insertion
+```
+
+A broader performance-planning layer can be added later, but it is not part of this guide.
+
+---
+
+## 15. Build order
+
+### Phase 1 — worker and model readiness
+- Add `soulx_singer` module.
+- Add isolated environment/worker setup.
+- Add Settings → Models status card.
+- Add model download/path registration.
+- Add health endpoint.
+
+### Phase 2 — preprocessing and metadata artifacts
+- Implement `POST /api/soulx/prepare`.
+- Persist metadata JSON, F0 files, vocal/acc separation artifacts.
+- Add Library lineage.
+- Add metadata inspection endpoint.
+
+### Phase 3 — SVS
+- Implement SVS worker invocation.
+- Explicitly pass `--control`.
+- Add 24 kHz → 44.1 kHz postprocess.
+- Add exact timeline placement.
+- Add result artifacts and lineage.
+
+### Phase 4 — SVC
+- Implement F0 preparation/reuse.
+- Implement SVC worker invocation.
+- Add output import and timeline placement.
+- Keep source performance immutable.
+
+### Phase 5 — metadata editor bridge
+- Implement metadata → MIDI export.
+- Connect MIDI/Piano Roll editing.
+- Implement MIDI → SoulX metadata import.
+- Validate lyric/note alignment before SVS render.
+
+---
+
+## 16. Final implementation decision
+
+Use SoulX in theDAW like this:
+
+```text
+SVS:
+Singer reference + SoulX target metadata
+→ SoulX-Singer
+→ new singing stem
+→ Library + EDIT timeline
+
+SVC:
+Singer reference + existing singing performance + F0
+→ SoulX-Singer-SVC
+→ converted singing stem
+→ Library + EDIT timeline
+```
+
+theDAW owns:
+```text
+- project timeline
+- Library assets
+- source lineage
+- job lifecycle
+- model status UI
+- input routing
+- result import
+- timeline placement
+- post-render resampling/normalization
+```
+
+SoulX owns:
+```text
+- SVS waveform synthesis from its metadata contract
+- SVC waveform synthesis from audio + F0 inputs
+- its preprocessing metadata generation
+```

--- a/docs/guides/theDAW_Vocal_Layer_Implementation_Brief.md
+++ b/docs/guides/theDAW_Vocal_Layer_Implementation_Brief.md
@@ -1,0 +1,887 @@
+# theDAW Vocal-Layer Generation — Implementation Brief for Agents
+
+**Purpose:** Add a production-oriented vocal-layer system to the existing theDAW application.
+
+**Primary output:** isolated, timeline-aligned vocal clips/stems that sit over a fixed existing instrumental. The system must produce usable lead vocals and optional layers, then route them into theDAW EDIT/MIX/Library/lineage system.
+
+**This is not a request for a replacement song generator.** The existing instrumental is the fixed musical context. The vocal system must listen to it, respect its timing and structure, then render vocals that belong on its exact timeline.
+
+---
+
+## 1. Non-negotiable product behavior
+
+### Mode A — Guide-performance / audio-to-audio
+
+Inputs:
+- Fixed instrumental from theDAW Library or EDIT timeline.
+- Optional guide recording, imported vocal, hum, rap, melody, or reference performance.
+- Optional target lyric text.
+- Optional target singer/timbre profile.
+- Optional target section/range on the timeline.
+
+Required behavior:
+1. Analyze the guide’s timing, phrase boundaries, pauses, rhythmic density, pitch/F0 contour, and optionally words.
+2. Preserve its **temporal behavior**: starts, stops, cadence, rhythm, phrase shape, note contour where requested.
+3. Create a new vocal layer aligned to the fixed instrumental timeline.
+4. Return a dry/mostly dry vocal stem and metadata, not a replacement instrumental.
+
+Examples:
+- Rough rap guide + new lyric text → new vocal that follows the rap’s cadence.
+- Hummed sung guide + lyric text → sung vocal with the guide’s melodic contour.
+- Existing clean singing take → alternate lyric version preserving its melody.
+
+### Mode B — Lyrics + structure tags
+
+Inputs:
+- Fixed instrumental.
+- Lyrics.
+- Section tags and delivery instructions.
+- Optional per-section vocal role/tone/register settings.
+- Optional voice/timbre profile.
+
+Required behavior:
+1. Read musical context from the instrumental: tempo, beats, downbeats, bar grid, key/scale if available, arrangement/energy regions, and available space.
+2. Build an editable **Vocal Performance Plan** before rendering.
+3. Decide syllable placement, rhythmic density, rests, breaths, line starts, held notes, pitch/MIDI/F0 curve, section-level energy, and vocal layers.
+4. Render aligned vocal stem(s) and place them on the existing theDAW timeline.
+
+Example:
+```text
+[VERSE 1 | 16 bars | low-energy melodic rap | intimate | sparse]
+lyrics...
+
+[PRE | 8 bars | build | rising melody | double final words]
+lyrics...
+
+[CHORUS | 8 bars | strong sung hook | wide doubles + high harmony]
+lyrics...
+```
+
+---
+
+## 2. Existing theDAW foundations to reuse, not duplicate
+
+Agents must integrate with the existing system rather than add another disconnected audio application.
+
+### Existing backend/module architecture
+
+The project already uses a FastAPI backend and independently mounted modules.
+
+Relevant paths:
+```text
+backend/server.py
+backend/modules/
+backend/modules/loader.py
+frontend/
+```
+
+Existing module pattern:
+```text
+backend/modules/<module_name>/
+├── module.json
+└── router.py
+```
+
+Existing relevant components:
+```text
+analysis       # audio analysis
+chimera        # source analysis, BPM/key/beat alignment, fusion
+library        # persistent assets and lineage
+midi           # audio-to-MIDI / symbolic artifacts
+stems          # Demucs separation
+effects        # effects and processing
+magenta        # real-time model sidecar
+settings       # model registration/readiness
+```
+
+### Existing workflow primitives to reuse
+
+```text
+Instrumental Library asset
+→ existing analysis / BPM/key/beats
+
+Mic or imported guide
+→ existing Library ingest and optional stem isolation
+
+Guide analysis
+→ existing MIDI module + new alignment/F0 data
+
+Generated vocal stem
+→ Library import + lineage edge
+
+Library asset
+→ EDIT timeline track + clip placement
+
+EDIT clip
+→ MIX vocal processing chain
+```
+
+### Existing UI/tooling that should remain the source of truth
+
+- Library assets and lineage
+- MAKE/EDIT/MIX workspace navigation
+- existing async job queue/progress behavior
+- Settings → Models readiness and local checkpoint registration
+- mic recorder
+- stem separation
+- MIDI / Piano Roll
+- EDIT timeline clip placement, tracks, fades, trims, snapping
+- MIX effects and exports
+
+Do not build:
+- a separate Gradio app as the user-facing workflow
+- a second standalone media library
+- an independent timeline
+- a parallel local-model setup page
+- a model loaded at startup by default
+
+---
+
+## 3. Proposed module
+
+Create one new backend module:
+
+```text
+backend/modules/vocal/
+├── module.json
+├── router.py
+├── schemas.py
+├── service.py
+├── jobs.py
+├── model_registry.py
+├── adapters/
+│   ├── soulx_singer.py
+│   ├── yingmusic_singer.py
+│   ├── acestep.py
+│   ├── diffsinger.py
+│   ├── rvc.py
+│   └── seed_vc.py
+├── preprocess/
+│   ├── guide_isolation.py
+│   ├── transcription.py
+│   ├── alignment.py
+│   ├── f0.py
+│   ├── notes.py
+│   ├── instrumental_context.py
+│   └── sections.py
+├── planning/
+│   ├── plan_builder.py
+│   ├── lyric_parser.py
+│   ├── cadence.py
+│   ├── melody.py
+│   └── layers.py
+├── render/
+│   ├── render_svs.py
+│   ├── render_svc.py
+│   ├── render_layers.py
+│   ├── normalize.py
+│   └── timeline.py
+└── workers/
+    ├── worker_protocol.py
+    ├── soulx_worker.py
+    ├── yingmusic_worker.py
+    ├── acestep_worker.py
+    └── vc_worker.py
+```
+
+### Mandatory architectural rules
+
+1. **One adapter interface.** Model-specific code stays inside `adapters/`.
+2. **Lazy model loading.** Do not load SoulX, YingMusic, ACE-Step, voice-conversion engines, or their dependencies at backend startup.
+3. **Per-engine environments/workers.** Do not force potentially incompatible model dependency stacks into the theDAW base environment.
+4. **Library IDs over arbitrary paths.** API payloads use theDAW Library IDs and timeline coordinates. Resolve paths internally.
+5. **Output artifacts must re-enter the Library.** Each output stem gets analysis/metadata/lineage, then may be inserted into EDIT.
+6. **The generated performance plan is an artifact.** Persist it as JSON alongside audio and link it to the source instrumental, guide, lyrics, and render.
+7. **Render dry stems first.** Doubles/harmonies/ad-libs should be individual clips/stems, not permanently baked into a full mix.
+
+---
+
+## 4. Engine classification
+
+These are different jobs. Do not collapse them into one misleading “AI vocal model” dropdown.
+
+| Engine class | Job | Candidate implementation | Position in pipeline |
+|---|---|---|---|
+| Singing voice synthesis (SVS) | Lyrics + MIDI/F0 → sung stem | SoulX-Singer, DiffSinger | Primary renderer |
+| Melody-preserving lyric edit | Guide singing + new lyrics → new vocal | YingMusic-Singer | Guide mode renderer |
+| Broad music/vocal model | Experimental lyric/audio generation or repairs | ACE-Step | Optional/experimental provider |
+| Voice conversion | Existing vocal performance → target timbre/identity | RVC/Applio, Seed-VC | Optional downstream pass |
+| Alignment | Word/syllable timing from guide | WhisperX | Guide preprocessing |
+| Pitch extraction | Dense melody/F0 contour | RMVPE | Guide preprocessing |
+| Audio-to-MIDI | Editable note events from guide | existing Basic Pitch integration | Guide preprocessing / Piano Roll |
+| Separation | Pull guide vocal from mixed reference | existing Demucs integration | Optional preprocessing |
+
+### Critical distinction: RVC is not a vocal generator
+
+RVC-style systems should not be presented as the core “Generate Vocals” engine.
+
+```text
+Vocal performance generation:
+lyrics + plan + melody/cadence
+→ actual sung/rapped performance
+
+Voice conversion:
+existing performance
+→ a different perceived singer/timbre
+```
+
+RVC/Applio/Seed-VC are useful **after** there is a performance to convert. They do not solve lyrics-to-performance planning.
+
+---
+
+## 5. Main external implementation links
+
+### Primary singing-render engines
+
+#### SoulX-Singer — primary initial engine
+- Repository: https://github.com/Soul-AILab/SoulX-Singer
+- Paper: https://arxiv.org/abs/2602.07803
+- Hugging Face organization/models: https://huggingface.co/Soul-AILab
+
+Why it matters:
+- Zero-shot singing voice synthesis.
+- Supports symbolic score/MIDI and melodic/F0-style conditioning.
+- Designed for controllable, multilingual singing output.
+- Strongest first engine for theDAW’s `lyrics + performance plan` route.
+
+Agent implementation focus:
+1. Read the repository’s inference, preprocessing, model download, and environment instructions.
+2. Identify the smallest programmatic inference entry point.
+3. Wrap it in a managed worker.
+4. Inputs should be: lyrics, target singer reference/profile, MIDI or F0, sample rate/config, and output target.
+5. Convert output into theDAW’s standard audio/import metadata pipeline.
+
+#### YingMusic-Singer — guide-singing + lyric replacement
+- Repository: https://github.com/ASLP-lab/YingMusic-Singer
+- Paper: https://arxiv.org/abs/2603.24589
+- Project/demos: inspect the repository README and linked demo/model pages.
+
+Why it matters:
+- Takes a melody-providing singing clip, altered lyrics, and optional timbre reference.
+- Designed to preserve melody while changing lyric content.
+- Direct candidate for guide mode when users have already performed the cadence/melody but need a regenerated version.
+
+Agent implementation focus:
+1. Keep its input guide vocal separate from the instrumental.
+2. Run guide-isolation first when the uploaded guide is a full mixed bounce.
+3. Pass output through alignment and timeline placement.
+4. Keep the original guide linked in lineage.
+
+#### DiffSinger — deterministic score-driven fallback
+- Repository: https://github.com/openvpi/diffsinger
+- OpenUTAU project: https://github.com/stakira/OpenUtau
+- OpenVPI documentation/community: https://github.com/openvpi
+
+Why it matters:
+- A controllable score-driven fallback for exact notes, phonemes, durations, and reproducible rerenders.
+- Useful when theDAW needs an explicit “vocal instrument / Piano Roll” workflow.
+
+### Experimental music/vocal model
+
+#### ACE-Step
+- Repository: https://github.com/ace-step/ACE-Step
+- Project site: https://ace-step.github.io/
+- Original paper: https://arxiv.org/abs/2506.00045
+- ACE-Step 1.5 paper: https://arxiv.org/abs/2602.00744
+
+Why it matters:
+- Broad music-generation foundation model with lyric alignment/editing and vocal-related tasks.
+- Treat as experimental in theDAW: useful for alternate ideas, localized regeneration, or exploratory workflows.
+- Do not assume it reliably returns clean isolated vocal stems against a fixed instrumental without testing.
+
+### Voice conversion providers
+
+#### RVC
+- Original project: https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI
+- API reference starting point: https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI/blob/main/api_240604.py
+
+#### Applio
+- Repository: https://github.com/IAHispano/Applio
+- Documentation: https://docs.applio.org/
+
+#### Seed-VC
+- Repository: https://github.com/Plachtaa/seed-vc
+- Project/demo page: https://plachtaa.github.io/
+
+Agent implementation focus:
+- Implement conversion as an optional `timbre_provider`, never as the only vocal render path.
+- Preserve guide performance timing and pitch by default.
+- Make conversion a separate render step and artifact so users can compare pre/post-conversion.
+- Review licenses before shipping or embedding each provider.
+
+### Guide preprocessing / alignment
+
+#### WhisperX
+- Repository: https://github.com/m-bain/whisperX
+- Examples: https://github.com/m-bain/whisperX/blob/main/EXAMPLES.md
+
+Use for:
+- transcript,
+- word timestamps,
+- aligned lyrics,
+- phrase boundaries,
+- optional diarization if it becomes relevant later.
+
+#### RMVPE
+- Repository: https://github.com/Dream-High/RMVPE
+
+Use for:
+- dense F0 extraction,
+- melody contour,
+- voiced/unvoiced masks,
+- note transition cues.
+
+#### Basic Pitch
+- Repository: https://github.com/spotify/basic-pitch
+- Programmatic usage: https://github.com/spotify/basic-pitch#programmatic
+
+Use for:
+- guide audio → MIDI/note events,
+- editable Piano Roll seeding,
+- note onset/duration candidates.
+
+#### Demucs
+- Repository: https://github.com/facebookresearch/demucs
+- Python usage: https://github.com/facebookresearch/demucs#calling-from-another-python-program
+
+Use for:
+- source separation only.
+- Prefer the existing theDAW stems module rather than new standalone integration.
+
+### Useful analysis/developer references
+
+- FastAPI: https://fastapi.tiangolo.com/
+- Pydantic: https://docs.pydantic.dev/
+- PyTorch: https://pytorch.org/docs/stable/index.html
+- librosa beat tracking: https://librosa.org/doc/latest/generated/librosa.beat.beat_track.html
+- librosa onset detection: https://librosa.org/doc/latest/onset.html
+- Essentia documentation: https://essentia.upf.edu/documentation.html
+- FFmpeg filters: https://ffmpeg.org/ffmpeg-filters.html
+- Web Audio API: https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API
+
+---
+
+## 6. Core data contracts
+
+### 6.1 Instrumental context
+
+Persist or retrieve this from existing analysis/Chimera/library machinery.
+
+```json
+{
+  "instrumental_entry_id": "lib_beat_001",
+  "duration_sec": 183.42,
+  "sample_rate": 44100,
+  "bpm": 140.0,
+  "key": "F# minor",
+  "beats_sec": [0.0, 0.4286, 0.8571],
+  "downbeats_sec": [0.0, 1.7143, 3.4286],
+  "bar_grid": [
+    {"bar": 1, "start_sec": 0.0, "end_sec": 1.7143}
+  ],
+  "sections": [
+    {"label": "verse_1", "start_bar": 1, "end_bar": 17, "energy": 0.41},
+    {"label": "chorus_1", "start_bar": 17, "end_bar": 25, "energy": 0.88}
+  ],
+  "analysis_source": "library/chimera"
+}
+```
+
+### 6.2 Guide performance
+
+```json
+{
+  "guide_entry_id": "lib_guide_013",
+  "source_type": "mic_take",
+  "isolated_vocal_entry_id": "lib_guide_013_vocals",
+  "transcript": "optional guide transcript",
+  "word_timestamps": [
+    {"word": "running", "start_sec": 32.14, "end_sec": 32.56, "confidence": 0.96}
+  ],
+  "phrases": [
+    {"start_sec": 32.14, "end_sec": 35.80, "beat_start": 65, "beat_end": 73}
+  ],
+  "f0_hz": [{"time_sec": 32.14, "hz": 220.0}],
+  "voiced_mask": [{"start_sec": 32.14, "end_sec": 35.80}],
+  "midi_notes": [
+    {"pitch": 57, "start_sec": 32.14, "end_sec": 32.52, "velocity": 94}
+  ],
+  "cadence_features": {
+    "syllables_per_beat": 2.25,
+    "onset_offsets_beats": [0.0, 0.5, 0.75],
+    "pause_regions_sec": [[33.19, 33.44]]
+  }
+}
+```
+
+### 6.3 Vocal Performance Plan
+
+This is the central missing artifact. It must exist before renderer invocation.
+
+```json
+{
+  "plan_id": "vocalplan_001",
+  "instrumental_entry_id": "lib_beat_001",
+  "timeline_start_sec": 32.0,
+  "timeline_end_sec": 64.0,
+  "mode": "lyrics_from_scratch",
+  "renderer_preference": "soulx_singer",
+  "voice_profile_id": "voice_profile_01",
+  "sections": [
+    {
+      "id": "verse_1",
+      "start_bar": 17,
+      "end_bar": 33,
+      "delivery": "melodic_rap",
+      "energy": 0.48,
+      "register": "low_mid",
+      "lyrics": "line one ...",
+      "phrase_events": [
+        {
+          "line_index": 0,
+          "start_sec": 32.14,
+          "end_sec": 35.80,
+          "word_timing": [
+            {"word": "line", "start_sec": 32.14, "end_sec": 32.35}
+          ],
+          "syllable_timing": [
+            {"text": "line", "start_sec": 32.14, "end_sec": 32.35}
+          ],
+          "rests": [{"start_sec": 33.19, "end_sec": 33.44}],
+          "breaths": [{"at_sec": 35.70, "strength": 0.4}],
+          "midi_notes": [
+            {"pitch": 57, "start_sec": 32.14, "end_sec": 32.52}
+          ],
+          "f0_source": "generated_or_guide",
+          "intensity_curve": [
+            {"time_sec": 32.14, "value": 0.42},
+            {"time_sec": 35.80, "value": 0.58}
+          ]
+        }
+      ],
+      "layer_plan": [
+        {"role": "lead", "enabled": true, "pan": 0.0, "gain_db": 0},
+        {"role": "low_double", "enabled": false, "pan": -0.18, "gain_db": -8},
+        {"role": "high_double", "enabled": false, "pan": 0.18, "gain_db": -8}
+      ]
+    }
+  ],
+  "created_by": "vocal.plan_from_lyrics.v1"
+}
+```
+
+### 6.4 Render request
+
+```json
+{
+  "plan_id": "vocalplan_001",
+  "engine": "soulx_singer",
+  "render_mode": "svs_midi",
+  "target_sample_rate": 44100,
+  "target_format": "wav",
+  "output_roles": ["lead", "low_double", "high_double"],
+  "dry_output": true,
+  "insert_into_edit": true,
+  "target_track_names": {
+    "lead": "VOCAL — Lead",
+    "low_double": "VOCAL — Low Double",
+    "high_double": "VOCAL — High Double"
+  }
+}
+```
+
+---
+
+## 7. Required API surface
+
+```text
+POST /api/vocal/prepare-guide
+POST /api/vocal/plan/from-guide
+POST /api/vocal/plan/from-lyrics
+POST /api/vocal/plan/{plan_id}/validate
+GET  /api/vocal/plan/{plan_id}
+
+POST /api/vocal/render
+POST /api/vocal/render/convert-voice
+POST /api/vocal/render/layers
+GET  /api/vocal/jobs/{job_id}
+POST /api/vocal/jobs/{job_id}/cancel
+
+GET  /api/vocal/providers
+GET  /api/vocal/providers/{provider_id}/health
+GET  /api/vocal/voices
+POST /api/vocal/voices/import-reference
+```
+
+### `POST /api/vocal/prepare-guide`
+
+Input:
+```json
+{
+  "guide_entry_id": "lib_guide_013",
+  "instrumental_entry_id": "lib_beat_001",
+  "separate_if_needed": true,
+  "transcribe": true,
+  "extract_f0": true,
+  "extract_midi": true,
+  "align_to_instrumental": true
+}
+```
+
+Expected output:
+```json
+{
+  "job_id": "job_vocal_prepare_001",
+  "status": "queued"
+}
+```
+
+### `POST /api/vocal/plan/from-lyrics`
+
+Input:
+```json
+{
+  "instrumental_entry_id": "lib_beat_001",
+  "lyrics_with_tags": "[VERSE | melodic rap]\n...\n[CHORUS | wide sung hook]\n...",
+  "timeline_start_bar": 17,
+  "voice_profile_id": "voice_profile_01",
+  "planner_options": {
+    "respect_sections": true,
+    "generate_midi": true,
+    "generate_f0": true,
+    "allow_rewrite_suggestions": false,
+    "max_layers": 3
+  }
+}
+```
+
+Expected output:
+```json
+{
+  "plan_id": "vocalplan_001",
+  "status": "ready_for_review"
+}
+```
+
+---
+
+## 8. End-to-end pipelines
+
+### Pipeline A — guide performance
+
+```text
+Guide audio / mic take
+→ Library import
+→ optional Demucs isolation
+→ WhisperX word alignment
+→ RMVPE F0 extraction
+→ existing Basic Pitch MIDI extraction
+→ guide-performance artifact
+
+Guide-performance artifact + fixed instrumental context + optional new lyrics
+→ Vocal Performance Plan
+→ Singing renderer:
+   - SoulX SVC/SVS OR
+   - YingMusic lyric editing
+→ optional voice conversion:
+   - RVC/Applio OR Seed-VC
+→ normalize / trim / stems metadata
+→ Library import + lineage
+→ insert dry vocal clip(s) into EDIT
+→ user mixes in MIX
+```
+
+### Pipeline B — lyrics + tags
+
+```text
+Fixed instrumental Library asset
+→ existing analysis:
+   BPM / key / beats / downbeats / sections / energy
+
+Lyrics + structure/delivery tags
+→ lyric parser
+→ cadence/melody planner
+→ Vocal Performance Plan:
+   word/syllable timing + rests + MIDI/F0 + layer roles
+
+Vocal Performance Plan
+→ SoulX-Singer SVS
+→ one isolated lead stem
+→ optional planned doubles / harmonies
+→ Library + lineage
+→ EDIT tracks, aligned to timeline
+→ MIX
+```
+
+### Pipeline C — voice conversion only
+
+```text
+Existing recorded/generated vocal stem
+→ optional pitch cleanup
+→ RVC/Applio OR Seed-VC
+→ converted stem
+→ A/B artifacts in Library
+→ EDIT replacement/parallel track
+```
+
+---
+
+## 9. Rendering and placement rules
+
+### Output policy
+
+Always preserve:
+- original instrumental unchanged,
+- source guide unchanged,
+- pre-conversion vocal unchanged,
+- converted vocal as a new artifact,
+- vocal plan JSON,
+- provider/model/version/config,
+- source assets and lineage edges.
+
+### Timeline policy
+
+1. Render vocal audio in the exact timeline window represented by the plan.
+2. Trim leading model padding/silence only after measuring it.
+3. Align the rendered phrase to `timeline_start_sec`.
+4. Use theDAW’s editor BPM/grid and source timecode.
+5. Place each requested layer on a separate EDIT track.
+6. Do not auto-merge lead/doubles/harmonies unless the user explicitly asks for a printed stack.
+
+### Suggested track naming
+
+```text
+VOCAL — Lead
+VOCAL — Low Double
+VOCAL — High Double
+VOCAL — Harmony Low
+VOCAL — Harmony High
+VOCAL — Ad-libs
+VOCAL — Guide (hidden/optional)
+```
+
+---
+
+## 10. Provider adapter interface
+
+Use one internal provider contract.
+
+```python
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, Literal
+
+@dataclass
+class VocalRenderInput:
+    plan_path: Path
+    lyrics: str
+    midi_path: Path | None
+    f0_path: Path | None
+    guide_audio_path: Path | None
+    voice_reference_path: Path | None
+    sample_rate: int
+    output_dir: Path
+    options: dict
+
+@dataclass
+class VocalRenderResult:
+    audio_path: Path
+    sample_rate: int
+    duration_sec: float
+    provider: str
+    provider_version: str | None
+    metadata: dict
+
+class VocalProvider(Protocol):
+    provider_id: str
+    display_name: str
+
+    def health(self) -> dict: ...
+    def ensure_ready(self) -> None: ...
+    def render(self, request: VocalRenderInput) -> VocalRenderResult: ...
+```
+
+Adapters must not leak Gradio/UI assumptions into `router.py`.
+
+---
+
+## 11. Model-worker policy
+
+Each heavyweight model gets a separate worker process/environment.
+
+Suggested worker strategy:
+```text
+theDAW backend
+→ writes immutable job spec JSON + resolved local paths
+→ starts/reuses named worker:
+   soulx-worker
+   yingmusic-worker
+   acestep-worker
+   voice-conversion-worker
+→ worker sends progress events
+→ worker writes result path + metadata JSON
+→ backend imports assets into Library and writes lineage
+```
+
+Worker status:
+```text
+not_installed
+installing
+ready
+busy
+error
+offline
+```
+
+Settings → Models should surface those states beside existing Stable Audio/Magenta/Demucs/MIDI entries.
+
+---
+
+## 12. MVP scope and build order
+
+### Phase 1 — no model yet: make the plan and asset flow real
+
+Deliver:
+- `vocal` module scaffold.
+- Library-linked guide preparation job.
+- guide transcript + F0 + MIDI + phrase data.
+- editable Vocal Performance Plan JSON.
+- plan review UI in theDAW.
+- dummy renderer that returns an existing guide/muted placeholder only for end-to-end timeline testing.
+
+Acceptance:
+- A mic take can become a guide artifact.
+- Plan is visible/editable.
+- One generated/placeholder stem can be inserted accurately into EDIT.
+- All source/output lineage is correct.
+
+### Phase 2 — SoulX-Singer as first real render provider
+
+Deliver:
+- SoulX model worker.
+- model registration/readiness UI.
+- `svs_midi` and `svs_f0` request paths.
+- lead-vocal rendering.
+- output normalization and exact timeline insertion.
+
+Acceptance:
+- Lyrics + hand-authored Piano Roll MIDI creates a lead vocal stem.
+- A guide-derived F0/MIDI path creates a vocal stem.
+- Result lands on the designated EDIT track in time.
+
+### Phase 3 — guide lyric replacement
+
+Deliver:
+- YingMusic worker.
+- guide singing + replacement lyric workflow.
+- guide vocal isolation preflight.
+- preserve-melody visual comparison.
+
+Acceptance:
+- A clean guide can be re-sung with changed lyric text while retaining its broad melody/timing.
+- Original guide and transformed output remain linked and independently auditionable.
+
+### Phase 4 — multiple layers and conversion
+
+Deliver:
+- lead/double/harmony plan roles.
+- optional RVC/Applio and/or Seed-VC conversion providers.
+- per-layer render configs.
+- stack placement and simple mixing defaults.
+
+Acceptance:
+- One plan creates separate lead, double, and harmony clips.
+- Voice conversion creates a separate child artifact, never overwrites the source performance.
+
+### Phase 5 — generative planner quality
+
+Deliver:
+- instrumental-aware lyric timing.
+- cadence selection.
+- energy/section-aware delivery.
+- melody/MIDI proposal.
+- auto-created rests/breaths.
+- editable plan review before render.
+
+Acceptance:
+- Lyrics+tags workflow can produce a reasonable editable first performance plan without a guide.
+- User can move words/notes/rests and re-render only the selected region/phrase.
+
+---
+
+## 13. Test matrix
+
+| Test | Expected |
+|---|---|
+| 140 BPM instrumental + rap guide | Output cadence starts on the same intended beat locations |
+| Sung guide + rewritten lyric | Melody and phrase timing broadly preserve; words change |
+| Lyrics only + tagged chorus | Planner builds notes/timing and output starts/ends within requested bar window |
+| Guide is a mixed bounce | Separation step is offered/required before lyric-edit route |
+| 44.1 kHz instrumental | Returned stem is 44.1 kHz and aligns correctly in EDIT |
+| Engine unavailable | Job reports `not_installed` or specific error; does not crash backend |
+| Provider returns extra silence | System measures/compensates offset, records adjustment |
+| Rerender same plan | Creates a new child artifact; never replaces prior audio |
+| RVC conversion | Is optional downstream process and preserves original performance artifact |
+| Model worker dies | Job fails cleanly, worker is marked unhealthy, existing backend stays live |
+
+---
+
+## 14. License / shipping caution
+
+Agents must verify current upstream licenses and model terms before bundling or commercial deployment.
+
+Known things to check:
+- SoulX-Singer code/model terms and included dependencies.
+- YingMusic-Singer code/model terms; verify all bundled VAE/checkpoint restrictions.
+- ACE-Step’s current code/model license and commercial-use policy.
+- RVC project terms and downloaded model provenance.
+- Applio license plus dependencies.
+- Seed-VC GPL-3.0 implications.
+- Demucs, WhisperX, RMVPE, and Basic Pitch licenses.
+- Consent and rights for uploaded voice references/training data.
+
+**Do not claim commercial clearance based on this document alone.** Confirm in the upstream repository and model-card license files at implementation time.
+
+---
+
+## 15. Decision summary
+
+### Build first
+```text
+SoulX-Singer
++ existing Demucs
++ WhisperX
++ RMVPE
++ existing Basic Pitch / Piano Roll
++ theDAW Library + job system + EDIT timeline
+```
+
+### Add second
+```text
+YingMusic-Singer
+```
+
+### Add later / optional
+```text
+RVC/Applio
+Seed-VC
+DiffSinger
+ACE-Step
+```
+
+### Product rule
+```text
+TheDAW owns:
+- instrumental context
+- project/timeline alignment
+- guide analysis
+- lyrics/tags parsing
+- Vocal Performance Plan
+- asset lifecycle
+- track placement
+- lineage
+
+External engines own:
+- singing waveform synthesis
+- optional voice/timbre conversion
+```

--- a/docs/plans/2026-06-24-akvj-volcap-roadmap.md
+++ b/docs/plans/2026-06-24-akvj-volcap-roadmap.md
@@ -107,6 +107,45 @@ rotation.
   source over AKV1 (ARKit/ARCore or on-device monocular) with intrinsics added to the header.
 - P6 Splat fidelity tier + WebGPU/TSL compute port of `AkvjCloudRenderer` (toward ~1M points).
 
+## Coming up (kinda soon) — priority queue
+
+The running upcoming-features queue layered on top of the P-phases above. ASCII keeps
+its slot; everything else is sequenced smallest-valuable-first, with one hard dependency
+(the Show Designer mapping matrix lands before or with FaceViz/Sway so those plug in as
+sources rather than needing a retrofit).
+
+1. ASCII source (P4 above): ASCILINE GPU glyph source, depth-driven glyph density,
+   dynamic font size, audio-reactive.
+2. SPECTRA-RIDER VJ cameraSource: port the 3D audio spectrogram-terrain visualizer in as a
+   framework-free three.js source like cymatics, plus the `getAudioSpectrum` 128-bin audio
+   seam it needs. Lowest dependency, immediate visible win. See the Show Designer plan.
+3. VSTs (re-added after the earlier deferral): host VST/CLAP audio plugins in the MIX /
+   FX chain. A licensing and hosting-approach pass is needed before building.
+4. Show Designer mapping matrix (foundation): one source-to-target grid that subsumes the
+   separate DJ and VJ MIDI mapping. Lands before FaceViz/Sway. See the Show Designer plan.
+5. Skeletal tracking with segmentation and AR: MediaPipe pose plus body segmentation /
+   masking to cut the performer out of the webcam, then composite AR layers and drive
+   particles and clouds from the skeleton. Delivered together with the FaceViz module.
+6. FaceViz module integration: fold the gantasmo INFINIGHTCapture / FaceViz gesture-mocap
+   app into theDAW (absorb, in-process). Now consumes the matrix as a control source.
+7. Sway controller integration: ingest the Audima Sway expressive motion MIDI controller
+   as a control source on the matrix and route its six dimensions across DJ, VJ, akvj, FX, XR.
+8. Presets + per-song bindings + pads: genre presets, bindings saved per song and recalled
+   on load, and FX-rack/toggle pads for mid-song changes, layered over the matrix.
+9. Vocal suite (capture + MIDI home): absorb vocal2midi-architect as one in-browser YIN
+   capture engine landing in the piano roll / channel rack / SpessaSynth.
+10. Vocal suite (generation): Gemini metadata/cleanup server-side, the Architect agent onto
+    the control bus, and vocal-to-inpainting through the already-wired inpaint contract.
+11. Vocal suite (performance): vocalize-an-effect (beatbox timbre drives an FX) and
+    beat-for-a-section. The trickiest, genuinely new code, last of the vocal items.
+12. SPECTRA VR (Route A, in-VJ WebXR), gated on item 2 being confirmed live. Route B
+    (theDAW-XR Unity HLSL) held as the polished-show follow-up.
+13. SoulX singer sidecar: the singing-voice endpoint of the vocal suite, its own multi-phase
+    build (see `docs/guides/theDAW_SoulX_Singer_Integration_Guide.md`).
+
+Design for items 4-8 + 9-12 is in `docs/plans/2026-06-24-show-matrix-vocal-spectra.md`;
+items 5-7 also in `docs/plans/2026-06-24-faceviz-sway-skeletal-integration.md`.
+
 ## Risks (honest)
 
 - Monocular depth is relative/affine + flickery; needs EMA + near/far remap; stylized look only.

--- a/docs/plans/2026-06-24-faceviz-sway-skeletal-integration.md
+++ b/docs/plans/2026-06-24-faceviz-sway-skeletal-integration.md
@@ -1,0 +1,277 @@
+# FaceViz + Sway + skeletal/segmentation/AR: integration plan
+
+Status: living plan. Created 2026-06-24 from a grounded multi-agent brainstorm
+(two grounding agents reading the real theDAW/VJ seams + verifying MediaPipe and
+browser AR from live docs, three brainstorm lenses, one synthesis pass). Not in RAG.
+
+## Decisions locked (2026-06-24, user)
+
+- ABSORB FaceViz in-process as the VJ `gesturecam` source. FaceViz stops being the primary
+  surface. gantasmo/INFINIGHTCapture-theDAW-module is a FORK of upstream
+  morganlavery/INFINIGHTCapture, so any FaceViz-side change lands on the gantasmo fork and the
+  user opens a PR upstream if Morgan wants it. The absorb itself moves code INTO the VJ, so most
+  changes land in VJ + theDAW.
+- Wire the gesture/pose control data into DJ controls (DJ_TARGETS) AS WELL AS VJ params: FaceViz
+  becomes a hands-free DJ controller, not only a visual source. One poseControlSource feeds both.
+- Headset AR is IN SCOPE and first-class (Plan C C4 markerless + C8 Quest path), not deferred.
+- Push convention: VJ changes go to the `gantasmo` remote (gantasmo/VJ-9000; its origin push is
+  disabled); theDAW changes go to origin (gantasmo/theDAW); never Stability-AI; never push without
+  the explicit word in the moment and the user's live eyes on the visual work first.
+
+## What these are
+
+- FaceViz = gantasmo/INFINIGHTCapture-theDAW-module ("by DJ INFINIGHT"). A standalone
+  React + Vite + Electron app. MediaPipe Tasks Vision HandLandmarker (2 hands x 21
+  landmarks) + PoseLandmarker (33-point lite) feed a gesture engine, which drives a
+  Canvas2D compositor (fire / melt / warp / bloom + a skeleton rig) and a Syphon (macOS)
+  / Spout (Windows) texture-share output. Its own named weaknesses: the output path is a
+  Canvas2D `getImageData` readback at 30fps (slow), the gestures collapse to five coarse
+  booleans, and the product of the app is a flat texture rather than control data.
+- Sway = Audima Labs "Sway", an expressive motion MIDI controller. Sixteen onboard
+  sensors resolve to six dimensions (Strike / Sway / Pulse / Glide / Press / Sculpt),
+  over USB-C plus hardware MIDI IN/OUT. It is class-compliant, so theDAW's MIDI subsystem
+  already enumerates it with no driver work. Hardware also has 8 encoders, a 3.2-inch
+  OLED, performance pads, and a motion-reactive RGB LED grid.
+- New ask = skeletal/pose tracking with body segmentation/masking and AR. This is the
+  same lineage as FaceViz, so it folds into one initiative.
+
+## The unifying insight
+
+Two existing pieces collapse all three of these into "wire to a seam we already have":
+
+1. One control bus. `registerXrControlSource({area, buildEntries, apply})`
+   (`frontend/src/state/xrControlClient.ts`) over the transport-only relay at
+   `backend/modules/xrcontrol/router.py` already lets a namespace publish self-describing
+   control entries and receive `control-set` values routed by id prefix. DJ is already
+   wired this way via `DJ_TARGETS` (`frontend/src/state/bindableTargets.ts`). FaceViz
+   gestures, Sway dimensions, and pose/face landmarks all become routable signals by
+   registering one source each, with no per-control plumbing.
+2. One source-agnostic renderer. `AkvjCloudRenderer.ts` (the VJ app) unprojects
+   `pos = (rayX, -rayY, 1) * depth` in a vertex shader and applies 14 styles + bloom +
+   audio reactivity. It does not care where depth and color originate. Two producers
+   already prove it (`useAkvj3d` parsing Kinect AKV1 frames, `useDepthCloud` running
+   Depth-Anything-V2 in a WebGPU worker). A segmented body or a sparse skeleton becomes
+   a cloud by feeding the same `setXYTable` + `pushFrame` contract, inheriting every
+   style and the audio reactivity for free.
+
+So the strategy is: emit control data onto the existing manifest, and feed pixels into
+the existing renderer. Almost nothing here needs new transport or new shaders.
+
+## Plan A: FaceViz integration
+
+Path decision: port the FaceViz trackers into the VJ in-process as a new `gesturecam`
+cameraSource. Reject the Spout/Syphon bridge and the nested-module-iframe.
+
+Justification (verified against code): the VJ is the consumer, so Spout/Syphon only exist
+to cross an app boundary that disappears in-process. Receiving Spout needs an Electron-main
+native addon and a GPU-to-CPU readback that reintroduces exactly FaceViz's `getImageData`
+bottleneck, and it is Windows-only. A module iframe spawns a third nested browser GPU
+context with no shared renderer. In-process reuses the existing off-thread worker pattern
+and the cloud renderer, cross-platform, with zero transport and zero native code.
+
+Steps:
+
+- A0. Decouple first, no pixels. `gestureEngine.ts buildTrackedHand` already computes
+  `openness`, `pinch`, `velocity`, `centroid`, `wrist` per hand, then `analyzeMotion`
+  discards them into five booleans. Lift the continuous scalars before the boolean
+  reduction.
+- A1. Register a `poseControlSource` (area `pose`) modeled on `xrControlDjSource.ts`,
+  exposing the continuous scalars as manifest entries (`pose.leftPinch`, `pose.rightOpenness`,
+  `pose.handX`, `pose.bodyY`). Register beside `djControlSource` in theDAW `App.tsx`. A
+  pinch now drives a filter cutoff or a clip launch through the same bus DJ uses.
+- A2. Add `@mediapipe/tasks-vision` as a VJ dependency (it ships in the FaceViz clone, not
+  yet in the VJ). Pull model versions from the live Google AI Edge model table, never from
+  memory.
+- A3. Create `src/akvj/gestureWorker.ts` mirroring `depthWorker.ts`: off-thread, reduced-res
+  inference decoupled from the 60fps render loop, running HandLandmarker + PoseLandmarker
+  on the GPU delegate.
+- A4. Register the `gesturecam` cameraSource through the six known seams (the `types.ts`
+  union AND the `useMedia.ts` signature default, the generative-source guard, the genStream
+  ternary, a new positional stream param appended after `depthCloudStream`, the effect dep
+  array, the `App.tsx` hook + standalone-preview block, and a `VJControls.tsx` SOURCE chip +
+  status panel).
+- A5. Write `src/useGestureCam.ts`: run the worker, composite the performer over generated
+  visuals in a WebGL fragment shader, `captureStream(30)` the result. The composite never
+  leaves the GPU, which is the FaceViz fix.
+- A6. Optional add-on: add FaceLandmarker (`outputFaceBlendshapes:true`) in the same worker,
+  exposing a curated subset of the 52 blendshapes (jawOpen, browInnerUp, mouthSmile) as extra
+  `pose.*` entries, off by default, smoothed before driving audible params.
+- A-fallback. If FaceViz must remain a separate app or run on a second PC, do not chase
+  Spout/Syphon input. Replace its `outputTargets.ts` sender with an AKV1-framed depth+color
+  emitter pointed at `backendWsBase() + '/api/akvj/ws/source'` (the akvj relay is
+  frame-agnostic). One caveat: a single akvj source at a time, so this evicts the Kinect
+  sidecar.
+
+## Plan B: Sway integration
+
+The Sway is already enumerated as class-compliant MIDI, so the work is destinations, not
+transport. The master Web MIDI gate defaults OFF, so nothing sees the Sway until the user
+enables MIDI. Never hardcode the Sway's CC numbers (firmware-configurable, no MIDI 1.0
+layout query); bind every dimension by learn.
+
+Steps:
+
+- B1. Add one Row to `controllerProfiles.ts` for the Sway (`match=['sway','audima']`) with a
+  bespoke sections layout that labels the six dimensions plus 8 encoders and the pads. The
+  labels are physical layout only; the dims still bind by learn.
+- B2. Build a small `swayBus` that reads the six learned CCs off the shared `midiBus` and
+  normalizes each to 0..1.
+- B3. Register a `swayControlSource` (area `sway`) with six entries
+  (`sway.strike` ... `sway.sculpt`) fed by `swayBus`. The dims are now first-class routable
+  signals on the same bus DJ uses, converging with the FaceViz gesture signals so a pinch and
+  a Sculpt sweep can drive the same target.
+- B4. Novel target 1, akvj cloud: a `sa3-vj/sway-params` branch in `sa3Bridge.ts` calls the
+  renderer's `setParams` / `setStyle`. Map Sway to spin, Pulse to wind, Press to density,
+  Glide to distance, Strike to a bloom/size transient, Sculpt to a style crossfade across
+  `AKVJ_STYLES` (needs a small interp layer since `setStyle` is a discrete key).
+- B5. Novel target 2, VJ FX + clip grid: learn each dim onto a `midiParams.ts MIDI_PARAMS`
+  entry (one entry yields MIDI-mappable + crossfader-routable + audio-reactive at once).
+  Suggested map: Press to feedback, Pulse to glitch, Sway to the CAM/MEM crossfader, Glide to
+  hue, Sculpt to tiling, Strike to strobe. Clip launch on Strike uses note-on pads via DJ-style
+  action learn.
+- B6. Novel target 3, Spatializer 3D placement: map three dims through the exported
+  `azElToXYZ` into a live Spatializer (`rackEffects.ts`): Sway to azimuth, Pulse to elevation,
+  Glide to distance, via click-free `setParams`. Two-handed motion physically places a stem in
+  3D space.
+- B7. Novel target 4, MAKE/Magenta: register a second source (area `make`) wrapping concrete
+  generation setters (`makeTargets.ts` modeled on `DJ_TARGETS`). Map Press to guidance, Glide
+  to duration, Pulse to Magenta density/temperature, Sculpt to a prompt-A/B blend, Strike to
+  trigger a generate. Honest limit: SA3 text-to-audio is request-time, so only Magenta RT gives
+  true continuous live response.
+- B8. Sway page UI: a view in `SlidePanel.tsx` with six live meters (from `swayBus`) and a
+  routing matrix of destination pickers populated from `buildManifest()`. Every select needs a
+  stable id+name+associated label and valid ARIA; custom dropdowns need aria-expanded /
+  aria-haspopup. Tailwind v4 class forms only.
+- B9. MIDI-OUT feedback (deferred behind a capability flag): theDAW keeps no MIDIOutput today.
+  A `midiOutBus` could pulse the Sway's RGB grid on the DJ beat phase and color decks. OLED
+  text needs SysEx, which the app deliberately avoids, so it forces a sysex opt-in and a second
+  permission, plus an IN-to-OUT echo guard. The Sway's exact LED/OLED protocol is vendor-specific
+  and not in-repo, so this is reverse-engineered without Audima's MIDI implementation chart.
+
+## Plan C: skeletal tracking + segmentation/masking + AR
+
+All inference runs off-thread at reduced res mirroring `depthWorker.ts`, reusing the
+`sa3-vj/visibility` iframe park. Use a standalone ImageSegmenter (GPU) for the matte and
+PoseLandmarker (GPU) for landmarks only, because PoseLandmarker's own segmentation mask
+returns blank under the GPU delegate on web (MediaPipe issue #4757, still open).
+
+Steps:
+
+- C1. Matte as a renderer INPUT, not a new source. `segmentWorker.ts` runs ImageSegmenter
+  (GPU, `outputCategoryMask:true`); `useBodyMatte.ts` returns a per-frame `WebGLTexture` mask
+  via `MPMask.getAsWebGLTexture()` (stays on-GPU). A fragment pass composites performer RGB
+  times mask over whatever cameraSource is active, keying out background. On-GPU green-screen
+  with no chroma key. Never call `getAsFloat32Array` / `getAsUint8Array` in the hot path; call
+  `mask.close()` each frame.
+- C2. Sparse skeleton cloud, cheapest reuse first. Sample N points along each bone from the 33
+  PoseLandmarker joints, pack X/Y into a one-time ray table (`setXYTable`) and per-frame depth
+  into Uint16 mm (`pushFrame`). The performer renders as a glowing particle stick-figure in any
+  style, audio-reactive, with zero new shader code.
+- C3. Fuller body cloud. Clone `useDepthCloud.ts` to `useBodyCloud.ts`. After the depth worker
+  returns `depthU16`, multiply each sample by the segmentation mask read ONCE at the ~8fps
+  inference grid res (320 wide), zeroing background so the renderer culls it. Register a `pose`
+  cameraSource through the six seams. Add temporal EMA/feather for edge shimmer.
+- C4. Markerless AR overlay, no headset. `useArOverlay.ts`: getUserMedia, PoseLandmarker per
+  frame, place three.js content (fingertip emitters, a chest cymatics ring, wrist wind affectors)
+  at landmark positions mapped to camera-plane world coords, render over the mirrored video,
+  `captureStream(30)`. Use the C1 matte as an occlusion gate. Do NOT implement as WebXR
+  immersive-ar (unsupported on desktop browsers, absent in Firefox/Safari). The real cost is
+  authoring the three.js scene, not the plumbing.
+- C5. Pose to control data. The shared area `pose` source (same as A1) publishes pose world
+  landmarks and FaceLandmarker blendshapes as 0..1 entries, bindable to DJ/VJ/MAKE and mappable
+  onto `MIDI_PARAMS`. Update entry values in place; do not rebuild the manifest per frame.
+- C6. Pose to 3D audio. Map a wrist/torso centroid through `azElToXYZ` into a live Spatializer
+  (setParams for continuous, scheduleTeleport for beat-locked jumps).
+- C7. Hero matting (optional QUALITY toggle). `matteWorker.ts` cloning `depthWorker.ts` runs
+  transformers.js `pipeline('background-removal', ...)` on WebGPU with WASM fallback for clean
+  hair/edge alpha, for hero/low-fps shots only. License gate: briaai/RMBG-1.4 has a
+  non-commercial/commercial split; prefer an Apache/MIT model or MediaPipe for commercial use.
+- C8. Headset path (separate effort). Stream the C3 masked body depth+color as AKV1 frames over
+  the akvj relay and add a Quest-side consumer in theDAW-XR rendering on a transparent
+  immersive-ar background. Quest Browser exposes no raw RGB passthrough, so only the
+  already-segmented cloud crosses; one akvj source at a time means this evicts the Kinect sidecar
+  unless a second relay or a source-id multiplex is added.
+
+## Wild cross-tool combinations (the mind-blowing stuff)
+
+Each ties to a real seam from the plans above, so they are buildable, not hand-waving.
+
+- Conduct the generator. Sway Sculpt and FaceLandmarker expression drive Magenta RT live
+  (density / temperature / prompt-A-B blend) while the performer's own segmented body is the
+  visual via the body cloud. The body is both the controller and the picture. Seams: B7 makeTargets
+  + B3 swayControlSource + C3 body cloud.
+- You are the instrument and the visual. Pose drives audio (Spatializer + FX setParams) and the
+  cloud that is literally your silhouette; a pinch fires a stem. Seams: C5 pose source + C6 spatial
+  audio + C3 cloud + DJ live stems.
+- Dancer as volumetric broadcast. The segmented body depth cloud is sent over the existing WebRTC
+  broadcast/watch-link module to remote viewers, reconstructed on-device, so a remote audience sees
+  a live volumetric performer. Seams: C3 body cloud + the broadcast module.
+- Gesture-as-stem-mixer. Hands-up and openness map to DJ live-stem faders; body position pans each
+  stem in 3D via the Spatializer. The DJ mixes with the whole body. Seams: A1/C5 pose source + DJ
+  stems + B6/C6 spatializer.
+- Two-performer colocation jam. One performer on Sway, one on FaceViz pose, both feeding the same VJ
+  manifest; Quest colocation puts them in a shared AR space. Seams: B3 + A1 over the manifest +
+  theDAW-XR colocation.
+- Self-shading ASCII portrait. When the ASCII source lands (roadmap P4), render the body cloud as
+  depth-driven glyphs: near is dense, far is sparse, font size tracks bass. The performer becomes a
+  living volumetric ASCII figure. Seams: C3 body cloud + the ASCILINE source.
+
+## Recommended build order (smallest valuable first)
+
+1. `poseControlSource` (area `pose`) over the manifest. Smallest valuable unit, fixes the
+   flat-texture weakness with no pixels, shared foundation for FaceViz + skeletal + Sway.
+2. `swayControlSource` (area `sway`) + `swayBus` + the Sway controller profile. Pure reuse, makes
+   the six dims routable immediately.
+3. Sparse skeleton cloud into the renderer. S effort, zero new shaders, first visible skeletal win.
+4. Sway to Spatializer 3D placement (azElToXYZ). S effort, intuitive payoff.
+5. Sway to akvj cloud params (sa3Bridge branch). Headline novel destination; depends on 2.
+6. On-GPU body matte compositor input. Unlocks green-screen and gates the fuller cloud.
+7. Body-masked depth cloud (`pose` cameraSource). Depends on 6.
+8. `gesturecam` cameraSource (FaceViz port in-process). L effort; reuses the worker from 3/7.
+9. FaceLandmarker blendshapes + gesture/Sway to live FX rack setParams.
+10. Markerless pose-AR overlay (`pose-ar`). L; three.js scene authoring is the real cost.
+11. Sway to MAKE/Magenta `make` source. Needs new generation setters; only Magenta RT is truly live.
+12. Sway page UI in SlidePanel. After enough destinations exist to populate the matrix; a11y-heavy.
+13. Hero matting worker. Optional QUALITY toggle, license-gated.
+14. Headset body-cloud over the akvj relay to theDAW-XR. L; Unity consumer + relay multiplex.
+15. MIDI-OUT feedback to the Sway LED/OLED. Deferred; vendor protocol not in-repo.
+
+## Risks
+
+- GPU contention from stacking MediaPipe trackers + ImageSegmenter + the depth worker + the cloud
+  renderer inside one iframe. Keep inference off-thread at reduced res, reuse the visibility park,
+  share one WebGL context, and gate so depth + live matte + hero matte never run concurrently.
+- The readback trap. `MPMask.getAsFloat32Array/getAsUint8Array` are the same GPU-to-CPU readback that
+  is FaceViz's bottleneck. Stay on `getAsWebGLTexture` in the hot path; the one allowed `getAsUint8Array`
+  (the body-cloud mask multiply) must stay at inference res.
+- PoseLandmarker GPU segmentation mask is blank on web (issue #4757); use a standalone ImageSegmenter
+  for the matte.
+- Segmentation flicker at edges and on fast motion; 2-class selfie is body-only. Add temporal feather;
+  use hair-aware matting only at low fps.
+- The cameraSource union is duplicated (types.ts AND the useMedia.ts signature default), and a new
+  stream param must be appended in exact positional order after `depthCloudStream` and added to the
+  effect dep array, or the stream silently never binds.
+- Spout/Syphon are platform-locked and input-hostile to the web; bridge over the frame-agnostic akvj
+  relay instead.
+- Do not pin model/library versions from memory (HARD RULE 1). Pull MediaPipe versions from the live
+  Google AI Edge table; do not downgrade `@huggingface/transformers` or `@mediapipe/tasks-vision`.
+- Licensing: MediaPipe Tasks models are Google AI Edge assets (Apache-friendly); briaai/RMBG-1.4 has a
+  non-commercial/commercial split. Confirm FaceViz and Sway-software licensing permit absorbing or
+  redistributing.
+- Accessibility (HARD RULE 3): every new select, toggle, and SOURCE pad needs a real label + valid
+  ARIA; never wrap a non-native control in `<label>`.
+- Visual work needs the user's live eyes; tsc/vite build/lint/unseen screenshots do not count.
+- MIDI master gate defaults OFF; never hardcode the Sway CC numbers; bind by learn.
+- The akvj relay holds one source at a time; a body-cloud or external source evicts the Kinect sidecar.
+  Connect VJ-to-backend WebSockets directly to :8600 via `backendWsBase()`.
+
+## Open questions for the user (remaining after 2026-06-24 decisions)
+
+- Sway MIDI implementation chart: is Audima's chart available for the LED/OLED feedback path, or is it
+  purely reverse-engineered? Is a physical Sway on hand to learn the six CCs and verify routing live?
+  (User: getting back on the MIDI chart.)
+- Commercial-use posture: does theDAW ship as a product (forcing an Apache/MIT/MediaPipe-only matting
+  choice), or is non-commercial acceptable for hero matting?
+- Pose-AR look: who authors the three.js AR scene content? That authoring, not the plumbing, is the cost.
+- MAKE/Magenta: which generation params are genuinely live-pushable today vs request-time only, and what
+  are the prompt-A/B blend semantics before Sculpt can drive them?

--- a/docs/plans/2026-06-24-show-matrix-vocal-spectra.md
+++ b/docs/plans/2026-06-24-show-matrix-vocal-spectra.md
@@ -1,0 +1,251 @@
+# Show Designer matrix + Vocal suite + SPECTRA-RIDER + presets/pads: integration plan
+
+Status: living plan. Created 2026-06-24 from a grounded multi-agent design pass (two
+grounding agents reading the vocal2midi-architect and SPECTRA-RIDER repos and confirming
+theDAW seams, four design lenses, one synthesis). Not in RAG. Design only; nothing built.
+
+Companion to `docs/plans/2026-06-24-faceviz-sway-skeletal-integration.md`. The unified
+matrix here is the surface the FaceViz `poseControlSource` and Sway `swayControlSource`
+plug into rather than wire bespoke, so the two plans interlock.
+
+## Decisions locked (2026-06-24, user)
+
+- "CV" means COMPUTER VISION (the pose / skeletal / facial tracking already in the
+  FaceViz / INFINIGHT module), not control-voltage. The FaceViz CV source and the vocal
+  source are two inputs to the same mapping matrix; a gesture and a voice can co-drive the
+  same target.
+- The unified mapping matrix is the centerpiece and subsumes the separate DJ and VJ
+  MIDI-mapping surfaces into one source-to-target grid with genre presets, per-song
+  bindings, and mid-song FX/toggle pads.
+- SPECTRA-RIDER comes in as a VJ cameraSource first, then a VR path once the source is
+  confirmed live. Headset VR is in scope (immersive-vr works because the scene is synthetic).
+- ASCII keeps its slot; VSTs stay queued after ASCII.
+
+## The unifying insight (most of this is reuse, not new control plane)
+
+theDAW already has both halves of the matrix, unjoined:
+
+- Source half: `XrControlSource {area, buildEntries(), apply(id, value)}` in
+  `frontend/src/state/xrControlClient.ts`. `xrControlDjSource.ts` already wraps a target
+  catalogue into a source with zero per-control code. The FaceViz/Sway plan registers
+  `poseControlSource` and `swayControlSource` through this same call.
+- Target half: `BindableTarget {id, label, group, kind, min, max, step, unit, invoke}` in
+  `frontend/src/components/surface/widgetTypes.ts`. `DJ_TARGETS` (`bindableTargets.ts`) is
+  the only instance today, each a concrete live setter.
+- Transport: the `/api/xr/control` relay already routes by id prefix. It stays the wire.
+
+So the Show Designer is one canonical normalized data model, a fan-out binding engine, one
+matrix UI, and a preset layer over the registries that exist. The three MIDI-learn stores
+(`controllerMapStore` position-based, `djControlMap` action-based, `learnedProfilesStore`
+capture-based) become the learn backing store for one `MidiDeviceSource`, not parallel systems.
+
+## Plan W: the Show Designer mapping matrix
+
+Effort XL, high impact. Land incrementally or it stalls.
+
+Data model (new `frontend/src/state/showMatrix/`):
+- `ControlSource {id, label, area, channels[], subscribe(cb(channelId, value|'trigger'))}`
+  and `ControlChannel {id, label, group, kind: 'continuous'|'trigger'}`. This is exactly
+  what `poseControlSource` / `swayControlSource` already emit (`pose.leftPinch`, `sway.strike`
+  as 0..1 entries). A `MidiDeviceSource` adapter reads `midiBus` and emits one channel per
+  learned control.
+- Target shape is `BindableTarget` verbatim. Generalize off DJ by generating sibling
+  catalogues from registries that exist: `VJ_TARGETS` from `midiParams.ts MIDI_PARAMS`
+  (invoke routes through `controlSyncBus`/`sa3Bridge`), `FX_TARGETS` from `rackEffects.ts`
+  `RackParamDescriptor`s plus a per-effect `ChainEntry` enable toggle (the FX pad), and
+  `MAKE_TARGETS` from `makeTargets.ts` (the same file the FaceViz/Sway plan B7 calls for).
+- `Binding {sourceId, channelId, targetId, curve?{invert, min, max, gamma}}`. The binding
+  engine subscribes the channel, applies the curve, scales 0..1 into `[min,max]` reusing
+  `scaleCcValue`/`scaleAudioValue` (`midiParams.ts`) and `toNative` (`controlSyncBus.ts`),
+  and calls `target.invoke`. One channel may fan out to many targets (a Sculpt sweep driving
+  a VJ tiling and an FX mix at once), which neither learn store can express today. Reuse the
+  `controlSyncBus` `applying` echo-guard.
+
+Steps M0-M9: define the model, build the source registry (mirrors the `sources` Map in
+`xrControlClient`), wrap the three learn stores into one `MidiDeviceSource` (honoring the
+master MIDI gate, default OFF), generalize targets, write the fan-out binding engine, adopt
+the FaceViz/Sway sources through one thin `XrControlSource -> ControlChannel` adapter, build
+`MatrixView.tsx` (rows = source channels grouped by source, columns = target groups, cell =
+binding + per-cell LEARN, auto-populated from the manifest), and register the matrix's
+aggregated manifest back onto the XR bus so every binding is reachable from a headset for free.
+
+Accessibility (HARD RULE 3): native `<select>` pickers with id+name+`<label htmlFor>`; the
+grid is `role=grid` with `aria-rowindex`/`aria-colindex`; cells and LEARN chips are custom
+controls (never wrapped in `<label>`) carrying `aria-label` naming both axes; learning cells
+expose `aria-live`; pads use `role=button` with `aria-pressed` (latch) / `aria-label`
+(momentary). Tailwind v4 class forms only.
+
+## Plan V: the Vocal suite
+
+Effort L, high impact. One capture engine, four destinations.
+
+Capture spine (new `frontend/src/lib/vocalToMidi.ts`): port ONLY the math from vocal2midi
+`utils/audioProcessing.ts` (the from-scratch YIN `detectPitch`, `frequencyToMidi`,
+`cleanupNotes` with 2-semitone hysteresis and the RMS-gated sensitivity curve), emitting
+theDAW `RenderNote {midi, startSec, durationSec, velocity}` (a 1:1 rename from `NoteEvent`).
+Reimplement the live frame loop as an `AudioWorkletNode` processor rather than vocal2midi's
+deprecated main-thread `ScriptProcessorNode`. Return `VocalCapture {notes, onsets,
+rmsEnvelope, pitchContour}`, where onsets and RMS come from the EXISTING
+`frontend/src/lib/audioAnalysis.ts` (`detectOnsets`, `rms`, `downmixMono`). YIN is monophonic,
+so the beatbox / effect / beat paths read the onset and RMS stream, never the YIN note list.
+
+The shipped vocal2midi transcription is fully LOCAL in-browser DSP, not Gemini. The
+`docs/progress-report.md` describing Gemini-makes-notes is a discarded experiment; the shipped
+code reverted to local YIN. Port the YIN path, not the report.
+
+Destination 1, the MIDI home: `VocalCapture.notes` feed `pianoRollStore`
+(`pianoNotesToMidiNotes`) as an `editorStore` piano-roll clip, play through `soundfontEngine`
+(SpessaSynth + the GM picker), export via `lib/midiWrite.ts notesToSmf`, and save as
+first-class v5 stems+MIDI library items. The vocal2midi `midiSynth.ts` (dead
+soundfont-player/oscillator-force), its canvas `PianoRoll.tsx`, the hand-rolled SMF binary,
+and the no-RPN pitch-bend exporter are all dropped.
+
+Gemini roles run server-side through `backend/assistant_routes.py`, never bundled
+`VITE_GEMINI_API_KEYS` (a key/quota leak baked into the client). The three roles are metadata
+(BPM / time-sig / instrument / sound-profile id), basic cleanup, and an 8192-budget Smart
+Cleanup. Preserve the `gemini-3-flash-preview` id and thinking-budget params per HARD RULE 1.
+
+The "Architect" agent's six tools (config / notes / playback) are exposed as TARGETS via
+`registerXrControlSource`, so natural language, MIDI, and gesture sources all reach the same
+actions through one bus. Keep the natural-language role; drop the standalone orb shell and its
+browser key rotator.
+
+Destination 2, vocal to INPAINTING: render `VocalCapture.notes` to a guide WAV
+(`renderNotesToBlob` / SpessaSynth) and feed it into the already-wired inpaint contract.
+`backend/server.py generate` already accepts `inpaint_audio` + `mask_start`/`mask_end`;
+`generateStore.ts` already builds the FormData and `editorStore` `InpaintSelection` plus
+`WaveformEditor.tsx` already select the region. So hum-to-inpaint is mostly wiring. The
+Magenta alternative reuses the same notes through `buildMagentaFormData` (it already appends a
+notes event list) for a section continuation.
+
+Destination 3, vocal + CV to "vocalize an effect" and "beat for a section": on the onset / RMS
+/ pitch stream, map a beatboxed timbre fingerprint to the nearest `rackEffects.ts` effect and
+drive its params live via `setParams`, with `effectChainStore` `ChainEntry` toggles as the
+manual pads. A FaceViz gesture (the CV input on the same matrix) can co-modulate the effect.
+"Beat for a section" feeds onsets plus tempo (Gemini BPM or a small ported tap-tempo util) into
+a triggered SpessaSynth GM-percussion pattern (deterministic default) or a Magenta RT beat
+behind the existing reverse-swap guard. The timbre-to-effect matcher and the section-beat
+trigger are the only genuinely new code in the suite.
+
+SoulX is a downstream singing endpoint, not part of capture. The
+`docs/guides/theDAW_SoulX_Singer_Integration_Guide.md` already in the tree scopes a separate
+lazy `backend/modules/soulx_singer/` sidecar. The chain is VOCAL capture -> piano-roll clip ->
+`notesToSmf` -> SoulX `midi2meta` -> SVS render. The vocal suite supplies SoulX's note/timing
+metadata; SoulX synthesis stays its own build.
+
+## Plan S: SPECTRA-RIDER as a VJ cameraSource + VR
+
+Effort L, high impact. Drop R3F; port to a framework-free three.js class.
+
+De-JSX to `GANTASMO-LIVE-VJ/src/spectra/SpectraRenderer.ts` modeled 1:1 on
+`cymatics/CymaticsRenderer.ts` (build / animate / dispose, `getLevels`-driven, three/addons
+`EffectComposer` + `UnrealBloomPass`, fixed offscreen size, `captureStream(30)` via a
+`useSpectra.ts` hook mirroring `useCymatics.ts`). The `<mesh>`/`<shaderMaterial>` declarations
+become `new THREE.*`; `useFrame` bodies become one `animate()`; the inline GLSL extracts into
+`spectra/*-shader.ts`. The five camera modes (Canyon Flight, Dynamic Orbit, Bird's Eye, Deep
+Horizon, Free Flight) port as plain math on a `PerspectiveCamera` switched by `this.mode`,
+defaulting to a hands-off Auto-Pan so the source runs without keyboard focus. R3F must be fully
+removed so a second three instance and a competing render loop never enter the VJ's three 0.184.
+
+The load-bearing seam is audio. SPECTRA-RIDER's look IS a frequency spectrogram, but the VJ
+and host bridge carry only four collapsed bands. `useAudioAnalyzer.ts` already runs
+`getByteFrequencyData` on a 128-bin AnalyserNode, so add a sibling `getAudioSpectrum():
+Uint8Array | null`, and add an optional 128-byte spectrogram-column field to
+`sa3Bridge.ts ExternalAudioLevels` so the SA3 host (whose cymatics analyser already runs
+`getByteFrequencyData`) can forward real detail. `SpectraRenderer` runs SPECTRA-RIDER's exact
+mel-mapping over that buffer, falling back to the four bands. Without this the terrain collapses
+to four flat plateaus, so the spectrum getter ships with the source, not later.
+
+UI: a SPECTRA chip + sub-panel in `VJControls.tsx` mirroring the cymatics TogglePad row (five
+camera-mode pads, Auto-Pan, a theme dropdown with a real label, and the akvj-style slider rack
+for sensitivity / smoothing / noise-gate / height / energy-impact), plus new `VJState` fields.
+Wire the source through the same six-edit cameraSource pattern as cymatics/akvj3d.
+
+VR: unlike the AR-over-webcam cases, SPECTRA-RIDER is a synthetic scene, so it runs in
+immersive-vr. Route A (recommended first): a minimal in-VJ WebXR session on the same
+`SpectraRenderer` (`renderer.xr.enabled`, a VRButton, `setAnimationLoop`), with the camera
+pinned to a fixed vantage so the headset pose owns the look. Route B (held as the polished-show
+path): re-implement the terrain shader in HLSL inside theDAW-XR Unity, fed the same spectrogram
+column over the `/api/xr/control` + QuestMIDI relay for passthrough, hand-tracking, and
+colocation. VR is gated on the cameraSource being confirmed live.
+
+## Plan P: presets + per-song bindings + pads
+
+Effort L. Three persistence tiers over one binding table.
+
+- PRESET tier: `presetStore.ts` (zustand+persist, cloning the `setlistStore.ts` idiom).
+  `MappingPreset {id, name, genre?, bindings, fx: ChainEntry[], vjLook?, pads}`. FX state
+  snapshots reuse `effectChainStore.ChainEntry[]` verbatim. Genre presets seed from the
+  absorbed vocal2midi `GENRE_PROFILES` / `SOUND_PROFILES` CC maps so a "techno" or "ambient"
+  preset arrives pre-wired.
+- PER-SONG tier: per-song bindings must NOT ride the library PATCH, because the backend
+  `USER_MUTABLE_FIELDS` whitelist (`store.py`) drops unknown fields. Use a `songBindingStore.ts`
+  keyed by library entry id (the orphan-tolerant pattern `setlistStore` already uses), storing
+  only the DIFF against the active preset so a preset edit still flows to songs that did not
+  override that target.
+- Composition: `resolveActiveBindings(entryId)` = preset base, then per-song overrides win per
+  targetId, then live pads apply transiently and never persist. A latch pad reverts to the
+  composed base, not the bare preset.
+- PADS: a `PadAction` tagged union over the named moves (launch/toggle an FX `ChainEntry`
+  snapshot, mute/solo a stem, swap a VJ look, fire any `BindableTarget`). A surface pad and a
+  matrix pad are one record; pads learn through the same loop.
+- Auto-recall on track load through the existing now-playing signal, with explicit-edit
+  precedence so recall never clobbers an in-progress edit (the vocal2midi genre-auto-overwrite
+  bug is the precedent).
+
+## Where these slot into the "coming up" queue
+
+Smallest-valuable-first, respecting the one hard dependency (the matrix foundation should land
+before or with FaceViz/Sway so those sources plug in as channels rather than needing a retrofit):
+
+1. ASCII (ASCILINE GPU glyph source) -- unchanged head of the list.
+2. SPECTRA-RIDER VJ cameraSource (+ the `getAudioSpectrum` / sa3Bridge column). Lowest
+   dependency, immediate visible win.
+3. VSTs -- unchanged, stays after ASCII.
+4. Unified mapping matrix FOUNDATION (M0-M4: model + source registry + MidiDeviceSource + one
+   target catalogue + binding engine). Lands before FaceViz/Sway.
+5. Skeletal tracking + segmentation + AR.
+6. FaceViz module (now consumes the matrix as a ControlSource).
+7. Sway controller (consumes the matrix).
+8. Presets + per-song + pads (layers over the matrix; genre seeds from item 9's vocal2midi data).
+9. Vocal suite destination 1 (capture engine + piano-roll landing + library item).
+10. Vocal: Gemini server-side + Architect-on-bus + vocal-to-inpainting.
+11. Vocal: vocalize-an-effect + beat-for-section (the trickiest, genuinely new code, last).
+12. SPECTRA VR Route A (gated on item 2 signed off live); Route B held as a later show item.
+13. SoulX singer sidecar (its own multi-phase build; downstream of the vocal suite).
+
+## Risks
+
+- GPU/CPU contention: SPECTRA's terrain + walls + particles + Bloom on top of the VJ's chain,
+  plus a per-frame YIN worklet, plus a possible Magenta RT model swap. Needs render-scale tiers,
+  density sliders, and the reverse-swap guard.
+- Cloud dependency: vocal transcription is fully local (works offline); only Gemini metadata /
+  cleanup / Architect degrade without network. Route Gemini through the backend, never bundled keys.
+- Inpaint fidelity is unproven (monophonic guide); open whether note/timing metadata can also be
+  passed as explicit region conditioning into the DiT.
+- Do not pin model/library versions from memory (HARD RULE 1): the `gemini-3-flash-preview` id and
+  thinking budgets are current; the backend catalog is the source of truth.
+- Licensing: confirm vocal2midi (incl. MusyngKite GM samples, already replaced by SpessaSynth +
+  bundled GM SF3), SPECTRA-RIDER's three/R3F stack, and SoulX before absorbing.
+- a11y on the dense matrix grid is the hardest surface in the batch; do not regress HARD RULE 3.
+- Visual work needs the user's eyes; tsc/build/lint/unseen screenshots never count.
+- Scope creep: the matrix touches DJ, VJ (separate repo), FX, MAKE, the library schema, and XR.
+  Pick one canonical binding shape and land incrementally.
+- Preset/per-song clobber: recall must not overwrite a hand-tweaked binding; needs explicit-edit
+  precedence + confirm.
+
+## Open questions for the user
+
+- CV is resolved (computer vision). Remaining:
+- Fan-out conflict policy: when two sources bind one target, last-writer-wins or a priority order?
+- Per-song persistence: localStorage keyed by entry id (no backend change, not synced) or a
+  backend bindings column (approval-gated migration, gives sync/export)?
+- Vocalize-an-effect: should a beatboxed timbre PICK one effect (classifier) or DRIVE several
+  params of an active effect (continuous)? The matcher design differs.
+- Beat-for-section default: deterministic GM-percussion (no model swap) or Magenta RT (richer,
+  GPU-swappy mid-show)?
+- SPECTRA VR: ship Route A (in-VJ WebXR), or invest in Route B (theDAW-XR Unity HLSL)? Is
+  colocated multi-headset VR in scope here?
+- Does the unified matrix fully replace the existing DJ MIDI-learn panel and VJ MidiPanel, or do
+  those remain as per-area shortcuts writing into the same store?
+- SoulX: assume the sidecar exists, or ship a stub handoff until its own build lands?

--- a/docs/plans/2026-06-25-asciiline-glsl-port-spec.md
+++ b/docs/plans/2026-06-25-asciiline-glsl-port-spec.md
@@ -1,0 +1,150 @@
+# ASCILINE -> GLSL ASCII VJ source: porting spec
+
+Status: spec, no code. Created 2026-06-25. This is the load-bearing first step of
+the ASCII source (head of the next-block queue, see
+`docs/plans/2026-06-25-next-block-vfx.md`). It captures the exact ASCILINE
+conversion semantics so the GLSL port is a mechanical translation rather than a
+guess.
+
+## Source and license
+
+ASCILINE by YusufB5 (`D:\StableAudio\ASCILINE`,
+https://github.com/YusufB5/ASCILINE). Distributed under the MIT License WITH an
+ANTI-ADVERTISEMENT RESTRICTION clause (see its LICENSE). Obligations for absorbing
+it:
+
+- Vendor with attribution. Keep a copyright + MIT + anti-advertisement notice in
+  code comments and an ACKNOWLEDGMENTS entry.
+- Port only the algorithm, the palette, and (if the streaming transport is ever
+  wanted) the codec. Never port the Canvas2D / ANSI text-write render path; the
+  GLSL source replaces it.
+- Honor the anti-advertisement clause: the source must not be used to render
+  advertising. Surface that restriction wherever the source is documented.
+
+## The conversion to replicate (AsciiMapper.convert)
+
+From `ascii_video_player2.py` (MODULE 2, lines 110-181). Per output cell:
+
+1. Downscale the source frame to the cell grid `(cols, rows)` with bilinear
+   interpolation (`cv2.resize(..., INTER_LINEAR)`).
+2. Luminance per cell from the downscaled BGR via OpenCV BGR2GRAY, which is
+   Rec.601: `Y = 0.299*R + 0.587*G + 0.114*B`, on 0..255.
+3. Glyph index from luminance over the 93-character ramp (next section).
+4. Color per cell is the cell's own source RGB (true color). ASCILINE optionally
+   quantizes color to 6 bits for its RLE transport; that is a wire optimization
+   with no visual purpose, so the GLSL port samples full-precision color and drops
+   quantization.
+
+The RLE / per-row escape-code construction and the ANSI string output are terminal
+transport, not part of the visual, and are dropped.
+
+## The glyph ramp (93 chars, dark to light), verbatim
+
+```
+ `.-':_,^=;><+!rc*/z?sLTv)J7(|Fi{C}fI31tlu[neoZ5Yxjya]2ESwqkP6h9d4VpOGbUAKXHm8RD#$Bg0MNWQ%&@
+```
+
+The first character is a space (darkest), the last is `@` (lightest). `N = 93`.
+
+## Glyph index formula and one quirk to decide
+
+ASCILINE computes `index = clip(gray // (256 // N), 0, N-1)`. With `N = 93`,
+`256 // 93 = 2` (integer floor), so the real behavior is:
+
+```
+index = clamp(floor(gray_u8 / 2), 0, 92)
+```
+
+Consequence: gray maps to glyphs only across 0..184; every cell brighter than gray
+184 saturates onto the single brightest glyph `@`. The top ~28% of the brightness
+range collapses to one glyph. This is an integer-division artifact in the original,
+not an intentional curve.
+
+Two options for the port, the user picks:
+
+- Faithful: replicate the saturating step exactly, `index = clamp(floor(luma*127.5),
+  0, 92)` with `luma` in 0..1. Matches ASCILINE byte for byte.
+- Corrected (recommended for the GLSL look): spread the whole ramp,
+  `index = clamp(floor(luma * 93.0), 0, 92)`. Uses all 93 glyphs, so highlights
+  read as `%`, `&`, `@` rather than flattening to `@`. This is the better-looking
+  default for a VJ source; flag it as a deliberate divergence.
+
+## GLSL implementation
+
+A dedicated `AsciilineRenderer.ts` modeled on the new `ShaderRenderer.ts` (raw
+WebGL2 fullscreen quad, same audio-uniform and dispose lifecycle), with two added
+inputs the self-generating shaders do not need:
+
+- `u_source` (sampler2D): the live upstream frame, uploaded each frame from the
+  active `<video>` element via `texImage2D` (the loaded clip, else the webcam).
+  This is why ASCII is a distinct renderer rather than a `ShaderRenderer` preset:
+  it transforms an external frame instead of synthesizing one. A later option is
+  to generalize `ShaderRenderer` to accept input textures so ASCII becomes a
+  preset, but the first build keeps them separate.
+- `u_atlas` (sampler2D): the 93 glyphs prebaked once at load into a horizontal
+  strip atlas. Rasterize each glyph centered in a fixed cell (a monospace font on
+  an offscreen Canvas2D, white on transparent) into a `glyphPx*N` by `glyphPx`
+  texture, uploaded once. This is the only allowed Canvas2D use, and it runs once
+  at init, never per frame.
+
+Fragment shader, per output pixel `uv` in 0..1:
+
+```
+// 1. cell coordinates
+vec2 grid = vec2(u_cols, u_rows);
+vec2 cell = floor(uv * grid);
+vec2 inCell = fract(uv * grid);
+// 2. sample source at the cell center (point-ish; source is already cell-sized
+//    if uploaded at grid res, or sample the full frame here and let it average)
+vec2 cuv = (cell + 0.5) / grid;
+vec3 src = texture(u_source, cuv).rgb;
+float luma = dot(src, vec3(0.299, 0.587, 0.114));
+// 3. glyph index (corrected spread; swap for the faithful step if chosen)
+float idx = clamp(floor(luma * 93.0), 0.0, 92.0);
+// 4. map the within-cell uv into that glyph's sub-rect of the strip atlas
+vec2 auv = vec2((idx + inCell.x) / 93.0, inCell.y);
+float ink = texture(u_atlas, auv).a; // glyph coverage 0..1
+// 5. compose: glyph tinted by source colour (true-colour mode) over background
+vec3 col = (u_mono > 0.5) ? (u_accent * ink) : (src * ink);
+fragColor = vec4(col, 1.0);
+```
+
+Cell aspect: monospace glyph cells are about 0.5 wide-to-tall, so to keep glyphs
+unstretched derive `rows` from `cols`, the canvas aspect, and the glyph aspect:
+`rows = round(cols * (canvasH / canvasW) * (glyphW / glyphH))`. Expose `cols`
+(density) as the user control and compute `rows`.
+
+Color modes mirror ASCILINE: a true-color mode (tint each glyph by its source
+pixel, the default) and a mono mode (a single accent color, the classic terminal
+look), toggled by `u_mono` with a `u_accent` color.
+
+## Audio reactivity
+
+Cheap, shader-uniform-only, using the bands the renderer already provides
+(`u_bass/u_mid/u_high/u_volume`):
+
+- Bass drives glyph density: nudge `u_cols` (or a within-cell scale) on bass so the
+  type grid breathes with the kick.
+- High band lifts ink brightness or adds a faint per-cell jitter for sparkle.
+- The "dynamic font-size" idea from the roadmap becomes a per-cell scale on `inCell`
+  driven by `bass`, so loud cells render larger glyphs.
+
+## Out of scope for this base source
+
+- The adaptive frame codec (`codec.py` / `codec.js`, RAW/ZLIB/DELTA): that is a
+  WebSocket transport optimization for ASCILINE's streaming path and is irrelevant
+  to a local GLSL render. It is a separate, optional reuse for VJ thumbnails or the
+  watch-link feed later.
+- Depth-aware glyph density (pick the glyph by depth instead of luminance for a
+  self-shading volumetric ASCII portrait): that is the glyph-skin / body-cloud
+  combination in the next-block plan, a later item that needs the segmentation
+  matte or the depth cloud.
+
+## The six VJ seams (when built)
+
+Same cameraSource pattern as the shader and spectra sources: add `'asciiline'` to
+the `types.ts` union plus `asciiCols` / `asciiMono` / `asciiAccent` state fields and
+defaults; the `useMedia.ts` guard, positional stream param, genStream ternary, and
+dep array; the `App.tsx` `useAsciiline` hook, `useMedia` arg, and SourcePreview; and
+a `VJControls.tsx` SOURCE chip plus a sub-panel (density slider, mono/true-color
+toggle, accent color), all ARIA-labelled, Tailwind v4 forms only.

--- a/docs/plans/2026-06-25-next-block-vfx.md
+++ b/docs/plans/2026-06-25-next-block-vfx.md
@@ -1,0 +1,196 @@
+# Next block: generative VFX sources + body control + sung voice
+
+Status: living plan. Created 2026-06-25 from a grounded multi-agent design pass
+(five grounding agents reading the live VJ + theDAW + source repos, three brainstorm
+lenses, one synthesis). Not in RAG. Design only; nothing built. Reordered per the
+user: Sway lands before skeletal/INFINIGHT.
+
+Scope: an ASCII source, a generic GLSL shader source seeded by yotta, the Sway
+controller, skeletal/INFINIGHT body tracking, and the SoulX singing sidecar. The
+SPECTRA source is already built and is awaiting the user's eyes, so it is out of
+scope here. Companions: `2026-06-24-show-matrix-vocal-spectra.md`,
+`2026-06-24-faceviz-sway-skeletal-integration.md`, `2026-06-24-akvj-volcap-roadmap.md`.
+
+## 1. yotta / generic GLSL shader source -- the design
+
+yotta (`D:\StableAudio\yotta`, MIT, Matthias Hurrle / atzedent) is a fullscreen
+WebGL2 fragment-shader raymarcher using atzedent's uniform convention (time,
+resolution, move, touch, pointerCount, zoom, wheel, startRandom, daytime), with
+`wheel.y` scrubbing a Catmull-Rom camera spline. That uniform convention is shared
+across a large library of atzedent shadertoys, so the leveraged move is a generic
+loader, with yotta as its first entry. The VJ port drops the live-code editor and
+pointer steering, then follows the camera-source pattern the VJ already proves with
+Cymatics and Spectra: a framework-free renderer class draws to an offscreen canvas,
+a React hook owns the lifecycle and `captureStream(30)`, and VJControls exposes the
+chip plus a settings sub-panel.
+
+- Renderer stays a raw WebGL2 single quad like yotta's own `Renderer`, so
+  performance matches the original and the existing `performanceMode` lever covers
+  heavy raymarchers.
+- Audio reactivity injected each frame from `getAudioLevels`: `u_bass`, `u_mid`,
+  `u_high`, `u_volume`. The 256-bin `u_spectrum` from `getAudioSpectrum` (already
+  added for SPECTRA) is a deferred v2 lever and stays out of scope this block.
+- Auto-advancing `wheel.y` and `time` replace the dropped mouse interaction, so the
+  source runs hands-off.
+- A `test()` compile method validates the fragment source at load and routes a
+  failure to the existing camera error banner, so a bad shader never renders silent
+  black.
+- yotta's MIT attribution (Matthias Hurrle) lives in code comments plus an
+  attribution surface, which also clears the latent Cymatics/Spectra attribution debt.
+- Build single-yotta-first to prove the pipe end to end, then generalize to a source
+  string loaded from library entries once the uniform plumbing and compile-error path
+  are sound.
+
+The six VJ cameraSource seams:
+- `GANTASMO-LIVE-VJ/src/types.ts` -- add `'shader'` to the cameraSource union plus
+  `shaderUrl` / `shaderLibraryId` / `shaderAudio` fields in `DEFAULT_VJ_STATE`.
+- `GANTASMO-LIVE-VJ/src/useMedia.ts` -- add `'shader'` to the generative-source
+  guard, a positional `shaderStream` param after `spectraStream`, a genStream
+  ternary branch, and the effect dep-array entry.
+- `GANTASMO-LIVE-VJ/src/App.tsx` -- add the `useShader` hook after `useSpectra`,
+  pass `getAudioLevels` plus `shaderUrl`, inject `shaderFeed.stream` into `useMedia`,
+  add a SourcePreview block.
+- `GANTASMO-LIVE-VJ/src/components/VJControls.tsx` -- add the SHADER chip plus a
+  sub-panel with a library/URL picker and audio-reactivity controls, each
+  ARIA-labelled, Tailwind v4 forms only.
+- `GANTASMO-LIVE-VJ/src/shader/ShaderRenderer.ts` -- new raw WebGL2 class on yotta's
+  Renderer pattern: `constructor(canvas, getAudioLevels, shaderSource, opts)`,
+  `updateShader()`, `test()`, `render(time)`, `dispose()`.
+- `GANTASMO-LIVE-VJ/src/useShader.ts` -- new hook on the useCymatics/useSpectra
+  lifecycle: fresh canvas on enable, instantiate, `captureStream(30)`, dispose plus
+  stop tracks on cleanup.
+
+## 2. Sequenced build order (reordered: Sway before skeletal)
+
+Control-bus note: the XR control bus (`registerXrControlSource` in
+`frontend/src/state/xrControlClient.ts`, routed by the `/api/xr/control` relay) already
+exists and `djControlSource` already publishes on it. So Sway and pose can register as
+working sources on the EXISTING bus now. The unified Show Designer matrix is the later
+UI that subsumes DJ and VJ mapping into one grid; it is an enhancement, not a hard gate
+for getting Sway or pose live. Confirm that call when Sway is built.
+
+1. **ASCII source (ASCILINE port, head slot).** State: ASCILINE is readable at
+   `D:\StableAudio\ASCILINE`; the VJ camera-source pattern is proven; no asciiline
+   implementation exists. First step (no code): read `AsciiMapper.convert`
+   (`ascii_video_player2.py` ~lines 129-181) and write a luminance-to-glyph GLSL
+   porting spec (pseudocode, reference palette, BGR-to-RGB, ramp-bin quantization).
+   The port's correctness depends on capturing the original semantics exactly. Effort:
+   L. Dependencies: ASCILINE for the algorithm; CymaticsRenderer as the structural
+   template; MIT-plus-anti-advertisement attribution in code comments and ACKNOWLEDGMENTS.
+
+2. **Shader / yotta source.** State: no shader camera source exists; yotta is readable.
+   First step: build `ShaderRenderer.ts` as a minimal standalone raw WebGL2 quad
+   rendering one yotta fragment source with the four audio-band uniforms and
+   auto-advancing `wheel.y`, proven before the six seams are wired. Effort: L.
+   Dependencies: WebGL2 baseline; `getAudioLevels` (already wired); yotta MIT
+   attribution.
+
+3. **Sway controller ingestion.** State: theDAW's MIDI subsystem and the
+   `registerXrControlSource` pattern are complete; no Sway profile, `swayBus`, or
+   `swayControlSource` exists; Sway enumerates as class-compliant but unmapped; the Web
+   MIDI master gate defaults off. First step: create `swayControlSource.ts` as a copy of
+   `xrControlDjSource` (area `sway`, `buildEntries` returns the six dims
+   strike/sway/pulse/glide/press/sculpt at 0..1, `apply` routes to a `swayBus`),
+   register it in `App.tsx` after `djControlSource`, and add a Sway profile row with
+   `match=['sway','audima']`. Effort: M. Dependencies: `learnedProfilesStore` for
+   capturing the six firmware-configurable CCs (never hardcode a CC; `swayBus` reads
+   learned bindings at runtime); the MIDI gate is off by default. The unified matrix is
+   optional here, not required.
+
+4. **Skeletal + INFINIGHT body tracking (poseControlSource first).** State:
+   FaceViz/INFINIGHT is a standalone Electron app with MediaPipe HandLandmarker plus
+   PoseLandmarker; no local clone in the tree; `@mediapipe/tasks-vision ^0.10.35` is
+   already a VJ dependency; the XR bus is production-proven. First step: build
+   `poseControlSource` as a structural copy of `xrControlDjSource` (six 0..1 entries
+   like armSpan, handHeight), fed by a new off-thread `gestureWorker.ts` running
+   PoseLandmarker on the GPU delegate at ~8fps reduced to control scalars. Land the
+   control source before any AR pixel output. Effort: L. Dependencies: MediaPipe
+   versions verified live against the Google AI Edge table before pinning (HARD RULE 1);
+   FaceViz fork license review before any code absorb; the `gesturecam` cameraSource and
+   AR overlay come after and need live eyes (HARD RULE 2). MediaPipe issue #4757
+   (blank GPU mask) and the `MPMask` readback trap block the segmentation-matte combos,
+   not the pose-scalar source.
+
+5. **SoulX singing-voice sidecar.** State: fully spec'd in the integration guide but
+   unbuilt; no module directory, router, or worker; the magenta-rt2 sidecar is the
+   structural template. First step: scaffold `backend/modules/soulx_singer/module.json`
+   (enable=false) plus a stub `router.py` exposing `/health` and `/models` that probe
+   the env and checkpoints without spawning a process, establishing the module contract
+   and the `midi2meta` handoff boundary. Effort: XL. Dependencies: the vocal-capture
+   engine (YIN pitch detection, RenderNote emission, library stem binding) is a separate
+   L build that must land first, or SoulX sits headless with no test data; `notesToSmf`
+   already exists in `midiWrite.ts`; the magenta job/poll and WSL spawn patterns; model
+   downloads at setup; the reverse-swap guard to park SA3 before a render; the mandatory
+   metadata-review UI per the guide.
+
+Honest blocking summary: steps 1 and 2 block nothing and can proceed immediately, in
+parallel. Step 3 (Sway) and step 4 (pose) ride the existing XR control bus; the unified
+matrix UI is a later unifier, not a prerequisite. Step 5 (SoulX) is blocked end-to-end
+by the unbuilt vocal-capture engine; its scaffold can land but cannot be tested until
+capture exists.
+
+## 3. Top novel cross-tool VFX combinations
+
+1. **Glyph-skin.** The live webcam runs through ImageSegmenter (matte kept on-GPU via
+   `getAsWebGLTexture`); the matte gates the ASCII glyph ramp so the performer is
+   spelled out in audio-jittering ASCII while the background dissolves. Seams:
+   `AsciilineRenderer.ts` (setMatteTexture), `akvj/gestureWorker.ts`, `useAsciiline.ts`.
+
+2. **Skeleton-flown raymarcher.** PoseLandmarker scalars map onto yotta's native
+   move/zoom/wheel/touch uniforms (centroid to move, wrist span to zoom, hand height to
+   wheel scrub, spine tilt to roll), so any atzedent-convention shader becomes
+   body-flyable with no shader rewrite. Seams: `shader/ShaderRenderer.ts`
+   (setPoseUniforms), `akvj/gestureWorker.ts`, `useShader.ts`.
+
+3. **Self-sculpting cloud.** The existing depthcloud path makes the performer a point
+   cloud via in-browser monocular depth, while the same webcam's HandLandmarker scalars
+   drive `AkvjCloudRenderer.setStyle` / `setParams` (pinch flips style, spread drives
+   distance, fist collapses density). Seams: `useDepthCloud.ts`, `AkvjCloudRenderer.ts`,
+   `akvj/gestureWorker.ts`.
+
+4. **Body as one control event.** `poseControlSource` publishes six pose scalars over
+   the `/api/xr/control` relay (transport-only), so one gesture binds to `DJ_TARGETS`
+   (filter cutoff, crossfader, FX wet) on theDAW and to shader uniforms on the VJ, heard
+   and seen as one event. Seams: `xrControlDjSource.ts`, `xrControlClient.ts`,
+   `bindableTargets.ts`.
+
+5. **Markerless AR raiment.** ShaderRenderer renders to an FBO, then a composite pass
+   multiplies it by the on-GPU segmentation matte with a sternum-anchored UV from pose,
+   so a raymarched texture flows across the dancer and edge-locks to the silhouette as
+   on-body AR. Seams: `shader/ShaderRenderer.ts` (two-pass FBO), `akvj/gestureWorker.ts`.
+
+6. **Sway six-dimension shader cockpit.** The six learned Sway dims map onto the
+   shader's move/zoom/wheel plus three SDF-shape uniforms exposed in the control
+   manifest, so the physical controller hand-flies the raymarcher with no CC hardcoded
+   and two-way fader mirroring. Seams: `swayControlSource.ts`, `learnedProfilesStore.ts`,
+   `shader/ShaderRenderer.ts`.
+
+7. **Provenance autopilot.** The `sa3-vj/track-meta` channel already forwards model,
+   title, source, and isPlaying on every load, so `useShader` derives `shaderLibraryId`
+   from a model-plus-title hash and phase-locks wheel/time to track position, giving each
+   generated track a reproducible look with no chip press. Seams: `sa3Bridge.ts`
+   (subscribeToMeta), `useShader.ts`.
+
+8. **Shader params as headset faders and recallable pads.** Register
+   `shaderControlSource` on the XR bus so band gains and library selection surface as
+   headset faders with no Unity authoring, and a saved per-song pad recalls
+   `shaderLibraryId` plus the four band gains mid-set with the widget following back.
+   Seams: `xrControlClient.ts` (publishControlChanged), `shader/ShaderRenderer.ts`.
+
+## 4. Recommended start-here
+
+Build the **shader / yotta source** first: `ShaderRenderer.ts` as the minimal standalone
+raw WebGL2 quad rendering one yotta fragment source with the four audio-band uniforms and
+auto-advancing `wheel.y`. It has the lowest dependency surface in the block (no control
+bus, no MediaPipe worker, no sidecar, no license absorb), it produces an immediate
+visible win to put eyes on (an audio-reactive fractal as a VJ source), and its uniform
+plumbing, compile-error path, and captureStream lifecycle are the reusable spine that
+combos 2, 5, 6, 7, and 8 all build on.
+
+Run in parallel, no code: the **ASCII GLSL porting spec** (step 1, first step only),
+since ASCII holds the head slot, the spec is load-bearing for a correct port, and writing
+it does not contend with the shader build.
+
+Then **Sway** (step 3), which rides the existing XR control bus and is pure reuse of the
+`xrControlDjSource` shape, followed by **poseControlSource** (step 4), which unlocks
+combos 2, 3, 4, and 5.

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-25T01:57:35.311Z · Git revision: `9cf384cc8384` · Repomix tracked: **no**
+> Generated: 2026-06-26T02:46:33.447Z · Git revision: `30537fb9dde8` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-25T01:57:35.311Z",
-  "repoRevision": "9cf384cc8384",
+  "generatedAt": "2026-06-26T02:46:33.447Z",
+  "repoRevision": "30537fb9dde8",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,11 @@ import { publishMidi } from './state/midiBus';
 import { startQuestMidi, stopQuestMidi } from './state/questMidiClient';
 import { startXrControl, stopXrControl, registerXrControlSource } from './state/xrControlClient';
 import { djControlSource } from './state/xrControlDjSource';
+import { swayControlSource, startSwayXrMirror } from './state/swayControlSource';
+import { startSwayBus } from './state/swayBus';
+import { startSwayRouting } from './state/swayRouting';
+import { poseControlSource, startPoseXrMirror } from './state/poseControlSource';
+import { startPoseRouting } from './state/poseRouting';
 import { startXrViz, stopXrViz } from './state/xrViz';
 import { XrBusTester } from './components/dev/XrBusTester';
 import { useMidiDevicesStore } from './state/midiDevicesStore';
@@ -222,16 +227,38 @@ export default function App() {
     // DJ_TARGETS to spatial controls with no per-control wiring; it lazy-loads
     // the DJ engine so registering it here does not pull djEngine into boot.
     registerXrControlSource(djControlSource);
+    // Sway (Audima): the six expressive dimensions become named 0..1 signals on
+    // the same control bus, learned from the device's CCs. Target-agnostic, so
+    // they can drive VFX, 3D audio, and MAKE/voice targets once those subscribe.
+    registerXrControlSource(swayControlSource);
+    const stopSway = startSwayBus();
+    const stopSwayMirror = startSwayXrMirror();
+    const stopSwayRoute = startSwayRouting();
+    // Body-pose source (camera, forwarded from the VJ). Publish its channels on
+    // the same bus; the pose values themselves arrive via poseBus regardless of MIDI.
+    registerXrControlSource(poseControlSource);
+    const stopPoseMirror = startPoseXrMirror();
     startXrControl();
     // Stream the visualization feed (waveform pack) over the same bridge so a
     // theDAW-XR headset can render theDAW's live audio natively.
     startXrViz();
     return () => {
       stopQuestMidi();
+      stopSway();
+      stopSwayMirror();
+      stopSwayRoute();
+      stopPoseMirror();
       stopXrControl();
       stopXrViz();
     };
   }, [midiEnabled]);
+
+  // Pose routing is camera-driven (forwarded from the VJ), independent of the
+  // Web MIDI gate, so it runs for the app's lifetime.
+  useEffect(() => {
+    const stop = startPoseRouting();
+    return stop;
+  }, []);
 
   const handleAssistantAction = useCallback((action: { type: string; payload?: any }) => {
     const result = handletheDAWAction(action);

--- a/frontend/src/components/layout/BottomMultiTabPanel.tsx
+++ b/frontend/src/components/layout/BottomMultiTabPanel.tsx
@@ -9,7 +9,7 @@
 import React, { useState } from 'react';
 import {
   Activity, Info, Piano, Layers, FolderOpen, SlidersVertical, ExternalLink, Maximize2, Minimize2,
-  FileMusic,
+  FileMusic, Waves,
 } from 'lucide-react';
 import { AdvancedVisualizer } from '../audio/AdvancedVisualizer';
 import { PianoRoll } from '../audio/PianoRoll';
@@ -18,6 +18,7 @@ import { DetailsView } from './DetailsView';
 import { ScoreView } from './ScoreView';
 import { MediaBucketView } from './MediaBucketView';
 import { SlidePanel } from './SlidePanel';
+import { SwayPanel } from './SwayPanel';
 import { DetachableWindow } from './DetachableWindow';
 import { useBottomPanelStore, type BottomPanelTab } from '../../state/bottomPanelStore';
 import { useSlideStore } from '../../state/slideStore';
@@ -30,6 +31,7 @@ const TAB_DEFS: Array<{ id: BottomPanelTab; label: string; icon: React.Component
   { id: 'details',    label: 'Details',      icon: Info,       colorActive: 'border-emerald-500 text-emerald-300' },
   { id: 'bucket',     label: 'Media',        icon: FolderOpen, colorActive: 'border-amber-500 text-amber-300' },
   { id: 'slide',      label: 'SLIDE',        icon: SlidersVertical, colorActive: 'border-pink-500 text-pink-300' },
+  { id: 'sway',       label: 'SWAY',         icon: Waves,      colorActive: 'border-fuchsia-500 text-fuchsia-300' },
 ];
 
 export const BottomMultiTabPanel: React.FC = () => {
@@ -148,6 +150,11 @@ export const BottomMultiTabPanel: React.FC = () => {
         {activeTab === 'bucket' && (
           <div className="absolute inset-0">
             <MediaBucketView />
+          </div>
+        )}
+        {activeTab === 'sway' && (
+          <div className="absolute inset-0">
+            <SwayPanel />
           </div>
         )}
         {activeTab === 'slide' && (

--- a/frontend/src/components/layout/SwayPanel.tsx
+++ b/frontend/src/components/layout/SwayPanel.tsx
@@ -1,0 +1,170 @@
+/**
+ * SWAY panel -- learn, meter, and route the Audima Sway's six expressive
+ * dimensions. Each row arms LEARN (binds the dimension to the next CC the
+ * controller sends), shows the bound CC and a live 0..1 meter, and routes the
+ * dimension to a BindableTarget (DJ targets today). Lives as a tab in the global
+ * bottom multi-tab panel, beside SLIDE.
+ *
+ * Works with ANY MIDI controller via learn, not only a physical Sway; the Sway
+ * profile just labels the surface.
+ */
+import React, { useEffect, useMemo, useState } from 'react';
+import { useSwayStore, SWAY_DIMS } from '../../state/swayBus';
+import { useSwayRoutingStore, loadSwayTargets } from '../../state/swayRouting';
+import { usePoseStore, POSE_CHANNELS } from '../../state/poseBus';
+import { usePoseRoutingStore } from '../../state/poseRouting';
+import type { BindableTarget } from '../surface/widgetTypes';
+import { useMidiTriggerStore } from '../../state/midiTriggerStore';
+
+export const SwayPanel: React.FC = () => {
+  const bindings = useSwayStore((s) => s.bindings);
+  const values = useSwayStore((s) => s.values);
+  const learningDim = useSwayStore((s) => s.learningDim);
+  const startLearn = useSwayStore((s) => s.startLearn);
+  const cancelLearn = useSwayStore((s) => s.cancelLearn);
+  const clearBinding = useSwayStore((s) => s.clearBinding);
+  const routes = useSwayRoutingStore((s) => s.routes);
+  const setRoute = useSwayRoutingStore((s) => s.setRoute);
+  const poseValues = usePoseStore((s) => s.values);
+  const poseActive = usePoseStore((s) => s.active);
+  const poseRoutes = usePoseRoutingStore((s) => s.routes);
+  const setPoseRoute = usePoseRoutingStore((s) => s.setRoute);
+  const midiEnabled = useMidiTriggerStore((s) => s.enabled);
+  const [targets, setTargets] = useState<BindableTarget[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+    void loadSwayTargets().then((t) => {
+      if (alive) setTargets(t);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const groups = useMemo(() => {
+    const m = new Map<string, BindableTarget[]>();
+    for (const t of targets) {
+      const arr = m.get(t.group) ?? [];
+      arr.push(t);
+      m.set(t.group, arr);
+    }
+    return Array.from(m.entries());
+  }, [targets]);
+
+  return (
+    <div className="h-full overflow-y-auto p-3 text-zinc-200">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-fuchsia-300">Sway</h3>
+        <span className="text-[8px] font-mono uppercase tracking-widest text-zinc-500">Audima 6-dimension motion</span>
+      </div>
+      {!midiEnabled && (
+        <p className="mb-2 text-[9px] font-mono text-amber-300/80 leading-snug">
+          MIDI is off. Turn on the master MIDI toggle to receive Sway input, then Learn each dimension.
+        </p>
+      )}
+      <div className="space-y-1.5">
+        {SWAY_DIMS.map((d) => {
+          const b = bindings[d.id];
+          const v = values[d.id] ?? 0;
+          const learning = learningDim === d.id;
+          const routeId = routes[d.id] ?? '';
+          const selectId = `sway-route-${d.id}`;
+          return (
+            <div key={d.id} className="flex items-center gap-2 rounded border border-white/10 bg-white/3 px-2 py-1.5">
+              <span className="w-14 shrink-0 text-[10px] font-bold uppercase tracking-wider text-fuchsia-200">{d.label}</span>
+              <button
+                onClick={() => (learning ? cancelLearn() : startLearn(d.id))}
+                aria-label={learning ? `Cancel learning ${d.label}` : `Learn ${d.label}`}
+                className={`shrink-0 px-2 py-1 rounded border text-[8px] font-black uppercase tracking-widest ${
+                  learning
+                    ? 'border-amber-400/60 bg-amber-400/15 text-amber-200 animate-pulse'
+                    : 'border-white/15 text-zinc-300 hover:border-fuchsia-400/50 hover:text-fuchsia-200'
+                }`}
+              >
+                {learning ? 'Listening' : 'Learn'}
+              </button>
+              <span className="w-16 shrink-0 text-[8px] font-mono text-zinc-500">
+                {b ? `Ch${b.channel + 1} CC${b.cc}` : 'unmapped'}
+              </span>
+              {b && (
+                <button
+                  onClick={() => clearBinding(d.id)}
+                  aria-label={`Clear ${d.label} binding`}
+                  className="shrink-0 text-[10px] text-zinc-600 hover:text-rose-300 leading-none"
+                >
+                  x
+                </button>
+              )}
+              <div className="flex-1 min-w-12 h-2 rounded bg-black/50 overflow-hidden" aria-hidden="true">
+                <div className="h-full bg-fuchsia-500/70" style={{ width: `${Math.round(v * 100)}%` }} />
+              </div>
+              <label htmlFor={selectId} className="sr-only">{`Route ${d.label} to a target`}</label>
+              <select
+                id={selectId}
+                name={selectId}
+                value={routeId}
+                onChange={(e) => setRoute(d.id, e.target.value || null)}
+                className="shrink-0 w-36 bg-black/40 border border-zinc-800 rounded px-1.5 py-1 text-[9px] font-mono text-zinc-200 focus:border-fuchsia-500/50 outline-none"
+              >
+                <option value="">route to...</option>
+                {groups.map(([g, list]) => (
+                  <optgroup key={g} label={g}>
+                    {list.map((t) => (
+                      <option key={t.id} value={t.id}>{t.label}</option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </div>
+          );
+        })}
+      </div>
+      <p className="mt-2 text-[8px] font-mono text-zinc-600 leading-snug">
+        Learn binds a dimension to the next CC the controller sends. Routing drives DJ targets today; VJ, MAKE, and vocal targets join as the unified mapping matrix lands.
+      </p>
+
+      <div className="mt-3 mb-2 flex items-center justify-between">
+        <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-cyan-300">Camera Pose</h3>
+        <span className={`text-[8px] font-mono uppercase tracking-widest ${poseActive ? 'text-cyan-400' : 'text-zinc-600'}`}>
+          {poseActive ? 'live' : 'enable GESTURE in the VJ'}
+        </span>
+      </div>
+      <div className="space-y-1.5">
+        {POSE_CHANNELS.map((c) => {
+          const v = poseValues[c.id] ?? 0;
+          const routeId = poseRoutes[c.id] ?? '';
+          const selectId = `pose-route-${c.id}`;
+          return (
+            <div key={c.id} className="flex items-center gap-2 rounded border border-white/10 bg-white/3 px-2 py-1.5">
+              <span className="w-16 shrink-0 text-[10px] font-bold uppercase tracking-wider text-cyan-200">{c.label}</span>
+              <div className="flex-1 min-w-12 h-2 rounded bg-black/50 overflow-hidden" aria-hidden="true">
+                <div className="h-full bg-cyan-500/70" style={{ width: `${Math.round(v * 100)}%` }} />
+              </div>
+              <label htmlFor={selectId} className="sr-only">{`Route ${c.label} to a target`}</label>
+              <select
+                id={selectId}
+                name={selectId}
+                value={routeId}
+                onChange={(e) => setPoseRoute(c.id, e.target.value || null)}
+                className="shrink-0 w-36 bg-black/40 border border-zinc-800 rounded px-1.5 py-1 text-[9px] font-mono text-zinc-200 focus:border-cyan-500/50 outline-none"
+              >
+                <option value="">route to...</option>
+                {groups.map(([g, list]) => (
+                  <optgroup key={g} label={g}>
+                    {list.map((t) => (
+                      <option key={t.id} value={t.id}>{t.label}</option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </div>
+          );
+        })}
+      </div>
+      <p className="mt-2 text-[8px] font-mono text-zinc-600 leading-snug">
+        Camera pose comes from the VJ's webcam body tracking (toggle GESTURE in the VJ). The six channels route to targets like Sway; no learn needed.
+      </p>
+    </div>
+  );
+};

--- a/frontend/src/state/bottomPanelStore.ts
+++ b/frontend/src/state/bottomPanelStore.ts
@@ -20,7 +20,8 @@ export type BottomPanelTab =
   | 'piano-roll'
   | 'step-seq'
   | 'bucket'
-  | 'slide';
+  | 'slide'
+  | 'sway';
 
 interface BottomPanelState {
   activeTab: BottomPanelTab;

--- a/frontend/src/state/controllerProfiles.ts
+++ b/frontend/src/state/controllerProfiles.ts
@@ -315,6 +315,12 @@ const ROWS: Row[] = [
   ['icon-platform', 'iCON Platform / Qcon', 'iCON', 'mixer', ['platform m', 'platform nano', 'qcon', 'icon'], MCU],
   ['ssl-uf', 'SSL UF8 / UC1', 'SSL', 'mixer', ['ssl uf8', 'ssl uc1', 'uf8'], MCU],
 
+  /* ───────── Audima (expressive motion) ───────── */
+  // Six motion dimensions (Strike/Sway/Pulse/Glide/Press/Sculpt) read as
+  // continuous controls, plus the 8 encoders and the performance pads. The dims
+  // bind by learn (swayBus); this row only labels the physical surface.
+  ['audima-sway', 'Audima Sway', 'Audima', 'generic', ['sway', 'audima'], [K(1, 6, '6 DIMENSIONS'), K(1, 8, 'ENCODERS'), P(2, 8, 'PERF PADS')]],
+
   /* ───────── Generic fallbacks (lowest priority) ───────── */
   ['generic-16', 'Generic 16-channel', 'Generic', 'generic', [], [K(2, 8, 'KNOBS'), F(1, 8, 'FADERS'), B(2, 8, 'BUTTONS')]],
   ['generic-8', 'Generic 8-channel', 'Generic', 'generic', [], [K(1, 8, 'KNOBS'), F(1, 8, 'FADERS')]],

--- a/frontend/src/state/poseBus.ts
+++ b/frontend/src/state/poseBus.ts
@@ -1,0 +1,84 @@
+/**
+ * Pose control bus.
+ *
+ * Receives the six normalized body-pose scalars the VJ's MediaPipe gesture
+ * detector forwards over the iframe bridge (`sa3-vj/pose`) and exposes them as
+ * named 0..1 channels other subsystems can route, mirroring swayBus. Pose is a
+ * camera-driven control SOURCE: the channels are target-agnostic, so the same
+ * signals can drive VFX, 3D audio, and music/voice targets once those subscribe.
+ *
+ * The window listener auto-starts on import (like the VJ's own sa3Bridge), so the
+ * meters and routing receive frames whenever the VJ is forwarding, regardless of
+ * the MIDI gate. poseControlSource publishes the channels onto the XR control bus.
+ */
+import { create } from 'zustand';
+
+export type PoseChannel = 'handLeft' | 'handRight' | 'armSpan' | 'bodyX' | 'bodyY' | 'lean';
+
+export const POSE_CHANNELS: { id: PoseChannel; label: string }[] = [
+  { id: 'handLeft', label: 'Hand L' },
+  { id: 'handRight', label: 'Hand R' },
+  { id: 'armSpan', label: 'Arm Span' },
+  { id: 'bodyX', label: 'Body X' },
+  { id: 'bodyY', label: 'Body Y' },
+  { id: 'lean', label: 'Lean' },
+];
+
+const ZERO: Record<PoseChannel, number> = {
+  handLeft: 0,
+  handRight: 0,
+  armSpan: 0,
+  bodyX: 0,
+  bodyY: 0,
+  lean: 0,
+};
+
+interface PoseState {
+  values: Record<PoseChannel, number>;
+  /** True once a pose frame has arrived (the detector is live). */
+  active: boolean;
+}
+
+export const usePoseStore = create<PoseState>(() => ({ values: { ...ZERO }, active: false }));
+
+type ValueListener = (ch: PoseChannel, value: number) => void;
+const valueListeners = new Set<ValueListener>();
+
+export function subscribePoseValue(cb: ValueListener): () => void {
+  valueListeners.add(cb);
+  return () => {
+    valueListeners.delete(cb);
+  };
+}
+
+export function getPoseValue(ch: PoseChannel): number {
+  return usePoseStore.getState().values[ch] ?? 0;
+}
+
+function ingest(p: Record<string, unknown>): void {
+  const cur = usePoseStore.getState().values;
+  const next = { ...cur };
+  for (const { id } of POSE_CHANNELS) {
+    const raw = p[id];
+    if (typeof raw === 'number') {
+      const val = raw < 0 ? 0 : raw > 1 ? 1 : raw;
+      next[id] = val;
+      for (const cb of valueListeners) {
+        try {
+          cb(id, val);
+        } catch {
+          /* one faulty subscriber never breaks the bus */
+        }
+      }
+    }
+  }
+  usePoseStore.setState({ values: next, active: true });
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('message', (e: MessageEvent) => {
+    const d = e.data;
+    if (!d || typeof d !== 'object' || (d as { type?: unknown }).type !== 'sa3-vj/pose') return;
+    ingest(d as Record<string, unknown>);
+  });
+}

--- a/frontend/src/state/poseControlSource.ts
+++ b/frontend/src/state/poseControlSource.ts
@@ -1,0 +1,49 @@
+/**
+ * Pose control source for the XR control bus.
+ *
+ * Publishes the six body-pose channels (`pose.handLeft` ... `pose.lean`, each
+ * 0..1) as manifest entries so they are first-class routable signals on the same
+ * bus DJ and Sway use, and mirrors their live values out to XR so a headset sees
+ * the motion. Pose is an INPUT source: values flow outward to bound targets, so an
+ * inbound control-set has nothing to set here.
+ */
+import type { XrControlSource, XrManifestEntry } from './xrControlClient';
+import { publishControlChanged } from './xrControlClient';
+import { POSE_CHANNELS, subscribePoseValue } from './poseBus';
+
+export const poseControlSource: XrControlSource = {
+  area: 'pose',
+
+  buildEntries(): XrManifestEntry[] {
+    return POSE_CHANNELS.map((c) => ({
+      id: `pose.${c.id}`,
+      area: 'pose',
+      group: 'Pose',
+      label: c.label,
+      kind: 'knob',
+      min: 0,
+      max: 1,
+      step: 0.001,
+    }));
+  },
+
+  apply(): boolean {
+    return false;
+  },
+};
+
+let mirroring = false;
+
+/** Mirror live pose channel values out to XR widgets. publishControlChanged is a
+ *  no-op when no headset is connected. Returns a stop function. */
+export function startPoseXrMirror(): () => void {
+  if (mirroring) return () => {};
+  mirroring = true;
+  const unsub = subscribePoseValue((ch, value) => {
+    publishControlChanged(`pose.${ch}`, value);
+  });
+  return () => {
+    mirroring = false;
+    unsub();
+  };
+}

--- a/frontend/src/state/poseRouting.ts
+++ b/frontend/src/state/poseRouting.ts
@@ -1,0 +1,89 @@
+/**
+ * Pose routing -- fan the six body-pose channels out to BindableTargets, mirroring
+ * swayRouting. Each channel can bind to one target; when its value changes the
+ * bound target is driven (scaled into [min,max] for ranges, thresholded for
+ * toggles, rising-edge for pads). Reuses the same lazily-loaded target catalogue
+ * as Sway (DJ targets today). The unified Show Designer matrix can later subsume
+ * both scoped routers.
+ */
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { BindableTarget } from '../components/surface/widgetTypes';
+import { subscribePoseValue, type PoseChannel } from './poseBus';
+import { loadSwayTargets } from './swayRouting';
+
+let targets: BindableTarget[] | null = null;
+
+interface PoseRoutingState {
+  /** channel -> targetId. */
+  routes: Partial<Record<PoseChannel, string>>;
+  setRoute: (ch: PoseChannel, targetId: string | null) => void;
+}
+
+export const usePoseRoutingStore = create<PoseRoutingState>()(
+  persist(
+    (set) => ({
+      routes: {},
+      setRoute: (ch, targetId) =>
+        set((s) => {
+          const next = { ...s.routes };
+          if (targetId) next[ch] = targetId;
+          else delete next[ch];
+          return { routes: next };
+        }),
+    }),
+    { name: 'thedaw-pose-routes-v1' },
+  ),
+);
+
+const prev: Record<PoseChannel, number> = {
+  handLeft: 0,
+  handRight: 0,
+  armSpan: 0,
+  bodyX: 0,
+  bodyY: 0,
+  lean: 0,
+};
+
+function drive(t: BindableTarget, value01: number, previous: number): void {
+  try {
+    if (t.kind === 'toggle') {
+      t.invoke(value01 > 0.5);
+    } else if (t.kind === 'pad') {
+      if (value01 > 0.5 && previous <= 0.5) t.invoke(true);
+    } else {
+      const min = t.min ?? 0;
+      const max = t.max ?? 1;
+      t.invoke(min + value01 * (max - min));
+    }
+  } catch {
+    /* a setter that throws (engine not started yet) is non-fatal */
+  }
+}
+
+let unsub: (() => void) | null = null;
+
+/** Fan the six pose channels out to their bound targets. Idempotent. Camera-driven
+ *  (not MIDI-gated), so App starts it on mount. Returns a stop function. */
+export function startPoseRouting(): () => void {
+  if (unsub) return () => {};
+  void loadSwayTargets().then((t) => {
+    targets = t;
+  });
+  unsub = subscribePoseValue((ch, value) => {
+    const previous = prev[ch];
+    prev[ch] = value;
+    const targetId = usePoseRoutingStore.getState().routes[ch];
+    if (!targetId || !targets) return;
+    const t = targets.find((x) => x.id === targetId);
+    if (t) drive(t, value, previous);
+  });
+  return stopPoseRouting;
+}
+
+export function stopPoseRouting(): void {
+  if (unsub) {
+    unsub();
+    unsub = null;
+  }
+}

--- a/frontend/src/state/swayBus.ts
+++ b/frontend/src/state/swayBus.ts
@@ -1,0 +1,155 @@
+/**
+ * Sway control bus.
+ *
+ * Normalizes the Audima Sway's six expressive dimensions (Strike / Sway / Pulse /
+ * Glide / Press / Sculpt) from raw MIDI CCs into 0..1 signals other subsystems can
+ * route. The Sway is class-compliant MIDI, so its CCs already arrive on the global
+ * midiBus; this bus adds the named-dimension layer plus learn. The CC numbers are
+ * firmware-configurable and there is no MIDI 1.0 way to query a device's layout,
+ * so every dimension binds by LEARN rather than a hardcoded CC (the same reason
+ * controllerProfiles never hardcodes CCs).
+ *
+ * The six dims are target-agnostic: the same 0..1 signals can drive VFX (shader
+ * uniforms, the akvj cloud, VJ FX), 3D audio placement (the Spatializer), and
+ * MUSIC and VOICE targets (MAKE / Magenta generation and the vocal / SoulX path)
+ * once those consumers subscribe. swayControlSource publishes them onto the XR
+ * control bus so a headset can see and bind them too.
+ */
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { subscribeToMidi } from './midiBus';
+
+export type SwayDim = 'strike' | 'sway' | 'pulse' | 'glide' | 'press' | 'sculpt';
+
+export const SWAY_DIMS: { id: SwayDim; label: string }[] = [
+  { id: 'strike', label: 'Strike' },
+  { id: 'sway', label: 'Sway' },
+  { id: 'pulse', label: 'Pulse' },
+  { id: 'glide', label: 'Glide' },
+  { id: 'press', label: 'Press' },
+  { id: 'sculpt', label: 'Sculpt' },
+];
+
+/** A learned CC binding for one dimension (channel 0..15, cc 0..127). */
+export interface SwayBinding {
+  channel: number;
+  cc: number;
+}
+
+interface SwayState {
+  /** Persisted dim -> CC bindings (learned). */
+  bindings: Partial<Record<SwayDim, SwayBinding>>;
+  /** Live normalized values 0..1 (session only). */
+  values: Record<SwayDim, number>;
+  /** The dimension currently armed for learn, or null. Session only. */
+  learningDim: SwayDim | null;
+
+  startLearn: (dim: SwayDim) => void;
+  cancelLearn: () => void;
+  clearBinding: (dim: SwayDim) => void;
+}
+
+const ZERO_VALUES: Record<SwayDim, number> = {
+  strike: 0,
+  sway: 0,
+  pulse: 0,
+  glide: 0,
+  press: 0,
+  sculpt: 0,
+};
+
+export const useSwayStore = create<SwayState>()(
+  persist(
+    (set) => ({
+      bindings: {},
+      values: { ...ZERO_VALUES },
+      learningDim: null,
+      startLearn: (dim) => set({ learningDim: dim }),
+      cancelLearn: () => set({ learningDim: null }),
+      clearBinding: (dim) =>
+        set((s) => {
+          const next = { ...s.bindings };
+          delete next[dim];
+          return { bindings: next };
+        }),
+    }),
+    {
+      name: 'thedaw-sway-bindings-v1',
+      partialize: (s) => ({ bindings: s.bindings }),
+    },
+  ),
+);
+
+/** Raw 0..1 value subscribers (high-rate, no React) for the control sources. */
+type ValueListener = (dim: SwayDim, value: number) => void;
+const valueListeners = new Set<ValueListener>();
+
+export function subscribeSwayValue(cb: ValueListener): () => void {
+  valueListeners.add(cb);
+  return () => {
+    valueListeners.delete(cb);
+  };
+}
+
+/** Current normalized value for a dimension (0..1). */
+export function getSwayValue(dim: SwayDim): number {
+  return useSwayStore.getState().values[dim] ?? 0;
+}
+
+function ingestCc(channel: number, cc: number, value01: number): void {
+  const st = useSwayStore.getState();
+  // Learn: bind the armed dimension to the first CC it sees, then disarm.
+  if (st.learningDim) {
+    const dim = st.learningDim;
+    useSwayStore.setState((s) => ({
+      bindings: { ...s.bindings, [dim]: { channel, cc } },
+      learningDim: null,
+    }));
+    return;
+  }
+  // Route: update every dimension bound to this (channel, cc) and notify the raw
+  // value subscribers (the XR mirror, future matrix consumers).
+  let changed = false;
+  const nextValues = { ...st.values };
+  for (const { id } of SWAY_DIMS) {
+    const b = st.bindings[id];
+    if (b && b.channel === channel && b.cc === cc) {
+      nextValues[id] = value01;
+      changed = true;
+      for (const cb of valueListeners) {
+        try {
+          cb(id, value01);
+        } catch {
+          /* one faulty subscriber never breaks the bus */
+        }
+      }
+    }
+  }
+  if (changed) useSwayStore.setState({ values: nextValues });
+}
+
+let unsub: (() => void) | null = null;
+
+/** Start listening to the global midiBus for Sway CCs. Idempotent. The caller
+ *  gates this behind the master MIDI toggle (App registers it in the midiEnabled
+ *  effect, matching djControlSource). Returns a stop function. */
+export function startSwayBus(): () => void {
+  if (unsub) return () => {};
+  unsub = subscribeToMidi((msg) => {
+    const [status, data1, data2] = msg.data;
+    if (typeof status !== 'number') return;
+    if ((status & 0xf0) !== 0xb0) return; // control-change only
+    const channel = status & 0x0f;
+    const cc = data1 ?? 0;
+    const value01 = Math.max(0, Math.min(1, (data2 ?? 0) / 127));
+    ingestCc(channel, cc, value01);
+  });
+  return stopSwayBus;
+}
+
+export function stopSwayBus(): void {
+  if (unsub) {
+    unsub();
+    unsub = null;
+  }
+}

--- a/frontend/src/state/swayControlSource.ts
+++ b/frontend/src/state/swayControlSource.ts
@@ -1,0 +1,56 @@
+/**
+ * Sway control source for the XR control bus.
+ *
+ * Publishes the Audima Sway's six expressive dimensions as named manifest entries
+ * (`sway.strike` ... `sway.sculpt`, each 0..1) so they are first-class routable
+ * signals on the same bus DJ uses, and mirrors their live values out to XR so a
+ * headset sees the motion. Unlike djControlSource, Sway is an INPUT: values flow
+ * outward to bound targets, so an inbound control-set has nothing to set here.
+ *
+ * The six dims are target-agnostic. The fan-out to concrete targets (VFX, the
+ * Spatializer, MAKE / Magenta generation, the vocal / SoulX path) is the binding
+ * layer's job; today a Sway can already drive DJ controls through the existing DJ
+ * MIDI-learn, and this source makes the named dims available to everything else.
+ */
+import type { XrControlSource, XrManifestEntry } from './xrControlClient';
+import { publishControlChanged } from './xrControlClient';
+import { SWAY_DIMS, subscribeSwayValue } from './swayBus';
+
+export const swayControlSource: XrControlSource = {
+  area: 'sway',
+
+  buildEntries(): XrManifestEntry[] {
+    return SWAY_DIMS.map((d) => ({
+      id: `sway.${d.id}`,
+      area: 'sway',
+      group: 'Sway',
+      label: d.label,
+      kind: 'knob',
+      min: 0,
+      max: 1,
+      step: 0.001,
+    }));
+  },
+
+  apply(): boolean {
+    // Input-only source: XR cannot set a physical dimension.
+    return false;
+  },
+};
+
+let mirroring = false;
+
+/** Mirror live Sway dimension values out to XR widgets so a headset sees the
+ *  motion. publishControlChanged is a no-op when no headset is connected, so this
+ *  is safe to run whenever MIDI is enabled. Returns a stop function. */
+export function startSwayXrMirror(): () => void {
+  if (mirroring) return () => {};
+  mirroring = true;
+  const unsub = subscribeSwayValue((dim, value) => {
+    publishControlChanged(`sway.${dim}`, value);
+  });
+  return () => {
+    mirroring = false;
+    unsub();
+  };
+}

--- a/frontend/src/state/swayRouting.ts
+++ b/frontend/src/state/swayRouting.ts
@@ -1,0 +1,108 @@
+/**
+ * Sway routing -- a small fan-out from the six Sway dimensions to BindableTargets.
+ *
+ * Each dimension can bind to one target; when the dimension's normalized value
+ * changes, the bound target is driven (scaled into its [min,max] for ranges,
+ * thresholded for toggles, rising-edge for pads). Today the catalogue is
+ * DJ_TARGETS, so a Sway can drive DJ controls hands-on; VJ, MAKE, and vocal
+ * targets join the picker as their catalogues land, and the unified Show Designer
+ * matrix can later subsume this scoped engine.
+ *
+ * The DJ catalogue (and through it djEngine) is imported lazily, so this stays out
+ * of app boot and only loads when a Sway target is wired or the panel opens.
+ */
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { BindableTarget } from '../components/surface/widgetTypes';
+import { subscribeSwayValue, type SwayDim } from './swayBus';
+
+let targetCache: BindableTarget[] | null = null;
+let targetLoad: Promise<BindableTarget[]> | null = null;
+
+function loadTargets(): Promise<BindableTarget[]> {
+  if (targetCache) return Promise.resolve(targetCache);
+  if (!targetLoad) {
+    targetLoad = import('./bindableTargets').then((m) => {
+      targetCache = m.DJ_TARGETS;
+      return targetCache;
+    });
+  }
+  return targetLoad;
+}
+
+/** Targets a Sway dimension can route to (lazy-loads the DJ catalogue). */
+export function loadSwayTargets(): Promise<BindableTarget[]> {
+  return loadTargets();
+}
+
+interface SwayRoutingState {
+  /** dim -> targetId. */
+  routes: Partial<Record<SwayDim, string>>;
+  setRoute: (dim: SwayDim, targetId: string | null) => void;
+}
+
+export const useSwayRoutingStore = create<SwayRoutingState>()(
+  persist(
+    (set) => ({
+      routes: {},
+      setRoute: (dim, targetId) =>
+        set((s) => {
+          const next = { ...s.routes };
+          if (targetId) next[dim] = targetId;
+          else delete next[dim];
+          return { routes: next };
+        }),
+    }),
+    { name: 'thedaw-sway-routes-v1' },
+  ),
+);
+
+const prev: Record<SwayDim, number> = {
+  strike: 0,
+  sway: 0,
+  pulse: 0,
+  glide: 0,
+  press: 0,
+  sculpt: 0,
+};
+
+function drive(t: BindableTarget, value01: number, previous: number): void {
+  try {
+    if (t.kind === 'toggle') {
+      t.invoke(value01 > 0.5);
+    } else if (t.kind === 'pad') {
+      if (value01 > 0.5 && previous <= 0.5) t.invoke(true); // rising edge triggers once
+    } else {
+      const min = t.min ?? 0;
+      const max = t.max ?? 1;
+      t.invoke(min + value01 * (max - min));
+    }
+  } catch {
+    /* a setter that throws (engine not started yet) is non-fatal */
+  }
+}
+
+let unsub: (() => void) | null = null;
+
+/** Fan the six Sway dimensions out to their bound targets. Idempotent. Started by
+ *  App in the midiEnabled effect; returns a stop function. */
+export function startSwayRouting(): () => void {
+  if (unsub) return () => {};
+  void loadTargets(); // warm so the first move routes without a stall
+  unsub = subscribeSwayValue((dim, value) => {
+    const previous = prev[dim];
+    prev[dim] = value;
+    const targetId = useSwayRoutingStore.getState().routes[dim];
+    if (!targetId || !targetCache) return;
+    const t = targetCache.find((x) => x.id === targetId);
+    if (t) drive(t, value, previous);
+  });
+  return stopSwayRouting;
+}
+
+export function stopSwayRouting(): void {
+  if (unsub) {
+    unsub();
+    unsub = null;
+  }
+}

--- a/frontend/src/views/VJView.tsx
+++ b/frontend/src/views/VJView.tsx
@@ -348,6 +348,10 @@ export const VJView: React.FC = () => {
     const lowEnd = Math.floor(buf.length * 0.05);
     const midEnd = Math.floor(buf.length * 0.30);
     const highEnd = buf.length;
+    // 256-bin spectrogram column for the SPECTRA VJ source (downsampled FFT).
+    const SPEC_BINS = 256;
+    const specBlock = Math.max(1, Math.floor(buf.length / SPEC_BINS));
+    const spec = new Array<number>(SPEC_BINS);
 
     const tick = () => {
       // Hold off until the iframe has loaded the VJ app (avoid posting to about:blank).
@@ -367,8 +371,14 @@ export const VJView: React.FC = () => {
         const mid = midEnd - lowEnd > 0 ? (midSum / (midEnd - lowEnd)) / 255 : 0;
         const high = highEnd - midEnd > 0 ? (highSum / (highEnd - midEnd)) / 255 : 0;
         const volume = (bassSum + midSum + highSum) / (buf.length * 255);
+        for (let i = 0; i < SPEC_BINS; i++) {
+          let s = 0;
+          const start = i * specBlock;
+          for (let j = 0; j < specBlock; j++) s += buf[start + j] || 0;
+          spec[i] = Math.round(s / specBlock);
+        }
         try {
-          targetWin()?.postMessage({ type: 'sa3-vj/audio-levels', bass, mid, high, volume, t: now }, vjOrigin);
+          targetWin()?.postMessage({ type: 'sa3-vj/audio-levels', bass, mid, high, volume, spectrum: spec, t: now }, vjOrigin);
         } catch { /* target unavailable this frame — retry next tick */ }
         frameCount += 1;
         if (now - fpsTick > 1000) {


### PR DESCRIPTION
swayBus learns 6 dims from controller CCs (0..1), swayControlSource mirrors them onto the XR control bus, swayRouting maps each dim to a DJ target; a new SWAY bottom-panel tab (SwayPanel) gives per-dim LEARN/meter/clear/route rows. poseBus + poseControlSource + poseRouting consume MediaPipe pose scalars the VJ forwards over the sa3-vj/pose bridge channel, surfaced in SwayPanel's Camera Pose section. controllerProfiles gains the Audima Sway row. Adds the next-block VFX, show-matrix, faceviz-sway, and vocal/SoulX plan + guide docs.