### PR TITLE
feat(draw+mix+vocal): configurable DRAW engine, MIX "All" browser, vocal MIDI tab + fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Isolated runtime venv + filtered reqs for the faster-whisper transcription sidecar
+backend/modules/vocal/transcription/.whisper_venv/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/backend/modules/vocal/convert.py
+++ b/backend/modules/vocal/convert.py
@@ -1,0 +1,164 @@
+"""Round-trip between the canonical VocalArtifact notes and Standard MIDI.
+
+meta2midi (`notes_to_midi`) writes artifact Notes (project-relative ms) to a
+type-0 SMF via mido; midi2meta (`midi_to_notes`) parses an SMF back to ms-timed
+Notes honoring running tempo. The two are inverses up to MIDI tick quantization,
+so notes -> .mid -> notes preserves pitch/velocity and ms timing within a tick.
+Lyrics/phonemes are intentionally NOT serialized to MIDI (they live in the
+artifact), matching the schema's lossless-round-trip contract.
+
+mido is imported lazily inside each function, so importing this module stays
+cheap and a missing mido degrades gracefully (notes_to_midi -> ok:False,
+midi_to_notes -> []).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from .schema import Note
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_TPB = 480
+_DEFAULT_TEMPO_BPM = 120.0
+
+
+def _have_mido() -> bool:
+    return importlib.util.find_spec("mido") is not None
+
+
+def notes_to_midi(
+    notes: list[Note],
+    out_path: Path,
+    tempo_bpm: Optional[float] = None,
+    ticks_per_beat: int = _DEFAULT_TPB,
+) -> dict:
+    """meta2midi: write artifact Notes to a type-0 SMF. Returns {ok, path, count}
+    or {ok: False, error}. Never raises."""
+    if not _have_mido():
+        return {"ok": False, "error": "mido not installed"}
+    import mido
+
+    bpm = tempo_bpm if (tempo_bpm and tempo_bpm > 0) else _DEFAULT_TEMPO_BPM
+    tempo = mido.bpm2tempo(bpm)
+    ms_per_tick = mido.tick2second(1, ticks_per_beat, tempo) * 1000.0
+    if ms_per_tick <= 0:
+        return {"ok": False, "error": "bad tempo/ppq"}
+
+    def ms_to_ticks(ms: float) -> int:
+        return max(0, int(round(ms / ms_per_tick)))
+
+    # Absolute-tick events (note_on at start, note_off at end); sort so note_off
+    # precedes note_on at equal ticks, then emit as delta times.
+    events: list[tuple[int, int, int, int]] = []  # (tick, kind, pitch, velocity)
+    for n in notes:
+        start = ms_to_ticks(n.start_ms)
+        end = max(start + 1, ms_to_ticks(n.end_ms))
+        pitch = max(0, min(127, int(n.pitch)))
+        vel = max(1, min(127, int(n.velocity)))
+        events.append((start, 1, pitch, vel))  # note_on
+        events.append((end, 0, pitch, 0))  # note_off
+    events.sort(key=lambda e: (e[0], e[1]))
+
+    try:
+        mid = mido.MidiFile(ticks_per_beat=ticks_per_beat)
+        track = mido.MidiTrack()
+        mid.tracks.append(track)
+        track.append(mido.MetaMessage("set_tempo", tempo=tempo, time=0))
+        prev = 0
+        for tick, kind, pitch, vel in events:
+            delta = tick - prev
+            prev = tick
+            if kind == 1:
+                track.append(
+                    mido.Message("note_on", note=pitch, velocity=vel, time=delta)
+                )
+            else:
+                track.append(
+                    mido.Message("note_off", note=pitch, velocity=0, time=delta)
+                )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        mid.save(str(out_path))
+    except Exception as e:
+        return {"ok": False, "error": repr(e)}
+    return {"ok": True, "path": str(out_path), "count": len(notes)}
+
+
+def midi_to_notes(mid_path: Path) -> list[Note]:
+    """midi2meta: parse an SMF into project-relative-ms Notes, honoring running
+    set_tempo. Returns [] if mido is missing or the file is unreadable."""
+    if not _have_mido():
+        return []
+    import mido
+
+    try:
+        mid = mido.MidiFile(str(mid_path))
+    except Exception:
+        return []
+    tpb = mid.ticks_per_beat or _DEFAULT_TPB
+    notes: list[Note] = []
+    for track in mid.tracks:
+        cur_tempo = 500000  # 120 BPM until a set_tempo arrives
+        elapsed_ms = 0.0
+        active: dict[int, tuple[int, int]] = {}
+        for msg in track:
+            elapsed_ms += mido.tick2second(msg.time, tpb, cur_tempo) * 1000.0
+            if msg.type == "set_tempo":
+                cur_tempo = msg.tempo
+            elif msg.type == "note_on" and msg.velocity > 0:
+                active[msg.note] = (int(elapsed_ms), int(msg.velocity))
+            elif msg.type == "note_off" or (
+                msg.type == "note_on" and msg.velocity == 0
+            ):
+                started = active.pop(msg.note, None)
+                if started is not None:
+                    start_ms, vel = started
+                    notes.append(
+                        Note(
+                            start_ms=start_ms,
+                            end_ms=int(elapsed_ms),
+                            pitch=int(msg.note),
+                            velocity=vel,
+                        )
+                    )
+    notes.sort(key=lambda n: n.start_ms)
+    return notes
+
+
+def roundtrip_check(notes: list[Note]) -> dict:
+    """notes -> SMF -> notes; report drift. Backs the review validator. Returns
+    {ok, count_in, count_out, count_match, max_drift_ms} or {ok: False, error}."""
+    if not _have_mido():
+        return {"ok": False, "error": "mido not installed"}
+    with tempfile.TemporaryDirectory() as td:
+        mid = Path(td) / "rt.mid"
+        w = notes_to_midi(notes, mid)
+        if not w.get("ok"):
+            return {"ok": False, "error": w.get("error")}
+        back = midi_to_notes(mid)
+    count_match = len(back) == len(notes)
+    max_drift_ms = 0
+    if count_match:
+        a = sorted(notes, key=lambda n: (n.start_ms, n.pitch))
+        b = sorted(back, key=lambda n: (n.start_ms, n.pitch))
+        for x, y in zip(a, b):
+            max_drift_ms = max(
+                max_drift_ms,
+                abs(x.start_ms - y.start_ms),
+                abs(x.end_ms - y.end_ms),
+            )
+    return {
+        "ok": True,
+        "count_in": len(notes),
+        "count_out": len(back),
+        "count_match": count_match,
+        "max_drift_ms": max_drift_ms,
+    }
+
+
+__all__ = ["midi_to_notes", "notes_to_midi", "roundtrip_check"]

--- a/backend/modules/vocal/preprocess/notes.py
+++ b/backend/modules/vocal/preprocess/notes.py
@@ -1,8 +1,9 @@
 """Vocal-to-MIDI notes via the existing basic-pitch engine, parsed to artifact Notes.
 
 Reuses backend/modules/midi convert_to_midi to write a MIDI file, then parses it
-with mido into project-relative-millisecond notes. Returns [] when basic-pitch is
-not installed; it never triggers a surprise pip install (auto_install=False).
+into project-relative-millisecond notes via the shared midi_to_notes converter (so
+there is one SMF->Note implementation). Returns [] when basic-pitch is not
+installed; it never triggers a surprise pip install (auto_install=False).
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import logging
 import tempfile
 from pathlib import Path
 
+from ..convert import midi_to_notes
 from ..schema import Note
 
 log = logging.getLogger(__name__)
@@ -33,41 +35,4 @@ def extract_notes(audio_path: Path) -> list[Note]:
                 "vocal.notes: basic-pitch unavailable/failed: %s", res.get("error")
             )
             return []
-        return _parse_midi(mid_path)
-
-
-def _parse_midi(mid_path: Path) -> list[Note]:
-    import mido
-
-    try:
-        mid = mido.MidiFile(str(mid_path))
-    except Exception:
-        return []
-    tpb = mid.ticks_per_beat or 480
-    notes: list[Note] = []
-    for track in mid.tracks:
-        cur_tempo = 500000  # default 120 BPM until a set_tempo arrives
-        elapsed_ms = 0.0
-        active: dict[int, tuple[int, int]] = {}
-        for msg in track:
-            elapsed_ms += mido.tick2second(msg.time, tpb, cur_tempo) * 1000.0
-            if msg.type == "set_tempo":
-                cur_tempo = msg.tempo
-            elif msg.type == "note_on" and msg.velocity > 0:
-                active[msg.note] = (int(elapsed_ms), int(msg.velocity))
-            elif msg.type == "note_off" or (
-                msg.type == "note_on" and msg.velocity == 0
-            ):
-                started = active.pop(msg.note, None)
-                if started is not None:
-                    start_ms, vel = started
-                    notes.append(
-                        Note(
-                            start_ms=start_ms,
-                            end_ms=int(elapsed_ms),
-                            pitch=int(msg.note),
-                            velocity=vel,
-                        )
-                    )
-    notes.sort(key=lambda n: n.start_ms)
-    return notes
+        return midi_to_notes(mid_path)

--- a/backend/modules/vocal/router.py
+++ b/backend/modules/vocal/router.py
@@ -7,7 +7,8 @@ artifact this module produces.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from backend.core.jobs import Job, create_job, get_job
@@ -26,13 +27,20 @@ class PrepareRequest(BaseModel):
     language: str = "en"
 
 
+class ReviewRequest(BaseModel):
+    reviewed: bool = False
+    notes: str = ""
+
+
 @router.get("/health")
 def health() -> dict:
     return service.health()
 
 
 @router.post("/prepare")
-def prepare(req: PrepareRequest) -> dict:
+async def prepare(req: PrepareRequest) -> dict:
+    # Must be async: start_prepare schedules the pipeline with asyncio.create_task,
+    # which needs a running loop (a sync route runs in a threadpool and would 500).
     job = create_job("vocal", f"Prepare vocal artifact ({req.asset_id})")
     service.start_prepare(job, req.model_dump())
     return {"ok": True, "job": {"id": job.id}}
@@ -72,3 +80,51 @@ def get_metadata(asset_id: str) -> dict:
     if art is None:
         raise HTTPException(status_code=404, detail="no artifact for asset")
     return art
+
+
+@router.post("/audio-to-notes")
+async def audio_to_notes(file: UploadFile = File(...)) -> dict:
+    """Convert a recorded/uploaded audio clip to notes via basic-pitch (the same
+    path as Analyze). Used by live mic recording in the MIDI tab."""
+    notes = await service.audio_to_notes(file)
+    return {"ok": True, "notes": [n.model_dump() for n in notes]}
+
+
+@router.get("/midi/{asset_id}")
+def export_midi(asset_id: str) -> FileResponse:
+    """Download the artifact's notes as a Standard MIDI file (meta2midi)."""
+    path = service.export_midi(asset_id)
+    if path is None:
+        raise HTTPException(status_code=404, detail="no notes to export")
+    return FileResponse(str(path), media_type="audio/midi", filename="vocal_notes.mid")
+
+
+@router.get("/validate/{asset_id}")
+def validate(asset_id: str) -> dict:
+    """notes -> MIDI -> notes round-trip drift, for the review surface."""
+    return service.validate_roundtrip(asset_id)
+
+
+@router.post("/review/{asset_id}")
+def set_review(asset_id: str, req: ReviewRequest) -> dict:
+    """Mark an artifact reviewed (the render-trust gate) and save reviewer notes."""
+    result = service.set_review(asset_id, req.reviewed, req.notes)
+    if not result.get("ok"):
+        raise HTTPException(status_code=404, detail=result.get("error", "no artifact"))
+    return result
+
+
+@router.get("/transcription/probe")
+def transcription_probe() -> dict:
+    """Sidecar status: is the isolated whisper venv built and importable?"""
+    return service.transcription_probe()
+
+
+@router.post("/transcription/install")
+async def transcription_install() -> dict:
+    """Provision the faster-whisper venv in the background (zero-terminal). Poll
+    the returned job for progress. Async so start_install_transcription's
+    asyncio.create_task has a running loop (a sync route would 500)."""
+    job = create_job("vocal", "Install transcription (faster-whisper)")
+    service.start_install_transcription(job)
+    return {"ok": True, "job": {"id": job.id}}

--- a/backend/modules/vocal/service.py
+++ b/backend/modules/vocal/service.py
@@ -25,7 +25,7 @@ from backend.core.jobs import Job
 from .preprocess import f0_curve, isolation
 from .preprocess import notes as notes_step
 from .preprocess import segments as segments_step
-from .schema import Lyrics, Source, Timing, VocalArtifact
+from .schema import Lyrics, Phrase, Source, Timing, VocalArtifact, Word
 
 log = logging.getLogger(__name__)
 
@@ -42,9 +42,25 @@ def health() -> dict[str, Any]:
 
 
 def transcription_available() -> bool:
-    # Wired in Phase 2b (the faster-whisper sidecar). Until then lyrics are
-    # hand-entered in the review step.
-    return False
+    """True once the isolated faster-whisper venv exists and imports. Probing is
+    a cheap subprocess and never raises into the request path."""
+    try:
+        from .transcription import available
+
+        return available()
+    except Exception as e:
+        log.info("vocal: transcription probe failed: %s", e)
+        return False
+
+
+def transcription_probe() -> dict:
+    """Full sidecar status for the UI (venv built? deps importable? model?)."""
+    try:
+        from .transcription import probe
+
+        return probe()
+    except Exception as e:
+        return {"ok": False, "error": repr(e)}
 
 
 def load_artifact(asset_id: str) -> Optional[dict]:
@@ -64,6 +80,67 @@ def load_artifact(asset_id: str) -> Optional[dict]:
     except Exception as e:
         log.info("vocal: artifact load failed for %s: %s", asset_id, e)
     return None
+
+
+def _artifact_obj(asset_id: str) -> Optional[VocalArtifact]:
+    """Load the persisted artifact dict and parse it back into a VocalArtifact."""
+    art_dict = load_artifact(asset_id)
+    if art_dict is None:
+        return None
+    try:
+        return VocalArtifact(**art_dict)
+    except Exception as e:
+        log.info("vocal: artifact parse failed for %s: %s", asset_id, e)
+        return None
+
+
+def export_midi(asset_id: str) -> Optional[Path]:
+    """meta2midi: render the artifact's notes to a .mid beside the audio and
+    return its path. None when there is no artifact / no notes / no mido."""
+    art = _artifact_obj(asset_id)
+    if art is None or not art.notes:
+        return None
+    src = _resolve_path(asset_id)
+    if src is None:
+        return None
+    from .convert import notes_to_midi
+
+    out = src.parent / "vocal_notes.mid"
+    res = notes_to_midi(art.notes, out, tempo_bpm=art.timing.tempo_bpm)
+    return out if res.get("ok") else None
+
+
+def validate_roundtrip(asset_id: str) -> dict:
+    """notes -> SMF -> notes drift report for the review surface."""
+    art = _artifact_obj(asset_id)
+    if art is None:
+        return {"ok": False, "error": "no artifact for asset"}
+    from .convert import roundtrip_check
+
+    return roundtrip_check(art.notes)
+
+
+def set_review(asset_id: str, reviewed: bool, notes_text: str) -> dict:
+    """Update the artifact's review gate in place (rewrite vocal_metadata.json and
+    the in-process cache) without adding another Library artifact row."""
+    art = _artifact_obj(asset_id)
+    if art is None:
+        return {"ok": False, "error": "no artifact for asset"}
+    art.review.reviewed = bool(reviewed)
+    art.review.notes = str(notes_text or "")
+    payload = art.model_dump()
+    src = _resolve_path(asset_id)
+    if src is not None:
+        try:
+            import json
+
+            (src.parent / "vocal_metadata.json").write_text(
+                json.dumps(payload, indent=2), encoding="utf-8"
+            )
+        except Exception as e:
+            log.info("vocal: review persist failed for %s: %s", asset_id, e)
+    _artifacts[asset_id] = payload
+    return {"ok": True, "review": payload["review"]}
 
 
 def _resolve_path(asset_id: str) -> Optional[Path]:
@@ -137,9 +214,80 @@ def _context(audio_path: Path) -> Timing:
     return Timing(tempo_bpm=_tempo_bpm(audio_path))
 
 
-async def _transcribe(path: Path, language: str) -> Lyrics:
-    """Phase 2b: faster-whisper sidecar (lazy). Until then, empty lyrics."""
-    return Lyrics(language=language)
+def _sec_ms(sec: float) -> int:
+    return int(round(float(sec) * 1000.0))
+
+
+def _lyrics_from_transcription(res: dict, language: str) -> Lyrics:
+    """Map the worker's seconds-based {language, text, segments[...]} onto the
+    artifact Lyrics in project-relative milliseconds. Segments become phrases;
+    word timestamps become Words."""
+    words: list[Word] = []
+    phrases: list[Phrase] = []
+    for seg in res.get("segments", []):
+        seg_text = (seg.get("text") or "").strip()
+        s_start, s_end = seg.get("start"), seg.get("end")
+        if seg_text and s_start is not None and s_end is not None:
+            phrases.append(
+                Phrase(text=seg_text, start_ms=_sec_ms(s_start), end_ms=_sec_ms(s_end))
+            )
+        for w in seg.get("words", []):
+            wt = (w.get("word") or "").strip()
+            ws, we = w.get("start"), w.get("end")
+            if wt and ws is not None and we is not None:
+                words.append(Word(text=wt, start_ms=_sec_ms(ws), end_ms=_sec_ms(we)))
+    return Lyrics(
+        language=res.get("language") or language,
+        text=(res.get("text") or "").strip(),
+        words=words,
+        phrases=phrases,
+        source="transcribed",
+    )
+
+
+async def audio_to_notes(upload: Any) -> list:
+    """Recorded/uploaded audio -> notes via the SAME offline basic-pitch path as
+    Analyze (much better than live YIN). Transcodes to wav first for decoder
+    robustness, then reuses extract_notes. Returns list[Note]; [] on failure."""
+    import tempfile
+
+    suffix = Path(getattr(upload, "filename", "") or "rec.webm").suffix or ".webm"
+    with tempfile.TemporaryDirectory() as td:
+        raw = Path(td) / f"rec{suffix}"
+        try:
+            raw.write_bytes(await upload.read())
+        except Exception as e:
+            log.info("vocal.audio_to_notes: read failed: %s", e)
+            return []
+        src = raw
+        try:
+            from backend.lib import ffmpeg
+
+            wav = Path(td) / "rec.wav"
+            await ffmpeg.render(raw, wav, [], ["-ac", "1", "-ar", "22050"])
+            src = wav
+        except Exception as e:
+            log.info("vocal.audio_to_notes: transcode failed, using raw: %s", e)
+        return notes_step.extract_notes(src)
+
+
+async def _transcribe(path: Path, language: str, job: Optional[Job] = None) -> Lyrics:
+    """Transcribe via the isolated faster-whisper sidecar and map to Lyrics.
+    Never raises: returns empty Lyrics when transcription is unavailable, so a
+    missing optional sidecar never fails the prepare pipeline."""
+    from .transcription import transcribe as run_transcribe
+
+    if job is not None:
+        job.update(message="transcribing (first run installs whisper)")
+    try:
+        res = await run_transcribe(path, language)
+    except Exception as e:
+        log.info("vocal: transcription failed: %s", e)
+        return Lyrics(language=language)
+    if not res.get("ok"):
+        log.info("vocal: transcription unavailable: %s", res.get("error"))
+        return Lyrics(language=language)
+    return _lyrics_from_transcription(res, language)
 
 
 def start_prepare(job: Job, req: dict[str, Any]) -> None:
@@ -147,6 +295,32 @@ def start_prepare(job: Job, req: dict[str, Any]) -> None:
     task = asyncio.create_task(run_prepare(job, req))
     _running.add(task)
     task.add_done_callback(_running.discard)
+
+
+def start_install_transcription(job: Job) -> None:
+    """Spawn the faster-whisper install as a tracked background job so the UI can
+    pre-provision the sidecar (zero-terminal) and poll progress."""
+    task = asyncio.create_task(_run_install_transcription(job))
+    _running.add(task)
+    task.add_done_callback(_running.discard)
+
+
+async def _run_install_transcription(job: Job) -> None:
+    try:
+        job.update(status="running", progress=0.05, message="creating isolated venv")
+        from .transcription import install_dependencies
+
+        result = await asyncio.to_thread(install_dependencies)
+        if result.get("ok"):
+            job.result = {"ok": True, "mode": result.get("install_mode")}
+            job.update(status="done", progress=1.0, message="faster-whisper installed")
+        else:
+            job.error = result.get("error") or (result.get("stderr") or "")[:600]
+            job.update(status="failed", message="transcription install failed")
+    except Exception as e:
+        log.exception("vocal transcription install failed")
+        job.error = repr(e)
+        job.update(status="failed", message=str(e))
 
 
 async def run_prepare(job: Job, req: dict[str, Any]) -> None:
@@ -188,7 +362,7 @@ async def run_prepare(job: Job, req: dict[str, Any]) -> None:
             job.update(progress=0.85, message="segments")
 
             if bool(req.get("transcribe", False)):
-                art.lyrics = await _transcribe(cur, str(req.get("language", "en")))
+                art.lyrics = await _transcribe(cur, str(req.get("language", "en")), job)
             job.update(progress=0.95, message="lyrics")
 
         payload = art.model_dump()

--- a/backend/modules/vocal/transcription/__init__.py
+++ b/backend/modules/vocal/transcription/__init__.py
@@ -1,0 +1,24 @@
+"""faster-whisper transcription sidecar for the vocal engine.
+
+Importing this package stays cheap: only the stdlib/subprocess-based sidecar
+manager loads here. faster-whisper itself is imported solely inside worker.py,
+which runs in the isolated .whisper_venv.
+"""
+
+from .sidecar import (
+    available,
+    ensure_ready,
+    install_dependencies,
+    probe,
+    resolve_config,
+    transcribe,
+)
+
+__all__ = [
+    "available",
+    "ensure_ready",
+    "install_dependencies",
+    "probe",
+    "resolve_config",
+    "transcribe",
+]

--- a/backend/modules/vocal/transcription/requirements.txt
+++ b/backend/modules/vocal/transcription/requirements.txt
@@ -1,0 +1,4 @@
+# Installed into the isolated .whisper_venv on first transcription request.
+# faster-whisper pulls ctranslate2 + tokenizers + huggingface_hub + onnxruntime + av.
+# CPU int8 is the default compute path, so no CUDA/cuDNN wheels are required here.
+faster-whisper>=1.0.0

