### PR TITLE
feat(vocal): prerequisite vocal engine backend (Phase 1-2) feat(sway): step 2 routing, Sway dims drive Magenta live params and the MIX chain

### DIFF
--- a/backend/modules/vocal/module.json
+++ b/backend/modules/vocal/module.json
@@ -1,0 +1,10 @@
+{
+  "name": "vocal",
+  "label": "Vocal Engine",
+  "enabled": true,
+  "icon": "Mic",
+  "sidebar": false,
+  "api_prefix": "/api/vocal",
+  "backend": true,
+  "description": "Prerequisite vocal pipeline: capture, preprocessing and analysis, and a canonical metadata artifact that singing-synthesis models (SoulX and others) later consume. Composes existing isolation, cleanup, basic-pitch notes, F0, segments, and transcription. Singing synthesis and voice conversion stay deferred."
+}

--- a/backend/modules/vocal/preprocess/f0_curve.py
+++ b/backend/modules/vocal/preprocess/f0_curve.py
@@ -1,0 +1,62 @@
+"""Dense per-frame F0 curve over librosa.pyin.
+
+Extends the scalar analysis/pitch.py (which returns only mean/median/std) to emit
+the full f0 array plus the voiced/unvoiced mask the vocal artifact needs. pyin
+reports NaN where it cannot track confidently; those map to 0.0 Hz, voiced=False.
+Heavy imports are lazy so importing this module stays cheap at startup.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from ..schema import F0Curve
+
+log = logging.getLogger(__name__)
+
+# Monophonic vocal range: ~C2 to ~C6. hop = frame_length // 4 (librosa pyin default).
+_FMIN = 65.0
+_FMAX = 1047.0
+_SR = 22050
+_FRAME = 2048
+_HOP = 512
+
+
+def compute_f0_curve(audio_path: Path) -> Optional[F0Curve]:
+    try:
+        import librosa
+        import numpy as np
+    except ImportError:
+        return None
+
+    p = Path(audio_path)
+    if not p.is_file():
+        return None
+
+    try:
+        y, sr = librosa.load(str(p), sr=_SR, mono=True)
+    except Exception as e:
+        log.info("vocal.f0: load failed for %s: %s", p.name, e)
+        return None
+    if y.size == 0:
+        return None
+
+    try:
+        f0, voiced_flag, _voiced_prob = librosa.pyin(
+            y, fmin=_FMIN, fmax=_FMAX, sr=sr, frame_length=_FRAME, hop_length=_HOP
+        )
+    except Exception as e:
+        log.info("vocal.f0: pyin failed for %s: %s", p.name, e)
+        return None
+    if f0 is None or len(f0) == 0:
+        return None
+
+    hz = [0.0 if np.isnan(v) else float(v) for v in f0]
+    if voiced_flag is not None:
+        voiced = [bool(b) for b in voiced_flag]
+    else:
+        voiced = [v > 0.0 for v in hz]
+    hop_ms = _HOP / float(sr) * 1000.0
+    return F0Curve(hop_ms=hop_ms, hz=hz, voiced=voiced)

--- a/backend/modules/vocal/preprocess/isolation.py
+++ b/backend/modules/vocal/preprocess/isolation.py
@@ -1,0 +1,38 @@
+"""Vocal isolation and cleanup, delegating to the existing restoration DSP.
+
+Default isolation is the instant mid/side extraction in restoration. Demucs
+(method="demucs") is a future quality upgrade; until it is wired it falls back to
+mid/side here. Every step returns the input path unchanged on failure, so a
+missing optional tool never breaks the prepare pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+async def isolate(
+    input_path: Path, output_path: Path, method: str = "vocal_isolate"
+) -> Path:
+    try:
+        from backend.modules.restoration import dsp
+
+        await dsp.vocal_isolate(input_path, output_path, {"output": "vocals"})
+        return output_path if output_path.is_file() else input_path
+    except Exception as e:
+        log.info("vocal.isolation: isolate failed (%s): %s", method, e)
+        return input_path
+
+
+async def cleanup(input_path: Path, output_path: Path) -> Path:
+    try:
+        from backend.modules.restoration import dsp
+
+        await dsp.breath_removal(input_path, output_path, {})
+        return output_path if output_path.is_file() else input_path
+    except Exception as e:
+        log.info("vocal.isolation: cleanup failed: %s", e)
+        return input_path

--- a/backend/modules/vocal/preprocess/notes.py
+++ b/backend/modules/vocal/preprocess/notes.py
@@ -1,0 +1,73 @@
+"""Vocal-to-MIDI notes via the existing basic-pitch engine, parsed to artifact Notes.
+
+Reuses backend/modules/midi convert_to_midi to write a MIDI file, then parses it
+with mido into project-relative-millisecond notes. Returns [] when basic-pitch is
+not installed; it never triggers a surprise pip install (auto_install=False).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import tempfile
+from pathlib import Path
+
+from ..schema import Note
+
+log = logging.getLogger(__name__)
+
+
+def extract_notes(audio_path: Path) -> list[Note]:
+    if importlib.util.find_spec("mido") is None:
+        return []
+    from backend.modules.midi.engine import convert_to_midi
+
+    p = Path(audio_path)
+    if not p.is_file():
+        return []
+    with tempfile.TemporaryDirectory() as td:
+        mid_path = Path(td) / "notes.mid"
+        res = convert_to_midi(p, mid_path, hint="auto", auto_install=False)
+        if not res.get("ok") or not mid_path.is_file():
+            log.info(
+                "vocal.notes: basic-pitch unavailable/failed: %s", res.get("error")
+            )
+            return []
+        return _parse_midi(mid_path)
+
+
+def _parse_midi(mid_path: Path) -> list[Note]:
+    import mido
+
+    try:
+        mid = mido.MidiFile(str(mid_path))
+    except Exception:
+        return []
+    tpb = mid.ticks_per_beat or 480
+    notes: list[Note] = []
+    for track in mid.tracks:
+        cur_tempo = 500000  # default 120 BPM until a set_tempo arrives
+        elapsed_ms = 0.0
+        active: dict[int, tuple[int, int]] = {}
+        for msg in track:
+            elapsed_ms += mido.tick2second(msg.time, tpb, cur_tempo) * 1000.0
+            if msg.type == "set_tempo":
+                cur_tempo = msg.tempo
+            elif msg.type == "note_on" and msg.velocity > 0:
+                active[msg.note] = (int(elapsed_ms), int(msg.velocity))
+            elif msg.type == "note_off" or (
+                msg.type == "note_on" and msg.velocity == 0
+            ):
+                started = active.pop(msg.note, None)
+                if started is not None:
+                    start_ms, vel = started
+                    notes.append(
+                        Note(
+                            start_ms=start_ms,
+                            end_ms=int(elapsed_ms),
+                            pitch=int(msg.note),
+                            velocity=vel,
+                        )
+                    )
+    notes.sort(key=lambda n: n.start_ms)
+    return notes

--- a/backend/modules/vocal/preprocess/segments.py
+++ b/backend/modules/vocal/preprocess/segments.py
@@ -1,0 +1,76 @@
+"""Voice-activity segmentation over librosa RMS.
+
+A thin VAD: frames above an RMS floor are voiced; contiguous voiced runs become
+phrase segments and gaps shorter than `max_merge_ms` are merged so a single
+phrase is not split by tiny pauses. All timing is project-relative milliseconds.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ..schema import Segment
+
+log = logging.getLogger(__name__)
+
+_SR = 22050
+_HOP = 512
+
+
+def detect_segments(
+    audio_path: Path,
+    max_merge_ms: float = 300.0,
+    rms_floor_db: float = -45.0,
+) -> list[Segment]:
+    try:
+        import librosa
+        import numpy as np
+    except ImportError:
+        return []
+
+    p = Path(audio_path)
+    if not p.is_file():
+        return []
+
+    try:
+        y, sr = librosa.load(str(p), sr=_SR, mono=True)
+    except Exception as e:
+        log.info("vocal.segments: load failed for %s: %s", p.name, e)
+        return []
+    if y.size == 0:
+        return []
+
+    rms = librosa.feature.rms(y=y, hop_length=_HOP)[0]
+    if rms.size == 0:
+        return []
+    db = 20.0 * np.log10(np.maximum(rms, 1e-6))
+    voiced = db > rms_floor_db
+    hop_ms = _HOP / float(sr) * 1000.0
+
+    # Contiguous voiced runs as [start_frame, end_frame).
+    runs: list[list[int]] = []
+    start: int | None = None
+    for i, v in enumerate(voiced):
+        if v and start is None:
+            start = i
+        elif not v and start is not None:
+            runs.append([start, i])
+            start = None
+    if start is not None:
+        runs.append([start, len(voiced)])
+    if not runs:
+        return []
+
+    # Merge runs separated by less than max_merge_ms.
+    merged = [runs[0]]
+    for s, e in runs[1:]:
+        if (s - merged[-1][1]) * hop_ms <= max_merge_ms:
+            merged[-1][1] = e
+        else:
+            merged.append([s, e])
+
+    return [
+        Segment(id=idx, start_ms=int(s * hop_ms), end_ms=int(e * hop_ms), kind="phrase")
+        for idx, (s, e) in enumerate(merged)
+    ]