--- a/backend/modules/vocal/transcription/sidecar.py
+++ b/backend/modules/vocal/transcription/sidecar.py
@@ -1,0 +1,306 @@
+"""faster-whisper transcription sidecar (isolated venv, one-shot CLI).
+
+Transcription needs faster-whisper (CTranslate2), kept OUT of the main app
+environment. This module bootstraps a dedicated venv next to worker.py, installs
+faster-whisper into it on demand (uv first, pip fallback), and runs worker.py as
+a one-shot subprocess that returns word-timed segments as JSON. faster-whisper is
+NEVER imported in the main process; only the worker (inside the isolated venv)
+imports it, so server startup stays cheap.
+
+Defaults to CPU int8 so it runs without any CUDA/cuDNN DLLs. Override via
+theDAW_WHISPER_DEVICE / theDAW_WHISPER_COMPUTE / theDAW_WHISPER_MODEL, or point at
+an existing interpreter with theDAW_WHISPER_PYTHON. The venv location is
+configurable with theDAW_WHISPER_VENV_DIR (default: next to this file).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_WORKER = _PACKAGE_DIR / "worker.py"
+_REQUIREMENTS = _PACKAGE_DIR / "requirements.txt"
+SIDECAR_VENV_DIRNAME = ".whisper_venv"
+_CRITICAL_PACKAGES: tuple[str, ...] = ("faster_whisper",)
+_INSTALL_TIMEOUT_SEC = 20 * 60
+_TRANSCRIBE_TIMEOUT_SEC = 30 * 60
+
+
+def _venv_python(base: Path) -> Path:
+    venv_dir = base / SIDECAR_VENV_DIRNAME
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+@dataclass
+class WhisperConfig:
+    venv_base: Path
+    python_exe: Path
+    model: str
+    device: str
+    compute_type: str
+
+
+def resolve_config() -> WhisperConfig:
+    base_env = os.getenv("theDAW_WHISPER_VENV_DIR")
+    venv_base = Path(base_env).expanduser().resolve() if base_env else _PACKAGE_DIR
+    py = os.getenv("theDAW_WHISPER_PYTHON")
+    python_exe = Path(py).expanduser().resolve() if py else _venv_python(venv_base)
+    return WhisperConfig(
+        venv_base=venv_base,
+        python_exe=python_exe,
+        model=os.getenv("theDAW_WHISPER_MODEL", "small"),
+        device=os.getenv("theDAW_WHISPER_DEVICE", "cpu"),
+        compute_type=os.getenv("theDAW_WHISPER_COMPUTE", "int8"),
+    )
+
+
+def _probe_packages(python_exe: Path) -> dict:
+    """Import faster_whisper in the sidecar Python in ONE subprocess. Cheap,
+    never raises; returns {pkg: {ok, version|error}} or {_error: ...}."""
+    script = (
+        "import json, importlib\n"
+        f"pkgs = {list(_CRITICAL_PACKAGES)!r}\n"
+        "out = {}\n"
+        "for p in pkgs:\n"
+        "    try:\n"
+        "        m = importlib.import_module(p)\n"
+        "        out[p] = {'ok': True, 'version': getattr(m, '__version__', None)}\n"
+        "    except Exception as e:\n"
+        "        out[p] = {'ok': False, 'error': repr(e)[:300]}\n"
+        "print(json.dumps(out))\n"
+    )
+    try:
+        result = subprocess.run(
+            [str(python_exe), "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return {"_error": repr(e)}
+    if result.returncode != 0:
+        return {"_error": result.stderr.strip()[:300] or "probe subprocess failed"}
+    try:
+        return json.loads(result.stdout.strip().splitlines()[-1])
+    except (ValueError, IndexError) as e:
+        return {"_error": f"probe parse failed: {e}"}
+
+
+def probe(cfg: Optional[WhisperConfig] = None) -> dict:
+    """Non-spawning health snapshot for the UI: is the venv built and can it
+    import faster-whisper?"""
+    cfg = cfg or resolve_config()
+    venv_dir = cfg.python_exe.parent.parent
+    out: dict = {
+        "ok": False,
+        "python_exe": str(cfg.python_exe),
+        "python_exe_exists": cfg.python_exe.is_file(),
+        "sidecar_venv": str(venv_dir),
+        "sidecar_venv_exists": venv_dir.exists(),
+        "worker_exists": _WORKER.is_file(),
+        "model": cfg.model,
+        "device": cfg.device,
+        "compute_type": cfg.compute_type,
+        "packages": {},
+        "missing_critical": list(_CRITICAL_PACKAGES),
+        "critical_ok": False,
+    }
+    if cfg.python_exe.is_file():
+        pkgs = _probe_packages(cfg.python_exe)
+        if "_error" in pkgs:
+            out["error"] = pkgs["_error"]
+        else:
+            out["packages"] = pkgs
+            out["missing_critical"] = [
+                p for p in _CRITICAL_PACKAGES if not pkgs.get(p, {}).get("ok")
+            ]
+            out["critical_ok"] = len(out["missing_critical"]) == 0
+    else:
+        out["error"] = f"sidecar venv not created yet: {cfg.python_exe}"
+    out["ok"] = out["critical_ok"] and out["worker_exists"]
+    return out
+
+
+def available() -> bool:
+    try:
+        return bool(probe().get("critical_ok"))
+    except Exception as e:
+        log.info("vocal.whisper: availability probe failed: %s", e)
+        return False
+
+
+def _bootstrap_venv(cfg: WhisperConfig) -> dict:
+    """Create the isolated venv on demand (uv venv --seed, stdlib venv fallback)."""
+    venv_dir = cfg.python_exe.parent.parent
+    if cfg.python_exe.is_file():
+        return {"ok": True, "created": False, "tool": "existing"}
+    venv_dir.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = subprocess.run(
+            ["uv", "venv", str(venv_dir), "--python", sys.executable, "--seed"],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        if result.returncode == 0 and cfg.python_exe.is_file():
+            return {"ok": True, "created": True, "tool": "uv"}
+    except (OSError, subprocess.TimeoutExpired) as e:
+        log.info("vocal.whisper: uv venv unavailable (%s), falling back", e)
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "venv", str(venv_dir)],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return {"ok": False, "created": False, "tool": "venv", "error": repr(e)}
+    return {
+        "ok": result.returncode == 0 and cfg.python_exe.is_file(),
+        "created": True,
+        "tool": "venv",
+        "stderr": result.stderr[-2000:],
+    }
+
+
+def _install_cmd(python_exe: Path, req: Path) -> tuple[list[str], str]:
+    """Prefer `uv pip install --python <exe>` (host project is uv-based); fall
+    back to the venv's own pip."""
+    try:
+        uv_check = subprocess.run(
+            ["uv", "--version"], capture_output=True, text=True, timeout=10
+        )
+        if uv_check.returncode == 0:
+            return (
+                ["uv", "pip", "install", "--python", str(python_exe), "-r", str(req)],
+                "uv-pip",
+            )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return ([str(python_exe), "-m", "pip", "install", "-r", str(req)], "pip")
+
+
+def install_dependencies(cfg: Optional[WhisperConfig] = None) -> dict:
+    """Bootstrap the isolated venv then install faster-whisper into it."""
+    cfg = cfg or resolve_config()
+    out: dict = {"ok": False, "python_exe": str(cfg.python_exe)}
+    if not _REQUIREMENTS.is_file():
+        out["error"] = f"requirements.txt not found at {_REQUIREMENTS}"
+        return out
+    bootstrap = _bootstrap_venv(cfg)
+    out["venv_bootstrap"] = bootstrap
+    if not bootstrap.get("ok"):
+        out["error"] = (
+            "could not create whisper venv at "
+            f"{cfg.python_exe.parent.parent}: "
+            f"{bootstrap.get('stderr', bootstrap.get('error', '?'))}"
+        )
+        return out
+    try:
+        argv, mode = _install_cmd(cfg.python_exe, _REQUIREMENTS)
+        out["install_mode"] = mode
+        result = subprocess.run(
+            argv, capture_output=True, text=True, timeout=_INSTALL_TIMEOUT_SEC
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        out["error"] = repr(e)
+        return out
+    out["returncode"] = result.returncode
+    out["stdout"] = result.stdout[-4000:]
+    out["stderr"] = result.stderr[-4000:]
+    out["ok"] = result.returncode == 0
+    return out
+
+
+def ensure_ready(cfg: Optional[WhisperConfig] = None) -> dict:
+    """Probe; install on demand if missing; re-probe. Returns the final probe."""
+    cfg = cfg or resolve_config()
+    pr = probe(cfg)
+    if pr.get("critical_ok"):
+        return pr
+    log.info("vocal.whisper: installing faster-whisper into isolated venv (first run)")
+    inst = install_dependencies(cfg)
+    if not inst.get("ok"):
+        pr["install"] = inst
+        pr["error"] = inst.get("error") or (inst.get("stderr") or "")[:600]
+        return pr
+    pr2 = probe(cfg)
+    pr2["install"] = {"ok": True, "mode": inst.get("install_mode")}
+    return pr2
+
+
+async def transcribe(
+    audio_path: Path, language: str = "en", cfg: Optional[WhisperConfig] = None
+) -> dict:
+    """Run the isolated worker on one file. Returns the worker's JSON dict:
+    {ok, language, text, segments} on success, {ok: False, error} otherwise.
+    Never raises; install/spawn/parse failures all come back as ok=False."""
+    cfg = cfg or resolve_config()
+    ready = await asyncio.to_thread(ensure_ready, cfg)
+    if not ready.get("critical_ok"):
+        return {
+            "ok": False,
+            "error": ready.get("error") or "faster-whisper not installed",
+            "probe": ready,
+        }
+    request = json.dumps(
+        {
+            "audio": str(audio_path),
+            "language": language,
+            "model": cfg.model,
+            "device": cfg.device,
+            "compute_type": cfg.compute_type,
+        }
+    )
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            str(cfg.python_exe),
+            str(_WORKER),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError as e:
+        return {"ok": False, "error": f"failed to spawn whisper worker: {e!r}"}
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(request.encode("utf-8")),
+            timeout=_TRANSCRIBE_TIMEOUT_SEC,
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        return {
+            "ok": False,
+            "error": f"whisper worker timed out after {_TRANSCRIBE_TIMEOUT_SEC}s",
+        }
+    err_tail = stderr.decode("utf-8", "replace").strip()[-500:]
+    if proc.returncode != 0 and not stdout.strip():
+        return {"ok": False, "error": f"whisper worker failed: {err_tail}"}
+    try:
+        last = stdout.decode("utf-8", "replace").strip().splitlines()[-1]
+        return json.loads(last)
+    except (ValueError, IndexError) as e:
+        return {"ok": False, "error": f"whisper worker bad output: {e}; {err_tail}"}
+
+
+__all__ = [
+    "WhisperConfig",
+    "available",
+    "ensure_ready",
+    "install_dependencies",
+    "probe",
+    "resolve_config",
+    "transcribe",
+]

--- a/backend/modules/vocal/transcription/worker.py
+++ b/backend/modules/vocal/transcription/worker.py
@@ -1,0 +1,96 @@
+"""faster-whisper transcription worker.
+
+Runs INSIDE the isolated .whisper_venv, never in the main app process. Reads one
+JSON request from stdin, transcribes with faster-whisper, and writes a single
+JSON line to stdout as the LAST line. All diagnostics and model-download progress
+go to stderr so stdout stays clean for the parent to parse.
+
+Request  : {"audio": str, "language": str|null, "model": str, "device": str,
+            "compute_type": str}
+Response : {"ok": true, "language": str, "text": str,
+            "segments": [{"text", "start", "end",
+                          "words": [{"word", "start", "end"}]}]}   (seconds)
+            or {"ok": false, "error": str}
+"""
+
+import json
+import sys
+
+
+def _emit(payload: dict) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def _fail(msg: object) -> int:
+    _emit({"ok": False, "error": str(msg)[:600]})
+    return 1
+
+
+def main() -> int:
+    try:
+        req = json.loads(sys.stdin.read() or "{}")
+    except ValueError as e:
+        return _fail(f"bad request json: {e}")
+
+    audio = req.get("audio")
+    if not audio:
+        return _fail("no audio path")
+
+    language = req.get("language") or None
+    if language in ("auto", ""):
+        language = None
+    model_size = req.get("model") or "small"
+    device = req.get("device") or "cpu"
+    compute_type = req.get("compute_type") or "int8"
+
+    try:
+        from faster_whisper import WhisperModel
+    except Exception as e:
+        return _fail(f"faster-whisper import failed: {e!r}")
+
+    try:
+        model = WhisperModel(model_size, device=device, compute_type=compute_type)
+        segments, info = model.transcribe(
+            audio,
+            language=language,
+            word_timestamps=True,
+            vad_filter=True,
+        )
+        seg_out = []
+        text_parts = []
+        for seg in segments:
+            words = []
+            for w in seg.words or []:
+                words.append(
+                    {
+                        "word": w.word,
+                        "start": float(w.start) if w.start is not None else None,
+                        "end": float(w.end) if w.end is not None else None,
+                    }
+                )
+            seg_out.append(
+                {
+                    "text": seg.text,
+                    "start": float(seg.start),
+                    "end": float(seg.end),
+                    "words": words,
+                }
+            )
+            text_parts.append(seg.text)
+    except Exception as e:
+        return _fail(f"transcription failed: {e!r}")
+
+    _emit(
+        {
+            "ok": True,
+            "language": getattr(info, "language", None) or (language or ""),
+            "text": "".join(text_parts).strip(),
+            "segments": seg_out,
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-26T16:49:49.639Z · Git revision: `d595ecf31847` · Repomix tracked: **no**
+> Generated: 2026-06-27T13:36:50.234Z · Git revision: `59d9e5de5e27` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-26T16:49:49.639Z",
-  "repoRevision": "d595ecf31847",
+  "generatedAt": "2026-06-27T13:36:50.234Z",
+  "repoRevision": "59d9e5de5e27",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/electron-ui/main/index.ts
+++ b/electron-ui/main/index.ts
@@ -5,6 +5,7 @@ import {
   dialog,
   protocol,
   net,
+  session,
 } from 'electron'
 import { ChildProcess, spawn, execFile } from 'child_process'
 import * as fs from 'fs'
@@ -516,6 +517,20 @@ protocol.registerSchemesAsPrivileged([
 ])
 
 app.whenReady().then(async () => {
+  // Identify as theDAW, not "Electron": names the process / menu / userData dir
+  // and, via the AppUserModelID, the Windows taskbar grouping + shortcut binding.
+  app.setName('theDAW')
+  app.setAppUserModelId('com.gantasmo.thedaw')
+
+  // Grant media (microphone / camera) capture to the renderer. Electron layers
+  // its own permission gate on top of the OS; with no handler a getUserMedia
+  // track can return MUTED — the OS opens the device but the renderer receives
+  // silence. The renderer only ever loads our own local content, so granting is
+  // safe. Mic capture (vocal record) and camera (VJ) both depend on this.
+  const ses = session.defaultSession
+  ses.setPermissionRequestHandler((_wc, _permission, callback) => callback(true))
+  ses.setPermissionCheckHandler(() => true)
+
   registerIpcHandlers()
 
   // In production, register our custom protocol

--- a/frontend/public/yin.worklet.js
+++ b/frontend/public/yin.worklet.js
@@ -1,0 +1,112 @@
+/**
+ * yin.worklet.js - monophonic pitch detector for live vocal capture.
+ *
+ * Runs the YIN algorithm (de Cheveigne & Kawahara, 2002) on a rolling analysis
+ * window and streams one frame per hop back to the main thread over the port:
+ *   { type: 'f0', tSec, hz, clarity, rms }
+ * hz is 0 when unvoiced/unclear; clarity is 1 - d'(tau) (0..1); rms is the window
+ * level. Per-frame pitch cannot ride AudioParams (k-rate), so it goes over the
+ * port like the granular-morph worklet's position messages.
+ *
+ * Input is the mic stream; output is silence (the node is connected through a
+ * zero gain only so the graph keeps pulling it). Capture-relative time is derived
+ * on the main thread by subtracting the AudioContext time captured at start.
+ */
+
+const MIN_HZ = 70; // lowest pitch tracked (covers most sung registers)
+const MAX_HZ = 1000; // highest pitch tracked
+const WINDOW = 2048; // analysis window in samples
+const HOP = 1024; // run YIN every HOP samples (~21ms @ 48k)
+const THRESHOLD = 0.15; // YIN absolute threshold
+
+class YinDetector extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.buf = new Float32Array(WINDOW);
+    this.filled = 0; // samples written into buf since last analysis
+    this.minTau = Math.max(2, Math.floor(sampleRate / MAX_HZ));
+    this.maxTau = Math.min(Math.floor(sampleRate / MIN_HZ), Math.floor(WINDOW / 2));
+    this.d = new Float32Array(this.maxTau + 1);
+    this.dp = new Float32Array(this.maxTau + 1);
+  }
+
+  // Shift the window left by `n` and append the newest `n` samples.
+  push(chunk) {
+    const n = chunk.length;
+    if (n >= WINDOW) {
+      this.buf.set(chunk.subarray(n - WINDOW));
+    } else {
+      this.buf.copyWithin(0, n);
+      this.buf.set(chunk, WINDOW - n);
+    }
+  }
+
+  analyze() {
+    const buf = this.buf;
+    const maxTau = this.maxTau;
+    const integ = WINDOW - maxTau; // integration length keeps indices valid
+    let rms = 0;
+    for (let j = 0; j < WINDOW; j++) rms += buf[j] * buf[j];
+    rms = Math.sqrt(rms / WINDOW);
+
+    const d = this.d;
+    d[0] = 0;
+    for (let tau = 1; tau <= maxTau; tau++) {
+      let sum = 0;
+      for (let j = 0; j < integ; j++) {
+        const diff = buf[j] - buf[j + tau];
+        sum += diff * diff;
+      }
+      d[tau] = sum;
+    }
+
+    const dp = this.dp;
+    dp[0] = 1;
+    let running = 0;
+    for (let tau = 1; tau <= maxTau; tau++) {
+      running += d[tau];
+      dp[tau] = running > 0 ? (d[tau] * tau) / running : 1;
+    }
+
+    // First dip below threshold, then descend to its local minimum.
+    let tau = -1;
+    for (let t = this.minTau; t <= maxTau; t++) {
+      if (dp[t] < THRESHOLD) {
+        while (t + 1 <= maxTau && dp[t + 1] < dp[t]) t++;
+        tau = t;
+        break;
+      }
+    }
+    if (tau === -1) return { hz: 0, clarity: 0, rms }; // unvoiced/no clear pitch
+
+    // Parabolic interpolation around the chosen tau for sub-sample precision.
+    const x0 = tau > this.minTau ? dp[tau - 1] : dp[tau];
+    const x2 = tau + 1 <= maxTau ? dp[tau + 1] : dp[tau];
+    const denom = x0 + x2 - 2 * dp[tau];
+    const betterTau = denom !== 0 ? tau + (x0 - x2) / (2 * denom) : tau;
+
+    const hz = betterTau > 0 ? sampleRate / betterTau : 0;
+    const clarity = Math.max(0, Math.min(1, 1 - dp[tau]));
+    if (hz < MIN_HZ || hz > MAX_HZ) return { hz: 0, clarity, rms };
+    return { hz, clarity, rms };
+  }
+
+  process(inputs, outputs) {
+    const input = inputs[0];
+    const ch = input && input[0] ? input[0] : null;
+    const output = outputs[0];
+    if (output) for (let c = 0; c < output.length; c++) output[c].fill(0);
+    if (!ch) return true;
+
+    this.push(ch);
+    this.filled += ch.length;
+    if (this.filled >= HOP) {
+      this.filled = 0;
+      const { hz, clarity, rms } = this.analyze();
+      this.port.postMessage({ type: 'f0', tSec: currentTime, hz, clarity, rms });
+    }
+    return true;
+  }
+}
+
+registerProcessor('yin-detector', YinDetector);

--- a/frontend/src/components/audio/FxRack.tsx
+++ b/frontend/src/components/audio/FxRack.tsx
@@ -31,6 +31,9 @@ interface FxRackProps {
    *  at the current playhead, so a control's displayed value follows its lane.
    *  Display-only: edits still write the stored params. */
   displayParams?: (entryId: string) => Record<string, number> | undefined;
+  /** Hide the built-in "+ Add effect" select (the caller supplies its own add UI,
+   *  e.g. DRAW's colored effect palette). The chain rows still render. */
+  hideAdd?: boolean;
 }
 
 const fmtValue = (v: number, step: number, unit?: string): string => {
@@ -48,33 +51,36 @@ export function FxRack({
   onUpdateParams,
   projectBpm,
   displayParams,
+  hideAdd,
 }: FxRackProps) {
   const addId = `${idPrefix}-add`;
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-2">
-        <label htmlFor={addId} className="sr-only">Add insert effect</label>
-        <select
-          id={addId}
-          name={addId}
-          value=""
-          onChange={(e) => {
-            if (e.target.value) onAdd(e.target.value);
-          }}
-          className="form-select px-2 py-1 text-[11px] font-mono"
-          style={{ colorScheme: 'dark' }}
-          title="Add a psychoacoustic insert effect to this chain"
-        >
-          <option value="">+ Add effect…</option>
-          {RACK_EFFECTS.map((d) => (
-            <option key={d.id} value={d.id}>{d.label}</option>
-          ))}
-        </select>
-        {chain.length === 0 && (
-          <span className="text-[9px] font-mono text-zinc-600 uppercase tracking-wider">no inserts</span>
-        )}
-      </div>
+      {!hideAdd && (
+        <div className="flex items-center gap-2">
+          <label htmlFor={addId} className="sr-only">Add insert effect</label>
+          <select
+            id={addId}
+            name={addId}
+            value=""
+            onChange={(e) => {
+              if (e.target.value) onAdd(e.target.value);
+            }}
+            className="form-select px-2 py-1 text-[11px] font-mono"
+            style={{ colorScheme: 'dark' }}
+            title="Add a psychoacoustic insert effect to this chain"
+          >
+            <option value="">+ Add effect…</option>
+            {RACK_EFFECTS.map((d) => (
+              <option key={d.id} value={d.id}>{d.label}</option>
+            ))}
+          </select>
+          {chain.length === 0 && (
+            <span className="text-[9px] font-mono text-zinc-600 uppercase tracking-wider">no inserts</span>
+          )}
+        </div>
+      )}
 
       {/* Effects tile and wrap (capped width) so they use horizontal space
           instead of one full-width column of stretched sliders. */}

--- a/frontend/src/components/audio/PianoRoll.tsx
+++ b/frontend/src/components/audio/PianoRoll.tsx
@@ -76,6 +76,7 @@ export const PianoRoll: React.FC = () => {
   const selectedNoteId = usePianoRollStore((s) => s.selectedNoteId);
   const isPlaying = usePianoRollStore((s) => s.isPlaying);
   const currentStep = usePianoRollStore((s) => s.currentStep);
+  const recordedRange = usePianoRollStore((s) => s.recordedRange);
 
   const setBpm = usePianoRollStore((s) => s.setBpm);
   const setTotalSteps = usePianoRollStore((s) => s.setTotalSteps);
@@ -406,6 +407,20 @@ export const PianoRoll: React.FC = () => {
     logInfo('piano-roll', `Applied timing feel: quantize ${quantizePct}% · swing/rag ${swingPct}%`);
   };
 
+  // Center the vertical scroll on the note content so it's visible in the tall
+  // full-piano grid (~88 rows). Re-centers when the content pitch range changes
+  // (a capture / import / clip load), not on edits within the current range.
+  const contentLo = notes.length ? notes.reduce((m, n) => Math.min(m, n.note), 127) : 60;
+  const contentHi = notes.length ? notes.reduce((m, n) => Math.max(m, n.note), 0) : 72;
+  useEffect(() => {
+    const el = gridScrollRef.current;
+    if (!el) return;
+    const midNote = (contentLo + contentHi) / 2;
+    const midY = (highestNote - midNote) * NOTE_HEIGHT;
+    el.scrollTop = Math.max(0, midY - el.clientHeight / 2);
+    if (keyboardRowsRef.current) keyboardRowsRef.current.scrollTop = el.scrollTop;
+  }, [contentLo, contentHi, highestNote]);
+
   // Build keyboard rows + grid rows for rendering.
   const rows: number[] = [];
   for (let n = highestNote; n >= lowestNote; n -= 1) rows.push(n);
@@ -429,8 +444,9 @@ export const PianoRoll: React.FC = () => {
         }}
       />
 
-      {/* Toolbar */}
-      <div className="flex items-center justify-between gap-2 px-2 py-1 border-b border-white/5 bg-black/40 shrink-0">
+      {/* Toolbar — extra right padding reserves space for the MIDI mapper pill
+          (absolute top-right) so it never covers CLEAR / the right-side controls. */}
+      <div className="flex items-center justify-between gap-2 pl-2 pr-20 py-1 border-b border-white/5 bg-black/40 shrink-0">
         <div className="flex items-center gap-2">
           <button
             onClick={handlePlayToggle}
@@ -613,6 +629,17 @@ export const PianoRoll: React.FC = () => {
                 style={{ left: i * stepPx }}
               />
             ))}
+            {/* Recorded-region highlight: marks the last live take without
+                shrinking the grid (the rest of the 256 stays empty). */}
+            {recordedRange && recordedRange.endStep > recordedRange.startStep && (
+              <div
+                className="absolute top-0 bottom-0 bg-emerald-400/8 border-x border-emerald-400/40 pointer-events-none"
+                style={{
+                  left: recordedRange.startStep * stepPx,
+                  width: (recordedRange.endStep - recordedRange.startStep) * stepPx,
+                }}
+              />
+            )}
             {/* Playhead */}
             {isPlaying && (
               <div

--- a/frontend/src/components/audio/StepSequencer.tsx
+++ b/frontend/src/components/audio/StepSequencer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  Play, Square, Layers, Target,
+  Play, Square, Target,
   Trash2, Sparkles, Plus, Activity,
   Download, Send, Music,
 } from 'lucide-react';
@@ -543,15 +543,10 @@ export const StepSequencer: React.FC = () => {
           if (key === 'bpm') setBpm(Math.round(value));
         }}
       />
-      <div className="flex items-center justify-between p-2 border-b border-white/5 bg-black/20">
+      {/* Extra right padding reserves space for the MIDI mapper pill (absolute
+          top-right) so it never covers the + / CLEAR controls. */}
+      <div className="flex items-center justify-between py-2 pl-2 pr-20 border-b border-white/5 bg-black/20">
         <div className="flex items-center gap-4">
-          <div className="flex items-center gap-1.5">
-            <Layers className="w-3.5 h-3.5 text-cyan-400" />
-            <span className="mono-label">Step Sequencer</span>
-          </div>
-
-          <div className="h-4 w-px bg-white/10" />
-
           <div className="flex items-center gap-4">
             <div className="flex flex-col">
               <span className="text-[7px] font-mono text-zinc-600 uppercase leading-none">Tempo (BPM)</span>

--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -1790,8 +1790,8 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
       clip.sourceBpm ?? 120,
       clip.sourceTotalSteps ?? 32,
     );
-    useBottomPanelStore.getState().showTab('piano-roll');
-    logInfo('editor', `Editing clip ${clip.id.slice(0, 8)} in Piano Roll (${clip.sourcePianoRoll.length} notes)`);
+    useBottomPanelStore.getState().showTab('midi');
+    logInfo('editor', `Editing clip ${clip.id.slice(0, 8)} in MIDI (${clip.sourcePianoRoll.length} notes)`);
   }, []);
 
   const onClipDoubleClick = (clip: AudioClip) => {

--- a/frontend/src/components/layout/BottomMultiTabPanel.tsx
+++ b/frontend/src/components/layout/BottomMultiTabPanel.tsx
@@ -9,29 +9,31 @@
 import React, { useState } from 'react';
 import {
   Activity, Info, Piano, Layers, FolderOpen, SlidersVertical, ExternalLink, Maximize2, Minimize2,
-  FileMusic, Waves,
+  FileMusic, Waves, Brush,
 } from 'lucide-react';
 import { AdvancedVisualizer } from '../audio/AdvancedVisualizer';
-import { PianoRoll } from '../audio/PianoRoll';
 import { StepSequencer } from '../audio/StepSequencer';
 import { DetailsView } from './DetailsView';
 import { ScoreView } from './ScoreView';
 import { MediaBucketView } from './MediaBucketView';
 import { SlidePanel } from './SlidePanel';
 import { SwayPanel } from './SwayPanel';
+import { MidiPanel } from './MidiPanel';
+import { DrawPanel } from './DrawPanel';
 import { DetachableWindow } from './DetachableWindow';
 import { useBottomPanelStore, type BottomPanelTab } from '../../state/bottomPanelStore';
 import { useSlideStore } from '../../state/slideStore';
 
-const TAB_DEFS: Array<{ id: BottomPanelTab; label: string; icon: React.ComponentType<{ className?: string }>; colorActive: string }> = [
-  { id: 'spectral',   label: 'Visualize',    icon: Activity,   colorActive: 'border-purple-500 text-purple-300' },
-  { id: 'piano-roll', label: 'Piano',        icon: Piano,      colorActive: 'border-cyan-500 text-cyan-300' },
-  { id: 'step-seq',   label: 'Sequence',     icon: Layers,     colorActive: 'border-cyan-500 text-cyan-300' },
-  { id: 'score',      label: 'Score',        icon: FileMusic,  colorActive: 'border-emerald-500 text-emerald-300' },
-  { id: 'details',    label: 'Details',      icon: Info,       colorActive: 'border-emerald-500 text-emerald-300' },
-  { id: 'bucket',     label: 'Media',        icon: FolderOpen, colorActive: 'border-amber-500 text-amber-300' },
-  { id: 'slide',      label: 'SLIDE',        icon: SlidersVertical, colorActive: 'border-pink-500 text-pink-300' },
-  { id: 'sway',       label: 'SWAY',         icon: Waves,      colorActive: 'border-fuchsia-500 text-fuchsia-300' },
+const TAB_DEFS: Array<{ id: BottomPanelTab; label: string; desc: string; icon: React.ComponentType<{ className?: string }>; colorActive: string }> = [
+  { id: 'spectral',   label: 'Visualize',  desc: 'Live spectrum + waveform visualizer of the playing audio',                 icon: Activity,   colorActive: 'border-purple-500 text-purple-300' },
+  { id: 'midi',       label: 'MIDI',       desc: 'Piano roll: sing in, record or analyze notes, edit them, export MIDI',     icon: Piano,      colorActive: 'border-cyan-500 text-cyan-300' },
+  { id: 'step-seq',   label: 'Sequence',   desc: 'Program drum and note patterns step by step on a grid',                    icon: Layers,     colorActive: 'border-cyan-500 text-cyan-300' },
+  { id: 'draw',       label: 'DRAW',       desc: 'Draw to play generative music; record it to the library or EDIT',          icon: Brush,      colorActive: 'border-purple-500 text-purple-300' },
+  { id: 'score',      label: 'Score',      desc: 'Sheet music + tabs for the selection; convert and arrange notation',       icon: FileMusic,  colorActive: 'border-emerald-500 text-emerald-300' },
+  { id: 'details',    label: 'Details',    desc: 'Metadata, prompt and analysis for the selected library item',              icon: Info,       colorActive: 'border-emerald-500 text-emerald-300' },
+  { id: 'bucket',     label: 'Media',      desc: 'Drag-and-drop bucket for staging clips and media files',                   icon: FolderOpen, colorActive: 'border-amber-500 text-amber-300' },
+  { id: 'slide',      label: 'SLIDE',      desc: 'Control surface: map sliders and pads to parameters',                      icon: SlidersVertical, colorActive: 'border-pink-500 text-pink-300' },
+  { id: 'sway',       label: 'SWAY',       desc: 'Pose control: drive music and effects from body movement',                 icon: Waves,      colorActive: 'border-fuchsia-500 text-fuchsia-300' },
 ];
 
 export const BottomMultiTabPanel: React.FC = () => {
@@ -78,7 +80,7 @@ export const BottomMultiTabPanel: React.FC = () => {
                 key={t.id}
                 onClick={() => setActiveTab(t.id)}
                 className={`px-3 py-1.5 flex items-center gap-1.5 border-b-2 text-[9px] uppercase tracking-widest font-black transition-colors whitespace-nowrap ${active ? t.colorActive : 'border-transparent text-zinc-500 hover:text-zinc-300'}`}
-                title={t.label}
+                title={t.desc}
               >
                 <Icon className="w-3 h-3" /> {t.label}
               </button>
@@ -132,9 +134,14 @@ export const BottomMultiTabPanel: React.FC = () => {
             <DetailsView />
           </div>
         )}
-        {activeTab === 'piano-roll' && (
+        {activeTab === 'midi' && (
           <div className="absolute inset-0">
-            <PianoRoll />
+            <MidiPanel />
+          </div>
+        )}
+        {activeTab === 'draw' && (
+          <div className="absolute inset-0">
+            <DrawPanel />
           </div>
         )}
         {activeTab === 'step-seq' && (

--- a/frontend/src/components/layout/CenterTabBar.tsx
+++ b/frontend/src/components/layout/CenterTabBar.tsx
@@ -27,6 +27,7 @@ interface CenterTabBarProps {
 const TABS: Array<{
   id: CenterTab;
   label: string;
+  desc: string;
   icon: React.ComponentType<{ className?: string }>;
   /** Per-tab accent color — used for active border + soft bg tint
    *  so each workspace gets a recognizable color at a glance. */
@@ -36,6 +37,7 @@ const TABS: Array<{
   {
     id: 'make',
     label: 'Make',
+    desc: 'Generate audio from a text prompt with the AI models',
     icon: Sparkles,
     accent: {
       border: 'border-purple-500/50',
@@ -47,6 +49,7 @@ const TABS: Array<{
   {
     id: 'edit',
     label: 'Edit',
+    desc: 'Arrange clips on a timeline, add effects and automation, export',
     icon: Scissors,
     accent: {
       border: 'border-emerald-500/50',
@@ -58,6 +61,7 @@ const TABS: Array<{
   {
     id: 'mix',
     label: 'Mix',
+    desc: 'Process and master audio with the effect and module rack',
     icon: Zap,
     accent: {
       border: 'border-orange-500/50',
@@ -69,6 +73,7 @@ const TABS: Array<{
   {
     id: 'dj',
     label: 'DJ',
+    desc: 'Two-deck DJ console: mix, cue, scratch, stems and automix',
     icon: Disc,
     accent: {
       border: 'border-pink-500/50',
@@ -80,6 +85,7 @@ const TABS: Array<{
   {
     id: 'vj',
     label: 'VJ',
+    desc: 'Live visuals engine: sources, effects and output for performance',
     icon: Tv2,
     accent: {
       border: 'border-fuchsia-500/50',
@@ -91,6 +97,7 @@ const TABS: Array<{
   {
     id: 'train',
     label: 'Train',
+    desc: 'Train and manage LoRA models on your own audio',
     icon: Brain,
     accent: {
       border: 'border-cyan-500/50',
@@ -102,6 +109,7 @@ const TABS: Array<{
   {
     id: 'learn',
     label: 'Learn',
+    desc: 'Guides, docs and the in-app assistant',
     icon: Workflow,
     accent: {
       border: 'border-rose-500/50',
@@ -143,7 +151,7 @@ export const CenterTabBar: React.FC<CenterTabBarProps> = ({
                   ? `${t.accent.border} ${t.accent.bg} ${t.accent.text}`
                   : 'border-white/5 text-zinc-500 hover:text-zinc-200 hover:bg-white/3',
               ].join(' ')}
-              title={t.label}
+              title={t.desc}
             >
               <Icon className={`w-3.5 h-3.5 ${active ? t.accent.iconText : ''}`} />
               <span>{t.label}</span>

--- a/frontend/src/components/layout/DrawPanel.tsx
+++ b/frontend/src/components/layout/DrawPanel.tsx
@@ -1,0 +1,682 @@
+/**
+ * DrawPanel - the DRAW bottom tab. A generative draw-to-music instrument ported
+ * from art2music onto the shared Web Audio graph (see lib/drawEngine). Draw on
+ * the canvas to play live; record the session and either save it to the library
+ * or drop it onto a new EDIT track. Switch between the faithful noise DRONE and a
+ * SOUNDFONT voice, pick a mode/instrument, and set the master level.
+ */
+
+import { ArrowLeft, Disc, Eraser, Save, Send, Sparkles, SlidersHorizontal, Square, X } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { BRUSHES, DrawEngine, DRAW_EFFECT_OPTIONS, drawEffectMeta, type BrushId, type SoundMode } from '../../lib/drawEngine';
+import { GM_NAMES } from '../../lib/gmInstruments';
+import { RACK_EFFECTS } from '../../lib/rackEffects';
+import { STUDIO_MODULES, type StudioModule } from '../../lib/moduleCatalog';
+import { sendAudioToEditor, type SendableAudio } from '../../lib/sendToTargets';
+import { useDrawFxStore } from '../../state/drawEffectChainStore';
+import { useDrawModeStore } from '../../state/drawModeStore';
+import { useLibraryStore } from '../../state/libraryStore';
+import { logError, logInfo } from '../../state/logStore';
+import { pollMagentaJob } from '../../state/instrumentStore';
+import { FxRack } from '../audio/FxRack';
+import { EffectGuiStage } from '../audio/EffectGuiStage';
+
+const stamp = (): string => new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+
+/** A distinct hue per live effect so each label in the palette reads its own color. */
+const EFFECT_HUE: Record<string, number> = Object.fromEntries(
+  RACK_EFFECTS.map((d, i) => [d.id, Math.round((i * 360) / RACK_EFFECTS.length)]),
+);
+
+/** Mode-effect dropdown groups (built-in draw effects, then live psychoacoustics). */
+const MODE_GROUPS = ['Draw', 'Psychoacoustic'];
+
+export const DrawPanel: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const engineRef = useRef<DrawEngine | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const recStartRef = useRef(0);
+
+  const selectedEntryId = useLibraryStore((s) => s.selectedEntryId);
+  const entries = useLibraryStore((s) => s.entries);
+  const [brush, setBrush] = useState<BrushId>('organic');
+  const [mode, setMode] = useState(0);
+  const [soundMode, setSoundMode] = useState<SoundMode>('drone');
+  const [program, setProgram] = useState(89);
+  const [volume, setVolume] = useState(0.8);
+  const [recording, setRecording] = useState(false);
+  const [blob, setBlob] = useState<Blob | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [grainName, setGrainName] = useState('');
+  const [magLive, setMagLive] = useState(false);
+  const [status, setStatus] = useState('');
+  const [fxOpen, setFxOpen] = useState(false);
+  const [studioModule, setStudioModule] = useState<StudioModule | null>(null);
+
+  const slots = useDrawModeStore((s) => s.slots);
+  const setSlot = useDrawModeStore((s) => s.setSlot);
+
+  const chain = useDrawFxStore((s) => s.chain);
+  const addEffect = useDrawFxStore((s) => s.addEffect);
+  const removeEffect = useDrawFxStore((s) => s.removeEffect);
+  const updateParams = useDrawFxStore((s) => s.updateParams);
+  const toggleEnabled = useDrawFxStore((s) => s.toggleEnabled);
+  const reorder = useDrawFxStore((s) => s.reorder);
+  const clearChain = useDrawFxStore((s) => s.clearChain);
+
+  // Create the engine once the canvas exists; keep the drawing buffer matched to
+  // the element size so strokes land where the cursor is.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+    const size = () => {
+      canvas.width = Math.max(1, container.clientWidth);
+      canvas.height = Math.max(1, container.clientHeight);
+    };
+    size();
+    const engine = new DrawEngine(canvas);
+    engineRef.current = engine;
+    engine.setMasterVolume(volume);
+    engine.onMagentaStatus = (s) => setStatus(s);
+    const ro = new ResizeObserver(size);
+    ro.observe(container);
+    return () => {
+      ro.disconnect();
+      engine.dispose();
+      engineRef.current = null;
+      try {
+        recorderRef.current?.stop();
+      } catch {
+        /* not recording */
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Rebuild the live FX chain on the engine when its STRUCTURE changes
+  // (add/remove/reorder/toggle). Pure param tweaks go straight to the running
+  // nodes via onChainParams, so a slider drag never re-wires the graph.
+  const chainSig = chain.map((e) => `${e.id}:${e.effect}:${e.enabled ? 1 : 0}`).join('|');
+  useEffect(() => {
+    engineRef.current?.setChain(useDrawFxStore.getState().chain);
+  }, [chainSig]);
+
+  // Push reassigned per-stroke mode slots to the engine.
+  useEffect(() => {
+    engineRef.current?.setModeSlots(slots);
+  }, [slots]);
+
+  // The latest recording, as a File the Studio module iframes can ingest.
+  const recordingFile = useMemo(
+    () => (blob ? new File([blob], `draw-${stamp()}.webm`, { type: blob.type || 'audio/webm' }) : null),
+    [blob],
+  );
+
+  const addAllEffects = useCallback(() => {
+    for (const d of RACK_EFFECTS) addEffect(d.id);
+  }, [addEffect]);
+
+  const onChainParams = useCallback(
+    (id: string, p: Record<string, number>) => {
+      updateParams(id, p);
+      engineRef.current?.updateChainParam(id, p);
+    },
+    [updateParams],
+  );
+
+  const pickBrush = useCallback((id: BrushId) => {
+    setBrush(id);
+    engineRef.current?.setBrush(id);
+  }, []);
+  const pickMode = useCallback((i: number) => {
+    setMode(i);
+    engineRef.current?.setMode(i);
+  }, []);
+  const loadGrain = useCallback(async () => {
+    const entry = entries.find((e) => e.id === selectedEntryId);
+    if (!entry) {
+      setGrainName('');
+      setStatus('select a library song to granulate');
+      return;
+    }
+    const url = useLibraryStore.getState().getAudioUrl(entry);
+    setStatus(`loading grains from "${entry.title}"...`);
+    const ok = await engineRef.current?.loadGrainSource(url);
+    setGrainName(ok ? entry.title : '');
+    setStatus(ok ? `grains: "${entry.title}"` : 'grain source failed to load');
+  }, [entries, selectedEntryId]);
+
+  const pickSoundMode = useCallback((m: SoundMode) => {
+    setSoundMode(m);
+    engineRef.current?.setSoundMode(m);
+  }, []);
+
+  // Load / reload the grain source when granular is active or the selection moves.
+  // Skip while the live Magenta loop owns the grain buffer.
+  useEffect(() => {
+    if (soundMode === 'granular' && !magLive) void loadGrain();
+  }, [soundMode, selectedEntryId, loadGrain, magLive]);
+
+  const toggleMagentaLive = useCallback(() => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    if (engine.magentaLive) {
+      engine.stopMagentaGrain();
+      setMagLive(false);
+      if (soundMode === 'granular') void loadGrain();
+    } else {
+      if (soundMode !== 'granular') pickSoundMode('granular');
+      setMagLive(true);
+      void engine.startMagentaGrain('evolving instrumental texture');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [soundMode, loadGrain]);
+  const pickInstrument = useCallback((p: number) => {
+    setProgram(p);
+    engineRef.current?.setInstrument(p);
+  }, []);
+  const changeVolume = useCallback((v: number) => {
+    setVolume(v);
+    engineRef.current?.setMasterVolume(v);
+  }, []);
+  const clear = useCallback(() => {
+    engineRef.current?.clear();
+    setStatus('cleared');
+  }, []);
+
+  const toggleRecord = useCallback(() => {
+    if (recording) {
+      recorderRef.current?.stop();
+      return;
+    }
+    const stream = engineRef.current?.recordDest.stream;
+    if (!stream) return;
+    const rec = new MediaRecorder(stream);
+    const chunks: Blob[] = [];
+    rec.ondataavailable = (e) => {
+      if (e.data.size) chunks.push(e.data);
+    };
+    rec.onstop = () => {
+      setRecording(false);
+      const b = new Blob(chunks, { type: rec.mimeType || 'audio/webm' });
+      setBlob(b);
+      setStatus(`recorded ${(b.size / 1024).toFixed(0)}KB - save or send`);
+      logInfo('draw', `recording stopped (${(b.size / 1024).toFixed(0)}KB)`);
+    };
+    recorderRef.current = rec;
+    recStartRef.current = performance.now();
+    rec.start();
+    setRecording(true);
+    setStatus('recording - draw away, then stop');
+    logInfo('draw', 'recording started');
+  }, [recording]);
+
+  const saveToLibrary = useCallback(async () => {
+    if (!blob) return;
+    setBusy(true);
+    try {
+      const name = `draw-${stamp()}`;
+      const entry = await useLibraryStore.getState().importEntry({
+        blob,
+        filename: `${name}.webm`,
+        mimeType: blob.type || 'audio/webm',
+        metadata: {
+          title: name,
+          model: 'draw',
+          duration: (performance.now() - recStartRef.current) / 1000,
+          source: 'import',
+          tags: ['draw'],
+        },
+      });
+      setStatus(`saved "${entry.title}" to library`);
+      logInfo('draw', `saved ${entry.title} to library`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setStatus(`save failed: ${msg}`);
+      logError('draw', `library save failed: ${msg}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [blob]);
+
+  const sendToEdit = useCallback(async () => {
+    if (!blob) return;
+    setBusy(true);
+    try {
+      const item: SendableAudio = {
+        label: `draw-${stamp()}.webm`,
+        mimeType: blob.type || 'audio/webm',
+        fetcher: async () => blob,
+      };
+      const clipId = await sendAudioToEditor(item, 'editor-new-track');
+      setStatus(clipId ? 'sent to EDIT (new track)' : 'send to EDIT failed');
+      if (clipId) logInfo('draw', 'sent recording to EDIT');
+    } finally {
+      setBusy(false);
+    }
+  }, [blob]);
+
+  // Hand the drawn melody to the Magenta RT2 sidecar for a full arrangement; the
+  // result lands in the library. Needs Magenta installed (412 -> setup prompt).
+  const jamMagenta = useCallback(async () => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    const melody = engine.getMelody();
+    if (!melody.length) {
+      setStatus('draw a melody first, then jam with Magenta');
+      return;
+    }
+    const span = Math.max(...melody.map((n) => n.end));
+    const duration = Math.min(20, Math.max(4, Math.round(span)));
+    setBusy(true);
+    setStatus('Magenta is jamming over your melody...');
+    try {
+      const form = new FormData();
+      form.append('prompt', 'instrumental jam, full arrangement');
+      form.append('duration', String(duration));
+      form.append('model_size', 'small');
+      form.append('notes', JSON.stringify(melody));
+      const res = await fetch('/api/magenta/generate', { method: 'POST', body: form });
+      if (res.status === 412) {
+        setStatus('Magenta is not installed - run Setup-MRT2 once (see Settings)');
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const { job } = await res.json();
+      const arr = await pollMagentaJob(job.id);
+      const b = new Blob([arr], { type: 'audio/wav' });
+      setBlob(b);
+      const name = `draw-jam-${stamp()}`;
+      const entry = await useLibraryStore.getState().importEntry({
+        blob: b,
+        filename: `${name}.wav`,
+        mimeType: 'audio/wav',
+        metadata: { title: name, model: 'magenta', duration, source: 'import', tags: ['draw', 'magenta'] },
+      });
+      setStatus(`Magenta jam saved: "${entry.title}"`);
+      logInfo('draw', `magenta jam saved ${entry.title}`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setStatus(`Magenta jam failed: ${msg}`);
+      logError('draw', `magenta jam failed: ${msg}`);
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const iconBtn =
+    'grid place-items-center w-7 h-7 rounded border transition-colors disabled:opacity-40';
+
+  return (
+    <div className="h-full w-full flex flex-col bg-zinc-950 text-zinc-200">
+      <div className="shrink-0 flex flex-wrap items-center gap-2 px-2 py-1.5 border-b border-white/8">
+        {/* brush — the visual + sonic character of a stroke */}
+        <div className="flex items-center gap-1" role="group" aria-label="Brush">
+          {BRUSHES.map((b) => (
+            <button
+              key={b.id}
+              type="button"
+              onClick={() => pickBrush(b.id)}
+              title={b.desc}
+              className="px-1.5 h-6 grid place-items-center text-[9px] font-black uppercase tracking-wide rounded border transition-colors"
+              style={
+                brush === b.id
+                  ? { borderColor: `hsl(${b.hue} 80% 60%)`, color: `hsl(${b.hue} 85% 78%)`, background: `hsl(${b.hue} 80% 50% / 0.2)` }
+                  : { borderColor: 'rgb(63 63 70)', color: 'rgb(161 161 170)' }
+              }
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
+
+        <span className="w-px h-4 bg-white/10" aria-hidden="true" />
+
+        {/* mode — per-stroke effect slots, each reassignable to any effect */}
+        <div className="flex items-center gap-1" role="group" aria-label="Effect mode">
+          {slots.map((eff, i) => {
+            const info = drawEffectMeta(eff);
+            const hue = info?.hue ?? 0;
+            return (
+              <button
+                key={i}
+                type="button"
+                onClick={() => pickMode(i)}
+                title={info ? `${info.label}: ${info.desc}` : eff}
+                className="w-6 h-6 grid place-items-center text-[10px] font-mono rounded border transition-colors"
+                style={
+                  mode === i
+                    ? { borderColor: `hsl(${hue} 80% 60%)`, color: `hsl(${hue} 85% 75%)`, background: `hsl(${hue} 80% 50% / 0.2)` }
+                    : { borderColor: 'rgb(82 82 91)', color: 'rgb(161 161 170)' }
+                }
+              >
+                {i + 1}
+              </button>
+            );
+          })}
+        </div>
+        {/* reassign the selected mode slot to any live effect */}
+        <label htmlFor="draw-mode-effect" className="sr-only">
+          Effect for the selected mode
+        </label>
+        <select
+          id="draw-mode-effect"
+          name="draw-mode-effect"
+          value={slots[mode] ?? 'clean'}
+          onChange={(e) => setSlot(mode, e.target.value)}
+          title="Change the selected mode to any effect"
+          className="bg-zinc-800 border border-zinc-500 text-zinc-100 text-[10px] font-mono px-1 py-1 rounded"
+        >
+          {MODE_GROUPS.map((grp) => (
+            <optgroup key={grp} label={grp}>
+              {DRAW_EFFECT_OPTIONS.filter((o) => o.group === grp).map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+
+        <span className="w-px h-4 bg-white/10" aria-hidden="true" />
+
+        {/* sound source */}
+        <label htmlFor="draw-sound-mode" className="sr-only">
+          Sound source
+        </label>
+        <select
+          id="draw-sound-mode"
+          name="draw-sound-mode"
+          value={soundMode}
+          onChange={(e) => pickSoundMode(e.target.value as SoundMode)}
+          title="How strokes make sound: a filtered-noise drone, played notes on a soundfont instrument, or grains sampled from a library song"
+          className="bg-zinc-800 border border-zinc-500 text-zinc-100 text-[10px] font-mono px-1 py-1 rounded"
+        >
+          <option value="drone">Drone</option>
+          <option value="soundfont">Soundfont</option>
+          <option value="granular">Granular</option>
+        </select>
+        {soundMode === 'soundfont' && (
+          <>
+            <label htmlFor="draw-instrument" className="sr-only">
+              Instrument
+            </label>
+            <select
+              id="draw-instrument"
+              name="draw-instrument"
+              value={program}
+              onChange={(e) => pickInstrument(Number(e.target.value))}
+              title="Instrument the drawn notes play through"
+              className="max-w-40 bg-zinc-800 border border-zinc-500 text-zinc-100 text-[10px] font-mono px-1 py-1 rounded"
+            >
+              {GM_NAMES.map((n, i) => (
+                <option key={n} value={i}>{`${i + 1}. ${n}`}</option>
+              ))}
+            </select>
+          </>
+        )}
+        {soundMode === 'granular' && (
+          <>
+            <span className="text-[9px] font-mono text-zinc-400 max-w-40 truncate" title="Source the grains are sampled from: a library song, or live Magenta when enabled">
+              {magLive ? 'Magenta live' : grainName ? grainName : 'select a library song'}
+            </span>
+            <button
+              type="button"
+              onClick={toggleMagentaLive}
+              title="Stream live Magenta audio as the grain source (continuous generation, Collider-style). Needs Magenta installed; cannot run at the same time as the Jam tools."
+              aria-label={magLive ? 'Stop live Magenta grain source' : 'Start live Magenta grain source'}
+              className={`px-1.5 h-6 grid place-items-center text-[9px] font-black uppercase tracking-wide rounded border transition-colors ${
+                magLive
+                  ? 'border-fuchsia-500 text-fuchsia-200 bg-fuchsia-600/25'
+                  : 'border-fuchsia-700 text-fuchsia-300 hover:bg-fuchsia-600/15'
+              }`}
+            >
+              {magLive ? 'Live on' : 'Live'}
+            </button>
+          </>
+        )}
+
+        <span className="w-px h-4 bg-white/10" aria-hidden="true" />
+
+        {/* master volume */}
+        <label htmlFor="draw-volume" className="text-[9px] font-mono text-zinc-500">
+          VOL
+        </label>
+        <input
+          id="draw-volume"
+          name="draw-volume"
+          type="range"
+          min={0}
+          max={1}
+          step={0.02}
+          value={volume}
+          onChange={(e) => changeVolume(Number(e.target.value))}
+          title="Master output level for the draw instrument"
+          className="w-20 accent-purple-400"
+        />
+
+        <button
+          type="button"
+          onClick={clear}
+          title="Clear the canvas and silence all voices"
+          aria-label="Clear"
+          className={`${iconBtn} border-zinc-600 text-zinc-300 hover:bg-white/10`}
+        >
+          <Eraser className="w-3.5 h-3.5" />
+        </button>
+
+        <span className="w-px h-4 bg-white/10" aria-hidden="true" />
+
+        {/* record + outputs */}
+        <button
+          type="button"
+          onClick={toggleRecord}
+          title={recording ? 'Stop recording' : 'Record the draw session to audio'}
+          aria-label={recording ? 'Stop recording' : 'Record'}
+          className={`${iconBtn} ${
+            recording
+              ? 'border-rose-500 text-rose-300 bg-rose-600/25'
+              : 'border-rose-600 text-rose-300 hover:bg-rose-600/15'
+          }`}
+        >
+          {recording ? <Square className="w-3.5 h-3.5" /> : <Disc className="w-3.5 h-3.5" />}
+        </button>
+        <button
+          type="button"
+          onClick={saveToLibrary}
+          disabled={!blob || busy}
+          title="Save the recording into the library"
+          aria-label="Save to library"
+          className={`${iconBtn} border-emerald-600 text-emerald-300 hover:bg-emerald-600/15`}
+        >
+          <Save className="w-3.5 h-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={sendToEdit}
+          disabled={!blob || busy}
+          title="Add the recording to a new track in EDIT"
+          aria-label="Send to EDIT"
+          className={`${iconBtn} border-cyan-600 text-cyan-300 hover:bg-cyan-600/15`}
+        >
+          <Send className="w-3.5 h-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={jamMagenta}
+          disabled={busy}
+          title="Send your drawn melody to Magenta to jam a full arrangement into the library (needs Magenta installed)"
+          aria-label="Jam with Magenta"
+          className={`${iconBtn} border-fuchsia-600 text-fuchsia-300 hover:bg-fuchsia-600/15`}
+        >
+          <Sparkles className="w-3.5 h-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={() => setFxOpen((v) => !v)}
+          title="FX chain: add any MIX effect to process all drawn audio, or open a Studio module"
+          aria-label="FX chain"
+          aria-expanded={fxOpen}
+          className={`${iconBtn} ${
+            fxOpen
+              ? 'border-purple-500 text-purple-200 bg-purple-600/25'
+              : 'border-purple-700 text-purple-300 hover:bg-purple-600/15'
+          }`}
+        >
+          <SlidersHorizontal className="w-3.5 h-3.5" />
+        </button>
+        <span className="text-[10px] font-mono text-zinc-500 truncate min-w-0 flex-1 text-right">
+          {status}
+        </span>
+      </div>
+
+      <div ref={containerRef} className="flex-1 min-h-0 relative bg-black">
+        <canvas
+          ref={canvasRef}
+          className="absolute inset-0 w-full h-full touch-none"
+          style={{ cursor: 'crosshair' }}
+          aria-label="Drawing canvas - draw to make music"
+        />
+
+        {fxOpen && (
+          <div className="absolute top-0 right-0 h-full w-90 max-w-[60%] bg-zinc-950/95 border-l border-white/10 flex flex-col z-10">
+            <div className="flex items-center justify-between px-2 py-1.5 border-b border-white/10 shrink-0">
+              <span className="text-[10px] font-black uppercase tracking-widest text-purple-200">
+                {studioModule ? studioModule.name : 'FX Chain'}
+              </span>
+              <div className="flex items-center gap-1">
+                {studioModule && (
+                  <button
+                    type="button"
+                    onClick={() => setStudioModule(null)}
+                    title="Back to the FX chain"
+                    aria-label="Back to FX chain"
+                    className="px-1.5 h-6 grid place-items-center rounded border border-white/10 text-zinc-300 hover:bg-white/10"
+                  >
+                    <ArrowLeft className="w-3.5 h-3.5" />
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setFxOpen(false)}
+                  title="Close the FX panel"
+                  aria-label="Close FX panel"
+                  className="px-1.5 h-6 grid place-items-center rounded border border-white/10 text-zinc-300 hover:bg-white/10"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            </div>
+
+            {studioModule ? (
+              <div className="flex-1 min-h-0 flex flex-col">
+                <span className="px-2 py-1 text-[9px] font-mono text-zinc-500 shrink-0">
+                  {recordingFile
+                    ? 'Processing your latest DRAW recording. Render inside the module, then save from there.'
+                    : 'No DRAW recording yet — record first, or use the module’s own Load Audio.'}
+                </span>
+                <div className="flex-1 min-h-0">
+                  <EffectGuiStage module={studioModule} sourceFile={recordingFile} />
+                </div>
+              </div>
+            ) : (
+              <div className="flex-1 min-h-0 overflow-y-auto p-2 flex flex-col gap-3">
+                {/* live palette: ALL + every MIX insert, each its own color */}
+                <div>
+                  <div className="text-[9px] font-black uppercase tracking-widest text-zinc-500 mb-1">
+                    Add live effect
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    <button
+                      type="button"
+                      onClick={addAllEffects}
+                      title="Add every live effect to the chain"
+                      className="px-2 h-6 grid place-items-center text-[9px] font-black uppercase tracking-wide rounded border border-white/30 text-white hover:bg-white/10"
+                    >
+                      All
+                    </button>
+                    {RACK_EFFECTS.map((d) => {
+                      const hue = EFFECT_HUE[d.id];
+                      return (
+                        <button
+                          key={d.id}
+                          type="button"
+                          onClick={() => addEffect(d.id)}
+                          title={d.description}
+                          className="px-2 h-6 grid place-items-center text-[9px] font-bold rounded border transition-colors hover:bg-white/5"
+                          style={{ borderColor: `hsl(${hue} 70% 45%)`, color: `hsl(${hue} 85% 70%)` }}
+                        >
+                          {d.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* the chain itself */}
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-[9px] font-black uppercase tracking-widest text-zinc-500">
+                      Chain ({chain.length})
+                    </span>
+                    {chain.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={clearChain}
+                        className="text-[9px] font-mono text-zinc-500 hover:text-red-400"
+                        title="Remove all effects from the chain"
+                      >
+                        clear
+                      </button>
+                    )}
+                  </div>
+                  {chain.length === 0 ? (
+                    <span className="text-[9px] font-mono text-zinc-600">
+                      No effects yet. Click one above to add it; all drawn audio runs through the chain in order.
+                    </span>
+                  ) : (
+                    <FxRack
+                      chain={chain}
+                      idPrefix="draw-fx"
+                      hideAdd
+                      onAdd={addEffect}
+                      onRemove={removeEffect}
+                      onReorder={reorder}
+                      onToggle={toggleEnabled}
+                      onUpdateParams={onChainParams}
+                    />
+                  )}
+                </div>
+
+                {/* studio modules (offline, open their GUI on a recording) */}
+                <div>
+                  <div className="text-[9px] font-black uppercase tracking-widest text-zinc-500 mb-1">
+                    Studio module (offline)
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {STUDIO_MODULES.map((m) => (
+                      <button
+                        key={m.id}
+                        type="button"
+                        onClick={() => setStudioModule(m)}
+                        title={`${m.desc} - opens the module GUI to process your DRAW recording`}
+                        className="px-2 h-6 grid place-items-center text-[9px] font-bold rounded border transition-colors hover:bg-white/5"
+                        style={{ borderColor: m.color, color: m.color }}
+                      >
+                        {m.name}
+                      </button>
+                    ))}
+                  </div>
+                  <span className="block mt-1 text-[8px] font-mono text-zinc-600">
+                    Studio modules process a recording offline; they are not part of the live realtime chain.
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/layout/MidiPanel.tsx
+++ b/frontend/src/components/layout/MidiPanel.tsx
@@ -1,0 +1,529 @@
+/**
+ * MidiPanel - the unified MIDI tab (merged Piano + Vocal).
+ *
+ * The shared Piano Roll is the surface; everything else feeds or operates on it.
+ * Vocal is one INPUT option: a live mic recording is converted to notes through
+ * the SAME backend basic-pitch path as "Analyze" (far better than the live YIN),
+ * and dropped into the roll without shrinking the grid (the take is highlighted).
+ * A mic monitor runs while the tab is open so the input level is always visible.
+ * When a vocal artifact is loaded, a right rail shows lyrics + segments (each arms
+ * an inpaint guide). Notes export to .mid, drive a drum Beat, or round-trip
+ * validate. No synthesis here.
+ */
+
+import { Activity, Download, Drum, FileCheck2, Loader2, Mic, Square } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { RenderNote } from '../../lib/midiSynth';
+import { colorAt, rgb, rgba } from '../../lib/trackColor';
+import { renderDrumBeatBlob, vocalizeEffect } from '../../lib/vocalBeat';
+import {
+  armInpaintGuide,
+  downloadVocalMidi,
+  fetchVocalArtifact,
+  type ArtifactNote,
+  type VocalArtifactDoc,
+} from '../../lib/vocalExport';
+import {
+  listAudioInputs,
+  queryMicPermission,
+  startInputMonitor,
+  type InputMonitor,
+} from '../../lib/vocalToMidi';
+import { useLibraryStore } from '../../state/libraryStore';
+import { logInfo, logWarn } from '../../state/logStore';
+import { usePianoRollStore, type PianoNote } from '../../state/pianoRollStore';
+import { PianoRoll } from '../audio/PianoRoll';
+
+const stepSec = (bpm: number): number => 60 / bpm / 4;
+
+const artifactToPiano = (notes: ArtifactNote[], bpm: number): PianoNote[] => {
+  const ss = stepSec(bpm);
+  return notes.map((n, i) => ({
+    id: `art-${i}-${n.start_ms}`,
+    note: n.pitch,
+    step: Math.max(0, Math.round(n.start_ms / 1000 / ss)),
+    length: Math.max(1, Math.round((n.end_ms - n.start_ms) / 1000 / ss)),
+    velocity: n.velocity,
+  }));
+};
+
+const pianoToArtifact = (notes: PianoNote[], bpm: number): ArtifactNote[] => {
+  const ss = stepSec(bpm);
+  return notes.map((n) => ({
+    start_ms: Math.round(n.step * ss * 1000),
+    end_ms: Math.round((n.step + n.length) * ss * 1000),
+    pitch: n.note,
+    velocity: n.velocity,
+  }));
+};
+
+const pianoToRender = (notes: PianoNote[], bpm: number): RenderNote[] => {
+  const ss = stepSec(bpm);
+  return notes.map((n) => ({
+    midi: n.note,
+    startSec: n.step * ss,
+    durationSec: Math.max(0.05, n.length * ss),
+    velocity: n.velocity,
+  }));
+};
+
+/**
+ * Self-contained input-level meter using the SLIDE temperature scale (colorAt).
+ * Runs its own rAF so the 60fps level updates never re-render the parent panel
+ * (which embeds the Piano Roll).
+ */
+const MicMeter: React.FC<{ monitorRef: React.MutableRefObject<InputMonitor | null> }> = ({
+  monitorRef,
+}) => {
+  const [level, setLevel] = useState(0);
+  useEffect(() => {
+    let raf = 0;
+    const loop = () => {
+      setLevel(monitorRef.current?.getLevel() ?? 0);
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [monitorRef]);
+  const col = colorAt(level);
+  return (
+    <div
+      role="meter"
+      aria-label="Microphone input level"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(level * 100)}
+      title={`mic level ${Math.round(level * 100)}%`}
+      className="w-24 h-2.5 shrink-0 rounded-full overflow-hidden border border-white/10 bg-black/50"
+    >
+      <div
+        className="h-full rounded-full"
+        style={{
+          width: `${Math.max(level * 100, 2)}%`,
+          background: rgb(col),
+          boxShadow: `0 0 8px ${rgba(col, 0.7)}`,
+        }}
+      />
+    </div>
+  );
+};
+
+export const MidiPanel: React.FC = () => {
+  const selectedEntryId = useLibraryStore((s) => s.selectedEntryId);
+  const [assetId, setAssetId] = useState('');
+  const [recording, setRecording] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState('idle');
+  const [artifact, setArtifact] = useState<VocalArtifactDoc | null>(null);
+  const [validateMsg, setValidateMsg] = useState('');
+  const [inputs, setInputs] = useState<MediaDeviceInfo[]>([]);
+  const [deviceId, setDeviceId] = useState<string>(
+    () => localStorage.getItem('vocal.inputDeviceId') ?? '',
+  );
+  const [micPerm, setMicPerm] = useState<string>('unknown');
+  const monitorRef = useRef<InputMonitor | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const recordStartRef = useRef(0);
+
+  // Default the asset field to the selected library item (override freely).
+  useEffect(() => {
+    if (selectedEntryId && !assetId) setAssetId(selectedEntryId);
+  }, [selectedEntryId, assetId]);
+
+  const refreshInputs = useCallback(async () => {
+    setMicPerm(await queryMicPermission());
+    setInputs(await listAudioInputs());
+  }, []);
+
+  const pickDevice = useCallback((id: string) => {
+    setDeviceId(id);
+    if (id) localStorage.setItem('vocal.inputDeviceId', id);
+    else localStorage.removeItem('vocal.inputDeviceId');
+  }, []);
+
+  // Always-on input monitor while the tab is open: opens the mic + an analyser so
+  // the level is visible even when not recording. Re-opens when the device
+  // changes; releases the mic when the tab unmounts.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const monitor = await startInputMonitor(deviceId || undefined);
+        if (cancelled) {
+          monitor.stop();
+          return;
+        }
+        monitorRef.current = monitor;
+        void refreshInputs();
+      } catch (e) {
+        if (!cancelled) {
+          setMicPerm(await queryMicPermission());
+          logWarn('vocal', `mic monitor unavailable: ${String(e)}`);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      try {
+        recorderRef.current?.stop();
+      } catch {
+        /* not recording */
+      }
+      recorderRef.current = null;
+      monitorRef.current?.stop();
+      monitorRef.current = null;
+    };
+  }, [deviceId, refreshInputs]);
+
+  const loadArtifact = useCallback(async (id: string) => {
+    const doc = await fetchVocalArtifact(id);
+    if (!doc) {
+      setStatus('no artifact for asset (analyze it first)');
+      return;
+    }
+    setArtifact(doc);
+    const bpm = doc.timing?.tempo_bpm || usePianoRollStore.getState().bpm;
+    usePianoRollStore.getState().importNotes(artifactToPiano(doc.notes, bpm), bpm);
+    setStatus(`loaded ${doc.notes.length} notes`);
+  }, []);
+
+  // Record the mic, then convert through the backend basic-pitch path and place
+  // the take in the roll WITHOUT shrinking the grid (it stays >= 256 steps).
+  const toggleRecord = useCallback(() => {
+    if (recording) {
+      recorderRef.current?.stop(); // onstop does the conversion
+      return;
+    }
+    const monitor = monitorRef.current;
+    if (!monitor) {
+      setStatus('no mic - check permission / input device');
+      return;
+    }
+    try {
+      const rec = new MediaRecorder(monitor.stream);
+      const chunks: Blob[] = [];
+      rec.ondataavailable = (e) => {
+        if (e.data.size) chunks.push(e.data);
+      };
+      rec.onstop = async () => {
+        setRecording(false);
+        const elapsedSec = (performance.now() - recordStartRef.current) / 1000;
+        const blob = new Blob(chunks, { type: rec.mimeType || 'audio/webm' });
+        logInfo(
+          'vocal',
+          `recording stopped - ${(blob.size / 1024).toFixed(0)}KB, converting via basic-pitch`,
+        );
+        setBusy(true);
+        setStatus('converting recording to notes...');
+        try {
+          const fd = new FormData();
+          fd.append('file', blob, 'recording.webm');
+          const res = await fetch('/api/vocal/audio-to-notes', { method: 'POST', body: fd });
+          const data = await res.json();
+          const notes: ArtifactNote[] = data.notes ?? [];
+          const bpm = usePianoRollStore.getState().bpm;
+          const piano = artifactToPiano(notes, bpm);
+          const endStep = Math.max(1, Math.ceil(elapsedSec / stepSec(bpm)));
+          usePianoRollStore.getState().placeRecording(piano, { startStep: 0, endStep });
+          setStatus(`recorded ${piano.length} notes (${elapsedSec.toFixed(1)}s)`);
+          logInfo('vocal', `recording -> ${piano.length} notes via basic-pitch`);
+        } catch (e) {
+          setStatus(`convert error: ${String(e)}`);
+          logWarn('vocal', `audio-to-notes failed: ${String(e)}`);
+        } finally {
+          setBusy(false);
+          recorderRef.current = null;
+        }
+      };
+      recorderRef.current = rec;
+      recordStartRef.current = performance.now();
+      rec.start();
+      setRecording(true);
+      setStatus('recording - sing, then stop');
+      const track = monitor.stream.getAudioTracks()[0];
+      const st = track?.getSettings?.() ?? {};
+      logInfo(
+        'vocal',
+        `recording from "${track?.label || 'default'}" ${st.sampleRate ?? '?'}Hz muted=${track?.muted}`,
+      );
+      window.setTimeout(() => {
+        if (recorderRef.current && (monitorRef.current?.getLevel() ?? 0) < 0.02) {
+          logWarn('vocal', 'no mic signal during recording (level ~0%) - wrong input or muted');
+        }
+      }, 1500);
+    } catch (e) {
+      setStatus(`record error: ${String(e)}`);
+      logWarn('vocal', `record error: ${String(e)}`);
+    }
+  }, [recording]);
+
+  const analyze = useCallback(async () => {
+    if (!assetId) {
+      setStatus('enter or select an asset id');
+      return;
+    }
+    setBusy(true);
+    setStatus('analyzing vocal...');
+    try {
+      const res = await fetch('/api/vocal/prepare', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ asset_id: assetId, transcribe: true }),
+      });
+      if (!res.ok) {
+        const detail = await res.text();
+        throw new Error(`prepare ${res.status}: ${detail.slice(0, 200)}`);
+      }
+      const { job } = await res.json();
+      for (;;) {
+        await new Promise((r) => setTimeout(r, 1000));
+        const jr = await fetch(`/api/vocal/jobs/${job.id}`);
+        const jd = await jr.json();
+        setStatus(jd.message || jd.status);
+        if (jd.status === 'done') {
+          await loadArtifact(assetId);
+          break;
+        }
+        if (jd.status === 'failed' || jd.status === 'cancelled') {
+          setStatus(`analyze ${jd.status}: ${jd.error ?? ''}`);
+          break;
+        }
+      }
+    } catch (e) {
+      setStatus(`analyze error: ${String(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [assetId, loadArtifact]);
+
+  const exportMidi = useCallback(() => {
+    const { notes, bpm } = usePianoRollStore.getState();
+    if (!notes.length) {
+      setStatus('no notes to export');
+      return;
+    }
+    // downloadVocalMidi wraps the canonical RenderNote->SMF writer. Export exactly
+    // what is in the roll (post-edit), not the stale artifact.
+    downloadVocalMidi(pianoToArtifact(notes, bpm), 'midi');
+    setStatus(`exported ${notes.length} notes to .mid`);
+  }, []);
+
+  const validate = useCallback(async () => {
+    if (!assetId) return;
+    const r = await fetch(`/api/vocal/validate/${assetId}`);
+    const d = await r.json();
+    setValidateMsg(
+      d.ok
+        ? `round-trip ${d.count_in} to ${d.count_out}, drift ${d.max_drift_ms}ms`
+        : `validate: ${d.error}`,
+    );
+  }, [assetId]);
+
+  const makeBeat = useCallback(async () => {
+    const { notes, bpm } = usePianoRollStore.getState();
+    if (!notes.length) {
+      setStatus('no notes for a beat');
+      return;
+    }
+    const render = pianoToRender(notes, bpm);
+    setStatus('rendering beat...');
+    try {
+      const { blob } = await renderDrumBeatBlob(render);
+      const span = Math.max(...render.map((r) => r.startSec)) + 0.5;
+      const fx = vocalizeEffect(render, span);
+      const url = URL.createObjectURL(blob);
+      void new Audio(url).play().catch(() => {});
+      setTimeout(() => URL.revokeObjectURL(url), 20000);
+      setStatus(`beat playing - fx idea: ${fx.effectId} (${fx.reason})`);
+    } catch (e) {
+      setStatus(`beat error: ${String(e)}`);
+    }
+  }, []);
+
+  const inpaintSegment = useCallback(
+    async (i: number) => {
+      if (!artifact) return;
+      const ok = await armInpaintGuide(artifact, i);
+      setStatus(
+        ok
+          ? 'inpaint guide armed - open MAKE and Generate to re-sing the segment'
+          : 'segment has no mask window (starts at 0)',
+      );
+    },
+    [artifact],
+  );
+
+  const btn =
+    'flex items-center gap-1 px-2 py-1 text-[10px] font-mono uppercase tracking-wide rounded border transition-colors disabled:opacity-40';
+
+  return (
+    <div className="h-full w-full flex flex-col bg-zinc-950 text-zinc-200">
+      {/* tools toolbar — vocal recording is the input; the rest operate on the roll */}
+      <div className="shrink-0 flex flex-wrap items-center gap-2 px-2 py-1.5 border-b border-white/8">
+        {/* Vocal input */}
+        <label htmlFor="midi-input-device" className="sr-only">
+          Microphone input
+        </label>
+        <select
+          id="midi-input-device"
+          name="midi-input-device"
+          value={deviceId}
+          onChange={(e) => pickDevice(e.target.value)}
+          aria-label="Microphone input"
+          title="Microphone input device used for recording and the level meter"
+          className="max-w-40 bg-zinc-800 border border-zinc-500 text-zinc-100 text-[10px] font-mono px-1 py-1 rounded"
+        >
+          <option value="">System default input</option>
+          {inputs.map((d) => (
+            <option key={d.deviceId} value={d.deviceId}>
+              {d.label || `Mic ${d.deviceId.slice(0, 6)}`}
+            </option>
+          ))}
+        </select>
+        {micPerm === 'denied' && (
+          <span className="text-[9px] font-mono text-rose-400">mic blocked</span>
+        )}
+        <button
+          type="button"
+          onClick={toggleRecord}
+          disabled={busy || micPerm === 'denied'}
+          aria-label={recording ? 'Stop recording' : 'Record vocal to notes'}
+          title={recording ? 'Stop recording' : 'Record (mic -> notes via basic-pitch)'}
+          className={`grid place-items-center w-7 h-7 rounded border transition-colors disabled:opacity-40 ${
+            recording
+              ? 'border-rose-500 text-rose-300 bg-rose-600/25'
+              : 'border-rose-600 text-rose-300 hover:bg-rose-600/15'
+          }`}
+        >
+          {recording ? <Square className="w-3.5 h-3.5" /> : <Mic className="w-3.5 h-3.5" />}
+        </button>
+        <MicMeter monitorRef={monitorRef} />
+
+        <span className="w-px h-4 bg-white/10" aria-hidden="true" />
+
+        {/* Analyze a library vocal into the roll */}
+        <label htmlFor="midi-asset-id" className="sr-only">
+          Library asset id
+        </label>
+        <input
+          id="midi-asset-id"
+          name="midi-asset-id"
+          type="text"
+          value={assetId}
+          onChange={(e) => setAssetId(e.target.value.trim())}
+          placeholder="asset id"
+          aria-label="Library asset id"
+          title="Library item id to analyze or load (defaults to the selected library item)"
+          className="w-36 bg-zinc-800 border border-zinc-500 text-zinc-100 text-[10px] font-mono px-1.5 py-1 rounded"
+        />
+        <button
+          type="button"
+          onClick={analyze}
+          disabled={busy}
+          title="Detect notes, pitch and lyrics from the library vocal (basic-pitch) and load them into the roll"
+          className={`${btn} border-emerald-600 text-emerald-300 hover:bg-emerald-600/15`}
+        >
+          {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Activity className="w-3 h-3" />}
+          Analyze
+        </button>
+        <button
+          type="button"
+          onClick={() => assetId && loadArtifact(assetId)}
+          disabled={busy || !assetId}
+          title="Load an already-analyzed artifact's notes + lyrics into the roll without re-detecting"
+          className={`${btn} border-zinc-500 text-zinc-200 hover:bg-white/10`}
+        >
+          Load
+        </button>
+
+        <span className="w-px h-4 bg-white/10" aria-hidden="true" />
+
+        {/* Roll tools */}
+        <button
+          type="button"
+          onClick={exportMidi}
+          title="Download the current roll as a Standard MIDI (.mid) file"
+          className={`${btn} border-zinc-500 text-zinc-200 hover:bg-white/10`}
+        >
+          <Download className="w-3 h-3" />
+          .mid
+        </button>
+        <button
+          type="button"
+          onClick={makeBeat}
+          title="Render a General MIDI drum beat from the notes (low/mid/high -> kick/snare/hat) and play it"
+          className={`${btn} border-amber-600 text-amber-300 hover:bg-amber-600/15`}
+        >
+          <Drum className="w-3 h-3" />
+          Beat
+        </button>
+        <button
+          type="button"
+          onClick={validate}
+          disabled={!assetId}
+          title="Check the notes survive a notes -> MIDI -> notes round-trip and report any timing drift"
+          className={`${btn} border-zinc-500 text-zinc-200 hover:bg-white/10`}
+        >
+          <FileCheck2 className="w-3 h-3" />
+          Validate
+        </button>
+        <span className="text-[10px] font-mono text-zinc-500 truncate min-w-0 flex-1 text-right">
+          {status}
+        </span>
+      </div>
+
+      {/* body: piano roll, plus a vocal rail only when an artifact is loaded */}
+      <div className="flex-1 min-h-0 flex">
+        <div className="flex-1 min-w-0 relative">
+          <PianoRoll />
+        </div>
+
+        {artifact && (
+          <div className="w-64 shrink-0 border-l border-white/8 overflow-y-auto p-2 space-y-3">
+            <section>
+              <h3 className="text-[8px] font-mono uppercase tracking-widest text-zinc-500 mb-1">
+                Lyrics
+              </h3>
+              <p className="text-[10px] text-zinc-300 whitespace-pre-wrap wrap-break-word">
+                {artifact.lyrics?.text || (
+                  <span className="text-zinc-600">none (analyze with transcription)</span>
+                )}
+              </p>
+            </section>
+
+            <section>
+              <h3 className="text-[8px] font-mono uppercase tracking-widest text-zinc-500 mb-1">
+                Segments
+              </h3>
+              {artifact.segments?.length ? (
+                <ul className="space-y-1">
+                  {artifact.segments.map((s, i) => (
+                    <li key={s.id} className="flex items-center gap-1.5">
+                      <span className="flex-1 min-w-0 truncate text-[10px] font-mono text-zinc-400">
+                        {(s.start_ms / 1000).toFixed(2)}-{(s.end_ms / 1000).toFixed(2)}s {s.kind}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => inpaintSegment(i)}
+                        className="text-[8px] font-mono uppercase px-1 py-0.5 rounded border border-fuchsia-600 text-fuchsia-300 hover:bg-fuchsia-600/15"
+                      >
+                        Inpaint
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-[10px] text-zinc-600">none</p>
+              )}
+            </section>
+
+            {validateMsg && (
+              <p className="text-[9px] font-mono text-zinc-400 wrap-break-word">{validateMsg}</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/lib/drawEngine.ts
+++ b/frontend/src/lib/drawEngine.ts
@@ -1,0 +1,1206 @@
+/**
+ * drawEngine.ts - generative draw-to-music engine, ported from the standalone
+ * "art2music" (paper.js + Tone.js) into the app's shared Web Audio graph so the
+ * output can be recorded into the library / EDIT.
+ *
+ * Two orthogonal axes shape what you draw:
+ *
+ *  - BRUSH = the character of a stroke: its visual growth model, its sonic
+ *    articulation, and how it samples grains. Four brushes:
+ *      organic   - L-system vines; a swelling drone that branches.
+ *      fibonacci - phyllotaxis spiral of dots; notes step by Fibonacci intervals,
+ *                  pulsed amplitude, grains taken at golden-ratio buffer offsets.
+ *      neural    - a wireframe node/edge graph with travelling pulses; a rigid,
+ *                  gated, glitchy voice and tiny stuttered grains.
+ *      nebulous  - a soft drifting particle cloud; a smooth pad that twinkles, with
+ *                  long overlapping grains.
+ *
+ *  - MODE = the post effect every voice is routed through. A wide, deliberately
+ *    distinct palette (compressor / tremolo / distortion / echo / reverb /
+ *    bitcrush / ring-mod / stereo widen / exciter / HRTF orbit / formant / lowpass),
+ *    several ported from the MIX rack so they don't all sound alike.
+ *
+ * Sound sources: a filtered-noise DRONE, held notes on the shared SpessaSynth GM
+ * engine (SOUNDFONT), or grains sampled from a library song (GRANULAR). The whole
+ * master is soft-clipped and tapped into a MediaStreamDestination; DrawPanel
+ * records that with a MediaRecorder. Each drawn note is also logged into a melody
+ * buffer so the session can be handed to Magenta to jam over.
+ */
+
+import { getEngineCtx, getMasterGain } from '../state/playerStore';
+import { pollMagentaJob } from '../state/instrumentStore';
+import {
+  buildEffectChain, ensureChopModule, getRackEffect, rackEffectDefaults, RACK_EFFECTS,
+  type ChainHandle, type RackEffectInstance,
+} from './rackEffects';
+import type { ChainEntry } from '../state/effectChainStore';
+import { ensureSoundfontReady, liveNoteOff, liveNoteOn } from './soundfontEngine';
+
+// ── musical constants (from art2music) ────────────────────────────────────────
+const SCALE = ['B3', 'Db4', 'Eb4', 'F4', 'G4', 'A4', 'B4', 'Db5', 'Eb5', 'F5', 'G5', 'A5', 'B5', 'Db6'];
+const INTERVALS = [1, 2, 3, 6];
+const FIB = [1, 1, 2, 3, 5, 8, 13];
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5)); // ~2.39996 rad (137.5 deg)
+const GOLDEN_FRAC = 0.6180339887498949;
+const SPAWN_RATE: [number, number] = [10, 30];
+const MAX_GROWTH_TIME = 10;
+/** Cap concurrent drawn paths so render + audio cost stays bounded under heavy
+ *  drawing; the oldest path is retired when the cap is exceeded. */
+const MAX_PATHS = 18;
+/** Release time-constant for the smooth voice fade-out (seconds). */
+const VOICE_RELEASE = 0.4;
+
+const SEMI: Record<string, number> = {
+  C: 0, 'C#': 1, Db: 1, D: 2, 'D#': 3, Eb: 3, E: 4, F: 5, 'F#': 6,
+  Gb: 6, G: 7, 'G#': 8, Ab: 8, A: 9, 'A#': 10, Bb: 10, B: 11,
+};
+const noteToMidi = (n: string): number => {
+  const m = n.match(/^([A-G][#b]?)(-?\d+)$/);
+  if (!m) return 60;
+  return (parseInt(m[2], 10) + 1) * 12 + (SEMI[m[1]] ?? 0);
+};
+const midiToFreq = (m: number): number => 440 * 2 ** ((m - 69) / 12);
+
+// ── tiny vec + rng helpers ────────────────────────────────────────────────────
+interface Pt { x: number; y: number }
+const dist = (a: Pt, b: Pt): number => Math.hypot(a.x - b.x, a.y - b.y);
+const rand = ([min, max]: [number, number]): number => min + Math.random() * (max - min);
+const randItem = <T>(a: T[]): T => a[Math.floor(Math.random() * a.length)];
+const scale01 = (v: number, [lo, hi]: [number, number]): number => lo + (hi - lo) * v;
+const clampN = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, v));
+const easeOutQuart = (t: number): number => 1 - --t * t * t * t;
+
+// ── waveshaper curves ─────────────────────────────────────────────────────────
+const driveCurve = (k: number): Float32Array => {
+  const n = 1024;
+  const c = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    const x = (i / n) * 2 - 1;
+    c[i] = ((1 + k) * x) / (1 + k * Math.abs(x));
+  }
+  return c;
+};
+const bitCurve = (bits: number): Float32Array => {
+  const n = 2048;
+  const c = new Float32Array(n);
+  const levels = Math.pow(2, clampN(bits, 1, 16));
+  const half = levels / 2;
+  for (let i = 0; i < n; i++) {
+    const x = (i / (n - 1)) * 2 - 1;
+    c[i] = Math.round(x * half) / half;
+  }
+  return c;
+};
+const softClipCurve = (drive: number): Float32Array => {
+  const n = 1024;
+  const c = new Float32Array(n);
+  const d = Math.tanh(drive);
+  for (let i = 0; i < n; i++) {
+    const x = (i / n) * 2 - 1;
+    c[i] = Math.tanh(x * drive) / d;
+  }
+  return c;
+};
+
+// ── L-system types (organic brush) ────────────────────────────────────────────
+interface LItem { symbol: string; params?: (p: any, age: number) => any }
+interface LChar { symbol: string; birthTime: number; age: number; terminalAge: number; params?: any }
+interface Production { terminalAge: [number, number]; successors: { p: number; items: LItem[] }[] }
+interface LSystem { axiom: { symbol: string; terminalAge: number; params?: any }[]; productions: Record<string, Production> }
+
+/** Organic synthesis + growth tuning. maxLineLength is deliberately small so the
+ *  drone reaches full level quickly (the old 10000 kept it near-silent). */
+const ORG = {
+  lengthRange: [10, 25] as [number, number],
+  angleRange: [20, 25] as [number, number],
+  growthFactor: 5,
+};
+
+const orgF = (): LItem => ({ symbol: 'F', params: () => ({ l: rand(ORG.lengthRange), lInit: 0 }) });
+const orgTurn = (sign: '+' | '-'): LItem => ({ symbol: sign, params: () => ({ a: rand(ORG.angleRange) }) });
+const grow: LItem = {
+  symbol: 'F',
+  params: ({ l, ageAcc }: any, prev: number) => ({ l, lInit: 1, ageAcc: prev + (ageAcc || 0) }),
+};
+
+const buildOrganicSystem = (): LSystem => {
+  const tA: [number, number] = [MAX_GROWTH_TIME / 3, MAX_GROWTH_TIME / 2];
+  const F = orgF;
+  const T = orgTurn;
+  return {
+    axiom: [{ symbol: 'X', terminalAge: 0 }],
+    productions: {
+      X: {
+        terminalAge: tA,
+        successors: [
+          { p: 0.34, items: [F(), T('-'), { symbol: '[' }, { symbol: '[' }, { symbol: 'X' }, { symbol: ']' }, T('+'), { symbol: 'X' }, { symbol: ']' }, T('+'), F(), { symbol: '[' }, T('+'), F(), { symbol: 'X' }, { symbol: ']' }, T('-'), { symbol: 'X' }] },
+          { p: 0.33, items: [F(), T('+'), { symbol: '[' }, { symbol: '[' }, { symbol: 'X' }, { symbol: ']' }, T('+'), { symbol: 'X' }, { symbol: ']' }, T('+'), F(), F(), { symbol: '[' }, T('-'), F(), { symbol: 'X' }, { symbol: ']' }] },
+          { p: 0.33, items: [F(), T('-'), { symbol: '[' }, { symbol: '[' }, { symbol: 'X' }, { symbol: ']' }, T('-'), { symbol: 'X' }, { symbol: ']' }, T('-'), F(), { symbol: '[' }, T('+'), F(), { symbol: 'X' }, { symbol: ']' }, T('+'), { symbol: '[' }, F(), { symbol: 'X' }, { symbol: ']' }] },
+        ],
+      },
+      F: { terminalAge: tA, successors: [{ p: 0.5, items: [grow, orgF()] }, { p: 0.5, items: [grow] }] },
+    },
+  };
+};
+const ORGANIC_SYSTEM = buildOrganicSystem();
+
+// ── effects (MODE axis) ───────────────────────────────────────────────────────
+export type DrawEffect =
+  | 'clean' | 'tremolo' | 'distortion' | 'echo' | 'reverb' | 'bitcrush'
+  | 'ringmod' | 'widen' | 'exciter' | 'orbit' | 'formant' | 'lowpass';
+
+/** Mode buttons, in order. `hue` tints the button; `effect` is the routed node;
+ *  `desc` is the hover tooltip. Order matches the constructor's effect graph. */
+export const DRAW_MODE_META: { label: string; hue: number; effect: DrawEffect; desc: string }[] = [
+  { label: 'Clean', hue: 200, effect: 'clean', desc: 'No colour: a gentle compressor that keeps the level even' },
+  { label: 'Tremolo', hue: 280, effect: 'tremolo', desc: 'Amplitude wobbles up and down at a steady rate' },
+  { label: 'Distort', hue: 350, effect: 'distortion', desc: 'Overdriven, gritty waveshaping' },
+  { label: 'Echo', hue: 170, effect: 'echo', desc: 'Discrete feedback repeats trailing each stroke' },
+  { label: 'Reverb', hue: 240, effect: 'reverb', desc: 'A long smooth tail, like a big room' },
+  { label: 'Crush', hue: 30, effect: 'bitcrush', desc: 'Lo-fi bit-depth reduction for digital crunch' },
+  { label: 'Ring', hue: 310, effect: 'ringmod', desc: 'Metallic, clangorous ring-modulation sidebands' },
+  { label: 'Widen', hue: 90, effect: 'widen', desc: 'True mid/side stereo widening with a mono-safe low end' },
+  { label: 'Air', hue: 55, effect: 'exciter', desc: 'Adds high harmonic air and presence' },
+  { label: 'Orbit', hue: 210, effect: 'orbit', desc: 'Spins the sound around your head in 3D (HRTF)' },
+  { label: 'Vowel', hue: 15, effect: 'formant', desc: 'Vowel-like formant filtering, a talk-box colour' },
+  { label: 'Lowpass', hue: 35, effect: 'lowpass', desc: 'Warms everything down by rolling off the highs' },
+];
+
+/** The default per-stroke mode slots: 8 slots, the first 8 built-in effects. Each
+ *  slot is user-reassignable to any effect value (see DrawEngine.setModeSlots). */
+export const DEFAULT_MODE_SLOTS: string[] = DRAW_MODE_META.slice(0, 8).map((m) => m.effect);
+
+/** Every effect a mode slot can be assigned to: the built-in draw effects plus
+ *  the live psychoacoustic inserts (prefixed `rack:`). All run in real time per
+ *  stroke. (Studio modules and the backend MIX effects are offline, so they are
+ *  not live mode options — they live in the FX panel's Studio section instead.) */
+export interface DrawEffectOption { value: string; label: string; group: string; hue: number; desc: string }
+export const DRAW_EFFECT_OPTIONS: DrawEffectOption[] = [
+  ...DRAW_MODE_META.map((m) => ({ value: m.effect, label: m.label, group: 'Draw', hue: m.hue, desc: m.desc })),
+  ...RACK_EFFECTS.map((d, i) => ({
+    value: `rack:${d.id}`, label: d.label, group: 'Psychoacoustic',
+    hue: Math.round((i * 360) / RACK_EFFECTS.length), desc: d.description,
+  })),
+];
+const EFFECT_META_BY_VALUE = new Map(DRAW_EFFECT_OPTIONS.map((o) => [o.value, o]));
+/** Label / hue / desc for a mode slot value (built-in or `rack:` insert). */
+export const drawEffectMeta = (value: string): DrawEffectOption | undefined => EFFECT_META_BY_VALUE.get(value);
+
+// ── brushes (BRUSH axis) ──────────────────────────────────────────────────────
+export type BrushId = 'organic' | 'fibonacci' | 'neural' | 'nebulous';
+type BrushVisual = 'lsystem' | 'phyllotaxis' | 'graph' | 'cloud';
+type BrushVoice = 'swell' | 'pulse' | 'gate' | 'twinkle';
+type NoteStep = 'scale' | 'fib';
+
+/** How a brush carves grains out of the granular source buffer. */
+export interface GrainProfile {
+  durRange: [number, number];
+  density: number;      // grains spawned per audio tick at full energy
+  rateSteps: number[];  // playbackRate choices (pitch / time-stretch)
+  attack: number;       // fraction of the grain spent fading in
+  spread: number;       // stereo spread 0..1
+  peak: number;         // per-grain peak gain
+  golden?: boolean;     // sample offsets at golden-ratio positions in the buffer
+}
+
+export interface BrushDef {
+  id: BrushId;
+  label: string;
+  hue: number;
+  desc: string;
+  visual: BrushVisual;
+  voice: BrushVoice;
+  noteStep: NoteStep;
+  filterQ: number;
+  gainRange: [number, number];
+  maxEnergy: number;    // raw measure that maps to full level
+  tau: number;          // gain smoothing time-constant
+  grain: GrainProfile;
+}
+
+export const BRUSHES: BrushDef[] = [
+  {
+    id: 'organic', label: 'Organic', hue: 135,
+    desc: 'Vine-like L-system growth; a swelling drone that branches as it spreads',
+    visual: 'lsystem', voice: 'swell', noteStep: 'scale',
+    filterQ: 1600, gainRange: [0.5, 4.6], maxEnergy: 2600, tau: 0.03,
+    grain: { durRange: [0.12, 0.26], density: 1, rateSteps: [1], attack: 0.3, spread: 0.85, peak: 0.6 },
+  },
+  {
+    id: 'fibonacci', label: 'Fibonacci', hue: 45,
+    desc: 'Sunflower phyllotaxis spirals; notes step by Fibonacci intervals with a pulsing amplitude',
+    visual: 'phyllotaxis', voice: 'pulse', noteStep: 'fib',
+    filterQ: 1200, gainRange: [0.4, 4.0], maxEnergy: 230, tau: 0.05,
+    grain: { durRange: [0.07, 0.3], density: 2, rateSteps: [1, 1.5, 1.6667, 2], attack: 0.25, spread: 0.9, peak: 0.45, golden: true },
+  },
+  {
+    id: 'neural', label: 'Neural', hue: 190,
+    desc: 'A wireframe node-and-edge net with travelling pulses; rigid, gated, glitchy sound',
+    visual: 'graph', voice: 'gate', noteStep: 'scale',
+    filterQ: 900, gainRange: [0.35, 3.6], maxEnergy: 52, tau: 0.02,
+    grain: { durRange: [0.03, 0.08], density: 4, rateSteps: [0.5, 1, 2, 4], attack: 0.04, spread: 0.6, peak: 0.5 },
+  },
+  {
+    id: 'nebulous', label: 'Nebulous', hue: 290,
+    desc: 'Soft drifting nebula clouds; a smooth pad that twinkles, with long overlapping grains',
+    visual: 'cloud', voice: 'twinkle', noteStep: 'scale',
+    filterQ: 700, gainRange: [0.6, 3.4], maxEnergy: 26, tau: 0.4,
+    grain: { durRange: [0.5, 1.1], density: 3, rateSteps: [0.5, 0.75, 1], attack: 0.5, spread: 1, peak: 0.3 },
+  },
+];
+
+const findProduction = (productions: Record<string, Production>, symbol: string) => {
+  const prod = productions[symbol];
+  if (!prod) return null;
+  let total = 0;
+  const rnd = Math.random();
+  for (const s of prod.successors) {
+    total += s.p;
+    if (rnd <= total) return { terminalAge: prod.terminalAge, items: s.items };
+  }
+  return null;
+};
+
+const lExpand = (ls: LSystem, str: LChar[], elapsed: number): void => {
+  for (let i = str.length - 1; i >= 0; i--) {
+    const chr = str[i];
+    chr.age = elapsed - chr.birthTime;
+    if (chr.age >= chr.terminalAge) {
+      const prod = findProduction(ls.productions, chr.symbol);
+      if (prod) {
+        const childBirth = chr.birthTime + chr.terminalAge;
+        const next: LChar[] = prod.items.map((it) => ({
+          symbol: it.symbol,
+          birthTime: childBirth,
+          age: elapsed - childBirth,
+          terminalAge: rand(prod.terminalAge),
+          params: it.params && it.params(chr.params, chr.age),
+        }));
+        str.splice(i, 1, ...next);
+      }
+    }
+  }
+};
+
+const turtle = (str: LChar[], origin: Pt, rotate: number, onF: (chr: LChar, from: Pt, to: Pt) => void): void => {
+  let loc = { ...origin };
+  let angle = rotate;
+  const stack: { loc: Pt; angle: number }[] = [];
+  for (const chr of str) {
+    switch (chr.symbol) {
+      case 'F': {
+        const { l, lInit } = chr.params;
+        const ageCoef = Math.min(lInit + chr.age / chr.terminalAge, 1);
+        const len = l * ageCoef;
+        const to = { x: loc.x + len * Math.cos((angle / 180) * Math.PI), y: loc.y + len * Math.sin((angle / 180) * Math.PI) };
+        onF(chr, loc, to);
+        loc = to;
+        break;
+      }
+      case '-': angle -= chr.params.a; break;
+      case '+': angle += chr.params.a; break;
+      case '[': stack.push({ loc: { ...loc }, angle }); break;
+      case ']': { const s = stack.pop(); if (s) { loc = s.loc; angle = s.angle; } break; }
+    }
+  }
+};
+
+const noteColor = (hue: number, noteIndex: number, alpha = 1): string => {
+  const light = scale01(noteIndex / SCALE.length, [38, 74]);
+  return `hsla(${hue}, 85%, ${light}%, ${alpha})`;
+};
+const nextNoteScale = (cur: number): number => {
+  const interval = randItem(INTERVALS) * randItem([-1, 1]);
+  const n = cur + interval;
+  return n >= 0 && n < SCALE.length ? n : cur - interval;
+};
+const nextNoteFib = (cur: number): number => {
+  const step = randItem(FIB) * randItem([-1, 1]);
+  return ((cur + step) % SCALE.length + SCALE.length) % SCALE.length;
+};
+
+// ── per-path state ────────────────────────────────────────────────────────────
+interface Voice {
+  filters: BiquadFilterNode[];
+  gain: GainNode;          // energy-driven level
+  panner: StereoPannerNode;
+  extra: AudioNode[];      // articulation nodes (shaper / lp / gate / twinkle gains)
+  lfos: OscillatorNode[];
+}
+interface Stroke { lastPoint: Pt; point: Pt; addedAt: number }
+interface Offshoot { str: LChar[]; age: number; point: Pt; angle: number; growthTime: number; lines?: Record<number, { from: Pt; to: Pt }[]>; alpha?: number }
+/** A particle for the non-organic brushes. Fields are reused per brush:
+ *  phyllotaxis -> n is the grown dot count; cloud -> life/vx/vy/a drive drift +
+ *  twinkle; graph -> r is the node square size. */
+interface Particle { x: number; y: number; vx: number; vy: number; born: number; life: number; seed: number; n: number; r: number; a: number }
+interface DrawPath {
+  brush: BrushDef;
+  effect: string;
+  hue: number;
+  strokes: Stroke[];
+  offshoots: Offshoot[];
+  particles: Particle[];
+  edges: [number, number][];
+  pulses: { a: number; b: number; t: number }[];
+  noteIndex: number;
+  lastActivityAt: number;
+  voice?: Voice;
+  sfChannel?: number;
+  sfMidi?: number;
+  melodyIdx?: number;
+}
+
+export type SoundMode = 'drone' | 'soundfont' | 'granular';
+
+export class DrawEngine {
+  private ctx = getEngineCtx();
+  private canvas: HTMLCanvasElement;
+  private c2d: CanvasRenderingContext2D;
+  brush: BrushDef = BRUSHES[0];
+  currentMode = 0;
+  /** Per-stroke mode slots; each holds an effect value (built-in or `rack:`). */
+  private modeSlots: string[] = DEFAULT_MODE_SLOTS.slice();
+  /** Lazily-built psychoacoustic insert instances, shared across strokes. */
+  private rackInsts = new Map<string, RackEffectInstance>();
+  soundMode: SoundMode = 'drone';
+  sfProgram = 89; // GM 90 = Pad 2 (warm); a soft default for drawn notes
+  private paths: DrawPath[] = [];
+  /** Voices fading out: torn down a few per frame once their tail has decayed,
+   *  so a wave of expiring strokes never disconnects everything in one hitch. */
+  private dying: { nodes: AudioNode[]; lfos: OscillatorNode[]; at: number }[] = [];
+  private noteIndex = Math.floor(Math.random() * SCALE.length);
+  private spawnTarget = 0;
+  private sinceSpawn = 0;
+  private active: DrawPath | null = null;
+  private last: Pt | null = null;
+  private raf = 0;
+  private audioTimer = 0;
+  private noise!: AudioBufferSourceNode;
+  private master: GainNode;
+  private fxBus: GainNode;
+  private chainHandle: ChainHandle | null = null;
+  private effects: Record<string, AudioNode> = {};
+  private fxOsc: OscillatorNode[] = [];
+  private sfChannelSeq = 1;
+  private grainBuffer: AudioBuffer | null = null;
+  private grainSeq = 0;
+  private magentaLoop = false;
+  private magentaToken = 0;
+  /** Panel-supplied status sink for the live Magenta loop. */
+  onMagentaStatus?: (s: string) => void;
+  private melody: { pitch: number; start: number; end: number }[] = [];
+  readonly recordDest: MediaStreamAudioDestinationNode;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+    this.c2d = canvas.getContext('2d')!;
+    const ctx = this.ctx;
+    if (ctx.state === 'suspended') void ctx.resume().catch(() => {});
+
+    // Master -> soft clip -> app master. The soft clip keeps loud drones from
+    // harshly clipping now that the levels are higher.
+    this.master = ctx.createGain();
+    this.master.gain.value = 0.9;
+    const clip = ctx.createWaveShaper();
+    clip.curve = softClipCurve(1.4);
+    clip.oversample = '2x';
+    this.master.connect(clip);
+    clip.connect(getMasterGain());
+    // Tap the FULL app master so every source lands in the recording.
+    this.recordDest = ctx.createMediaStreamDestination();
+    getMasterGain().connect(this.recordDest);
+
+    // Per-stroke built-in effects feed this bus, which then runs through the
+    // user-configurable global FX chain on its way to the master.
+    this.fxBus = ctx.createGain();
+    this.buildEffects(ctx);
+    this.chainHandle = buildEffectChain(ctx, this.fxBus, this.master, []);
+    // The Chop effect needs its worklet on this context before it can be chosen.
+    void ensureChopModule(ctx).catch(() => {});
+
+    // Looping white noise feeding every drone voice.
+    const buf = ctx.createBuffer(1, ctx.sampleRate * 2, ctx.sampleRate);
+    const d = buf.getChannelData(0);
+    for (let i = 0; i < d.length; i++) d[i] = Math.random() * 2 - 1;
+    this.noise = ctx.createBufferSource();
+    this.noise.buffer = buf;
+    this.noise.loop = true;
+    this.noise.start();
+
+    this.attach();
+    this.audioTimer = window.setInterval(() => this.audioTick(), 200);
+    this.raf = requestAnimationFrame(this.frame);
+  }
+
+  /** Build the per-stroke MODE effect graph. Each entry connects to the FX bus,
+   *  which then runs through the user-configurable global chain to the master. */
+  private buildEffects(ctx: AudioContext): void {
+    const master = this.fxBus;
+
+    // 1. Clean — gentle compressor.
+    const comp = ctx.createDynamicsCompressor();
+    comp.connect(master);
+    this.effects.clean = comp;
+
+    // 2. Tremolo — bus gain modulated by an LFO.
+    const trem = ctx.createGain();
+    trem.gain.value = 0.6;
+    const tlfo = ctx.createOscillator();
+    tlfo.frequency.value = 9;
+    const tdepth = ctx.createGain();
+    tdepth.gain.value = 0.4;
+    tlfo.connect(tdepth).connect(trem.gain);
+    tlfo.start();
+    trem.connect(master);
+    this.effects.tremolo = trem;
+    this.fxOsc.push(tlfo);
+
+    // 3. Distortion.
+    const shaper = ctx.createWaveShaper();
+    shaper.curve = driveCurve(12);
+    shaper.oversample = '2x';
+    shaper.connect(master);
+    this.effects.distortion = shaper;
+
+    // 4. Echo — discrete feedback repeats.
+    const echoIn = ctx.createGain();
+    const delay = ctx.createDelay(1.5);
+    delay.delayTime.value = 0.34;
+    const fb = ctx.createGain();
+    fb.gain.value = 0.45;
+    echoIn.connect(master);
+    echoIn.connect(delay);
+    delay.connect(fb).connect(delay);
+    delay.connect(master);
+    this.effects.echo = echoIn;
+
+    // 5. Reverb — long smooth convolver tail (distinct from the discrete echo).
+    const reverbIn = ctx.createGain();
+    const conv = ctx.createConvolver();
+    const irLen = Math.floor(ctx.sampleRate * 3.4);
+    const ir = ctx.createBuffer(2, irLen, ctx.sampleRate);
+    for (let ch = 0; ch < 2; ch++) {
+      const data = ir.getChannelData(ch);
+      for (let i = 0; i < irLen; i++) data[i] = (Math.random() * 2 - 1) * (1 - i / irLen) ** 2.4;
+    }
+    conv.buffer = ir;
+    const revWet = ctx.createGain();
+    revWet.gain.value = 0.9;
+    const revDry = ctx.createGain();
+    revDry.gain.value = 0.5;
+    reverbIn.connect(revDry).connect(master);
+    reverbIn.connect(conv).connect(revWet).connect(master);
+    this.effects.reverb = reverbIn;
+
+    // 6. Bitcrush — stepped waveshaper, mostly wet.
+    const crushIn = ctx.createGain();
+    const crush = ctx.createWaveShaper();
+    crush.curve = bitCurve(5);
+    const crushWet = ctx.createGain();
+    crushWet.gain.value = 0.9;
+    const crushDry = ctx.createGain();
+    crushDry.gain.value = 0.2;
+    crushIn.connect(crushDry).connect(master);
+    crushIn.connect(crush).connect(crushWet).connect(master);
+    this.effects.bitcrush = crushIn;
+
+    // 7. Ring modulator — signal x sine carrier.
+    const ringIn = ctx.createGain();
+    const ring = ctx.createGain();
+    ring.gain.value = 0; // carrier drives the value
+    const carrier = ctx.createOscillator();
+    carrier.frequency.value = 180;
+    carrier.connect(ring.gain);
+    const ringWet = ctx.createGain();
+    ringWet.gain.value = 0.9;
+    const ringDry = ctx.createGain();
+    ringDry.gain.value = 0.25;
+    ringIn.connect(ringDry).connect(master);
+    ringIn.connect(ring).connect(ringWet).connect(master);
+    carrier.start();
+    this.effects.ringmod = ringIn;
+    this.fxOsc.push(carrier);
+
+    // 8. Stereo widen — true mid/side (the voices arrive stereo via their panner).
+    const widenIn = ctx.createGain();
+    const wSplit = ctx.createChannelSplitter(2);
+    widenIn.connect(wSplit);
+    const mid = ctx.createGain();
+    const lMid = ctx.createGain(); lMid.gain.value = 0.5;
+    const rMid = ctx.createGain(); rMid.gain.value = 0.5;
+    wSplit.connect(lMid, 0); lMid.connect(mid);
+    wSplit.connect(rMid, 1); rMid.connect(mid);
+    const side = ctx.createGain();
+    const lSide = ctx.createGain(); lSide.gain.value = 0.5;
+    const rSide = ctx.createGain(); rSide.gain.value = -0.5;
+    wSplit.connect(lSide, 0); lSide.connect(side);
+    wSplit.connect(rSide, 1); rSide.connect(side);
+    const sideW = ctx.createGain(); sideW.gain.value = 1.9;
+    side.connect(sideW);
+    const sideWneg = ctx.createGain(); sideWneg.gain.value = -1;
+    sideW.connect(sideWneg);
+    const outL = ctx.createGain();
+    const outR = ctx.createGain();
+    mid.connect(outL); sideW.connect(outL);
+    mid.connect(outR); sideWneg.connect(outR);
+    const merger = ctx.createChannelMerger(2);
+    outL.connect(merger, 0, 0);
+    outR.connect(merger, 0, 1);
+    merger.connect(master);
+    this.effects.widen = widenIn;
+
+    // 9. Exciter — high-passed harmonics blended back as "air".
+    const exIn = ctx.createGain();
+    exIn.connect(master); // dry through
+    const exHp = ctx.createBiquadFilter();
+    exHp.type = 'highpass';
+    exHp.frequency.value = 3200;
+    const exShaper = ctx.createWaveShaper();
+    exShaper.curve = driveCurve(8);
+    exShaper.oversample = '4x';
+    const exWet = ctx.createGain();
+    exWet.gain.value = 0.5;
+    exIn.connect(exHp).connect(exShaper).connect(exWet).connect(master);
+    this.effects.exciter = exIn;
+
+    // 10. Orbit — HRTF panner spun by two slow LFOs (3D movement).
+    const orbitIn = ctx.createGain();
+    const oPan = ctx.createPanner();
+    oPan.panningModel = 'HRTF';
+    oPan.distanceModel = 'inverse';
+    oPan.refDistance = 1;
+    oPan.positionY.value = 0;
+    orbitIn.connect(oPan).connect(master);
+    const orbit = (rate: number, target: AudioParam, radius: number) => {
+      const lfo = ctx.createOscillator();
+      lfo.frequency.value = rate;
+      const g = ctx.createGain();
+      g.gain.value = radius;
+      lfo.connect(g).connect(target);
+      lfo.start();
+      this.fxOsc.push(lfo);
+    };
+    orbit(0.25, oPan.positionX, 2.2);
+    orbit(0.19, oPan.positionZ, 2.2);
+    this.effects.orbit = orbitIn;
+
+    // 11. Formant — parallel vowel-band bandpass filters (talk-box colour).
+    const fmIn = ctx.createGain();
+    const fmDry = ctx.createGain();
+    fmDry.gain.value = 0.3;
+    fmIn.connect(fmDry).connect(master);
+    const formants: Array<[number, number, number]> = [[800, 8, 1], [1150, 9, 0.7], [2900, 10, 0.4]];
+    for (const [freq, q, amp] of formants) {
+      const bp = ctx.createBiquadFilter();
+      bp.type = 'bandpass';
+      bp.frequency.value = freq;
+      bp.Q.value = q;
+      const g = ctx.createGain();
+      g.gain.value = amp;
+      fmIn.connect(bp).connect(g).connect(master);
+    }
+    this.effects.formant = fmIn;
+
+    // 12. Lowpass — warm everything down.
+    const lp = ctx.createBiquadFilter();
+    lp.type = 'lowpass';
+    lp.frequency.value = 700;
+    lp.Q.value = 0.7;
+    lp.connect(master);
+    this.effects.lowpass = lp;
+  }
+
+  setMode(i: number): void { if (i >= 0 && i < this.modeSlots.length) this.currentMode = i; }
+  /** Reassign the per-stroke mode slots (each slot can be any effect value). */
+  setModeSlots(slots: string[]): void {
+    if (slots.length) this.modeSlots = slots.slice();
+    if (this.currentMode >= this.modeSlots.length) this.currentMode = 0;
+  }
+  setBrush(id: BrushId): void {
+    const b = BRUSHES.find((x) => x.id === id);
+    if (b) this.brush = b;
+  }
+  /** Rewire the global FX chain (add/remove/reorder/toggle of MIX inserts). */
+  setChain(entries: ChainEntry[]): void { this.chainHandle?.rebuild(entries); }
+  /** Push a live param change into one running chain effect without a rebuild. */
+  updateChainParam(entryId: string, params: Record<string, number>): void {
+    this.chainHandle?.updateParams(entryId, params);
+  }
+  setSoundMode(m: SoundMode): void {
+    this.soundMode = m;
+    if (m === 'soundfont') void ensureSoundfontReady();
+  }
+  setInstrument(program: number): void { this.sfProgram = program; }
+  setMasterVolume(v: number): void { this.master.gain.setTargetAtTime(clampN(v, 0, 1.5), this.ctx.currentTime, 0.02); }
+
+  /** Load an audio URL (e.g. a library song) as the granular grain source. */
+  async loadGrainSource(url: string): Promise<boolean> {
+    try {
+      const res = await fetch(url);
+      const arr = await res.arrayBuffer();
+      this.grainBuffer = await this.ctx.decodeAudioData(arr);
+      return true;
+    } catch {
+      this.grainBuffer = null;
+      return false;
+    }
+  }
+  get hasGrainSource(): boolean { return this.grainBuffer !== null; }
+  get magentaLive(): boolean { return this.magentaLoop; }
+
+  /** Stream Magenta in real time (Collider-style): a continuous generation loop
+   *  feeds each freshly generated ~4s chunk in as the live granular grain source.
+   *  Reuses the batch /api/magenta/generate endpoint with extend=true, so there is
+   *  no backend change. The sidecar serialises generation, so this and the iframe
+   *  Jam/Collider tools are mutually exclusive (one live generative source at a time). */
+  async startMagentaGrain(prompt: string): Promise<void> {
+    if (this.magentaLoop) return;
+    this.magentaLoop = true;
+    const token = ++this.magentaToken;
+    let first = true;
+    this.onMagentaStatus?.('Magenta warming up...');
+    while (this.magentaLoop && this.magentaToken === token) {
+      try {
+        const form = new FormData();
+        form.append('prompt', prompt || 'evolving instrumental texture');
+        form.append('duration', '4');
+        form.append('model_size', 'small');
+        if (!first) form.append('extend', 'true');
+        const res = await fetch('/api/magenta/generate', { method: 'POST', body: form });
+        if (res.status === 412) { this.onMagentaStatus?.('Magenta not installed - run Setup-MRT2'); break; }
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const { job } = await res.json();
+        const arr = await pollMagentaJob(job.id);
+        if (!this.magentaLoop || this.magentaToken !== token) break;
+        this.grainBuffer = await this.ctx.decodeAudioData(arr);
+        first = false;
+        this.onMagentaStatus?.('Magenta live - draw to granulate it');
+      } catch (e) {
+        this.onMagentaStatus?.(`Magenta error: ${e instanceof Error ? e.message : String(e)}`);
+        await new Promise((r) => setTimeout(r, 900));
+      }
+    }
+    if (this.magentaToken === token) this.magentaLoop = false;
+  }
+
+  stopMagentaGrain(): void {
+    this.magentaLoop = false;
+    this.magentaToken++;
+    this.onMagentaStatus?.('Magenta live stopped');
+  }
+
+  /** Drawn-note melody captured this session (seconds, normalised to the first
+   *  note). Open notes are closed at "now". Used to hand the session to Magenta. */
+  getMelody(): { pitch: number; start: number; end: number }[] {
+    if (!this.melody.length) return [];
+    const now = performance.now() / 1000;
+    const t0 = this.melody[0].start;
+    return this.melody.map((e) => ({
+      pitch: e.pitch,
+      start: Math.max(0, e.start - t0),
+      end: Math.max(e.start - t0 + 0.05, (e.end < 0 ? now : e.end) - t0),
+    }));
+  }
+
+  private spawnGrain(profile: GrainProfile, energy: number, pan: number): void {
+    const buf = this.grainBuffer;
+    if (!buf) return;
+    const ctx = this.ctx;
+    const count = Math.max(1, Math.round(profile.density * (0.4 + energy)));
+    for (let i = 0; i < count; i++) {
+      const dur = rand(profile.durRange);
+      const span = Math.max(0, buf.duration - dur);
+      const offset = profile.golden ? ((this.grainSeq++ * GOLDEN_FRAC) % 1) * span : Math.random() * span;
+      const src = ctx.createBufferSource();
+      src.buffer = buf;
+      src.playbackRate.value = randItem(profile.rateSteps);
+      const g = ctx.createGain();
+      const panner = ctx.createStereoPanner();
+      panner.pan.value = clampN(pan * profile.spread + (Math.random() - 0.5) * profile.spread, -1, 1);
+      src.connect(g).connect(panner).connect(this.effectTarget(this.effectKey()));
+      const t = ctx.currentTime;
+      const atk = dur * profile.attack;
+      const peak = Math.min(profile.peak, profile.peak * (0.3 + energy));
+      g.gain.setValueAtTime(0, t);
+      g.gain.linearRampToValueAtTime(peak, t + atk);
+      g.gain.linearRampToValueAtTime(0, t + dur);
+      src.start(t, offset, dur);
+      src.stop(t + dur + 0.02);
+      src.onended = () => {
+        try { src.disconnect(); g.disconnect(); panner.disconnect(); } catch { /* gone */ }
+      };
+    }
+  }
+
+  private effectKey(): string { return this.modeSlots[this.currentMode] ?? 'clean'; }
+
+  /** Resolve a mode value to the live AudioNode input voices route into. Built-in
+   *  effects use the pre-built nodes; `rack:` values build (and cache) a live
+   *  psychoacoustic insert whose output feeds the FX bus. */
+  private effectTarget(value: string): AudioNode {
+    if (value.startsWith('rack:')) {
+      const id = value.slice(5);
+      let inst = this.rackInsts.get(id);
+      if (!inst) {
+        const def = getRackEffect(id);
+        if (!def) return this.effects.clean;
+        inst = def.make(this.ctx, rackEffectDefaults(id));
+        inst.output.connect(this.fxBus);
+        this.rackInsts.set(id, inst);
+      }
+      return inst.input;
+    }
+    return this.effects[value] ?? this.effects.clean;
+  }
+
+  clear(immediate = false): void {
+    for (const p of this.paths) this.killVoice(p, immediate);
+    this.paths = [];
+    this.melody = [];
+    this.c2d.clearRect(0, 0, this.canvas.width, this.canvas.height);
+  }
+
+  dispose(): void {
+    cancelAnimationFrame(this.raf);
+    clearInterval(this.audioTimer);
+    this.magentaLoop = false;
+    this.magentaToken++;
+    this.detach();
+    this.clear(true);
+    try { this.noise.stop(); } catch { /* already stopped */ }
+    for (const d of this.dying) {
+      for (const o of d.lfos) { try { o.stop(); } catch { /* not started */ } }
+      for (const n of d.nodes) { try { n.disconnect(); } catch { /* gone */ } }
+    }
+    this.dying = [];
+    for (const inst of this.rackInsts.values()) { try { inst.dispose(); } catch { /* gone */ } }
+    this.rackInsts.clear();
+    for (const o of this.fxOsc) { try { o.stop(); } catch { /* not started */ } }
+    try { this.chainHandle?.dispose(); } catch { /* gone */ }
+    try { getMasterGain().disconnect(this.recordDest); } catch { /* gone */ }
+    try { this.master.disconnect(); } catch { /* gone */ }
+  }
+
+  // ── pointer handling ────────────────────────────────────────────────────────
+  private toLocal(e: PointerEvent): Pt {
+    const r = this.canvas.getBoundingClientRect();
+    return { x: ((e.clientX - r.left) / r.width) * this.canvas.width, y: ((e.clientY - r.top) / r.height) * this.canvas.height };
+  }
+  private down = (e: PointerEvent): void => {
+    this.canvas.setPointerCapture?.(e.pointerId);
+    const pt = this.toLocal(e);
+    this.spawnTarget = rand(SPAWN_RATE);
+    this.sinceSpawn = 0;
+    this.last = pt;
+    const path: DrawPath = {
+      brush: this.brush,
+      effect: this.effectKey(),
+      hue: this.brush.hue,
+      strokes: [{ lastPoint: pt, point: pt, addedAt: Date.now() }],
+      offshoots: [],
+      particles: [],
+      edges: [],
+      pulses: [],
+      noteIndex: this.noteIndex,
+      lastActivityAt: Date.now(),
+    };
+    // Log the note so the session can be handed to Magenta.
+    path.melodyIdx = this.melody.length;
+    this.melody.push({ pitch: noteToMidi(SCALE[this.noteIndex]), start: performance.now() / 1000, end: -1 });
+    // Retire the oldest path(s) so the live set stays bounded under heavy drawing.
+    while (this.paths.length >= MAX_PATHS) {
+      const old = this.paths.shift();
+      if (old) this.killVoice(old);
+    }
+    this.active = path;
+    this.paths.push(path);
+    this.noteIndex = this.brush.noteStep === 'fib' ? nextNoteFib(this.noteIndex) : nextNoteScale(this.noteIndex);
+  };
+  private move = (e: PointerEvent): void => {
+    if (!this.active || !this.last) return;
+    const pt = this.toLocal(e);
+    const delta = dist(pt, this.last);
+    const angle = (Math.atan2(pt.y - this.last.y, pt.x - this.last.x) * 180) / Math.PI;
+    this.active.strokes.push({ lastPoint: this.last, point: pt, addedAt: Date.now() });
+    this.sinceSpawn += delta;
+    if (this.sinceSpawn >= this.spawnTarget) {
+      if (this.active.brush.visual === 'lsystem') {
+        const growth = Math.min(1, Math.max(0.2, ORG.growthFactor / Math.max(0.5, delta)));
+        this.active.offshoots.push({
+          str: ORGANIC_SYSTEM.axiom.map((a) => ({ symbol: a.symbol, birthTime: 0, age: 0, terminalAge: a.terminalAge, params: a.params })),
+          age: 0, point: this.last, angle, growthTime: MAX_GROWTH_TIME * growth,
+        });
+      } else {
+        this.spawnParticles(this.active, this.last);
+      }
+      this.active.lastActivityAt = Date.now();
+      this.spawnTarget = rand(SPAWN_RATE);
+      this.sinceSpawn = 0;
+    }
+    this.last = pt;
+  };
+  private up = (): void => { this.active = null; this.last = null; };
+  private attach(): void {
+    this.canvas.addEventListener('pointerdown', this.down);
+    this.canvas.addEventListener('pointermove', this.move);
+    window.addEventListener('pointerup', this.up);
+  }
+  private detach(): void {
+    this.canvas.removeEventListener('pointerdown', this.down);
+    this.canvas.removeEventListener('pointermove', this.move);
+    window.removeEventListener('pointerup', this.up);
+  }
+
+  // ── particle spawning (non-organic brushes) ───────────────────────────────────
+  private spawnParticles(path: DrawPath, at: Pt): void {
+    const now = performance.now();
+    const mk = (x: number, y: number, vx = 0, vy = 0, life = 0, r = 2): Particle =>
+      ({ x, y, vx, vy, born: now, life, seed: Math.random(), n: 0, r, a: 1 });
+    switch (path.brush.visual) {
+      case 'phyllotaxis':
+        if (path.particles.length < 16) path.particles.push(mk(at.x, at.y));
+        break;
+      case 'graph': {
+        if (path.particles.length >= 46) break;
+        const node = mk(at.x + (Math.random() - 0.5) * 6, at.y + (Math.random() - 0.5) * 6, 0, 0, 0, 2 + Math.random() * 2);
+        const idx = path.particles.length;
+        path.particles.push(node);
+        const near = path.particles
+          .map((p, i) => ({ i, d: i === idx ? Infinity : dist(p, node) }))
+          .sort((a, b) => a.d - b.d)
+          .slice(0, 2);
+        for (const nb of near) if (nb.d < 220) path.edges.push([idx, nb.i]);
+        if (path.edges.length && Math.random() < 0.7) {
+          const e = path.edges[path.edges.length - 1];
+          path.pulses.push({ a: e[0], b: e[1], t: 0 });
+        }
+        break;
+      }
+      case 'cloud': {
+        const k = 2 + Math.floor(Math.random() * 2);
+        for (let i = 0; i < k; i++) {
+          if (path.particles.length >= 64) break;
+          const ang = Math.random() * Math.PI * 2;
+          const sp = 4 + Math.random() * 10;
+          path.particles.push(mk(at.x, at.y, Math.cos(ang) * sp, Math.sin(ang) * sp, 3 + Math.random() * 3, 18 + Math.random() * 40));
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  // ── render loop ───────────────────────────────────────────────────────────────
+  private prevT = 0;
+  private frame = (t: number): void => {
+    const dt = this.prevT ? (t - this.prevT) / 1000 : 0;
+    this.prevT = t;
+    const ctx = this.c2d;
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.processDying(performance.now());
+    for (let i = this.paths.length - 1; i >= 0; i--) {
+      const p = this.paths[i];
+      if (p.lastActivityAt < Date.now() - MAX_GROWTH_TIME * 1000) {
+        this.killVoice(p);
+        this.paths.splice(i, 1);
+        continue;
+      }
+      // fading freehand strokes (immediate feedback, all brushes)
+      ctx.lineWidth = 2;
+      for (let j = p.strokes.length - 1; j >= 0; j--) {
+        const s = p.strokes[j];
+        const alpha = 1 - (Date.now() - s.addedAt) / 1000;
+        if (alpha > 0) {
+          ctx.strokeStyle = noteColor(p.hue, p.noteIndex, alpha);
+          ctx.beginPath();
+          ctx.moveTo(s.lastPoint.x, s.lastPoint.y);
+          ctx.lineTo(s.point.x, s.point.y);
+          ctx.stroke();
+        } else p.strokes.splice(j, 1);
+      }
+      if (p.brush.visual === 'lsystem') this.drawOffshoots(p, dt);
+      else this.drawParticles(p, dt);
+    }
+    this.raf = requestAnimationFrame(this.frame);
+  };
+
+  private drawOffshoots(p: DrawPath, dt: number): void {
+    const ctx = this.c2d;
+    for (let k = p.offshoots.length - 1; k >= 0; k--) {
+      const o = p.offshoots[k];
+      o.age += dt;
+      if (o.age >= MAX_GROWTH_TIME) { p.offshoots.splice(k, 1); continue; }
+      if (o.age < o.growthTime) {
+        const eased = easeOutQuart(o.age / o.growthTime) * o.growthTime;
+        lExpand(ORGANIC_SYSTEM, o.str, eased);
+        o.lines = {};
+        turtle(o.str, o.point, o.angle, (chr, from, to) => {
+          const w = Math.ceil(((chr.age + (chr.params?.ageAcc || 0)) / MAX_GROWTH_TIME) * 10);
+          (o.lines![w] ||= []).push({ from, to });
+        });
+      }
+      o.alpha = Math.min(1, 1 - (o.age - MAX_GROWTH_TIME / 2) / 5);
+      ctx.strokeStyle = noteColor(p.hue, p.noteIndex, o.alpha);
+      for (const w of Object.keys(o.lines || {})) {
+        ctx.beginPath();
+        ctx.lineWidth = Number(w) / 5;
+        for (const ln of o.lines![Number(w)]) { ctx.moveTo(ln.from.x, ln.from.y); ctx.lineTo(ln.to.x, ln.to.y); }
+        ctx.stroke();
+      }
+    }
+  }
+
+  private drawParticles(p: DrawPath, dt: number): void {
+    const ctx = this.c2d;
+    const hue = p.hue;
+    const now = performance.now();
+    if (p.brush.visual === 'phyllotaxis') {
+      for (const bl of p.particles) {
+        const age = (now - bl.born) / 1000;
+        bl.n = Math.min(78, Math.floor((age / 3.0) * 78));
+        for (let k = 0; k < bl.n; k++) {
+          const a = k * GOLDEN_ANGLE;
+          const rr = 4.2 * Math.sqrt(k);
+          const px = bl.x + Math.cos(a) * rr;
+          const py = bl.y + Math.sin(a) * rr;
+          const tt = k / Math.max(1, bl.n);
+          const alpha = Math.min(1, 1.1 - age / 6) * (0.5 + 0.5 * tt);
+          if (alpha <= 0) continue;
+          ctx.fillStyle = `hsla(${hue}, 88%, ${55 + tt * 20}%, ${alpha})`;
+          ctx.beginPath();
+          ctx.arc(px, py, 1.2 + tt * 2.4, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+    } else if (p.brush.visual === 'graph') {
+      ctx.lineWidth = 1;
+      for (const [a, b] of p.edges) {
+        const pa = p.particles[a];
+        const pb = p.particles[b];
+        if (!pa || !pb) continue;
+        const age = (now - pa.born) / 1000;
+        const alpha = Math.min(0.6, Math.max(0, 0.7 - age / 9));
+        if (alpha <= 0) continue;
+        ctx.strokeStyle = `hsla(${hue}, 90%, 60%, ${alpha})`;
+        ctx.beginPath();
+        ctx.moveTo(pa.x, pa.y);
+        ctx.lineTo(pb.x, pb.y);
+        ctx.stroke();
+      }
+      for (let i = p.pulses.length - 1; i >= 0; i--) {
+        const pu = p.pulses[i];
+        pu.t += dt * 1.6;
+        if (pu.t >= 1) { p.pulses.splice(i, 1); continue; }
+        const pa = p.particles[pu.a];
+        const pb = p.particles[pu.b];
+        if (!pa || !pb) { p.pulses.splice(i, 1); continue; }
+        ctx.fillStyle = `hsla(${hue}, 100%, 78%, ${1 - pu.t})`;
+        ctx.beginPath();
+        ctx.arc(pa.x + (pb.x - pa.x) * pu.t, pa.y + (pb.y - pa.y) * pu.t, 2.4, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      for (const nd of p.particles) {
+        if (Math.random() < 0.04) { nd.x += (Math.random() - 0.5) * 2; nd.y += (Math.random() - 0.5) * 2; } // glitch jitter
+        const flick = Math.random() < 0.08 ? 0.4 : 1;
+        ctx.fillStyle = `hsla(${hue}, 95%, 66%, ${0.9 * flick})`;
+        ctx.fillRect(nd.x - nd.r / 2, nd.y - nd.r / 2, nd.r, nd.r);
+      }
+    } else {
+      // cloud / nebula
+      ctx.globalCompositeOperation = 'lighter';
+      for (let i = p.particles.length - 1; i >= 0; i--) {
+        const pr = p.particles[i];
+        const age = (now - pr.born) / 1000;
+        if (age >= pr.life) { p.particles.splice(i, 1); continue; }
+        pr.x += pr.vx * dt; pr.y += pr.vy * dt; pr.vx *= 0.985; pr.vy *= 0.985;
+        const lifeFrac = 1 - age / pr.life;
+        const twinkle = 0.6 + 0.4 * Math.sin(now * 0.004 * (1 + pr.seed) + pr.seed * 6.28);
+        pr.a = lifeFrac * twinkle;
+        const grad = ctx.createRadialGradient(pr.x, pr.y, 0, pr.x, pr.y, pr.r);
+        grad.addColorStop(0, `hsla(${hue}, 80%, 72%, ${0.5 * pr.a})`);
+        grad.addColorStop(1, `hsla(${hue}, 80%, 50%, 0)`);
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.arc(pr.x, pr.y, pr.r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalCompositeOperation = 'source-over';
+    }
+  }
+
+  // ── audio loop (every 200ms) ───────────────────────────────────────────────────
+  private measure(p: DrawPath): { raw: number; avgX: number; count: number } {
+    let raw = 0;
+    let sx = 0;
+    let c = 0;
+    if (p.brush.visual === 'lsystem') {
+      for (const o of p.offshoots) {
+        for (const w of Object.keys(o.lines || {})) {
+          for (const ln of o.lines![Number(w)]) {
+            raw += dist(ln.to, ln.from) * (o.alpha ?? 1);
+            sx += ln.to.x;
+            c++;
+          }
+        }
+      }
+    } else if (p.brush.visual === 'phyllotaxis') {
+      for (const bl of p.particles) { raw += bl.n; sx += bl.x; c++; }
+    } else if (p.brush.visual === 'graph') {
+      raw = p.particles.length + 2 * p.pulses.length;
+      for (const nd of p.particles) { sx += nd.x; c++; }
+    } else {
+      for (const pr of p.particles) { raw += Math.max(0, pr.a); sx += pr.x; c++; }
+    }
+    return { raw, avgX: c > 0 ? sx / c : 0, count: c };
+  }
+
+  private audioTick(): void {
+    const ctx = this.ctx;
+    for (const p of this.paths) {
+      const { raw, avgX, count } = this.measure(p);
+      const energy = Math.min(1, raw / p.brush.maxEnergy);
+      const pan = count > 0 ? (avgX / this.canvas.width) * 2 - 1 : 0;
+      if (this.soundMode === 'drone') {
+        if (!p.voice) p.voice = this.makeVoice(p);
+        const g = Math.max(scale01(energy, p.brush.gainRange), 0.0001);
+        p.voice.gain.gain.setTargetAtTime(g, ctx.currentTime, p.brush.tau);
+        p.voice.panner.pan.setTargetAtTime(pan, ctx.currentTime, 0.03);
+      } else if (this.soundMode === 'soundfont') {
+        if (p.sfMidi === undefined) {
+          const channel = (this.sfChannelSeq = (this.sfChannelSeq % 15) + 1);
+          const midi = noteToMidi(SCALE[p.noteIndex]);
+          const vel = Math.round(scale01(energy, [44, 118]));
+          p.sfChannel = channel;
+          p.sfMidi = midi;
+          try { liveNoteOn(channel, this.sfProgram, midi, vel); } catch { /* engine warming */ }
+        }
+      } else {
+        if (!this.grainBuffer) continue;
+        if (energy < 0.02) continue;
+        this.spawnGrain(p.brush.grain, energy, pan);
+      }
+    }
+  }
+
+  private makeVoice(p: DrawPath): Voice {
+    const ctx = this.ctx;
+    const gain = ctx.createGain();
+    gain.gain.value = p.brush.gainRange[0];
+    const panner = ctx.createStereoPanner();
+    const baseMidi = noteToMidi(SCALE[p.noteIndex]);
+    const filters = [baseMidi, baseMidi - 12, baseMidi - 24].map((m) => {
+      const f = ctx.createBiquadFilter();
+      f.type = 'bandpass';
+      f.frequency.value = midiToFreq(m);
+      f.Q.value = p.brush.filterQ;
+      this.noise.connect(f);
+      f.connect(gain);
+      return f;
+    });
+
+    // Brush articulation between the energy gain and the panner.
+    const extra: AudioNode[] = [];
+    const lfos: OscillatorNode[] = [];
+    let tail: AudioNode = gain;
+    if (p.brush.voice === 'twinkle') {
+      // soft pad: lowpass + a slow gentle amplitude shimmer
+      const lp = ctx.createBiquadFilter();
+      lp.type = 'lowpass';
+      lp.frequency.value = 2600;
+      lp.Q.value = 0.6;
+      const tw = ctx.createGain();
+      tw.gain.value = 0.85;
+      const lfo = ctx.createOscillator();
+      lfo.type = 'sine';
+      lfo.frequency.value = 0.15 + Math.random() * 0.25;
+      const depth = ctx.createGain();
+      depth.gain.value = 0.18;
+      lfo.connect(depth).connect(tw.gain);
+      lfo.start();
+      gain.connect(lp).connect(tw);
+      extra.push(lp, tw, depth);
+      lfos.push(lfo);
+      tail = tw;
+    } else if (p.brush.voice === 'gate') {
+      // rigid glitch: a touch of drive into a hard square gate
+      const sh = ctx.createWaveShaper();
+      sh.curve = driveCurve(6);
+      const gt = ctx.createGain();
+      gt.gain.value = 0.62;
+      const lfo = ctx.createOscillator();
+      lfo.type = 'square';
+      lfo.frequency.value = 8 + Math.random() * 6;
+      const depth = ctx.createGain();
+      depth.gain.value = 0.38;
+      lfo.connect(depth).connect(gt.gain);
+      lfo.start();
+      gain.connect(sh).connect(gt);
+      extra.push(sh, gt, depth);
+      lfos.push(lfo);
+      tail = gt;
+    } else if (p.brush.voice === 'pulse') {
+      // fibonacci pulse: a sine tremolo at a Fibonacci-derived rate
+      const pg = ctx.createGain();
+      pg.gain.value = 0.55;
+      const lfo = ctx.createOscillator();
+      lfo.type = 'sine';
+      lfo.frequency.value = randItem([2, 3, 5]) * 0.8;
+      const depth = ctx.createGain();
+      depth.gain.value = 0.45;
+      lfo.connect(depth).connect(pg.gain);
+      lfo.start();
+      gain.connect(pg);
+      extra.push(pg, depth);
+      lfos.push(lfo);
+      tail = pg;
+    }
+    tail.connect(panner);
+    panner.connect(this.effectTarget(p.effect));
+    return { filters, gain, panner, extra, lfos };
+  }
+
+  /** Tear down a few decayed voices per frame to avoid a teardown burst. */
+  private processDying(now: number, budget = 3): void {
+    let n = 0;
+    for (let i = this.dying.length - 1; i >= 0 && n < budget; i--) {
+      const d = this.dying[i];
+      if (now >= d.at) {
+        for (const o of d.lfos) { try { o.stop(); } catch { /* not started */ } }
+        for (const node of d.nodes) { try { node.disconnect(); } catch { /* gone */ } }
+        this.dying.splice(i, 1);
+        n++;
+      }
+    }
+  }
+
+  private killVoice(p: DrawPath, immediate = false): void {
+    if (p.voice) {
+      const v = p.voice;
+      const lfos = v.lfos;
+      const nodes: AudioNode[] = [...v.filters, ...v.extra, v.panner, v.gain];
+      if (immediate) {
+        for (const o of lfos) { try { o.stop(); } catch { /* not started */ } }
+        for (const n of nodes) { try { n.disconnect(); } catch { /* gone */ } }
+      } else {
+        // Smooth release: ramp the voice down, then hand the nodes to the graveyard
+        // so teardown is spread across frames (no setTimeout storm when many
+        // strokes expire at once, which was the end-of-sound hitch).
+        const t = this.ctx.currentTime;
+        try {
+          v.gain.gain.cancelScheduledValues(t);
+          v.gain.gain.setTargetAtTime(0, t, VOICE_RELEASE);
+        } catch { /* param busy */ }
+        this.dying.push({ nodes, lfos, at: performance.now() + VOICE_RELEASE * 4 * 1000 + 80 });
+      }
+      p.voice = undefined;
+    }
+    if (p.sfMidi !== undefined && p.sfChannel !== undefined) {
+      try { liveNoteOff(p.sfChannel, p.sfMidi); } catch { /* gone */ }
+      p.sfMidi = undefined;
+    }
+    if (p.melodyIdx !== undefined && this.melody[p.melodyIdx] && this.melody[p.melodyIdx].end < 0) {
+      this.melody[p.melodyIdx].end = performance.now() / 1000;
+    }
+  }
+}

--- a/frontend/src/lib/effectCatalog.ts
+++ b/frontend/src/lib/effectCatalog.ts
@@ -86,16 +86,35 @@ export interface CategoryMeta {
   label: string;
   icon: React.ComponentType<{ className?: string }>;
   count: number;
+  /** Solid dot/swatch color (bg-*) for list rows and chips. */
+  dot: string;
   tile: { bg: string; text: string; border: string; ring: string; glow: string };
+  /** Sidebar rail button classes, so each category reads its own color. */
+  rail: { active: string; idle: string };
 }
 
+// Each category gets a distinct hue across the spectrum (purple → blue → cyan →
+// amber → emerald → rose) so the effects panel has real color diversity rather
+// than one all-purple wash.
 export const CATEGORY_META: CategoryMeta[] = [
-  { id: 'stacks',   label: 'Stacks',   icon: Layers,            count: 7, tile: { bg: 'bg-purple-950',  text: 'text-purple-200',  border: 'border-purple-500/50', ring: 'ring-purple-400/50', glow: 'bg-purple-500/20' } },
-  { id: 'dynamics', label: 'Dynamics', icon: Activity,          count: 6, tile: { bg: 'bg-blue-950',    text: 'text-blue-200',    border: 'border-blue-500/50',   ring: 'ring-blue-400/50',   glow: 'bg-blue-500/20' } },
-  { id: 'eq',       label: 'EQ',       icon: SlidersHorizontal, count: 3, tile: { bg: 'bg-teal-950',    text: 'text-teal-200',    border: 'border-teal-500/50',   ring: 'ring-teal-400/50',   glow: 'bg-teal-500/20' } },
-  { id: 'tempo',    label: 'Tempo',    icon: Clock,             count: 2, tile: { bg: 'bg-cyan-950',    text: 'text-cyan-200',    border: 'border-cyan-500/50',   ring: 'ring-cyan-400/50',   glow: 'bg-cyan-500/20' } },
-  { id: 'cleanup',  label: 'Cleanup',  icon: Eraser,            count: 3, tile: { bg: 'bg-emerald-950', text: 'text-emerald-200', border: 'border-emerald-500/50',ring: 'ring-emerald-400/50',glow: 'bg-emerald-500/20' } },
-  { id: 'export',   label: 'Export',   icon: Download,          count: 4, tile: { bg: 'bg-orange-950',  text: 'text-orange-200',  border: 'border-orange-500/50', ring: 'ring-orange-400/50', glow: 'bg-orange-500/20' } },
+  { id: 'stacks',   label: 'Stacks',   icon: Layers,            count: 7, dot: 'bg-purple-400',
+    tile: { bg: 'bg-purple-950',  text: 'text-purple-200',  border: 'border-purple-500/50', ring: 'ring-purple-400/50', glow: 'bg-purple-500/20' },
+    rail: { active: 'border-purple-400 text-purple-200 bg-purple-500/10', idle: 'border-transparent text-purple-300/70 hover:text-purple-200 hover:bg-purple-500/5' } },
+  { id: 'dynamics', label: 'Dynamics', icon: Activity,          count: 6, dot: 'bg-blue-400',
+    tile: { bg: 'bg-blue-950',    text: 'text-blue-200',    border: 'border-blue-500/50',   ring: 'ring-blue-400/50',   glow: 'bg-blue-500/20' },
+    rail: { active: 'border-blue-400 text-blue-200 bg-blue-500/10', idle: 'border-transparent text-blue-300/70 hover:text-blue-200 hover:bg-blue-500/5' } },
+  { id: 'eq',       label: 'EQ',       icon: SlidersHorizontal, count: 3, dot: 'bg-cyan-400',
+    tile: { bg: 'bg-cyan-950',    text: 'text-cyan-200',    border: 'border-cyan-500/50',   ring: 'ring-cyan-400/50',   glow: 'bg-cyan-500/20' },
+    rail: { active: 'border-cyan-400 text-cyan-200 bg-cyan-500/10', idle: 'border-transparent text-cyan-300/70 hover:text-cyan-200 hover:bg-cyan-500/5' } },
+  { id: 'tempo',    label: 'Tempo',    icon: Clock,             count: 2, dot: 'bg-amber-400',
+    tile: { bg: 'bg-amber-950',   text: 'text-amber-200',   border: 'border-amber-500/50',  ring: 'ring-amber-400/50',  glow: 'bg-amber-500/20' },
+    rail: { active: 'border-amber-400 text-amber-200 bg-amber-500/10', idle: 'border-transparent text-amber-300/70 hover:text-amber-200 hover:bg-amber-500/5' } },
+  { id: 'cleanup',  label: 'Cleanup',  icon: Eraser,            count: 3, dot: 'bg-emerald-400',
+    tile: { bg: 'bg-emerald-950', text: 'text-emerald-200', border: 'border-emerald-500/50',ring: 'ring-emerald-400/50',glow: 'bg-emerald-500/20' },
+    rail: { active: 'border-emerald-400 text-emerald-200 bg-emerald-500/10', idle: 'border-transparent text-emerald-300/70 hover:text-emerald-200 hover:bg-emerald-500/5' } },
+  { id: 'export',   label: 'Export',   icon: Download,          count: 4, dot: 'bg-rose-400',
+    tile: { bg: 'bg-rose-950',    text: 'text-rose-200',    border: 'border-rose-500/50',   ring: 'ring-rose-400/50',   glow: 'bg-rose-500/20' },
+    rail: { active: 'border-rose-400 text-rose-200 bg-rose-500/10', idle: 'border-transparent text-rose-300/70 hover:text-rose-200 hover:bg-rose-500/5' } },
 ];
 
 const catById = Object.fromEntries(CATEGORY_META.map((c) => [c.id, c])) as Record<string, CategoryMeta>;

--- a/frontend/src/lib/sendToTargets.ts
+++ b/frontend/src/lib/sendToTargets.ts
@@ -176,7 +176,7 @@ export function loadMidiIntoPianoRoll(
     }
     const piano = usePianoRollStore.getState();
     piano.importNotes(notes, midi.bpm); // auto-fits length + pitch range to the import
-    useBottomPanelStore.getState().showTab(target === 'piano-roll' ? 'piano-roll' : 'step-seq');
+    useBottomPanelStore.getState().showTab(target === 'piano-roll' ? 'midi' : 'step-seq');
     const totalSteps = usePianoRollStore.getState().totalSteps;
     logInfo(
       'send-to',

--- a/frontend/src/lib/soundfontEngine.ts
+++ b/frontend/src/lib/soundfontEngine.ts
@@ -96,7 +96,9 @@ function getLiveSynth(): Promise<WorkletSynthesizer> {
       const synth = new WorkletSynthesizer(ctx);
       synth.connect(getMasterGain());
       const sf = await loadDefaultSoundfont();
-      await synth.soundBankManager.addSoundBank(sf, 'main');
+      // Pass a copy: the worklet transfers (detaches) the buffer it receives, and
+      // the cached `sf` is reused by the offline render path too.
+      await synth.soundBankManager.addSoundBank(sf.slice(0), 'main');
       await synth.isReady;
       liveSynth = synth;
       channelProgram.clear();
@@ -165,7 +167,9 @@ async function renderMidiToBlob(
   synth.connect(ctx.destination);
   await synth.startOfflineRender({
     midiSequence: midi,
-    soundBankList: [{ bankOffset: 0, soundBankBuffer: sf }],
+    // Copy: startOfflineRender transfers (detaches) the buffer, but `sf` is the
+    // shared cached soundfont reused by the live synth and later renders.
+    soundBankList: [{ bankOffset: 0, soundBankBuffer: sf.slice(0) }],
     loopCount: 0,
   });
   await synth.isReady;

--- a/frontend/src/lib/vocalBeat.ts
+++ b/frontend/src/lib/vocalBeat.ts
@@ -1,0 +1,75 @@
+/**
+ * vocalBeat.ts - turn a sung/captured melody into a beat, and suggest an effect.
+ *
+ * Two Phase-6 pieces, both deterministic and composed from existing engines:
+ *
+ *  - notesToDrumPattern + renderDrumBeatBlob: map each note onset to a GM drum
+ *    voice by register and render a beat bed through the SpessaSynth GM soundfont
+ *    on channel 9 (renderNotesToBlobSF forces channel 0, so it cannot address a
+ *    kit; building the SMF with notesToSmf(..., 9) is the documented way in).
+ *
+ *  - vocalizeEffect: a feature-based heuristic ("vocalize an effect") that reads
+ *    note density / dynamics / pitch spread and names a rack effect. It is a
+ *    transparent stand-in, NOT a trained timbre classifier; applying the result
+ *    to the live rack chain is a follow-up that needs the editor's rack plumbing.
+ */
+
+import type { RenderNote } from './midiSynth';
+import { notesToSmf } from './midiWrite';
+import { ensureSoundfontReady, renderMidiBufferToBlobSF } from './soundfontEngine';
+
+// General MIDI percussion notes (channel 9).
+export const GM_KICK = 36;
+export const GM_SNARE = 38;
+export const GM_CLOSED_HAT = 42;
+
+const HIT_SEC = 0.12;
+
+/** Map melody notes to drum hits by register: low -> kick, mid -> snare,
+ * high -> closed hat. Onset timing and velocity are preserved. */
+export const notesToDrumPattern = (notes: RenderNote[]): RenderNote[] =>
+  notes.map((n) => ({
+    midi: n.midi < 50 ? GM_KICK : n.midi <= 64 ? GM_SNARE : GM_CLOSED_HAT,
+    startSec: n.startSec,
+    durationSec: HIT_SEC,
+    velocity: n.velocity,
+  }));
+
+/** Render a GM drum bed (channel 9) from melody notes. */
+export const renderDrumBeatBlob = async (
+  notes: RenderNote[],
+): Promise<{ blob: Blob; duration: number }> => {
+  await ensureSoundfontReady();
+  const smf = notesToSmf(notesToDrumPattern(notes), 0, 9);
+  return renderMidiBufferToBlobSF(smf, { sampleRate: 44100, tailSec: 0.5 });
+};
+
+export interface FxSuggestion {
+  effectId: string; // a RACK_EFFECTS id (gater | chop | ringmod | bitcrush)
+  reason: string;
+}
+
+/**
+ * Suggest a rack effect from melody features. Deterministic heuristic, not a
+ * model: dense onsets favour stutter chop, wide dynamics a rhythmic gate, wide
+ * pitch range ring modulation, otherwise a bitcrush texture.
+ */
+export const vocalizeEffect = (
+  notes: RenderNote[],
+  durationSec: number,
+): FxSuggestion => {
+  if (!notes.length) return { effectId: 'gater', reason: 'no input' };
+  const density = notes.length / Math.max(0.5, durationSec);
+  const pitches = notes.map((n) => n.midi);
+  const spread = Math.max(...pitches) - Math.min(...pitches);
+  const vels = notes.map((n) => n.velocity);
+  const meanV = vels.reduce((a, b) => a + b, 0) / vels.length;
+  const dynV = Math.sqrt(
+    vels.reduce((a, b) => a + (b - meanV) ** 2, 0) / vels.length,
+  );
+  if (density >= 5)
+    return { effectId: 'chop', reason: `dense ${density.toFixed(1)}/s -> stutter chop` };
+  if (dynV >= 25) return { effectId: 'gater', reason: 'wide dynamics -> rhythmic gate' };
+  if (spread >= 12) return { effectId: 'ringmod', reason: 'wide pitch range -> ring mod' };
+  return { effectId: 'bitcrush', reason: 'steady tone -> bitcrush texture' };
+};

--- a/frontend/src/lib/vocalExport.ts
+++ b/frontend/src/lib/vocalExport.ts
@@ -1,0 +1,105 @@
+/**
+ * vocalExport.ts - turn a VocalArtifact into a .mid download or an inpaint guide.
+ *
+ * Reuses the existing note/render surface end to end: artifact notes (ms) map to
+ * RenderNote (seconds), notesToSmf writes the SMF for a .mid download, and
+ * renderNotesToBlob renders a guide WAV. Arming an inpaint guide just patches
+ * generateParamsStore's existing inpaint fields, so the normal Generate flow
+ * regenerates the masked window (no new generate path).
+ */
+
+import { useGenerateParamsStore } from '../state/generateParamsStore';
+import { notesToSmf } from './midiWrite';
+import type { RenderNote } from './midiSynth';
+import { renderNotesToBlob } from './midiSynth';
+
+export interface ArtifactNote {
+  start_ms: number;
+  end_ms: number;
+  pitch: number;
+  velocity: number;
+}
+
+export interface ArtifactSegment {
+  id: number;
+  start_ms: number;
+  end_ms: number;
+  kind: string;
+}
+
+export interface VocalArtifactDoc {
+  notes: ArtifactNote[];
+  segments: ArtifactSegment[];
+  timing: { tempo_bpm: number | null };
+  source: { asset_id: string; duration_ms: number };
+  lyrics: { language: string; text: string; source: string };
+  review: { reviewed: boolean; notes: string };
+}
+
+export const fetchVocalArtifact = async (
+  assetId: string,
+): Promise<VocalArtifactDoc | null> => {
+  const res = await fetch(`/api/vocal/metadata/${encodeURIComponent(assetId)}`);
+  if (!res.ok) return null;
+  return (await res.json()) as VocalArtifactDoc;
+};
+
+export const artifactNotesToRenderNotes = (notes: ArtifactNote[]): RenderNote[] =>
+  notes.map((n) => ({
+    midi: n.pitch,
+    startSec: n.start_ms / 1000,
+    durationSec: Math.max(0.02, (n.end_ms - n.start_ms) / 1000),
+    velocity: n.velocity,
+  }));
+
+const anchorDownload = (blob: Blob, filename: string): void => {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+};
+
+/** Export the artifact notes as a .mid (type-0 SMF) and trigger a download. */
+export const downloadVocalMidi = (notes: ArtifactNote[], baseName = 'vocal'): void => {
+  const bytes = notesToSmf(artifactNotesToRenderNotes(notes));
+  anchorDownload(new Blob([bytes], { type: 'audio/midi' }), `${baseName}.mid`);
+};
+
+/** Render the artifact notes to a guide WAV (soundfont when active, else the
+ * built-in voice). */
+export const renderVocalGuideBlob = async (
+  notes: ArtifactNote[],
+): Promise<{ blob: Blob; duration: number }> =>
+  renderNotesToBlob(artifactNotesToRenderNotes(notes), { sampleRate: 44100, tailSec: 0.6 });
+
+/**
+ * Arm an inpaint regeneration of one segment: render the whole performance as a
+ * guide, then patch the Generate params with the guide file + the segment's mask
+ * window (seconds). The user triggers Generate to actually regenerate.
+ * Returns false when the segment has no usable mask window (mask_start and
+ * mask_end both 0 read as "no mask" at the API boundary).
+ */
+export const armInpaintGuide = async (
+  doc: VocalArtifactDoc,
+  segmentIndex: number,
+): Promise<boolean> => {
+  const seg = doc.segments[segmentIndex];
+  if (!seg) return false;
+  const maskStart = seg.start_ms / 1000;
+  const maskEnd = seg.end_ms / 1000;
+  if (maskStart <= 0 && maskEnd <= 0) return false;
+
+  const { blob } = await renderVocalGuideBlob(doc.notes);
+  const guide = new File([blob], 'vocal-guide.wav', { type: 'audio/wav' });
+  useGenerateParamsStore.getState().patch({
+    inpaintAudioFile: guide,
+    inpaintEnabled: true,
+    maskStart,
+    maskEnd,
+  });
+  return true;
+};

--- a/frontend/src/lib/vocalToMidi.ts
+++ b/frontend/src/lib/vocalToMidi.ts
@@ -1,0 +1,336 @@
+/**
+ * vocalToMidi.ts - monophonic vocal pitch capture spine.
+ *
+ * Drives the /yin.worklet.js detector on a live mic stream, accumulates its
+ * per-frame f0 estimates, and segments them into ms-timed notes that match the
+ * backend VocalArtifact Note shape (start_ms / end_ms / pitch / velocity). The
+ * offline complement lives server-side (backend basic-pitch in
+ * backend/modules/vocal/preprocess/notes.py); this is the live path.
+ *
+ * Reuse boundaries: RenderNote and PianoNote are imported, never redeclared, so
+ * a capture flows straight into the soundfont render path (renderNotesToBlob) and
+ * the Piano Roll (importNotes) without an adapter elsewhere.
+ */
+
+import { getEngineCtx } from '../state/playerStore';
+import type { PianoNote } from '../state/pianoRollStore';
+import type { RenderNote } from './midiSynth';
+
+export interface F0Frame {
+  tSec: number; // capture-relative seconds
+  hz: number; // 0 when unvoiced
+  clarity: number; // 0..1 (YIN clarity)
+  rms: number; // window level
+}
+
+export interface CaptureNote {
+  startMs: number;
+  endMs: number;
+  pitch: number; // MIDI 0..127
+  velocity: number; // 1..127
+}
+
+export interface VocalCapture {
+  notes: CaptureNote[];
+  frames: F0Frame[];
+  durationMs: number;
+}
+
+export interface CaptureOptions {
+  clarityMin?: number; // reject frames below this YIN clarity (default 0.5)
+  rmsGateRel?: number; // reject frames below peakRms * this (default 0.08)
+  minNoteMs?: number; // drop notes shorter than this (default 80)
+  maxGapMs?: number; // bridge same-pitch frames separated by <= this (default 60)
+  smoothWindow?: number; // median window in frames for pitch (default 5, odd)
+  pitchHysteresis?: number; // semitones a sustained change must exceed (default 0.6)
+}
+
+export const frequencyToMidi = (hz: number): number => 69 + 12 * Math.log2(hz / 440);
+
+// ── worklet registration (per-context, mirrors ensureChopModule) ──────────────
+const yinModuleByCtx = new WeakMap<BaseAudioContext, Promise<void>>();
+export const ensureYinModule = (ctx: BaseAudioContext): Promise<void> => {
+  let p = yinModuleByCtx.get(ctx);
+  if (!p) {
+    p = ctx.audioWorklet.addModule('/yin.worklet.js').catch((e) => {
+      yinModuleByCtx.delete(ctx);
+      throw e;
+    });
+    yinModuleByCtx.set(ctx, p);
+  }
+  return p;
+};
+
+const median = (xs: number[]): number => {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = s.length >> 1;
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+};
+
+/**
+ * Segment a frame stream into notes. Voiced frames (clear + above the RMS gate)
+ * are mapped to MIDI, median-smoothed to kill jitter/octave flickers, then run-
+ * length grouped by rounded pitch with gap bridging, a hysteresis guard on pitch
+ * changes, and a minimum-duration floor.
+ */
+export const framesToNotes = (
+  frames: F0Frame[],
+  opts: CaptureOptions = {},
+): CaptureNote[] => {
+  const clarityMin = opts.clarityMin ?? 0.5;
+  const rmsGateRel = opts.rmsGateRel ?? 0.08;
+  const minNoteMs = opts.minNoteMs ?? 80;
+  const maxGapMs = opts.maxGapMs ?? 60;
+  const win = Math.max(1, (opts.smoothWindow ?? 5) | 1); // force odd
+  const hyst = opts.pitchHysteresis ?? 0.6;
+
+  const peakRms = frames.reduce((m, f) => Math.max(m, f.rms), 0);
+  const gate = peakRms * rmsGateRel;
+
+  // Voiced frames carry a continuous MIDI pitch; unvoiced become null markers so
+  // gaps remain visible to the run-length pass.
+  type V = { tMs: number; midi: number | null; rms: number };
+  const voiced: V[] = frames.map((f) => {
+    const ok = f.hz > 0 && f.clarity >= clarityMin && f.rms >= gate;
+    return { tMs: f.tSec * 1000, midi: ok ? frequencyToMidi(f.hz) : null, rms: f.rms };
+  });
+
+  // Median-smooth pitch over a sliding window (ignoring unvoiced neighbours).
+  const half = win >> 1;
+  const smooth: V[] = voiced.map((v, i) => {
+    if (v.midi === null) return v;
+    const around: number[] = [];
+    for (let k = i - half; k <= i + half; k++) {
+      const m = voiced[k]?.midi;
+      if (m !== null && m !== undefined) around.push(m);
+    }
+    return { ...v, midi: median(around) };
+  });
+
+  const notes: CaptureNote[] = [];
+  let cur: { startMs: number; endMs: number; pitches: number[]; rmss: number[] } | null = null;
+  const flush = () => {
+    if (!cur) return;
+    if (cur.endMs - cur.startMs >= minNoteMs && cur.pitches.length) {
+      const pitch = Math.round(median(cur.pitches));
+      const meanRms = cur.rmss.reduce((a, b) => a + b, 0) / cur.rmss.length;
+      const velocity = Math.max(1, Math.min(127, Math.round(40 + meanRms * 600)));
+      notes.push({
+        startMs: Math.round(cur.startMs),
+        endMs: Math.round(cur.endMs),
+        pitch: Math.max(0, Math.min(127, pitch)),
+        velocity,
+      });
+    }
+    cur = null;
+  };
+
+  for (const v of smooth) {
+    if (v.midi === null) {
+      // Unvoiced: only break the note if the silence outlasts maxGapMs.
+      if (cur && v.tMs - cur.endMs > maxGapMs) flush();
+      continue;
+    }
+    if (!cur) {
+      cur = { startMs: v.tMs, endMs: v.tMs, pitches: [v.midi], rmss: [v.rms] };
+      continue;
+    }
+    const refPitch = median(cur.pitches);
+    if (Math.abs(v.midi - refPitch) > hyst && Math.round(v.midi) !== Math.round(refPitch)) {
+      flush();
+      cur = { startMs: v.tMs, endMs: v.tMs, pitches: [v.midi], rmss: [v.rms] };
+    } else {
+      cur.endMs = v.tMs;
+      cur.pitches.push(v.midi);
+      cur.rmss.push(v.rms);
+    }
+  }
+  flush();
+  return notes;
+};
+
+export interface VocalCaptureController {
+  stream: MediaStream;
+  /** Current mic RMS level, 0..1, for a live meter (independent of YIN). */
+  getLevel: () => number;
+  /** Number of f0 frames received so far (proof the worklet is running). */
+  frameCount: () => number;
+  /** Finalize: stop the graph + mic, return the segmented capture. */
+  stop: (opts?: CaptureOptions) => VocalCapture;
+}
+
+/** Available microphone inputs. Labels are blank until mic permission is granted
+ * once, so call this after a successful capture (or permission prompt). */
+export const listAudioInputs = async (): Promise<MediaDeviceInfo[]> => {
+  if (!navigator.mediaDevices?.enumerateDevices) return [];
+  const all = await navigator.mediaDevices.enumerateDevices();
+  return all.filter((d) => d.kind === 'audioinput');
+};
+
+export interface InputMonitor {
+  stream: MediaStream;
+  /** Current mic RMS level, 0..1. */
+  getLevel: () => number;
+  stop: () => void;
+}
+
+/**
+ * Open a lightweight always-on input monitor: just the mic + an analyser for the
+ * level meter, no pitch detection. Used so the level is observable before/without
+ * recording. AGC / noise-suppression / echo-cancellation stay OFF to match the
+ * capture path. Call stop() to release the mic.
+ */
+export const startInputMonitor = async (deviceId?: string): Promise<InputMonitor> => {
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: false,
+    },
+  });
+  const ctx = getEngineCtx();
+  // Best-effort resume; on mount there may be no user gesture yet, so don't block.
+  if (ctx.state === 'suspended') void ctx.resume().catch(() => {});
+  const source = ctx.createMediaStreamSource(stream);
+  const analyser = ctx.createAnalyser();
+  analyser.fftSize = 1024;
+  source.connect(analyser);
+  const buf = new Float32Array(analyser.fftSize);
+  const getLevel = (): number => {
+    analyser.getFloatTimeDomainData(buf);
+    let sum = 0;
+    for (let i = 0; i < buf.length; i++) sum += buf[i] * buf[i];
+    return Math.min(1, Math.sqrt(sum / buf.length) * 3);
+  };
+  const stop = (): void => {
+    try {
+      source.disconnect();
+      analyser.disconnect();
+    } catch {
+      /* already torn down */
+    }
+    for (const t of stream.getTracks()) t.stop();
+  };
+  return { stream, getLevel, stop };
+};
+
+/** Current microphone permission state, or 'unknown' where the API is absent. */
+export const queryMicPermission = async (): Promise<PermissionState | 'unknown'> => {
+  try {
+    const p = await navigator.permissions.query({
+      name: 'microphone' as PermissionName,
+    });
+    return p.state;
+  } catch {
+    return 'unknown';
+  }
+};
+
+/**
+ * Begin live capture. Requests the mic with AGC / noise-suppression / echo-
+ * cancellation OFF (all three distort f0), taps it into the shared engine
+ * context, and runs the YIN worklet. Pass a deviceId to pick a specific input.
+ * Call stop() to finalize.
+ */
+export const startVocalCapture = async (
+  deviceId?: string,
+): Promise<VocalCaptureController> => {
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: false,
+    },
+  });
+  const ctx = getEngineCtx();
+  if (ctx.state === 'suspended') await ctx.resume();
+  await ensureYinModule(ctx);
+
+  const source = ctx.createMediaStreamSource(stream);
+  const node = new AudioWorkletNode(ctx, 'yin-detector', {
+    numberOfInputs: 1,
+    numberOfOutputs: 1,
+    channelCount: 1,
+  });
+  // Pull the node through a muted sink so process() keeps running without
+  // routing the mic to the speakers.
+  const sink = ctx.createGain();
+  sink.gain.value = 0;
+
+  // A second tap drives the live level meter, independent of YIN so it responds
+  // even on unvoiced/breath input. An analyser needs no onward connection to run.
+  const analyser = ctx.createAnalyser();
+  analyser.fftSize = 1024;
+  const levelBuf = new Float32Array(analyser.fftSize);
+  const getLevel = (): number => {
+    analyser.getFloatTimeDomainData(levelBuf);
+    let sum = 0;
+    for (let i = 0; i < levelBuf.length; i++) sum += levelBuf[i] * levelBuf[i];
+    return Math.min(1, Math.sqrt(sum / levelBuf.length) * 3);
+  };
+
+  const frames: F0Frame[] = [];
+  const startTime = ctx.currentTime;
+  node.port.onmessage = (e: MessageEvent) => {
+    const d = e.data;
+    if (d?.type === 'f0') {
+      frames.push({
+        tSec: Math.max(0, d.tSec - startTime),
+        hz: d.hz,
+        clarity: d.clarity,
+        rms: d.rms,
+      });
+    }
+  };
+
+  source.connect(node);
+  source.connect(analyser);
+  node.connect(sink);
+  sink.connect(ctx.destination);
+
+  const stop = (opts?: CaptureOptions): VocalCapture => {
+    try {
+      node.port.onmessage = null;
+      source.disconnect();
+      analyser.disconnect();
+      node.disconnect();
+      sink.disconnect();
+    } catch {
+      /* already torn down */
+    }
+    for (const t of stream.getTracks()) t.stop();
+    const durationMs = frames.length ? frames[frames.length - 1].tSec * 1000 : 0;
+    return { notes: framesToNotes(frames, opts), frames, durationMs };
+  };
+
+  return { stream, getLevel, frameCount: () => frames.length, stop };
+};
+
+// ── converters to the shared note models ──────────────────────────────────────
+
+export const captureNotesToRenderNotes = (notes: CaptureNote[]): RenderNote[] =>
+  notes.map((n) => ({
+    midi: n.pitch,
+    startSec: n.startMs / 1000,
+    durationSec: Math.max(0.02, (n.endMs - n.startMs) / 1000),
+    velocity: n.velocity,
+  }));
+
+const stepSec = (bpm: number): number => 60 / bpm / 4; // one 16th note
+
+export const captureNotesToPianoNotes = (
+  notes: CaptureNote[],
+  bpm: number,
+): PianoNote[] => {
+  const ss = stepSec(bpm);
+  return notes.map((n, i) => ({
+    id: `vox-${i}-${n.startMs}`,
+    note: n.pitch,
+    step: Math.max(0, Math.round(n.startMs / 1000 / ss)),
+    length: Math.max(1, Math.round((n.endMs - n.startMs) / 1000 / ss)),
+    velocity: n.velocity,
+  }));
+};

--- a/frontend/src/state/bottomPanelStore.ts
+++ b/frontend/src/state/bottomPanelStore.ts
@@ -17,8 +17,9 @@ export type BottomPanelTab =
   | 'spectral'
   | 'details'
   | 'score'
-  | 'piano-roll'
+  | 'midi'
   | 'step-seq'
+  | 'draw'
   | 'bucket'
   | 'slide'
   | 'sway';
@@ -70,6 +71,16 @@ export const useBottomPanelStore = create<BottomPanelState>()(
     }),
     {
       name: 'thedaw-bottom-panel-v5',
+      version: 1,
+      // The old 'piano-roll' and 'vocal' tabs merged into one 'midi' tab; map a
+      // persisted active tab forward so a returning user lands somewhere valid.
+      migrate: (persisted, _version) => {
+        const p = (persisted ?? {}) as { activeTab?: string };
+        if (p.activeTab === 'piano-roll' || p.activeTab === 'vocal') {
+          p.activeTab = 'midi';
+        }
+        return p as unknown as BottomPanelState;
+      },
       // Open/maximized state is intentionally NOT persisted so the bottom dock
       // and the log start collapsed on every app open. The active tab and the
       // sizes are remembered.

--- a/frontend/src/state/drawEffectChainStore.ts
+++ b/frontend/src/state/drawEffectChainStore.ts
@@ -1,0 +1,54 @@
+/**
+ * drawEffectChainStore — the DRAW tab's global insert-effect chain.
+ *
+ * Same ChainEntry shape and mutators as the MIX effect chain, but its own
+ * persisted list so the DRAW rack is independent of the EDIT/MIX rack. The chain
+ * is built live by drawEngine via buildEffectChain (rackEffects), so every entry
+ * is one of the pure Web-Audio RACK_EFFECTS and runs in real time on the drawn
+ * audio (the offline Studio modules are surfaced separately in the panel).
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { uuid } from '../orb-kit/utils';
+import { rackEffectDefaults } from '../lib/rackEffects';
+import type { ChainEntry } from './effectChainStore';
+
+interface DrawFxState {
+  chain: ChainEntry[];
+  addEffect: (effect: string) => void;
+  removeEffect: (id: string) => void;
+  updateParams: (id: string, params: Record<string, number>) => void;
+  toggleEnabled: (id: string) => void;
+  reorder: (from: number, to: number) => void;
+  clearChain: () => void;
+}
+
+export const useDrawFxStore = create<DrawFxState>()(
+  persist(
+    (set) => ({
+      chain: [],
+      addEffect: (effect) =>
+        set((s) => ({
+          chain: [...s.chain, { id: uuid(), effect, params: { ...rackEffectDefaults(effect) }, enabled: true }],
+        })),
+      removeEffect: (id) => set((s) => ({ chain: s.chain.filter((e) => e.id !== id) })),
+      updateParams: (id, params) =>
+        set((s) => ({ chain: s.chain.map((e) => (e.id === id ? { ...e, params } : e)) })),
+      toggleEnabled: (id) =>
+        set((s) => ({ chain: s.chain.map((e) => (e.id === id ? { ...e, enabled: !e.enabled } : e)) })),
+      reorder: (from, to) =>
+        set((s) => {
+          const next = [...s.chain];
+          const [item] = next.splice(from, 1);
+          next.splice(to, 0, item);
+          return { chain: next };
+        }),
+      clearChain: () => set({ chain: [] }),
+    }),
+    {
+      name: 'thedaw-draw-fx-chain',
+      partialize: (s) => ({ chain: s.chain }),
+    },
+  ),
+);

--- a/frontend/src/state/drawModeStore.ts
+++ b/frontend/src/state/drawModeStore.ts
@@ -1,0 +1,40 @@
+/**
+ * drawModeStore — the DRAW tab's per-stroke "mode" slots.
+ *
+ * Each slot holds one effect id and is fully reassignable, so the numbered mode
+ * buttons can be set to whatever effect the user wants. Persisted so a custom
+ * mode layout survives reloads. The engine reads the slots via setModeSlots.
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { DEFAULT_MODE_SLOTS } from '../lib/drawEngine';
+
+interface DrawModeState {
+  slots: string[];
+  setSlot: (index: number, effect: string) => void;
+  reset: () => void;
+}
+
+export const useDrawModeStore = create<DrawModeState>()(
+  persist(
+    (set) => ({
+      slots: DEFAULT_MODE_SLOTS.slice(),
+      setSlot: (index, effect) =>
+        set((s) => {
+          const next = s.slots.slice();
+          if (index >= 0 && index < next.length) next[index] = effect;
+          return { slots: next };
+        }),
+      reset: () => set({ slots: DEFAULT_MODE_SLOTS.slice() }),
+    }),
+    {
+      name: 'thedaw-draw-modes',
+      version: 1,
+      partialize: (s) => ({ slots: s.slots }),
+      // v0 persisted 12 slots; reset to the 8-slot default on upgrade.
+      migrate: (state, version) =>
+        version < 1 ? { slots: DEFAULT_MODE_SLOTS.slice() } : (state as DrawModeState),
+    },
+  ),
+);

--- a/frontend/src/state/pianoRollStore.ts
+++ b/frontend/src/state/pianoRollStore.ts
@@ -24,6 +24,9 @@ interface PianoRollState {
   currentStep: number;
   /** If set, the roll is editing an existing editor clip — next "send to editor" updates that clip in place. */
   editingClipId: string | null;
+  /** Step span of the most recent live recording, highlighted in the grid; null
+   *  when no recording has been placed. */
+  recordedRange: { startStep: number; endStep: number } | null;
 
   setBpm: (bpm: number) => void;
   setTotalSteps: (s: number) => void;
@@ -41,24 +44,27 @@ interface PianoRollState {
   /** Replace the grid with imported notes, auto-fitting length AND pitch range
    *  to the content (so a full-song / out-of-range import is fully visible). */
   importNotes: (notes: PianoNote[], bpm?: number) => void;
+  /** Place a live recording WITHOUT shrinking the grid (keeps at least the 256
+   *  default), expanding the pitch range to fit, and marks the recorded span. */
+  placeRecording: (notes: PianoNote[], range: { startStep: number; endStep: number }) => void;
 }
+
+const DEFAULT_STEPS = 256;
 
 const MIN_STEPS = 16;
 const MAX_STEPS = 4096; // ~256 bars; enough for full-song MIDI imports
-const MIN_PITCH_SPAN = 24; // keep at least two octaves visible even for a 1-note clip
+const FULL_LOW = 21; // A0 — the full 88-key piano stays in view so the roll scrolls
+const FULL_HIGH = 108; // C8
 
-/** Fit grid length (snapped up to a bar) + pitch range (padded) to a note set. */
+/** Fit grid LENGTH (snapped up to a bar) to a note set, and keep the full piano
+ *  range in view (expanded if content goes beyond it) so vertical scrolling
+ *  always works and notes are never cropped. */
 const fitToNotes = (notes: PianoNote[]): { totalSteps: number; lowestNote: number; highestNote: number } => {
   const lastStep = notes.reduce((m, n) => Math.max(m, n.step + Math.max(1, n.length)), 0);
   const totalSteps = Math.max(MIN_STEPS, Math.min(MAX_STEPS, Math.ceil(lastStep / 16) * 16));
-  let lo = notes.reduce((m, n) => Math.min(m, n.note), 127) - 2;
-  let hi = notes.reduce((m, n) => Math.max(m, n.note), 0) + 2;
-  if (hi - lo < MIN_PITCH_SPAN) {
-    const mid = Math.round((hi + lo) / 2);
-    lo = mid - Math.floor(MIN_PITCH_SPAN / 2);
-    hi = mid + Math.ceil(MIN_PITCH_SPAN / 2);
-  }
-  return { totalSteps, lowestNote: Math.max(0, lo), highestNote: Math.min(127, hi) };
+  const lo = Math.max(0, Math.min(FULL_LOW, notes.reduce((m, n) => Math.min(m, n.note), 127) - 2));
+  const hi = Math.min(127, Math.max(FULL_HIGH, notes.reduce((m, n) => Math.max(m, n.note), 0) + 2));
+  return { totalSteps, lowestNote: lo, highestNote: hi };
 };
 
 const uid = (): string =>
@@ -79,13 +85,14 @@ const seed = (): PianoNote[] => {
 export const usePianoRollStore = create<PianoRollState>()((set) => ({
   notes: seed(),
   bpm: 120,
-  totalSteps: 32, // 2 bars at 16ths
-  lowestNote: 48, // C3
-  highestNote: 84, // C6
+  totalSteps: DEFAULT_STEPS, // 16 bars at 16ths — a roomy default canvas
+  lowestNote: FULL_LOW, // A0 — full piano in view, scrollable
+  highestNote: FULL_HIGH, // C8
   selectedNoteId: null,
   isPlaying: false,
   currentStep: 0,
   editingClipId: null,
+  recordedRange: null,
 
   setBpm: (bpm) => set({ bpm: Math.max(40, Math.min(240, bpm)) }),
   setTotalSteps: (totalSteps) => set({ totalSteps: Math.max(MIN_STEPS, Math.min(MAX_STEPS, totalSteps)) }),
@@ -112,7 +119,7 @@ export const usePianoRollStore = create<PianoRollState>()((set) => ({
   setPlaying: (isPlaying) => set({ isPlaying }),
   setCurrentStep: (currentStep) => set({ currentStep }),
   replaceAll: (notes) => set({ notes, selectedNoteId: null }),
-  clear: () => set({ notes: [], selectedNoteId: null, editingClipId: null }),
+  clear: () => set({ notes: [], selectedNoteId: null, editingClipId: null, recordedRange: null }),
 
   setEditingClip: (editingClipId) => set({ editingClipId }),
   loadFromClip: (clipId, incoming, bpm, totalSteps) =>
@@ -131,6 +138,7 @@ export const usePianoRollStore = create<PianoRollState>()((set) => ({
         selectedNoteId: null,
         isPlaying: false,
         currentStep: 0,
+        recordedRange: null,
       };
     }),
 
@@ -138,7 +146,7 @@ export const usePianoRollStore = create<PianoRollState>()((set) => ({
     set(() => {
       const notes = incoming.map((n) => ({ ...n }));
       if (notes.length === 0) {
-        return { notes, selectedNoteId: null, currentStep: 0, isPlaying: false };
+        return { notes, selectedNoteId: null, currentStep: 0, isPlaying: false, recordedRange: null };
       }
       return {
         notes,
@@ -146,9 +154,33 @@ export const usePianoRollStore = create<PianoRollState>()((set) => ({
         selectedNoteId: null,
         currentStep: 0,
         isPlaying: false,
+        recordedRange: null,
         ...(typeof bpm === 'number' && Number.isFinite(bpm)
           ? { bpm: Math.max(40, Math.min(240, Math.round(bpm))) }
           : {}),
+      };
+    }),
+
+  placeRecording: (incoming, range) =>
+    set((s) => {
+      const notes = incoming.map((n) => ({ ...n }));
+      // Keep at least the 256-step default — never shrink the grid for a short
+      // take. Expand the pitch range to include the take (full keyboard stays).
+      const lo = notes.length
+        ? Math.max(0, Math.min(s.lowestNote, notes.reduce((m, n) => Math.min(m, n.note), 127) - 2))
+        : s.lowestNote;
+      const hi = notes.length
+        ? Math.min(127, Math.max(s.highestNote, notes.reduce((m, n) => Math.max(m, n.note), 0) + 2))
+        : s.highestNote;
+      return {
+        notes,
+        totalSteps: Math.max(DEFAULT_STEPS, s.totalSteps),
+        lowestNote: lo,
+        highestNote: hi,
+        recordedRange: range,
+        selectedNoteId: null,
+        currentStep: 0,
+        isPlaying: false,
       };
     }),
 }));

--- a/frontend/src/views/MixView.tsx
+++ b/frontend/src/views/MixView.tsx
@@ -24,7 +24,7 @@ import { buildEffectChain, ensureChopModule, RACK_EFFECTS } from '../lib/rackEff
 import { encodeWav } from '../lib/wavEncode';
 import type { WidgetRegistry } from '../components/surface/widgetTypes';
 import type { SurfaceLayout } from '../state/surfaceLayoutStore';
-import { EFFECT_CATALOG, PARAM_BOUNDS, CATEGORY_META, fxToCategory } from '../lib/effectCatalog';
+import { EFFECT_CATALOG, PARAM_BOUNDS, CATEGORY_META, fxToCategory, type CategoryMeta } from '../lib/effectCatalog';
 import { STUDIO_MODULES, moduleById, effectToModuleId, type StudioModule } from '../lib/moduleCatalog';
 import { MAGENTA_TOOLS, magentaToolById, type MagentaTool } from '../lib/magentaToolCatalog';
 import { MagentaToolStage } from '../components/audio/MagentaToolStage';
@@ -51,6 +51,54 @@ if (import.meta.env.DEV) {
   const uncovered = [...new Set(RACK_EFFECTS.map((fx) => fx.group))].filter((g) => !(g in PSYCHO_GROUP_STYLE));
   if (uncovered.length) console.warn('[MixView] psychoacoustic groups with no tile style (fallback used):', uncovered);
 }
+
+/* ── "All" browser cells — shared by the list and tile (icon) views ──────────── */
+const AllHeader: React.FC<{ icon: React.ComponentType<{ className?: string }>; color: string; label: string; count: number }> = ({ icon: Icon, color, label, count }) => (
+  <div className="flex items-center gap-1.5 px-1 pt-0.5">
+    <Icon className={`w-3 h-3 shrink-0 ${color}`} />
+    <span className={`text-[9px] font-black uppercase tracking-widest ${color}`}>{label}</span>
+    <span className="text-[8px] font-mono text-zinc-600">{count}</span>
+  </div>
+);
+// A Studio module / psychoacoustic effect cell (color is a hex accent).
+const ModuleRow: React.FC<{ name: string; desc: string; color: string; marked: boolean; onClick: () => void }> = ({ name, desc, color, marked, onClick }) => (
+  <div onClick={onClick} className={`flex items-center gap-2 border rounded px-3 py-2 cursor-pointer transition-all ${marked ? 'border-white/30 bg-white/5' : 'border-zinc-800 hover:border-white/25 hover:bg-white/5'}`}>
+    <span aria-hidden="true" className="w-2 h-2 rounded-full shrink-0" style={{ background: color }} />
+    <div className="flex-1 min-w-0">
+      <span className="text-[11px] font-medium block truncate" style={{ color }}>{name}</span>
+      <p className="text-[9px] text-zinc-500 truncate mt-0.5">{desc}</p>
+    </div>
+    {marked && <span className="w-2 h-2 rounded-full shrink-0" style={{ background: color }} />}
+  </div>
+);
+const ModuleTile: React.FC<{ name: string; color: string; marked: boolean; onClick: () => void }> = ({ name, color, marked, onClick }) => (
+  <div onClick={onClick} style={{ width: 90, height: 98 }} className={`relative flex flex-col items-center justify-center gap-2 rounded border cursor-pointer transition-all overflow-hidden p-2 ${marked ? 'border-white/30 bg-white/5' : 'border-white/8 hover:border-white/20 hover:brightness-110'}`}>
+    <span className="w-7 h-7 rounded-full shrink-0" style={{ background: color, boxShadow: `0 0 10px ${color}80` }} />
+    <span className="text-[10px] font-medium text-center leading-tight line-clamp-2" style={{ color }}>{name}</span>
+  </div>
+);
+// A backend effect cell (color comes from its category classes).
+const FxRow: React.FC<{ name: string; desc: string; cat: CategoryMeta; inChain: boolean; onClick: () => void }> = ({ name, desc, cat, inChain, onClick }) => (
+  <div onClick={onClick} className={`flex items-center gap-2 border rounded px-3 py-2 cursor-pointer transition-all ${inChain ? 'border-white/30 bg-white/5' : 'border-zinc-800 hover:border-white/25 hover:bg-white/5'}`}>
+    <span aria-hidden="true" className={`w-2 h-2 rounded-full shrink-0 ${cat.dot}`} />
+    <div className="flex-1 min-w-0">
+      <span className={`text-[11px] font-medium block truncate ${cat.tile.text}`}>{name}</span>
+      <p className="text-[9px] text-zinc-500 truncate mt-0.5">{desc}</p>
+    </div>
+    {inChain && <span className={`w-2 h-2 rounded-full shrink-0 ${cat.dot}`} />}
+  </div>
+);
+const FxTile: React.FC<{ name: string; cat: CategoryMeta; inChain: boolean; onClick: () => void }> = ({ name, cat, inChain, onClick }) => {
+  const Icon = cat.icon;
+  return (
+    <div onClick={onClick} style={{ width: 90, height: 98 }} className={`relative flex flex-col items-center justify-start gap-1.5 rounded border cursor-pointer transition-all overflow-hidden p-2 ${cat.tile.bg} ${inChain ? `${cat.tile.border} ring-2 ${cat.tile.ring}` : 'border-white/8 hover:border-white/20 hover:brightness-110'}`}>
+      <div className={`absolute inset-0 ${cat.tile.glow} blur-xl pointer-events-none opacity-70`} />
+      <div className="relative z-10 flex items-center justify-center w-10 h-10 mt-1.5"><Icon className={`w-7 h-7 ${cat.tile.text}`} /></div>
+      <span className={`text-[10px] font-medium text-center leading-tight relative z-10 ${cat.tile.text} px-0.5 line-clamp-2`}>{name}</span>
+      {inChain && <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-white z-10" />}
+    </div>
+  );
+};
 
 /* ═══ MIX (PROCESS) tab — now on the Control-Surface editor ═══════════════════
    Layout (drag-arrangeable in Design Mode, like DJ):
@@ -270,17 +318,18 @@ function buildMixRegistry(p: MixRegArgs): WidgetRegistry {
     <div className="h-full w-full flex flex-col min-h-0 overflow-hidden p-1.5 gap-1.5">
       <span className={sectionTitle}>Effects</span>
       <div className="flex flex-col gap-0.5 overflow-y-auto min-h-0">
+        <button onClick={() => p.setActiveCategory('all')}
+          title="Every effect in MIX, grouped by category"
+          className={`flex items-center gap-1.5 px-1.5 py-1.5 rounded w-full text-left border-l-2 transition-colors ${p.activeCategory === 'all' ? 'border-purple-400 text-purple-200 bg-purple-500/10' : 'border-transparent text-zinc-300 hover:text-zinc-100 hover:bg-white/5'}`}>
+          <Library className="w-3.5 h-3.5 shrink-0" />
+          <span className="text-[10px] font-bold flex-1 truncate">All</span>
+          <span className="text-[8px] font-mono text-zinc-500 shrink-0">{p.allEffectCount}</span>
+        </button>
         <button onClick={() => p.setActiveCategory('studio')}
           className={`flex items-center gap-1.5 px-1.5 py-1.5 rounded w-full text-left border-l-2 transition-colors ${p.activeCategory === 'studio' ? 'border-cyan-400 text-cyan-200 bg-cyan-500/10' : 'border-transparent text-cyan-400/80 hover:text-cyan-200 hover:bg-cyan-500/5'}`}>
           <Boxes className="w-3.5 h-3.5 shrink-0" />
           <span className="text-[10px] font-bold flex-1 truncate">Studio</span>
           <span className="text-[8px] font-mono text-cyan-600 shrink-0">{STUDIO_MODULES.length}</span>
-        </button>
-        <button onClick={() => p.setActiveCategory('all')}
-          className={`flex items-center gap-1.5 px-1.5 py-1.5 rounded w-full text-left border-l-2 transition-colors ${p.activeCategory === 'all' ? 'border-purple-400 text-purple-200 bg-purple-500/10' : 'border-transparent text-zinc-400 hover:text-zinc-200 hover:bg-white/5'}`}>
-          <Library className="w-3.5 h-3.5 shrink-0" />
-          <span className="text-[10px] font-semibold flex-1 truncate">All</span>
-          <span className="text-[8px] font-mono text-zinc-600 shrink-0">{p.allEffectCount}</span>
         </button>
         <button onClick={() => p.setActiveCategory('psychoacoustics')}
           title="Psychoacoustic effects — pick one to open the rack in the Effect Stage"
@@ -291,17 +340,17 @@ function buildMixRegistry(p: MixRegArgs): WidgetRegistry {
         </button>
         <button onClick={() => p.setActiveCategory('magenta')}
           title="Magenta RealTime 2 — generative instruments (Collider · Jam · MRT2)"
-          className={`flex items-center gap-1.5 px-1.5 py-1.5 rounded w-full text-left border-l-2 transition-colors ${p.activeCategory === 'magenta' ? 'border-cyan-400 text-cyan-200 bg-cyan-500/10' : 'border-transparent text-cyan-400/80 hover:text-cyan-200 hover:bg-cyan-500/5'}`}>
+          className={`flex items-center gap-1.5 px-1.5 py-1.5 rounded w-full text-left border-l-2 transition-colors ${p.activeCategory === 'magenta' ? 'border-sky-400 text-sky-200 bg-sky-500/10' : 'border-transparent text-sky-400/80 hover:text-sky-200 hover:bg-sky-500/5'}`}>
           <Music className="w-3.5 h-3.5 shrink-0" />
           <span className="text-[10px] font-bold flex-1 truncate">Magenta</span>
-          <span className="text-[8px] font-mono text-cyan-600 shrink-0">{MAGENTA_TOOLS.length}</span>
+          <span className="text-[8px] font-mono text-sky-600 shrink-0">{MAGENTA_TOOLS.length}</span>
         </button>
         {CATEGORY_META.map((cat) => {
           const Icon = cat.icon;
           const active = p.activeCategory === cat.id;
           return (
             <button key={cat.id} onClick={() => p.setActiveCategory(cat.id)}
-              className={`flex items-center gap-1.5 px-1.5 py-1.5 rounded w-full text-left border-l-2 transition-colors ${active ? 'border-purple-400 text-purple-200 bg-purple-500/10' : 'border-transparent text-zinc-400 hover:text-zinc-200 hover:bg-white/5'}`}>
+              className={`flex items-center gap-1.5 px-1.5 py-1.5 rounded w-full text-left border-l-2 transition-colors ${active ? cat.rail.active : cat.rail.idle}`}>
               <Icon className="w-3.5 h-3.5 shrink-0" />
               <span className="text-[10px] font-semibold flex-1 truncate">{cat.label}</span>
               <span className="text-[8px] font-mono text-zinc-600 shrink-0">{cat.count}</span>
@@ -398,18 +447,66 @@ function buildMixRegistry(p: MixRegArgs): WidgetRegistry {
             );
           })}
         </div></div>
-      ) : p.viewMode === 'list' ? (
+      ) : p.activeCategory === 'all' ? (() => {
+        // Everything in MIX, in either list or icon view. Order: Studio +
+        // Psychoacoustics first, then the backend effect categories.
+        const tile = p.viewMode === 'tile';
+        const boxCls = tile ? 'flex flex-wrap gap-3 content-start justify-center p-1' : 'flex flex-col gap-1';
+        return (
+          <div className="flex-1 overflow-y-auto"><div className="flex flex-col gap-2 content-start">
+            <div className="flex flex-col gap-1">
+              <AllHeader icon={Boxes} color="text-cyan-300" label="Studio" count={STUDIO_MODULES.length} />
+              <div className={boxCls}>
+                {STUDIO_MODULES.map((m) => (tile
+                  ? <ModuleTile key={m.id} name={m.name} color={m.color} marked={p.activeModule?.id === m.id} onClick={() => p.onPickModule(m.id)} />
+                  : <ModuleRow key={m.id} name={m.name} desc={m.desc} color={m.color} marked={p.activeModule?.id === m.id} onClick={() => p.onPickModule(m.id)} />
+                ))}
+              </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <AllHeader icon={Headphones} color="text-fuchsia-300" label="Psychoacoustics" count={PSYCHO_MODULES.length} />
+              <div className={boxCls}>
+                {PSYCHO_MODULES.map((m) => {
+                  const marked = p.activePsychoId === m.id || p.rackChain.some((e) => e.effect === m.id);
+                  return tile
+                    ? <ModuleTile key={m.id} name={m.name} color={m.color} marked={marked} onClick={() => p.onPickPsycho(m.id)} />
+                    : <ModuleRow key={m.id} name={m.name} desc={m.desc} color={m.color} marked={marked} onClick={() => p.onPickPsycho(m.id)} />;
+                })}
+              </div>
+            </div>
+            {CATEGORY_META.map((cat) => {
+              const fxs = EFFECT_CATALOG[cat.id] || [];
+              if (!fxs.length) return null;
+              return (
+                <div key={cat.id} className="flex flex-col gap-1">
+                  <AllHeader icon={cat.icon} color={cat.tile.text} label={cat.label} count={fxs.length} />
+                  <div className={boxCls}>
+                    {fxs.map((fx) => {
+                      const inChain = p.chainEffectIds.has(fx.id);
+                      return tile
+                        ? <FxTile key={fx.id} name={fx.name} cat={cat} inChain={inChain} onClick={() => p.addEffect(fx.id)} />
+                        : <FxRow key={fx.id} name={fx.name} desc={fx.desc} cat={cat} inChain={inChain} onClick={() => p.addEffect(fx.id)} />;
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div></div>
+        );
+      })() : p.viewMode === 'list' ? (
         <div className="flex-1 overflow-y-auto"><div className="flex flex-col gap-1 content-start">
           {p.activeEffects.map((fx) => {
+            const cat = fxToCategory[fx.id] ?? CATEGORY_META[0];
             const inChain = p.chainEffectIds.has(fx.id);
             return (
               <div key={fx.id} onClick={() => p.addEffect(fx.id)}
-                className={`flex items-center gap-2 border rounded px-3 py-2 cursor-pointer transition-all ${inChain ? 'border-purple-400/40 bg-purple-500/5' : 'border-zinc-800 hover:border-purple-500/30 hover:bg-white/5'}`}>
+                className={`flex items-center gap-2 border rounded px-3 py-2 cursor-pointer transition-all ${inChain ? 'border-white/30 bg-white/5' : 'border-zinc-800 hover:border-white/25 hover:bg-white/5'}`}>
+                <span aria-hidden="true" className={`w-2 h-2 rounded-full shrink-0 ${cat.dot}`} />
                 <div className="flex-1 min-w-0">
-                  <span className="text-[11px] font-medium text-zinc-100 block truncate">{fx.name}</span>
+                  <span className={`text-[11px] font-medium block truncate ${cat.tile.text}`}>{fx.name}</span>
                   <p className="text-[9px] text-zinc-500 truncate mt-0.5">{fx.desc}</p>
                 </div>
-                {inChain && <span className="w-2 h-2 rounded-full bg-purple-400 shrink-0" />}
+                {inChain && <span className={`w-2 h-2 rounded-full shrink-0 ${cat.dot}`} />}
               </div>
             );
           })}
@@ -750,7 +847,7 @@ export const MixView: React.FC = () => {
     onClearSource: () => setSourceBoth(null),
     isChainProcessing,
     onDownload: handleDownload, onSendToDAW: () => void handleSendToDAW(), onSendToInpaint: () => void handleSendToInpaint(),
-    activeCategory, setActiveCategory, allEffectCount: allEffects.length,
+    activeCategory, setActiveCategory, allEffectCount: allEffects.length + PSYCHO_MODULES.length + STUDIO_MODULES.length,
     quickMaster, setQuickParam, applyQuickMaster, masterEntry: !!masterEntry,
     activeEffects, viewMode, setViewMode, addEffect, chainEffectIds,
     onPickModule: handlePickModule, activeModuleId, activeModule,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,4 +153,6 @@ exclude = [
     "stable_audio_3/training",
     # Vendored git submodule (third-party MRT2 port); not linted by the parent project.
     "sidecars/magenta-rt2-nvidia",
+    # Runtime-created isolated venv for the faster-whisper transcription sidecar.
+    "backend/modules/vocal/transcription/.whisper_venv",
 ]


### PR DESCRIPTION
DRAW tab (lib/drawEngine, layout/DrawPanel, state/drawEffectChainStore, state/drawModeStore):
- four brushes (organic / fibonacci / neural / nebulous), each with its own visual, voice articulation and granular grain extraction
- per-stroke "mode" is now 8 reassignable slots; each slot can be any built-in effect OR a live psychoacoustic insert (rack:*), built lazily and shared
- global FX chain reusing rackEffects.buildEffectChain, plus an offline Studio module surface (EffectGuiStage) over the latest recording
- realtime Magenta as a live granular grain source (continuous extend=true loop), plus the batch drawn-melody -> Magenta jam
- louder drone (maxLineLength fix) + master soft-clip; smooth voice fade-out via a graveyard drained per frame; concurrent-path cap so heavy drawing stays bounded

MIX effects panel (views/MixView, lib/effectCatalog):
- "All" moved to the top of the rail and now contains everything (backend categories
  + psychoacoustics + studio), in both list and icon views, grouped + colored, with Studio and Psychoacoustics first
- per-category color diversity in the rail and rows (replacing the all-purple wash)

Vocal -> MIDI (backend/modules/vocal/*, frontend MidiPanel/vocalToMidi/vocalExport/vocalBeat):
- merged piano + vocal into one MIDI tab; faster-whisper isolated-venv transcription sidecar; meta<->MIDI convert + export/validate routes
- fix: /api/vocal/prepare and /transcription/install were sync routes calling asyncio.create_task (no running loop -> 500); made them async
- fix: the soundfont offline render transferred (detached) the cached SF ArrayBuffer, breaking the beat render with DataCloneError; pass a copy at each consumer
- harden Analyze to surface non-JSON server errors instead of a JSON parse failure