--- a/backend/modules/vocal/router.py
+++ b/backend/modules/vocal/router.py
@@ -1,0 +1,74 @@
+"""Vocal engine API.
+
+The prerequisite pipeline that produces the canonical vocal artifact. Singing
+synthesis and voice conversion (SoulX and others) stay deferred; they consume the
+artifact this module produces.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.core.jobs import Job, create_job, get_job
+
+from . import service
+
+router = APIRouter()
+
+
+class PrepareRequest(BaseModel):
+    asset_id: str
+    isolate: bool = True
+    isolation: str = "vocal_isolate"  # vocal_isolate | demucs
+    cleanup: bool = True
+    transcribe: bool = False
+    language: str = "en"
+
+
+@router.get("/health")
+def health() -> dict:
+    return service.health()
+
+
+@router.post("/prepare")
+def prepare(req: PrepareRequest) -> dict:
+    job = create_job("vocal", f"Prepare vocal artifact ({req.asset_id})")
+    service.start_prepare(job, req.model_dump())
+    return {"ok": True, "job": {"id": job.id}}
+
+
+def _job_payload(job: Job) -> dict:
+    return {
+        "id": job.id,
+        "status": job.status,
+        "progress": job.progress,
+        "message": job.message,
+        "result": job.result,
+        "error": job.error,
+    }
+
+
+@router.get("/jobs/{job_id}")
+def job_status(job_id: str) -> dict:
+    job = get_job(job_id)
+    if job is None or job.module != "vocal":
+        raise HTTPException(status_code=404, detail="job not found")
+    return _job_payload(job)
+
+
+@router.post("/jobs/{job_id}/cancel")
+def job_cancel(job_id: str) -> dict:
+    job = get_job(job_id)
+    if job is None or job.module != "vocal":
+        raise HTTPException(status_code=404, detail="job not found")
+    job.update(status="cancelled", message="cancelled by user")
+    return {"ok": True}
+
+
+@router.get("/metadata/{asset_id}")
+def get_metadata(asset_id: str) -> dict:
+    art = service.load_artifact(asset_id)
+    if art is None:
+        raise HTTPException(status_code=404, detail="no artifact for asset")
+    return art

--- a/backend/modules/vocal/schema.py
+++ b/backend/modules/vocal/schema.py
@@ -1,0 +1,108 @@
+"""Canonical vocal artifact.
+
+The single contract the vocal engine produces and that singing-synthesis models
+(SoulX and others) later consume. This is ONE reconciled schema, merging the
+metadata.json and VocalPlan specs. ALL timing is project-relative MILLISECONDS,
+never seconds and never project-global, fixed here so every analyzer and the
+meta-to-MIDI round-trip agree on units.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+ARTIFACT_VERSION = 1
+TIMING_UNIT = "ms_project_relative"
+
+
+class Word(BaseModel):
+    """One lyric word, timed to the audio and optionally tied to a sung note."""
+
+    text: str
+    start_ms: int
+    end_ms: int
+    phonemes: list[str] = Field(default_factory=list)
+    note_index: Optional[int] = None
+
+
+class Phrase(BaseModel):
+    text: str
+    start_ms: int
+    end_ms: int
+
+
+class Lyrics(BaseModel):
+    language: str = "en"
+    text: str = ""
+    words: list[Word] = Field(default_factory=list)
+    phrases: list[Phrase] = Field(default_factory=list)
+    # "transcribed" | "manual" | "" — phoneme/word alignment is carried here,
+    # never in the SMF, so a round-trip through MIDI does not lose it.
+    source: str = ""
+
+
+class Note(BaseModel):
+    """One sung note. `word_index` ties it back to a lyric word when known."""
+
+    start_ms: int
+    end_ms: int
+    pitch: int
+    velocity: int = 96
+    word_index: Optional[int] = None
+
+
+class Segment(BaseModel):
+    id: int
+    start_ms: int
+    end_ms: int
+    kind: str = "phrase"  # phrase | silence
+
+
+class F0Curve(BaseModel):
+    """Dense per-frame pitch. `hz` is 0.0 where unvoiced; `voiced` is the mask."""
+
+    hop_ms: float
+    hz: list[float] = Field(default_factory=list)
+    voiced: list[bool] = Field(default_factory=list)
+
+
+class Section(BaseModel):
+    name: str  # verse | chorus | bridge | ...
+    start_ms: int
+    end_ms: int
+
+
+class Timing(BaseModel):
+    unit: str = TIMING_UNIT
+    tempo_bpm: Optional[float] = None
+    time_signature: str = "4/4"
+
+
+class Source(BaseModel):
+    asset_id: str = ""
+    sample_rate: int = 44100
+    duration_ms: int = 0
+    isolation: str = ""  # vocal_isolate | demucs | none
+
+
+class Review(BaseModel):
+    """Auto alignment can harm quality, so a render-consuming model should only
+    trust a reviewed artifact. Set true once a human confirms notes and lyrics."""
+
+    reviewed: bool = False
+    notes: str = ""
+
+
+class VocalArtifact(BaseModel):
+    version: int = ARTIFACT_VERSION
+    timing_unit: str = TIMING_UNIT
+    source: Source = Field(default_factory=Source)
+    timing: Timing = Field(default_factory=Timing)
+    segments: list[Segment] = Field(default_factory=list)
+    lyrics: Lyrics = Field(default_factory=Lyrics)
+    notes: list[Note] = Field(default_factory=list)
+    f0: Optional[F0Curve] = None
+    sections: list[Section] = Field(default_factory=list)
+    review: Review = Field(default_factory=Review)

--- a/backend/modules/vocal/service.py
+++ b/backend/modules/vocal/service.py
@@ -1,0 +1,202 @@
+"""Vocal engine orchestration.
+
+Composes existing theDAW tools (restoration isolation and cleanup, the basic-pitch
+midi engine) and the new analyzers (dense F0 curve, segment VAD) into the canonical
+VocalArtifact. Heavy work runs inside a job; heavy libraries load lazily inside the
+preprocess steps, so importing this module stays cheap at startup. Singing synthesis
+stays out of scope.
+
+Tempo context and Library persistence are wired below. The offline vocal_processing
+FFmpeg chain shapes the OUTPUT vocal, so it belongs to the render path and stays with
+deferred SOULX rather than the prerequisite artifact. Faster-whisper transcription is
+Phase 2b.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
+
+from backend.core.jobs import Job
+
+from .preprocess import f0_curve, isolation
+from .preprocess import notes as notes_step
+from .preprocess import segments as segments_step
+from .schema import Lyrics, Source, Timing, VocalArtifact
+
+log = logging.getLogger(__name__)
+
+# In-process artifact store so /metadata works in-session. A later increment also
+# persists each artifact to the Library as a first-class item.
+_artifacts: dict[str, dict] = {}
+
+# Keep references to in-flight prepare tasks so they are not garbage-collected.
+_running: set[asyncio.Task] = set()
+
+
+def health() -> dict[str, Any]:
+    return {"ok": True, "module": "vocal", "transcription": transcription_available()}
+
+
+def transcription_available() -> bool:
+    # Wired in Phase 2b (the faster-whisper sidecar). Until then lyrics are
+    # hand-entered in the review step.
+    return False
+
+
+def load_artifact(asset_id: str) -> Optional[dict]:
+    if asset_id in _artifacts:
+        return _artifacts[asset_id]
+    # Fall back to the persisted metadata file written next to the audio.
+    try:
+        import json
+
+        from backend.modules.library.router import get_store
+
+        audio = get_store().get_audio_path(asset_id)
+        if audio:
+            f = Path(audio).parent / "vocal_metadata.json"
+            if f.is_file():
+                return json.loads(f.read_text(encoding="utf-8"))
+    except Exception as e:
+        log.info("vocal: artifact load failed for %s: %s", asset_id, e)
+    return None
+
+
+def _resolve_path(asset_id: str) -> Optional[Path]:
+    """Resolve a Library asset id to its audio file via the library store."""
+    try:
+        from backend.modules.library.router import get_store
+
+        path = get_store().get_audio_path(asset_id)
+        return Path(path) if path else None
+    except Exception as e:
+        log.info("vocal: asset path resolution failed for %s: %s", asset_id, e)
+        return None
+
+
+def _fill_source_info(art: VocalArtifact, path: Path) -> None:
+    try:
+        import soundfile as sf
+
+        info = sf.info(str(path))
+        art.source.sample_rate = int(info.samplerate)
+        art.source.duration_ms = int(info.frames / max(1, info.samplerate) * 1000)
+    except Exception as e:
+        log.info("vocal: source info read failed for %s: %s", path.name, e)
+
+
+def _persist(asset_id: str, src_path: Path, payload: dict) -> None:
+    """Write the artifact next to the audio and register it as a first-class
+    Library artifact (kind="vocal"), reusing the notation-artifact table."""
+    try:
+        import json
+        import uuid
+
+        from backend.modules.library.router import get_store
+
+        out = src_path.parent / "vocal_metadata.json"
+        out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        get_store().db.add_notation_artifact(
+            artifact_id=str(uuid.uuid4()),
+            entry_id=asset_id,
+            kind="vocal",
+            path=str(out),
+            engine="vocal",
+            metadata={"version": payload.get("version")},
+        )
+    except Exception as e:
+        log.info("vocal: artifact persist failed for %s: %s", asset_id, e)
+
+
+def _tempo_bpm(audio_path: Path) -> Optional[float]:
+    """Estimate tempo from the full mix; vocals alone have weak beats."""
+    try:
+        import librosa
+        import numpy as np
+    except ImportError:
+        return None
+    try:
+        y, sr = librosa.load(str(audio_path), sr=22050, mono=True)
+        if y.size == 0:
+            return None
+        tempo, _beats = librosa.beat.beat_track(y=y, sr=sr)
+        val = float(np.atleast_1d(tempo)[0])
+        return round(val, 2) if val > 0 else None
+    except Exception as e:
+        log.info("vocal.context: tempo failed: %s", e)
+        return None
+
+
+def _context(audio_path: Path) -> Timing:
+    """Musical context. Tempo from the full mix; key and bars join later from the
+    library analysis row when present."""
+    return Timing(tempo_bpm=_tempo_bpm(audio_path))
+
+
+async def _transcribe(path: Path, language: str) -> Lyrics:
+    """Phase 2b: faster-whisper sidecar (lazy). Until then, empty lyrics."""
+    return Lyrics(language=language)
+
+
+def start_prepare(job: Job, req: dict[str, Any]) -> None:
+    """Spawn the prepare pipeline and track the task so it survives GC."""
+    task = asyncio.create_task(run_prepare(job, req))
+    _running.add(task)
+    task.add_done_callback(_running.discard)
+
+
+async def run_prepare(job: Job, req: dict[str, Any]) -> None:
+    asset_id = str(req.get("asset_id", ""))
+    try:
+        job.update(status="running", progress=0.05, message="starting")
+        src_path = _resolve_path(asset_id)
+        if src_path is None or not src_path.is_file():
+            raise FileNotFoundError(f"no audio for asset {asset_id}")
+
+        art = VocalArtifact(source=Source(asset_id=asset_id))
+        _fill_source_info(art, src_path)
+
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td)
+            cur = src_path
+
+            isolate = bool(req.get("isolate", True))
+            method = str(req.get("isolation", "vocal_isolate"))
+            if isolate:
+                cur = await isolation.isolate(cur, work / "isolated.wav", method)
+                art.source.isolation = method
+            else:
+                art.source.isolation = "none"
+            job.update(progress=0.2, message="isolated")
+
+            if bool(req.get("cleanup", True)):
+                cur = await isolation.cleanup(cur, work / "cleaned.wav")
+            job.update(progress=0.35, message="cleaned")
+
+            art.f0 = f0_curve.compute_f0_curve(cur)
+            job.update(progress=0.5, message="pitch")
+
+            art.notes = notes_step.extract_notes(cur)
+            job.update(progress=0.7, message="notes")
+
+            art.segments = segments_step.detect_segments(cur)
+            art.timing = _context(src_path)
+            job.update(progress=0.85, message="segments")
+
+            if bool(req.get("transcribe", False)):
+                art.lyrics = await _transcribe(cur, str(req.get("language", "en")))
+            job.update(progress=0.95, message="lyrics")
+
+        payload = art.model_dump()
+        _artifacts[asset_id] = payload
+        _persist(asset_id, src_path, payload)
+        job.result = payload
+        job.update(status="done", progress=1.0, message="artifact ready")
+    except Exception as e:
+        log.exception("vocal prepare failed")
+        job.error = repr(e)
+        job.update(status="failed", message=str(e))

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-26T12:08:10.437Z · Git revision: `f92b145fcdf8` · Repomix tracked: **no**
+> Generated: 2026-06-26T16:47:02.307Z · Git revision: `1cc8a625439f` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-26T16:47:02.307Z · Git revision: `1cc8a625439f` · Repomix tracked: **no**
+> Generated: 2026-06-26T16:49:49.639Z · Git revision: `d595ecf31847` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-26T16:47:02.307Z",
-  "repoRevision": "1cc8a625439f",
+  "generatedAt": "2026-06-26T16:49:49.639Z",
+  "repoRevision": "d595ecf31847",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-26T12:08:10.437Z",
-  "repoRevision": "f92b145fcdf8",
+  "generatedAt": "2026-06-26T16:47:02.307Z",
+  "repoRevision": "1cc8a625439f",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,8 @@ import { publishMidi } from './state/midiBus';
 import { startQuestMidi, stopQuestMidi } from './state/questMidiClient';
 import { startXrControl, stopXrControl, registerXrControlSource } from './state/xrControlClient';
 import { djControlSource } from './state/xrControlDjSource';
+import { makeControlSource } from './state/makeControlSource';
+import { processControlSource } from './state/processControlSource';
 import { swayControlSource, startSwayXrMirror } from './state/swayControlSource';
 import { startSwayBus } from './state/swayBus';
 import { startSwayRouting } from './state/swayRouting';
@@ -238,6 +240,12 @@ export default function App() {
     // the same bus; the pose values themselves arrive via poseBus regardless of MIDI.
     registerXrControlSource(poseControlSource);
     const stopPoseMirror = startPoseXrMirror();
+    // MAKE (Magenta RT2): live generation params as bindable targets, so SWAY and
+    // an XR headset can drive generation. Bidirectional like DJ; lazy-loaded.
+    registerXrControlSource(makeControlSource);
+    // PROCESS (MIX effect chain): drive effect params on the next offline render,
+    // including the vocal_processing path. Bidirectional like DJ; lazy-loaded.
+    registerXrControlSource(processControlSource);
     startXrControl();
     // Stream the visualization feed (waveform pack) over the same bridge so a
     // theDAW-XR headset can render theDAW's live audio natively.

--- a/frontend/src/components/audio/MagentaToolStage.tsx
+++ b/frontend/src/components/audio/MagentaToolStage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Music } from 'lucide-react';
 import type { MagentaTool } from '../../lib/magentaToolCatalog';
+import { registerMakeInstrument } from '../../state/makeBridge';
 
 /* ── MagentaToolStage ────────────────────────────────────────────────────────
    Mounts a Magenta RealTime 2 instrument (Collider / Jam / MRT2 standalone) in
@@ -36,10 +37,17 @@ export const MagentaToolStage: React.FC<{
         try { doc.defaultView?.dispatchEvent(new Event('resize')); } catch { /* ignore */ }
       }
     } catch { /* cross-origin guard — same-origin in practice */ }
+    // Hand the instrument's window to the MAKE bridge so SWAY and an XR headset
+    // can drive its live generation params. Cleared when the tool changes or the
+    // stage unmounts (the effect cleanup below).
+    try { registerMakeInstrument(iframeRef.current?.contentWindow ?? null); } catch { /* ignore */ }
     setLoaded(true);
   };
 
-  useEffect(() => { setLoaded(false); }, [tool?.id]);
+  useEffect(() => {
+    setLoaded(false);
+    return () => { registerMakeInstrument(null); };
+  }, [tool?.id]);
 
   if (!tool) {
     return (

--- a/frontend/src/components/layout/SlidePanel.tsx
+++ b/frontend/src/components/layout/SlidePanel.tsx
@@ -45,6 +45,7 @@ import {
   profileKindCount,
   detectProfileFromNames,
   GANTASMO_WORLDS_COLLIDE_ID,
+  AUDIMA_SWAY_ID,
   type ControlKind,
 } from '../../state/controllerProfiles';
 import { useEditorStore } from '../../state/editorStore';
@@ -961,6 +962,13 @@ export const SlidePanel: React.FC = () => {
               <option value={p.id}>{p.name} · {profileControlCount(p)}</option>
             </optgroup>
           ))}
+          {/* Audima Sway — pinned second so the 6-dimension motion surface sits
+              one click below the GANTASMO twin. */}
+          {CONTROLLER_PROFILES.filter((p) => p.id === AUDIMA_SWAY_ID).map((p) => (
+            <optgroup key="sway" label="SWAY">
+              <option value={p.id}>{p.name} · {profileControlCount(p)}</option>
+            </optgroup>
+          ))}
           {learnedProfiles.length > 0 && (
             <optgroup label="LEARNED (your devices)">
               {learnedProfiles
@@ -973,7 +981,7 @@ export const SlidePanel: React.FC = () => {
           )}
           {(['dj', 'pad', 'mixer', 'keys', 'generic'] as const).map((cat) => {
             const inCat = CONTROLLER_PROFILES
-              .filter((p) => (p.category ?? 'generic') === cat && p.id !== GANTASMO_WORLDS_COLLIDE_ID)
+              .filter((p) => (p.category ?? 'generic') === cat && p.id !== GANTASMO_WORLDS_COLLIDE_ID && p.id !== AUDIMA_SWAY_ID)
               .sort((a, b) => a.name.localeCompare(b.name)); // alpha within each group
             if (inCat.length === 0) return null;
             return (

--- a/frontend/src/components/layout/SwayPanel.tsx
+++ b/frontend/src/components/layout/SwayPanel.tsx
@@ -1,9 +1,13 @@
 /**
  * SWAY panel -- learn, meter, and route the Audima Sway's six expressive
- * dimensions. Each row arms LEARN (binds the dimension to the next CC the
- * controller sends), shows the bound CC and a live 0..1 meter, and routes the
- * dimension to a BindableTarget (DJ targets today). Lives as a tab in the global
- * bottom multi-tab panel, beside SLIDE.
+ * dimensions, plus the VJ's six camera-pose channels. Each Sway row arms LEARN
+ * (binds the dimension to the next CC the controller sends), shows the bound CC
+ * (folded into the Learn button) and a live 0..1 meter, and routes the dimension
+ * to a BindableTarget (DJ targets today). Lives as a tab in the global bottom
+ * multi-tab panel, beside SLIDE.
+ *
+ * Laid out in two columns (Sway | Camera Pose) so the wide-but-short bottom
+ * panel is filled horizontally instead of scrolling.
  *
  * Works with ANY MIDI controller via learn, not only a physical Sway; the Sway
  * profile just labels the surface.
@@ -15,6 +19,50 @@ import { usePoseStore, POSE_CHANNELS } from '../../state/poseBus';
 import { usePoseRoutingStore } from '../../state/poseRouting';
 import type { BindableTarget } from '../surface/widgetTypes';
 import { useMidiTriggerStore } from '../../state/midiTriggerStore';
+
+type TargetGroups = Array<[string, BindableTarget[]]>;
+
+/** Shared route picker — both Sway dims and pose channels fan out to the same
+ *  grouped target catalog. */
+const RouteSelect: React.FC<{
+  id: string;
+  label: string;
+  value: string;
+  groups: TargetGroups;
+  accent: 'fuchsia' | 'cyan';
+  onChange: (v: string | null) => void;
+}> = ({ id, label, value, groups, accent, onChange }) => (
+  <>
+    <label htmlFor={id} className="sr-only">{`Route ${label} to a target`}</label>
+    <select
+      id={id}
+      name={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value || null)}
+      className={`shrink-0 w-28 bg-black/40 border border-zinc-800 rounded px-1 py-1 text-[9px] font-mono text-zinc-200 outline-none ${
+        accent === 'fuchsia' ? 'focus:border-fuchsia-500/50' : 'focus:border-cyan-500/50'
+      }`}
+    >
+      <option value="">route to</option>
+      {groups.map(([g, list]) => (
+        <optgroup key={g} label={g}>
+          {list.map((t) => (
+            <option key={t.id} value={t.id}>{t.label}</option>
+          ))}
+        </optgroup>
+      ))}
+    </select>
+  </>
+);
+
+const Meter: React.FC<{ value: number; accent: 'fuchsia' | 'cyan' }> = ({ value, accent }) => (
+  <div className="flex-1 min-w-8 h-2 rounded bg-black/50 overflow-hidden" aria-hidden="true">
+    <div
+      className={`h-full ${accent === 'fuchsia' ? 'bg-fuchsia-500/70' : 'bg-cyan-500/70'}`}
+      style={{ width: `${Math.round(value * 100)}%` }}
+    />
+  </div>
+);
 
 export const SwayPanel: React.FC = () => {
   const bindings = useSwayStore((s) => s.bindings);
@@ -42,7 +90,7 @@ export const SwayPanel: React.FC = () => {
     };
   }, []);
 
-  const groups = useMemo(() => {
+  const groups = useMemo<TargetGroups>(() => {
     const m = new Map<string, BindableTarget[]>();
     for (const t of targets) {
       const arr = m.get(t.group) ?? [];
@@ -53,117 +101,95 @@ export const SwayPanel: React.FC = () => {
   }, [targets]);
 
   return (
-    <div className="h-full overflow-y-auto p-3 text-zinc-200">
-      <div className="flex items-center justify-between mb-2">
-        <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-fuchsia-300">Sway</h3>
-        <span className="text-[8px] font-mono uppercase tracking-widest text-zinc-500">Audima 6-dimension motion</span>
-      </div>
+    <div className="h-full overflow-y-auto p-2.5 text-zinc-200">
       {!midiEnabled && (
         <p className="mb-2 text-[9px] font-mono text-amber-300/80 leading-snug">
-          MIDI is off. Turn on the master MIDI toggle to receive Sway input, then Learn each dimension.
+          MIDI is off. Enable the master MIDI toggle to receive Sway input, then Learn each dimension.
         </p>
       )}
-      <div className="space-y-1.5">
-        {SWAY_DIMS.map((d) => {
-          const b = bindings[d.id];
-          const v = values[d.id] ?? 0;
-          const learning = learningDim === d.id;
-          const routeId = routes[d.id] ?? '';
-          const selectId = `sway-route-${d.id}`;
-          return (
-            <div key={d.id} className="flex items-center gap-2 rounded border border-white/10 bg-white/3 px-2 py-1.5">
-              <span className="w-14 shrink-0 text-[10px] font-bold uppercase tracking-wider text-fuchsia-200">{d.label}</span>
-              <button
-                onClick={() => (learning ? cancelLearn() : startLearn(d.id))}
-                aria-label={learning ? `Cancel learning ${d.label}` : `Learn ${d.label}`}
-                className={`shrink-0 px-2 py-1 rounded border text-[8px] font-black uppercase tracking-widest ${
-                  learning
-                    ? 'border-amber-400/60 bg-amber-400/15 text-amber-200 animate-pulse'
-                    : 'border-white/15 text-zinc-300 hover:border-fuchsia-400/50 hover:text-fuchsia-200'
-                }`}
-              >
-                {learning ? 'Listening' : 'Learn'}
-              </button>
-              <span className="w-16 shrink-0 text-[8px] font-mono text-zinc-500">
-                {b ? `Ch${b.channel + 1} CC${b.cc}` : 'unmapped'}
-              </span>
-              {b && (
-                <button
-                  onClick={() => clearBinding(d.id)}
-                  aria-label={`Clear ${d.label} binding`}
-                  className="shrink-0 text-[10px] text-zinc-600 hover:text-rose-300 leading-none"
-                >
-                  x
-                </button>
-              )}
-              <div className="flex-1 min-w-12 h-2 rounded bg-black/50 overflow-hidden" aria-hidden="true">
-                <div className="h-full bg-fuchsia-500/70" style={{ width: `${Math.round(v * 100)}%` }} />
-              </div>
-              <label htmlFor={selectId} className="sr-only">{`Route ${d.label} to a target`}</label>
-              <select
-                id={selectId}
-                name={selectId}
-                value={routeId}
-                onChange={(e) => setRoute(d.id, e.target.value || null)}
-                className="shrink-0 w-36 bg-black/40 border border-zinc-800 rounded px-1.5 py-1 text-[9px] font-mono text-zinc-200 focus:border-fuchsia-500/50 outline-none"
-              >
-                <option value="">route to...</option>
-                {groups.map(([g, list]) => (
-                  <optgroup key={g} label={g}>
-                    {list.map((t) => (
-                      <option key={t.id} value={t.id}>{t.label}</option>
-                    ))}
-                  </optgroup>
-                ))}
-              </select>
-            </div>
-          );
-        })}
-      </div>
-      <p className="mt-2 text-[8px] font-mono text-zinc-600 leading-snug">
-        Learn binds a dimension to the next CC the controller sends. Routing drives DJ targets today; VJ, MAKE, and vocal targets join as the unified mapping matrix lands.
-      </p>
 
-      <div className="mt-3 mb-2 flex items-center justify-between">
-        <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-cyan-300">Camera Pose</h3>
-        <span className={`text-[8px] font-mono uppercase tracking-widest ${poseActive ? 'text-cyan-400' : 'text-zinc-600'}`}>
-          {poseActive ? 'live' : 'enable GESTURE in the VJ'}
-        </span>
-      </div>
-      <div className="space-y-1.5">
-        {POSE_CHANNELS.map((c) => {
-          const v = poseValues[c.id] ?? 0;
-          const routeId = poseRoutes[c.id] ?? '';
-          const selectId = `pose-route-${c.id}`;
-          return (
-            <div key={c.id} className="flex items-center gap-2 rounded border border-white/10 bg-white/3 px-2 py-1.5">
-              <span className="w-16 shrink-0 text-[10px] font-bold uppercase tracking-wider text-cyan-200">{c.label}</span>
-              <div className="flex-1 min-w-12 h-2 rounded bg-black/50 overflow-hidden" aria-hidden="true">
-                <div className="h-full bg-cyan-500/70" style={{ width: `${Math.round(v * 100)}%` }} />
+      <div className="grid gap-x-4 gap-y-3 md:grid-cols-2">
+        {/* Sway dimensions */}
+        <section>
+          <div className="flex items-center justify-between mb-1.5">
+            <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-fuchsia-300">Sway</h3>
+            <span className="text-[8px] font-mono uppercase tracking-widest text-zinc-500">6-dim motion</span>
+          </div>
+          <div className="space-y-1">
+            {SWAY_DIMS.map((d) => {
+              const b = bindings[d.id];
+              const learning = learningDim === d.id;
+              return (
+                <div key={d.id} className="flex items-center gap-1.5 rounded border border-white/10 bg-white/3 px-1.5 py-1">
+                  <span className="w-11 shrink-0 text-[10px] font-bold uppercase tracking-wider text-fuchsia-200">{d.label}</span>
+                  <button
+                    onClick={() => (learning ? cancelLearn() : startLearn(d.id))}
+                    aria-label={learning ? `Cancel learning ${d.label}` : `Learn ${d.label}`}
+                    title={b ? `Bound to Ch${b.channel + 1} CC${b.cc} — click to relearn` : 'Learn — bind to the next CC'}
+                    className={`shrink-0 w-14 px-1.5 py-0.5 rounded border text-[8px] font-black uppercase tracking-widest ${
+                      learning
+                        ? 'border-amber-400/60 bg-amber-400/15 text-amber-200 animate-pulse'
+                        : b
+                          ? 'border-fuchsia-400/40 text-fuchsia-200/90 hover:border-fuchsia-400/70'
+                          : 'border-white/15 text-zinc-300 hover:border-fuchsia-400/50 hover:text-fuchsia-200'
+                    }`}
+                  >
+                    {learning ? 'Listen' : b ? `CC${b.cc}` : 'Learn'}
+                  </button>
+                  {b && (
+                    <button
+                      onClick={() => clearBinding(d.id)}
+                      aria-label={`Clear ${d.label} binding`}
+                      title="Clear binding"
+                      className="shrink-0 text-[10px] text-zinc-600 hover:text-rose-300 leading-none"
+                    >
+                      x
+                    </button>
+                  )}
+                  <Meter value={values[d.id] ?? 0} accent="fuchsia" />
+                  <RouteSelect
+                    id={`sway-route-${d.id}`}
+                    label={d.label}
+                    value={routes[d.id] ?? ''}
+                    groups={groups}
+                    accent="fuchsia"
+                    onChange={(v) => setRoute(d.id, v)}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Camera pose */}
+        <section>
+          <div className="flex items-center justify-between mb-1.5">
+            <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-cyan-300">Camera Pose</h3>
+            <span className={`text-[8px] font-mono uppercase tracking-widest ${poseActive ? 'text-cyan-400' : 'text-zinc-600'}`}>
+              {poseActive ? 'live' : 'enable GESTURE in the VJ'}
+            </span>
+          </div>
+          <div className="space-y-1">
+            {POSE_CHANNELS.map((c) => (
+              <div key={c.id} className="flex items-center gap-1.5 rounded border border-white/10 bg-white/3 px-1.5 py-1">
+                <span className="w-16 shrink-0 text-[10px] font-bold uppercase tracking-wider text-cyan-200">{c.label}</span>
+                <Meter value={poseValues[c.id] ?? 0} accent="cyan" />
+                <RouteSelect
+                  id={`pose-route-${c.id}`}
+                  label={c.label}
+                  value={poseRoutes[c.id] ?? ''}
+                  groups={groups}
+                  accent="cyan"
+                  onChange={(v) => setPoseRoute(c.id, v)}
+                />
               </div>
-              <label htmlFor={selectId} className="sr-only">{`Route ${c.label} to a target`}</label>
-              <select
-                id={selectId}
-                name={selectId}
-                value={routeId}
-                onChange={(e) => setPoseRoute(c.id, e.target.value || null)}
-                className="shrink-0 w-36 bg-black/40 border border-zinc-800 rounded px-1.5 py-1 text-[9px] font-mono text-zinc-200 focus:border-cyan-500/50 outline-none"
-              >
-                <option value="">route to...</option>
-                {groups.map(([g, list]) => (
-                  <optgroup key={g} label={g}>
-                    {list.map((t) => (
-                      <option key={t.id} value={t.id}>{t.label}</option>
-                    ))}
-                  </optgroup>
-                ))}
-              </select>
-            </div>
-          );
-        })}
+            ))}
+          </div>
+        </section>
       </div>
-      <p className="mt-2 text-[8px] font-mono text-zinc-600 leading-snug">
-        Camera pose comes from the VJ's webcam body tracking (toggle GESTURE in the VJ). The six channels route to targets like Sway; no learn needed.
+
+      <p className="mt-2.5 text-[8px] font-mono text-zinc-600 leading-snug">
+        Learn binds a dimension to the next CC sent; routing drives DJ targets today (VJ, MAKE, and vocal join as the unified matrix lands). Camera pose comes from the VJ webcam (toggle GESTURE there) and routes like Sway, no learn needed.
       </p>
     </div>
   );

--- a/frontend/src/state/controllerProfiles.ts
+++ b/frontend/src/state/controllerProfiles.ts
@@ -333,6 +333,11 @@ export const CONTROLLER_PROFILES: ControllerProfile[] = ROWS.map(([id, name, ven
 /** The on-screen GANTASMO XR twin surface (see WorldsCollidePanel). */
 export const GANTASMO_WORLDS_COLLIDE_ID = 'gantasmo-worlds-collide';
 
+/** The Audima Sway expressive-motion controller — pinned second in the SLIDE
+ *  picker (right below the GANTASMO twin) so the 6-dimension surface is one
+ *  click away. Its dims bind by learn via swayBus. */
+export const AUDIMA_SWAY_ID = 'audima-sway';
+
 // Default to the on-screen GANTASMO surface so it is front-and-centre with no
 // hardware connected. Auto-detect still switches to a real controller when one
 // is connected.

--- a/frontend/src/state/makeBridge.ts
+++ b/frontend/src/state/makeBridge.ts
@@ -1,0 +1,59 @@
+/**
+ * MAKE (Magenta RT2) live-control bridge.
+ *
+ * The Magenta instrument runs in a same-origin <iframe> (MagentaToolStage) whose
+ * bridge.js recreates the WKWebView host at
+ * `window.webkit.messageHandlers.auHost`. Posting `{type:'param', name, value}`
+ * sets the bridge's live `state[name]`, which the NEXT generate chunk (~every 4s)
+ * reads. So a control move here shapes the next generated chunk, not the audio
+ * currently playing: continuous and chunk-rate, not knob-instant. The post is a
+ * direct same-origin function call, so no throttling or store mirror is needed.
+ *
+ * When no instrument is mounted, a move stages into `pending` and flushes to the
+ * iframe the moment one registers, so a staged gesture applies when the
+ * instrument opens. No engine is ever auto-started from a move.
+ *
+ * Param keys are the bridge's live state keys (see public/magenta-tools/bridge.js):
+ * temperature, topk, cfgmusiccoca, cfgnotes, cfgdrums, drumless, volume, bypass, seed.
+ */
+type AuHostWindow = Window & {
+  webkit?: { messageHandlers?: { auHost?: { postMessage: (m: unknown) => void } } };
+};
+
+let target: AuHostWindow | null = null;
+const pending: Record<string, number> = {};
+
+function post(win: AuHostWindow, msg: unknown): void {
+  try {
+    win.webkit?.messageHandlers?.auHost?.postMessage(msg);
+  } catch {
+    /* iframe torn down between mount and post — non-fatal */
+  }
+}
+
+/** Register (or clear with null) the mounted Magenta instrument's window. On
+ *  register, any staged params are flushed so a gesture made before the
+ *  instrument opened takes effect immediately. */
+export function registerMakeInstrument(win: Window | null): void {
+  target = (win as AuHostWindow | null) ?? null;
+  if (target) {
+    for (const [name, value] of Object.entries(pending)) post(target, { type: 'param', name, value });
+  }
+}
+
+/** Set a live Magenta param by its bridge state key (e.g. 'temperature', 'cfgdrums'). */
+export function setMakeParam(name: string, value: number): void {
+  pending[name] = value;
+  if (target) post(target, { type: 'param', name, value });
+}
+
+/** Toggle the instrument's play/pause. No-op when nothing is mounted (a gesture
+ *  never auto-starts the engine). */
+export function toggleMakePlay(): void {
+  if (target) post(target, { type: 'togglePlay' });
+}
+
+/** Whether a Magenta instrument is currently mounted, so a move will actually sound. */
+export function isMakeInstrumentLive(): boolean {
+  return target != null;
+}

--- a/frontend/src/state/makeControlSource.ts
+++ b/frontend/src/state/makeControlSource.ts
@@ -1,0 +1,55 @@
+/**
+ * MAKE control source for the XR control bus.
+ *
+ * Mirrors xrControlDjSource: publishes MAKE_TARGETS as manifest entries and
+ * routes an inbound control-set straight to each target's wired `invoke`, so the
+ * MAKE surface is bidirectional on XR exactly like DJ, with no per-control code.
+ * makeTargets (and through it makeBridge) is imported lazily so it stays out of
+ * app boot.
+ */
+import type { XrControlSource, XrManifestEntry, XrControlValue } from './xrControlClient';
+import type { BindableTarget } from '../components/surface/widgetTypes';
+
+let cache: BindableTarget[] | null = null;
+
+async function targets(): Promise<BindableTarget[]> {
+  if (!cache) {
+    const mod = await import('./makeTargets');
+    cache = mod.MAKE_TARGETS;
+  }
+  return cache;
+}
+
+function toKind(k: BindableTarget['kind']): string {
+  if (k === 'pad') return 'button';
+  if (k === 'crossfader') return 'fader';
+  return k; // knob | fader | toggle
+}
+
+export const makeControlSource: XrControlSource = {
+  area: 'make',
+
+  async buildEntries(): Promise<XrManifestEntry[]> {
+    const list = await targets();
+    return list.map((t) => ({
+      id: t.id,
+      area: 'make',
+      group: t.group,
+      label: t.label,
+      kind: toKind(t.kind),
+      min: t.min,
+      max: t.max,
+      step: t.step,
+      unit: t.unit,
+    }));
+  },
+
+  async apply(id: string, value: XrControlValue): Promise<boolean> {
+    const t = (await targets()).find((x) => x.id === id);
+    if (!t) return false;
+    if (t.kind === 'toggle') t.invoke(Boolean(value));
+    else if (t.kind === 'pad') t.invoke(true);
+    else t.invoke(Number(value));
+    return true;
+  },
+};

--- a/frontend/src/state/makeTargets.ts
+++ b/frontend/src/state/makeTargets.ts
@@ -1,0 +1,26 @@
+/**
+ * MAKE (Magenta RealTime 2) bindable targets.
+ *
+ * Each target drives a LIVE generation parameter on the mounted Magenta
+ * instrument through makeBridge. The value reaches the NEXT generated chunk
+ * (~4 s), so response is chunk-rate, not knob-instant. Param keys are the
+ * bridge's live `state` keys (see public/magenta-tools/bridge.js). These share
+ * the BindableTarget shape with DJ_TARGETS, so the Sway routing engine and the
+ * XR control source drive them with no per-control wiring.
+ */
+import type { BindableTarget } from '../components/surface/widgetTypes';
+import { setMakeParam, toggleMakePlay } from './makeBridge';
+
+const G = 'Make (Magenta)';
+
+export const MAKE_TARGETS: BindableTarget[] = [
+  { id: 'make.temperature', label: 'Temperature', group: G, kind: 'knob', min: 0.1, max: 2, step: 0.01, invoke: (v) => setMakeParam('temperature', Number(v)) },
+  { id: 'make.topK', label: 'Top-K', group: G, kind: 'knob', min: 1, max: 256, step: 1, invoke: (v) => setMakeParam('topk', Math.round(Number(v))) },
+  { id: 'make.cfgMusic', label: 'CFG Music', group: G, kind: 'knob', min: 0, max: 6, step: 0.05, invoke: (v) => setMakeParam('cfgmusiccoca', Number(v)) },
+  { id: 'make.cfgNotes', label: 'CFG Notes', group: G, kind: 'knob', min: 0, max: 6, step: 0.05, invoke: (v) => setMakeParam('cfgnotes', Number(v)) },
+  { id: 'make.cfgDrums', label: 'CFG Drums', group: G, kind: 'knob', min: 0, max: 6, step: 0.05, invoke: (v) => setMakeParam('cfgdrums', Number(v)) },
+  { id: 'make.volume', label: 'Volume', group: G, kind: 'fader', min: 0, max: 1, step: 0.01, invoke: (v) => setMakeParam('volume', Number(v)) },
+  { id: 'make.drumless', label: 'Drumless', group: G, kind: 'toggle', invoke: (v) => setMakeParam('drumless', v ? 1 : 0) },
+  { id: 'make.bypass', label: 'Bypass', group: G, kind: 'toggle', invoke: (v) => setMakeParam('bypass', v ? 1 : 0) },
+  { id: 'make.play', label: 'Play / Pause', group: G, kind: 'pad', invoke: () => toggleMakePlay() },
+];

--- a/frontend/src/state/processControlSource.ts
+++ b/frontend/src/state/processControlSource.ts
@@ -1,0 +1,53 @@
+/**
+ * PROCESS control source for the XR control bus. Mirrors xrControlDjSource and
+ * makeControlSource: publishes PROCESS_TARGETS as manifest entries and routes an
+ * inbound control-set to each target's wired `invoke`, so the MIX process surface
+ * is bidirectional on XR like DJ and MAKE. processTargets is imported lazily so
+ * it stays out of app boot.
+ */
+import type { XrControlSource, XrManifestEntry, XrControlValue } from './xrControlClient';
+import type { BindableTarget } from '../components/surface/widgetTypes';
+
+let cache: BindableTarget[] | null = null;
+
+async function targets(): Promise<BindableTarget[]> {
+  if (!cache) {
+    const mod = await import('./processTargets');
+    cache = mod.PROCESS_TARGETS;
+  }
+  return cache;
+}
+
+function toKind(k: BindableTarget['kind']): string {
+  if (k === 'pad') return 'button';
+  if (k === 'crossfader') return 'fader';
+  return k;
+}
+
+export const processControlSource: XrControlSource = {
+  area: 'process',
+
+  async buildEntries(): Promise<XrManifestEntry[]> {
+    const list = await targets();
+    return list.map((t) => ({
+      id: t.id,
+      area: 'process',
+      group: t.group,
+      label: t.label,
+      kind: toKind(t.kind),
+      min: t.min,
+      max: t.max,
+      step: t.step,
+      unit: t.unit,
+    }));
+  },
+
+  async apply(id: string, value: XrControlValue): Promise<boolean> {
+    const t = (await targets()).find((x) => x.id === id);
+    if (!t) return false;
+    if (t.kind === 'toggle') t.invoke(Boolean(value));
+    else if (t.kind === 'pad') t.invoke(true);
+    else t.invoke(Number(value));
+    return true;
+  },
+};

--- a/frontend/src/state/processTargets.ts
+++ b/frontend/src/state/processTargets.ts
@@ -1,0 +1,36 @@
+/**
+ * PROCESS (MIX effect chain) bindable targets -- the offline "voice / process"
+ * surface for SWAY.
+ *
+ * Each target drives one parameter of a MIX effect by EFFECT TYPE: it finds that
+ * effect in the live effect chain and updates its param, so the value applies on
+ * the next MIX render (offline FFmpeg via /api/studio). If the effect is not in
+ * the chain, the move is a no-op -- add the effect in MIX first, then SWAY shapes
+ * it. No effect is ever auto-added from a gesture.
+ *
+ * The vocal_processing effect (highpassFreq / presenceBoost / targetLUFS) is the
+ * real vocal-processing path; the rest are general process controls. Same
+ * BindableTarget shape as DJ/MAKE, so the routing engine and XR source drive them
+ * with no per-control wiring.
+ */
+import type { BindableTarget } from '../components/surface/widgetTypes';
+import { useEffectChainStore } from './effectChainStore';
+
+const G = 'Process (MIX)';
+
+/** Drive one param of the first chain entry of `effect`. No-op if absent. */
+function setChainParam(effect: string, key: string, value: number): void {
+  const st = useEffectChainStore.getState();
+  const entry = st.chain.find((e) => e.effect === effect);
+  if (!entry) return;
+  st.updateParams(entry.id, { ...entry.params, [key]: value });
+}
+
+export const PROCESS_TARGETS: BindableTarget[] = [
+  { id: 'process.vocalHighpass', label: 'Vocal High-Pass', group: G, kind: 'knob', min: 20, max: 400, step: 1, unit: 'Hz', invoke: (v) => setChainParam('vocal_processing', 'highpassFreq', Number(v)) },
+  { id: 'process.vocalPresence', label: 'Vocal Presence', group: G, kind: 'knob', min: 0, max: 12, step: 0.1, unit: 'dB', invoke: (v) => setChainParam('vocal_processing', 'presenceBoost', Number(v)) },
+  { id: 'process.vocalLufs', label: 'Vocal LUFS', group: G, kind: 'fader', min: -24, max: -9, step: 0.5, unit: 'LUFS', invoke: (v) => setChainParam('vocal_processing', 'targetLUFS', Number(v)) },
+  { id: 'process.eqMid', label: 'Mid EQ Gain', group: G, kind: 'knob', min: -12, max: 12, step: 0.5, unit: 'dB', invoke: (v) => setChainParam('eq_mid', 'gain', Number(v)) },
+  { id: 'process.width', label: 'Stereo Width', group: G, kind: 'knob', min: 0, max: 40, step: 1, unit: 'ms', invoke: (v) => setChainParam('stereo_widener', 'delayMs', Number(v)) },
+  { id: 'process.pitch', label: 'Pitch Shift', group: G, kind: 'knob', min: -12, max: 12, step: 1, unit: 'st', invoke: (v) => setChainParam('pitch_shift', 'shift', Number(v)) },
+];

--- a/frontend/src/state/swayRouting.ts
+++ b/frontend/src/state/swayRouting.ts
@@ -22,8 +22,12 @@ let targetLoad: Promise<BindableTarget[]> | null = null;
 function loadTargets(): Promise<BindableTarget[]> {
   if (targetCache) return Promise.resolve(targetCache);
   if (!targetLoad) {
-    targetLoad = import('./bindableTargets').then((m) => {
-      targetCache = m.DJ_TARGETS;
+    targetLoad = Promise.all([
+      import('./bindableTargets'),
+      import('./makeTargets'),
+      import('./processTargets'),
+    ]).then(([dj, make, proc]) => {
+      targetCache = [...dj.DJ_TARGETS, ...make.MAKE_TARGETS, ...proc.PROCESS_TARGETS];
       return targetCache;
     });
   }
@@ -57,6 +61,18 @@ export const useSwayRoutingStore = create<SwayRoutingState>()(
   ),
 );
 
+/** First-run defaults: the six dims to live Magenta make-targets, so SWAY drives
+ *  generation out of the box. Seeded only when no routes exist at all, so a
+ *  returning user's saved DJ/MAKE bindings are never overwritten. */
+const DEFAULT_MAKE_ROUTES: Partial<Record<SwayDim, string>> = {
+  strike: 'make.cfgDrums',
+  sway: 'make.cfgMusic',
+  pulse: 'make.temperature',
+  glide: 'make.cfgNotes',
+  press: 'make.volume',
+  sculpt: 'make.topK',
+};
+
 const prev: Record<SwayDim, number> = {
   strike: 0,
   sway: 0,
@@ -88,6 +104,11 @@ let unsub: (() => void) | null = null;
  *  App in the midiEnabled effect; returns a stop function. */
 export function startSwayRouting(): () => void {
   if (unsub) return () => {};
+  // Seed the MAKE defaults non-destructively: only when the user has no routes,
+  // so existing bindings (DJ or MAKE) are never clobbered.
+  if (Object.keys(useSwayRoutingStore.getState().routes).length === 0) {
+    useSwayRoutingStore.setState({ routes: { ...DEFAULT_MAKE_ROUTES } });
+  }
   void loadTargets(); // warm so the first move routes without a stall
   unsub = subscribeSwayValue((dim, value) => {
     const previous = prev[dim];


### PR DESCRIPTION
feat(vocal): prerequisite vocal engine backend (Phase 1-2)

Auto-discovered /api/vocal module producing the canonical VocalArtifact (one
reconciled schema, project-relative milliseconds). POST /prepare composes existing
tools (restoration mid/side isolation and breath cleanup, the basic-pitch midi
engine) with two new analyzers (dense librosa.pyin F0 curve, RMS segment VAD), adds
tempo from the full mix, and persists the artifact as a kind=vocal library artifact
plus a JSON file. Reuses core/jobs. Singing synthesis (SoulX) stays deferred; this
builds only the input contract it will later consume.

Backend verified with ruff and import; not yet live-run.

feat(sway): step 2 routing, Sway dims drive Magenta live params and the MIX chain

Reuses the BindableTarget routing engine. New makeBridge/makeTargets/makeControlSource
drive live Magenta RT2 params through the instrument iframe auHost bridge; new
processTargets/processControlSource drive the MIX effect chain including
vocal_processing. swayRouting loads MAKE and PROCESS targets and seeds the six music
defaults non-destructively; App.tsx registers both XR control sources; MagentaToolStage
registers the instrument window. Includes SWAY step 1 (Sway pinned second in the SLIDE
dropdown, condensed SWAY tab).