### PR TITLE
feat: native vocal2midi suite + arpeggiator/quantum/synesteez/genealogy UI + mix & vocal fixes

### DIFF
--- a/backend/modules/genaiproxy/module.json
+++ b/backend/modules/genaiproxy/module.json
@@ -1,0 +1,1 @@
+{"name":"genaiproxy","description":"Gemini API proxy (injects GEMINI_API_KEY) for the vocal2midi suite","enabled":true,"api_prefix":"/api/genai-proxy"}

--- a/backend/modules/genaiproxy/router.py
+++ b/backend/modules/genaiproxy/router.py
@@ -1,0 +1,87 @@
+"""Google Gemini native-REST proxy module.
+
+A thin pass-through layer that forwards any request from theDAW's frontend to
+Google's Generative Language API at ``https://generativelanguage.googleapis.com``
+while injecting the server-side ``GEMINI_API_KEY`` (the same env var the in-app
+assistant uses). The browser never sees the real key.
+
+What this module does:
+  - Catches every path + method under its mount and replays it verbatim to
+    Google, swapping in the server key as ``x-goog-api-key``.
+  - Strips any client-supplied ``key`` query param and ``authorization`` header
+    so a frontend placeholder key cannot leak through or override the real one.
+  - Returns Google's status, body, and content-type unchanged so the client SDK
+    behaves exactly as if it had hit Google directly.
+
+Mounted at /api/genai-proxy by backend/modules/loader.py (api_prefix in
+module.json). The APIRouter here has NO prefix — the loader applies it.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+from fastapi import APIRouter, Request, Response
+
+router = APIRouter()
+
+UPSTREAM_BASE = "https://generativelanguage.googleapis.com"
+
+
+@router.api_route("/{rest:path}", methods=["GET", "POST", "OPTIONS"])
+async def proxy(rest: str, request: Request) -> Response:
+    """Forward any path + method to Google, injecting the server-side key."""
+    body = await request.body()
+    key = os.environ.get("GEMINI_API_KEY", "")
+
+    if not key:
+        return Response(
+            status_code=503,
+            content=b'{"error":"GEMINI_API_KEY not set on server"}',
+            media_type="application/json",
+        )
+
+    url = f"{UPSTREAM_BASE}/{rest}"
+
+    # Pass through every query param except any client-supplied ``key``; the real
+    # key travels in the ``x-goog-api-key`` header instead.
+    params = {k: v for k, v in request.query_params.items() if k.lower() != "key"}
+
+    # Build a clean header set: only the content type and our server key. We
+    # deliberately drop the client's authorization header and any placeholder key.
+    headers = {
+        "content-type": request.headers.get("content-type", "application/json"),
+        "x-goog-api-key": key,
+    }
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(120.0, read=120.0)
+        ) as client:
+            resp = await client.request(
+                method=request.method,
+                url=url,
+                params=params,
+                content=body,
+                headers=headers,
+            )
+    except httpx.HTTPError as e:
+        return Response(
+            status_code=502,
+            content=f'{{"error":{_json_str(str(e))}}}'.encode(),
+            media_type="application/json",
+        )
+
+    return Response(
+        content=resp.content,
+        status_code=resp.status_code,
+        media_type=resp.headers.get("content-type", "application/json"),
+    )
+
+
+def _json_str(s: str) -> str:
+    """Encode a string as a JSON string literal (quotes included)."""
+    import json
+
+    return json.dumps(s)

--- a/backend/modules/vocal/service.py
+++ b/backend/modules/vocal/service.py
@@ -70,11 +70,9 @@ def load_artifact(asset_id: str) -> Optional[dict]:
     try:
         import json
 
-        from backend.modules.library.router import get_store
-
-        audio = get_store().get_audio_path(asset_id)
+        audio = _resolve_path(asset_id)
         if audio:
-            f = Path(audio).parent / "vocal_metadata.json"
+            f = audio.parent / "vocal_metadata.json"
             if f.is_file():
                 return json.loads(f.read_text(encoding="utf-8"))
     except Exception as e:
@@ -143,12 +141,38 @@ def set_review(asset_id: str, reviewed: bool, notes_text: str) -> dict:
     return {"ok": True, "review": payload["review"]}
 
 
-def _resolve_path(asset_id: str) -> Optional[Path]:
-    """Resolve a Library asset id to its audio file via the library store."""
+def _resolve_entry_id(asset_id: str) -> Optional[str]:
+    """Map an asset reference to a real library entry id. Accepts either a true
+    entry id OR a human track title — the MIDI/vocal panel often passes the
+    visible title (e.g. "Et Tu Machina"), which is not a directory name, so a
+    plain id lookup misses every track. Fall back to an exact, then
+    case-insensitive, title match."""
     try:
         from backend.modules.library.router import get_store
 
-        path = get_store().get_audio_path(asset_id)
+        store = get_store()
+        if store.get_audio_path(asset_id) is not None:
+            return asset_id
+        entries = list(store.list_entries())
+        for rec in entries:
+            if rec.title == asset_id:
+                return rec.id
+        low = asset_id.strip().lower()
+        for rec in entries:
+            if (rec.title or "").strip().lower() == low:
+                return rec.id
+    except Exception as e:
+        log.info("vocal: entry id resolution failed for %s: %s", asset_id, e)
+    return None
+
+
+def _resolve_path(asset_id: str) -> Optional[Path]:
+    """Resolve a Library asset id (or title) to its audio file."""
+    try:
+        from backend.modules.library.router import get_store
+
+        rid = _resolve_entry_id(asset_id) or asset_id
+        path = get_store().get_audio_path(rid)
         return Path(path) if path else None
     except Exception as e:
         log.info("vocal: asset path resolution failed for %s: %s", asset_id, e)

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-06-27T13:36:50.234Z · Git revision: `59d9e5de5e27` · Repomix tracked: **no**
+> Generated: 2026-06-28T03:27:14.274Z · Git revision: `d4af4806854c` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-27T13:36:50.234Z",
-  "repoRevision": "59d9e5de5e27",
+  "generatedAt": "2026-06-28T03:27:14.274Z",
+  "repoRevision": "d4af4806854c",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/frontend/public/synesteez/index.html
+++ b/frontend/public/synesteez/index.html
@@ -1,0 +1,2065 @@
+<!DOCTYPE html>
+<!--
+Img to Audio Spectrogram Converter - GANTASMO
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self'; worker-src blob:">
+  <title>GANTASMO AudiTize v1.0</title>
+  <style>
+    :root {
+      --bg: #0d0d0f;
+      --panel: #16161a;
+      --card: #1e1e24;
+      --border: #2a2a35;
+      --accent: #00e676;
+      --accent2: #ff6d00;
+      --accent3: #7c4dff;
+      --accent4: #00b0ff;
+      --text: #d8d8e0;
+      --muted: #55556a;
+      --danger: #f44336;
+      --slider-bg: #2a2a35;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { background: var(--bg); color: var(--text); font-family: 'Segoe UI', system-ui, sans-serif; font-size: 12px; min-height: 100vh; }
+
+    .app { display: flex; flex-direction: column; min-height: 100vh; }
+
+    /* TABS — slim top strip (the branded header was removed for compactness) */
+    .tab-nav { display: flex; gap: 2px; padding: 6px 12px 0; background: var(--panel); border-bottom: 1px solid var(--border); flex-shrink: 0; }
+    .tab-btn {
+      background: none; border: none; color: var(--muted); padding: 6px 16px;
+      cursor: pointer; font-size: 12px; border-radius: 4px 4px 0 0;
+      border-bottom: 2px solid transparent; transition: color .15s, border-color .15s;
+    }
+    .tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+    .tab-btn:hover:not(.active) { color: var(--text); }
+
+    /* TAB PANES */
+    .tab-pane { display: none; flex: 1; padding: 10px; }
+    .tab-pane.active { display: flex; flex-direction: column; gap: 10px; }
+
+    /* LAYOUT */
+    .two-col { display: flex; gap: 12px; align-items: flex-start; }
+    .ctrl-col { flex: 0 0 320px; display: flex; flex-direction: column; gap: 8px; }
+    .preview-col { flex: 1; display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+
+    /* SECTIONS */
+    details.section {
+      background: var(--card); border: 1px solid var(--border);
+      border-radius: 6px; overflow: hidden;
+    }
+    details.section summary {
+      padding: 8px 12px; cursor: pointer; font-weight: 600; font-size: 11px;
+      letter-spacing: .5px; text-transform: uppercase; color: var(--muted);
+      list-style: none; display: flex; align-items: center; gap: 6px;
+      user-select: none;
+    }
+    details.section summary::before { content: '▸'; transition: transform .15s; }
+    details.section[open] summary::before { transform: rotate(90deg); }
+    details.section summary:hover { color: var(--text); }
+    .section-body { padding: 10px 12px; display: flex; flex-direction: column; gap: 10px; }
+
+    /* CONTROLS */
+    .ctrl { display: flex; flex-direction: column; gap: 4px; }
+    .ctrl-row { display: flex; align-items: center; gap: 8px; }
+    .ctrl label { font-size: 11px; color: var(--muted); display: flex; justify-content: space-between; }
+    .ctrl label span { color: var(--text); font-weight: 600; }
+
+    /* SLIDE-style capsule: dark glass track, colour value-fill, white glowing knob.
+       --fill (0-100%) is painted live from JS; --sl is the per-slider accent. */
+    input[type=range] {
+      -webkit-appearance: none; appearance: none; width: 100%; height: 10px;
+      border-radius: 9999px; cursor: pointer; outline: none;
+      --sl: var(--accent);
+      background: linear-gradient(to right, var(--sl) var(--fill, 0%), rgba(0,0,0,.5) var(--fill, 0%));
+      border: 1px solid rgba(255,255,255,.12);
+      box-shadow: inset 0 0 4px rgba(0,0,0,.6);
+    }
+    input[type=range].orange { --sl: var(--accent2); }
+    input[type=range].purple { --sl: var(--accent3); }
+    input[type=range].blue   { --sl: var(--accent4); }
+    input[type=range]::-webkit-slider-thumb {
+      -webkit-appearance: none; appearance: none; width: 14px; height: 14px;
+      background: #fff; border-radius: 50%; cursor: pointer;
+      box-shadow: 0 0 8px var(--sl), 0 0 2px rgba(0,0,0,.5);
+    }
+    input[type=range]::-moz-range-thumb {
+      width: 14px; height: 14px; border: none; background: #fff; border-radius: 50%;
+      cursor: pointer; box-shadow: 0 0 8px var(--sl);
+    }
+    input[type=range]::-moz-range-track { background: transparent; border: none; }
+
+    select, input[type=number] {
+      background: var(--slider-bg); border: 1px solid var(--border);
+      color: var(--text); padding: 4px 8px; border-radius: 4px;
+      font-size: 11px; outline: none;
+    }
+    select { cursor: pointer; }
+    select:hover, input[type=number]:hover { border-color: var(--muted); }
+
+    input[type=checkbox] { accent-color: var(--accent); cursor: pointer; }
+
+    .seg-ctrl { display: flex; border-radius: 4px; overflow: hidden; border: 1px solid var(--border); }
+    .seg-ctrl button {
+      flex: 1; background: none; border: none; color: var(--muted);
+      padding: 5px 4px; font-size: 10px; cursor: pointer; transition: background .1s, color .1s;
+    }
+    .seg-ctrl button.active { background: var(--accent); color: #000; font-weight: 700; }
+    .seg-ctrl button:not(.active):hover { background: var(--border); color: var(--text); }
+
+    /* BUTTONS */
+    .btn {
+      background: var(--accent); color: #000; border: none; padding: 9px 16px;
+      border-radius: 4px; cursor: pointer; font-size: 12px; font-weight: 700;
+      transition: opacity .15s; letter-spacing: .3px;
+    }
+    .btn:hover { opacity: .85; }
+    .btn:disabled { opacity: .35; cursor: not-allowed; }
+    .btn.orange { background: var(--accent2); color: #fff; }
+    .btn.purple { background: var(--accent3); color: #fff; }
+    .btn.blue { background: var(--accent4); color: #000; }
+    .btn.danger { background: var(--danger); color: #fff; }
+    .btn.ghost { background: none; border: 1px solid var(--border); color: var(--text); }
+    .btn.sm { padding: 5px 10px; font-size: 11px; }
+
+    /* PROGRESS */
+    .progress-wrap { background: var(--slider-bg); border-radius: 4px; height: 6px; overflow: hidden; }
+    .progress-bar { height: 100%; background: var(--accent); width: 0%; transition: width .1s; border-radius: 4px; }
+
+    /* CANVAS */
+    canvas { display: block; width: 100%; background: #000; border-radius: 4px; border: 1px solid var(--border); }
+
+    /* AUDIO */
+    audio { width: 100%; height: 36px; border-radius: 4px; }
+    audio::-webkit-media-controls-panel { background: var(--card); }
+    .audio-row { display: flex; gap: 8px; align-items: center; }
+    .output-section { background: var(--card); border: 1px solid var(--border); border-radius: 6px; padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+    .output-section h4 { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; }
+
+    /* FILE INPUT */
+    .file-drop {
+      border: 2px dashed var(--border); border-radius: 6px; padding: 16px;
+      text-align: center; cursor: pointer; color: var(--muted); transition: border-color .15s;
+    }
+    .file-drop:hover, .file-drop.drag-over { border-color: var(--accent); color: var(--text); }
+    .file-drop input { display: none; }
+
+    /* ---- SEQUENCE TAB ---- */
+    .seq-list { display: flex; flex-direction: column; gap: 6px; }
+    .seq-item {
+      background: var(--card); border: 1px solid var(--border); border-radius: 6px;
+      display: flex; align-items: center; gap: 10px; padding: 8px 10px;
+    }
+    .seq-item.drag-over { border-color: var(--accent); }
+    .seq-thumb { width: 48px; height: 32px; object-fit: cover; border-radius: 3px; background: #000; flex-shrink: 0; }
+    .seq-name { flex: 1; font-size: 11px; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .seq-item-ctrls { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+    .seq-item-ctrls label { font-size: 10px; color: var(--muted); }
+    .seq-item-ctrls input[type=number] { width: 52px; }
+    .drag-handle { cursor: grab; color: var(--muted); font-size: 14px; flex-shrink: 0; }
+    .drag-handle:active { cursor: grabbing; }
+
+    /* ---- META COMPOSER TAB ---- */
+    .meta-layout { display: flex; gap: 10px; flex: 1; min-height: 0; }
+    .meta-library { flex: 0 0 140px; display: flex; flex-direction: column; gap: 6px; }
+    .meta-library h4 { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; }
+    .tile-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; overflow-y: auto; max-height: 400px; }
+    .tile-item {
+      border-radius: 4px; overflow: hidden; cursor: pointer;
+      border: 2px solid transparent; position: relative; aspect-ratio: 1;
+    }
+    .tile-item.selected { border-color: var(--accent); }
+    .tile-item img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    .tile-item .tile-del {
+      position: absolute; top: 1px; right: 1px; background: rgba(0,0,0,.7);
+      color: #f44; border: none; border-radius: 2px; cursor: pointer; font-size: 10px;
+      padding: 0 3px; display: none;
+    }
+    .tile-item:hover .tile-del { display: block; }
+
+    .meta-canvas-wrap { flex: 1; display: flex; flex-direction: column; gap: 6px; }
+    .meta-canvas-wrap h4 { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; }
+    #metaCanvas { cursor: crosshair; }
+
+    .meta-props { flex: 0 0 160px; display: flex; flex-direction: column; gap: 8px; }
+    .meta-props h4 { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; }
+    .prop-group { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 8px; display: flex; flex-direction: column; gap: 6px; }
+
+    /* STATUS */
+    .status { font-size: 11px; color: var(--muted); min-height: 16px; }
+    .status.err { color: var(--danger); }
+    .status.ok { color: var(--accent); }
+
+    /* SCROLLBAR */
+    ::-webkit-scrollbar { width: 6px; }
+    ::-webkit-scrollbar-track { background: var(--bg); }
+    ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+    /* Compact desktop targets (embedded in the app, mouse-first) */
+    .btn { min-height: 30px; display: inline-flex; align-items: center; justify-content: center; padding: 6px 14px; }
+    .btn.sm { min-height: 24px; padding: 4px 9px; }
+    .tab-btn { min-height: 28px; display: inline-flex; align-items: center; }
+    details.section summary { min-height: 30px; }
+
+    select, input[type=number] { font-size: 12px; }
+    input[type=range] { touch-action: pan-y; }
+
+    /* Move buttons for mobile reorder */
+    .move-btns { display: flex; flex-direction: column; gap: 2px; flex-shrink: 0; }
+    .move-btns button {
+      background: none; border: 1px solid var(--border); color: var(--muted);
+      border-radius: 3px; cursor: pointer; font-size: 11px; padding: 3px 7px; line-height: 1;
+      min-height: 20px;
+    }
+    .move-btns button:hover { color: var(--text); border-color: var(--muted); }
+
+    @media (max-width: 800px) {
+      .two-col { flex-direction: column; }
+      .ctrl-col { flex: none; width: 100%; }
+      .meta-layout { flex-direction: column; }
+      .meta-library { flex: none; width: 100%; }
+      .meta-props { flex: none; width: 100%; }
+      .meta-library .tile-grid { grid-template-columns: repeat(5, 1fr); max-height: 100px; }
+      .tab-nav { width: 100%; }
+      .tab-btn { flex: 1; text-align: center; font-size: 11px; padding: 6px 4px; justify-content: center; }
+      .seq-item { flex-wrap: wrap; }
+      .seq-item-ctrls { flex-wrap: wrap; }
+    }
+    @media (max-width: 480px) {
+      .tab-pane { padding: 10px 8px; }
+      .section-body { padding: 8px 10px; gap: 8px; }
+    }
+  </style>
+</head>
+<body>
+<div class="app">
+  <nav class="tab-nav">
+    <button class="tab-btn active" data-tab="composer">Composer</button>
+    <button class="tab-btn" data-tab="sequence">Sequence</button>
+    <button class="tab-btn" data-tab="meta">Meta Composer</button>
+  </nav>
+
+  <!-- ═══════════════════════════════ COMPOSER ═══════════════════════════════ -->
+  <div class="tab-pane active" id="tab-composer">
+    <div class="two-col">
+      <div class="ctrl-col">
+
+        <details class="section" open>
+          <summary>Image</summary>
+          <div class="section-body">
+            <div class="file-drop" id="composerDrop">
+              <input type="file" id="imageInput" accept="image/*">
+              <div>Drop image here or <strong>click to browse</strong></div>
+            </div>
+            <div class="ctrl">
+              <label>Scan direction</label>
+              <div class="seg-ctrl" id="directionCtrl">
+                <button class="active" data-val="lr">L→R</button>
+                <button data-val="rl">R→L</button>
+                <button data-val="tb">T→B</button>
+                <button data-val="bt">B→T</button>
+              </div>
+            </div>
+            <div class="ctrl-row">
+              <input type="checkbox" id="invertBrightness">
+              <label for="invertBrightness">Invert brightness</label>
+              <input type="checkbox" id="mirrorTime" style="margin-left:10px">
+              <label for="mirrorTime">Mirror time</label>
+            </div>
+          </div>
+        </details>
+
+        <details class="section" open>
+          <summary>Duration</summary>
+          <div class="section-body">
+            <div class="ctrl">
+              <label>Duration <span id="durationValue">5.0</span>s</label>
+              <input type="range" id="duration" min="0.1" max="300" step="0.1" value="5.0">
+            </div>
+            <div class="ctrl-row" style="gap:6px">
+              <label style="color:var(--muted);font-size:11px">Precise:</label>
+              <input type="number" id="durationExact" min="0.1" max="300" step="0.1" value="5.0" style="width:70px">
+              <span style="font-size:11px;color:var(--muted)">sec</span>
+            </div>
+          </div>
+        </details>
+
+        <details class="section" open>
+          <summary>Frequency</summary>
+          <div class="section-body">
+            <div class="ctrl">
+              <label>Base frequency <span id="baseFreqValue">20</span> Hz</label>
+              <input type="range" class="blue" id="baseFreq" min="20" max="8000" step="1" value="20">
+            </div>
+            <div class="ctrl">
+              <label>Frequency span <span id="freqSpanValue">20000</span> Hz</label>
+              <input type="range" class="blue" id="freqSpan" min="100" max="22000" step="100" value="20000">
+            </div>
+            <div class="ctrl">
+              <label>Frequency scale</label>
+              <div class="seg-ctrl" id="freqScaleCtrl">
+                <button class="active" data-val="linear">Linear</button>
+                <button data-val="log">Log</button>
+                <button data-val="mel">Mel</button>
+              </div>
+            </div>
+            <div class="ctrl">
+              <label>Transposition <span id="freqShiftValue">0</span> Hz</label>
+              <input type="range" class="blue" id="frequencyShift" min="-10000" max="10000" step="50" value="0">
+            </div>
+            <div class="ctrl">
+              <label>Pitch quantize</label>
+              <select id="pitchQuantize">
+                <option value="none">None (free)</option>
+                <option value="chromatic">Chromatic</option>
+                <option value="major">Major scale</option>
+                <option value="minor">Minor scale</option>
+                <option value="pentatonic">Pentatonic</option>
+                <option value="whole">Whole tone</option>
+              </select>
+            </div>
+          </div>
+        </details>
+
+        <details class="section">
+          <summary>Synthesis</summary>
+          <div class="section-body">
+            <div class="ctrl">
+              <label>Waveform</label>
+              <div class="seg-ctrl" id="waveformCtrl">
+                <button class="active" data-val="sine">Sine</button>
+                <button data-val="square">Square</button>
+                <button data-val="sawtooth">Saw</button>
+                <button data-val="triangle">Tri</button>
+              </div>
+            </div>
+            <div class="ctrl">
+              <label>Harmonics <span id="harmonicCountValue">1</span></label>
+              <input type="range" class="orange" id="harmonicCount" min="1" max="12" step="1" value="1">
+            </div>
+            <div class="ctrl">
+              <label>Harmonic rolloff <span id="harmonicRolloffValue">0.50</span></label>
+              <input type="range" class="orange" id="harmonicRolloff" min="0.05" max="1" step="0.05" value="0.5">
+            </div>
+            <div class="ctrl">
+              <label>Chaos / detune <span id="chaosValue">0</span>%</label>
+              <input type="range" class="orange" id="chaos" min="0" max="100" step="1" value="0">
+            </div>
+            <div class="ctrl">
+              <label>Vibrato rate <span id="vibratoRateValue">0.0</span> Hz</label>
+              <input type="range" class="orange" id="vibratoRate" min="0" max="20" step="0.1" value="0">
+            </div>
+            <div class="ctrl">
+              <label>Vibrato depth <span id="vibratoDepthValue">0</span> Hz</label>
+              <input type="range" class="orange" id="vibratoDepth" min="0" max="500" step="5" value="0">
+            </div>
+            <div class="ctrl-row">
+              <input type="checkbox" id="phaseRandomize">
+              <label for="phaseRandomize">Randomize phase offsets</label>
+            </div>
+          </div>
+        </details>
+
+        <details class="section">
+          <summary>Envelope</summary>
+          <div class="section-body">
+            <div class="ctrl">
+              <label>Attack <span id="attackValue">10</span> ms</label>
+              <input type="range" class="purple" id="attackMs" min="0" max="500" step="5" value="10">
+            </div>
+            <div class="ctrl">
+              <label>Release <span id="releaseValue">10</span> ms</label>
+              <input type="range" class="purple" id="releaseMs" min="0" max="500" step="5" value="10">
+            </div>
+          </div>
+        </details>
+
+        <details class="section">
+          <summary>Dynamics</summary>
+          <div class="section-body">
+            <div class="ctrl">
+              <label>Brightness threshold <span id="brightnessThresholdValue">50</span></label>
+              <input type="range" id="brightnessThreshold" min="0" max="255" step="1" value="50">
+            </div>
+            <div class="ctrl-row">
+              <input type="checkbox" id="dynamicRangeToggle">
+              <label for="dynamicRangeToggle">Dynamic range (dB)</label>
+            </div>
+            <div class="ctrl" id="dynamicRangeControl" style="display:none">
+              <label>Dynamic range <span id="dynamicRangeValue">24</span> dB</label>
+              <input type="range" id="dynamicRange" min="6" max="120" step="1" value="24">
+            </div>
+            <div class="ctrl">
+              <label>Gain <span id="gainValue">100</span>%</label>
+              <input type="range" id="gain" min="10" max="300" step="5" value="100">
+            </div>
+          </div>
+        </details>
+
+        <details class="section">
+          <summary>Stereo</summary>
+          <div class="section-body">
+            <div class="ctrl">
+              <label>Stereo mode</label>
+              <div class="seg-ctrl" id="stereoModeCtrl">
+                <button class="active" data-val="mono">Mono</button>
+                <button data-val="lh">Lo/Hi</button>
+                <button data-val="pan">Pan→</button>
+                <button data-val="freq">Freq</button>
+              </div>
+            </div>
+          </div>
+        </details>
+
+        <details class="section">
+          <summary>Output Format</summary>
+          <div class="section-body">
+            <div class="ctrl">
+              <label>Sample rate</label>
+              <select id="sampleRate">
+                <option value="22050">22050 Hz</option>
+                <option value="44100" selected>44100 Hz</option>
+                <option value="48000">48000 Hz</option>
+                <option value="96000">96000 Hz</option>
+              </select>
+            </div>
+            <div class="ctrl">
+              <label>Bit depth</label>
+              <select id="bitDepth">
+                <option value="8">8-bit</option>
+                <option value="16" selected>16-bit</option>
+                <option value="24">24-bit</option>
+                <option value="32">32-bit</option>
+              </select>
+            </div>
+            <div class="ctrl">
+              <label>Spectrogram colormap</label>
+              <select id="colormap">
+                <option value="inferno">Inferno</option>
+                <option value="viridis">Viridis</option>
+                <option value="plasma">Plasma</option>
+                <option value="hot">Hot</option>
+                <option value="cool">Cool</option>
+                <option value="electric">Electric</option>
+              </select>
+            </div>
+          </div>
+        </details>
+
+        <div style="display:flex;gap:8px;flex-wrap:wrap">
+          <button class="btn" id="convertBtn">Generate WAV</button>
+          <button class="btn ghost sm" id="cancelBtn" style="display:none">Cancel</button>
+        </div>
+        <div class="status" id="composerStatus"></div>
+        <div class="progress-wrap" id="composerProgressWrap" style="display:none">
+          <div class="progress-bar" id="composerProgress"></div>
+        </div>
+      </div>
+
+      <div class="preview-col">
+        <div class="two-col" style="gap:8px">
+          <div style="flex:1;min-width:0">
+            <div style="font-size:10px;color:var(--muted);margin-bottom:4px;text-transform:uppercase;letter-spacing:.5px">Original</div>
+            <canvas id="imageCanvas"></canvas>
+          </div>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:10px;color:var(--muted);margin-bottom:4px;text-transform:uppercase;letter-spacing:.5px">Spectrogram Preview</div>
+            <canvas id="spectrogramPreviewCanvas"></canvas>
+          </div>
+        </div>
+        <div class="output-section">
+          <h4>Audio Output</h4>
+          <audio id="audioPlayer" controls></audio>
+          <div class="audio-row">
+            <button class="btn ghost sm" id="downloadBtn" disabled>Download WAV</button>
+            <span class="status" id="fileSizeLabel"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ═══════════════════════════════ SEQUENCE ═══════════════════════════════ -->
+  <div class="tab-pane" id="tab-sequence">
+    <div class="two-col" style="align-items:flex-start">
+      <div style="flex:1;display:flex;flex-direction:column;gap:10px">
+        <div style="display:flex;gap:8px;align-items:center">
+          <button class="btn blue sm" id="seqAddBtn">+ Add Images</button>
+          <input type="file" id="seqFileInput" accept="image/*" multiple style="display:none">
+          <span style="font-size:11px;color:var(--muted)">Drag items to reorder</span>
+        </div>
+        <div class="seq-list" id="seqList">
+          <div style="color:var(--muted);font-size:11px;padding:20px;text-align:center;border:1px dashed var(--border);border-radius:6px">
+            No images added yet
+          </div>
+        </div>
+      </div>
+      <div style="flex:0 0 260px;display:flex;flex-direction:column;gap:10px">
+        <details class="section" open>
+          <summary>Transition</summary>
+          <div class="section-body">
+            <div class="ctrl">
+              <label>Transition type</label>
+              <div class="seg-ctrl" id="transitionTypeCtrl">
+                <button class="active" data-val="none">None</button>
+                <button data-val="crossfade">Crossfade</button>
+                <button data-val="morph">Morph</button>
+              </div>
+            </div>
+            <div class="ctrl" id="transitionDurCtrl">
+              <label>Transition duration <span id="transitionDurValue">1.0</span>s</label>
+              <input type="range" class="blue" id="transitionDur" min="0.1" max="10" step="0.1" value="1.0">
+            </div>
+            <div style="font-size:10px;color:var(--muted);line-height:1.6">
+              <strong style="color:var(--accent4)">Crossfade</strong>: blends audio amplitudes<br>
+              <strong style="color:var(--accent3)">Morph</strong>: blends image pixels spectrally
+            </div>
+          </div>
+        </details>
+        <details class="section" open>
+          <summary>Sequence Settings</summary>
+          <div class="section-body">
+            <div class="ctrl-row">
+              <input type="checkbox" id="seqUseComposerSettings" checked>
+              <label for="seqUseComposerSettings">Use Composer settings</label>
+            </div>
+            <div style="font-size:10px;color:var(--muted)">Synthesis params (waveform, harmonics, etc.) are pulled from the Composer tab.</div>
+            <div class="ctrl" id="seqDefaultDurCtrl">
+              <label>Default image duration <span id="seqDefaultDurValue">5.0</span>s</label>
+              <input type="range" id="seqDefaultDur" min="0.5" max="60" step="0.5" value="5.0">
+            </div>
+          </div>
+        </details>
+        <div class="status" id="seqTotalDurLabel" style="margin-bottom:2px"></div>
+        <button class="btn orange" id="seqGenerateBtn">Generate Sequence</button>
+        <button class="btn ghost sm" id="seqCancelBtn" style="display:none">Cancel</button>
+        <div class="status" id="seqStatus"></div>
+        <div class="progress-wrap" id="seqProgressWrap" style="display:none">
+          <div class="progress-bar" id="seqProgress"></div>
+        </div>
+        <div class="output-section">
+          <h4>Audio Output</h4>
+          <audio id="seqAudioPlayer" controls></audio>
+          <div class="audio-row">
+            <button class="btn ghost sm" id="seqDownloadBtn" disabled>Download WAV</button>
+            <span class="status" id="seqFileSizeLabel"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══════════════════════════ META COMPOSER ═══════════════════════════════ -->
+  <div class="tab-pane" id="tab-meta">
+    <div style="font-size:11px;color:var(--muted);margin-bottom:8px">
+      Build a spectrogram as a <strong style="color:var(--text)">collage of images</strong>. Each tile occupies a time×frequency region — its brightness maps directly to amplitude at that pitch and moment.
+    </div>
+    <div class="meta-layout">
+      <div class="meta-library">
+        <h4>Tile Library</h4>
+        <button class="btn blue sm" id="metaAddTileBtn" style="width:100%">+ Add Tiles</button>
+        <input type="file" id="metaTileInput" accept="image/*" multiple style="display:none">
+        <div class="tile-grid" id="tileGrid"></div>
+        <div style="margin-top:8px">
+          <div class="ctrl">
+            <label>Mosaic grid</label>
+            <div class="ctrl-row">
+              <input type="number" id="mosaicCols" min="1" max="16" value="3" style="width:44px"> ×
+              <input type="number" id="mosaicRows" min="1" max="16" value="3" style="width:44px">
+            </div>
+          </div>
+          <button class="btn ghost sm" id="mosaicFillBtn" style="width:100%;margin-top:6px">Auto-fill Mosaic</button>
+        </div>
+      </div>
+
+      <div class="meta-canvas-wrap">
+        <div style="display:flex;align-items:center;justify-content:space-between">
+          <h4>Spectrogram Canvas <span style="color:var(--muted);font-weight:400">(click to place selected tile)</span></h4>
+          <button class="btn danger sm" id="metaClearBtn">Clear All</button>
+        </div>
+        <canvas id="metaCanvas" height="300"></canvas>
+        <div style="display:flex;justify-content:space-between;font-size:10px;color:var(--muted)">
+          <span>0s</span><span id="metaTimeLabel">— s</span>
+          <span style="float:right">← Lo freq · Hi freq →</span>
+        </div>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:4px">
+          <div class="ctrl" style="flex:1;min-width:80px">
+            <label>Duration <span id="metaDurValue">10.0</span>s</label>
+            <input type="range" id="metaDuration" min="1" max="300" step="1" value="10">
+          </div>
+          <div class="ctrl" style="flex:1;min-width:80px">
+            <label>Base freq <span id="metaBaseFreqValue">20</span> Hz</label>
+            <input type="range" class="blue" id="metaBaseFreq" min="20" max="4000" value="20">
+          </div>
+          <div class="ctrl" style="flex:1;min-width:80px">
+            <label>Freq span <span id="metaFreqSpanValue">20000</span> Hz</label>
+            <input type="range" class="blue" id="metaFreqSpan" min="100" max="22000" step="100" value="20000">
+          </div>
+        </div>
+      </div>
+
+      <div class="meta-props">
+        <h4>Selected Tile</h4>
+        <div id="metaNoSelection" style="color:var(--muted);font-size:11px">Click a tile in the library, then click the canvas to place it.</div>
+        <div id="metaTileProps" style="display:none;flex-direction:column;gap:8px">
+          <div class="prop-group">
+            <div style="font-size:10px;color:var(--muted)">Position (% of canvas)</div>
+            <div class="ctrl-row">
+              <label style="font-size:10px;color:var(--muted);width:16px">X:</label>
+              <input type="number" id="tileX" min="0" max="100" value="0" style="width:52px">
+              <label style="font-size:10px;color:var(--muted);width:16px">Y:</label>
+              <input type="number" id="tileY" min="0" max="100" value="0" style="width:52px">
+            </div>
+            <div style="font-size:10px;color:var(--muted)">Size (% of canvas)</div>
+            <div class="ctrl-row">
+              <label style="font-size:10px;color:var(--muted);width:16px">W:</label>
+              <input type="number" id="tileW" min="1" max="100" value="25" style="width:52px">
+              <label style="font-size:10px;color:var(--muted);width:16px">H:</label>
+              <input type="number" id="tileH" min="1" max="100" value="25" style="width:52px">
+            </div>
+          </div>
+          <div class="prop-group">
+            <div class="ctrl">
+              <label>Weight <span id="tileWeightValue">1.00</span></label>
+              <input type="range" id="tileWeight" min="0.05" max="2" step="0.05" value="1">
+            </div>
+            <div class="ctrl">
+              <label>Blend mode</label>
+              <select id="tileBlend">
+                <option value="add">Add</option>
+                <option value="max">Max</option>
+                <option value="multiply">Multiply</option>
+                <option value="screen">Screen</option>
+              </select>
+            </div>
+          </div>
+          <button class="btn danger sm" id="deleteTileBtn">Remove Tile</button>
+        </div>
+        <div style="margin-top:auto;padding-top:12px;display:flex;flex-direction:column;gap:8px">
+          <button class="btn purple" id="metaGenerateBtn">Generate Audio</button>
+          <button class="btn ghost sm" id="metaCancelBtn" style="display:none">Cancel</button>
+          <div class="status" id="metaStatus"></div>
+          <div class="progress-wrap" id="metaProgressWrap" style="display:none">
+            <div class="progress-bar" id="metaProgress"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="output-section" style="margin-top:10px">
+      <h4>Audio Output</h4>
+      <audio id="metaAudioPlayer" controls></audio>
+      <div class="audio-row">
+        <button class="btn ghost sm" id="metaDownloadBtn" disabled>Download WAV</button>
+        <span class="status" id="metaFileSizeLabel"></span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+// ═══════════════════════════════════════════════════════════════════
+// SHARED CONFIG
+// ═══════════════════════════════════════════════════════════════════
+const config = {
+  duration: 5.0,
+  imageDirection: 'lr',
+  invertBrightness: false,
+  mirrorTime: false,
+  baseFrequency: 20,
+  frequencySpan: 20000,
+  freqScale: 'linear',
+  frequencyShift: 0,
+  pitchQuantize: 'none',
+  waveform: 'sine',
+  harmonicCount: 1,
+  harmonicRolloff: 0.5,
+  chaos: 0,
+  vibratoRate: 0,
+  vibratoDepth: 0,
+  phaseRandomize: false,
+  attackMs: 10,
+  releaseMs: 10,
+  brightnessThreshold: 50,
+  useDynamicRange: false,
+  dynamicRange: 24,
+  gain: 1.0,
+  stereoMode: 'mono',
+  sampleRate: 44100,
+  bitDepth: 16,
+  colormap: 'inferno',
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// COLORMAPS
+// ═══════════════════════════════════════════════════════════════════
+const COLORMAPS = {
+  inferno: [[0,0,3],[20,11,53],[46,9,93],[84,14,131],[114,25,147],[140,35,156],[165,44,160],[188,52,161],[210,60,159],[230,69,154],[245,78,148],[253,85,142],[255,102,127],[255,136,90],[255,182,35],[255,255,0]],
+  viridis: [[68,1,84],[72,40,120],[62,83,160],[49,104,142],[38,130,142],[31,158,137],[53,183,121],[110,206,88],[181,222,43],[253,231,37]],
+  plasma: [[13,8,135],[75,3,161],[125,3,168],[168,34,150],[203,70,121],[229,107,93],[245,144,60],[252,188,22],[240,249,33]],
+  hot: [[0,0,0],[64,0,0],[128,0,0],[192,0,0],[255,0,0],[255,64,0],[255,128,0],[255,192,0],[255,255,0],[255,255,255]],
+  cool: [[0,255,255],[32,224,255],[64,192,255],[96,160,255],[128,128,255],[160,96,255],[192,64,255],[224,32,255],[255,0,255]],
+  electric: [[0,0,0],[0,0,128],[0,0,255],[0,128,255],[0,255,255],[128,255,128],[255,255,0],[255,128,0],[255,0,0],[255,255,255]],
+};
+
+function getColor(intensity, colormap) {
+  const cm = COLORMAPS[colormap] || COLORMAPS.inferno;
+  const pos = Math.max(0, Math.min(1, intensity)) * (cm.length - 1);
+  const i1 = Math.floor(pos), i2 = Math.min(i1 + 1, cm.length - 1);
+  const f = pos - i1;
+  return [
+    Math.round(cm[i1][0] + f * (cm[i2][0] - cm[i1][0])),
+    Math.round(cm[i1][1] + f * (cm[i2][1] - cm[i1][1])),
+    Math.round(cm[i1][2] + f * (cm[i2][2] - cm[i1][2])),
+  ];
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// WEB WORKER CODE (inline blob)
+// ═══════════════════════════════════════════════════════════════════
+const WORKER_CODE = `
+'use strict';
+const SIN_N = 131072;
+const sinTable = new Float32Array(SIN_N);
+for (let i = 0; i < SIN_N; i++) sinTable[i] = Math.sin(2 * Math.PI * i / SIN_N);
+
+function fsin(phase) {
+  let idx = ((phase / (2 * Math.PI)) * SIN_N) | 0;
+  idx = ((idx % SIN_N) + SIN_N) % SIN_N;
+  return sinTable[idx];
+}
+
+function waveAt(wf, phase) {
+  switch (wf) {
+    case 'square': return fsin(phase) >= 0 ? 1 : -1;
+    case 'sawtooth': { const p = ((phase / (2*Math.PI)) % 1 + 1) % 1; return 2*p - 1; }
+    case 'triangle': { const p = ((phase / (2*Math.PI)) % 1 + 1) % 1; return p < .5 ? 4*p-1 : 3-4*p; }
+    default: return fsin(phase);
+  }
+}
+
+const NOTE_INTERVALS = {
+  chromatic: [0,1,2,3,4,5,6,7,8,9,10,11],
+  major:     [0,2,4,5,7,9,11],
+  minor:     [0,2,3,5,7,8,10],
+  pentatonic:[0,2,4,7,9],
+  whole:     [0,2,4,6,8,10],
+};
+
+function quantizeFreq(freq, scale) {
+  if (scale === 'none') return freq;
+  const A4 = 440, intervals = NOTE_INTERVALS[scale] || null;
+  if (!intervals) return freq;
+  const semitone = 12 * Math.log2(freq / A4);
+  const octave = Math.floor(semitone / 12);
+  const degree = ((semitone % 12) + 12) % 12;
+  let best = intervals[0], bestDist = 999;
+  for (const iv of intervals) {
+    const d = Math.abs(iv - degree);
+    const d2 = Math.min(d, 12 - d);
+    if (d2 < bestDist) { bestDist = d2; best = iv; }
+  }
+  return A4 * Math.pow(2, (octave * 12 + best) / 12);
+}
+
+function getFreq(normY, cfg) {
+  const b = cfg.baseFrequency, s = cfg.frequencySpan;
+  switch (cfg.freqScale) {
+    case 'log': return b * Math.pow((b + s) / b, normY);
+    case 'mel': {
+      const hm = f => 2595 * Math.log10(1 + f/700);
+      const mh = m => 700 * (Math.pow(10, m/2595) - 1);
+      return mh(hm(b) + normY * (hm(b+s) - hm(b)));
+    }
+    default: return b + normY * s;
+  }
+}
+
+function synthesize(pixels, width, height, cfg, startSampleOffset) {
+  const sr = cfg.sampleRate;
+  const dur = cfg.duration;
+  const totalSamples = Math.floor(sr * dur);
+  const stereo = cfg.stereoMode !== 'mono';
+
+  const chL = new Float32Array(totalSamples);
+  const chR = stereo ? new Float32Array(totalSamples) : null;
+
+  const samplesPerCol = totalSamples / width;
+  const threshold = cfg.brightnessThreshold;
+  const gainFactor = cfg.gain;
+  const chaosScale = cfg.chaos / 100;
+  const vibRate = cfg.vibratoRate;
+  const vibDepth = cfg.vibratoDepth;
+  const attackSamples = (cfg.attackMs / 1000) * sr;
+  const releaseSamples = (cfg.releaseMs / 1000) * sr;
+  const wf = cfg.waveform;
+  const harmonics = cfg.harmonicCount;
+  const rolloff = cfg.harmonicRolloff;
+  const phRand = cfg.phaseRandomize;
+  const freqShift = cfg.frequencyShift;
+
+  // Random chaos seed per pixel column
+  const chaos_rng = [];
+  for (let i = 0; i < width * height; i++) chaos_rng.push(Math.random() * 2 - 1);
+
+  const phaseOffsets = phRand ? new Float64Array(height).map(() => Math.random() * 2 * Math.PI) : null;
+
+  const TWOPI = 2 * Math.PI;
+
+  for (let x = 0; x < width; x++) {
+    const t0 = x * samplesPerCol;
+    const t1 = Math.min(totalSamples, (x + 1) * samplesPerCol);
+    const startS = Math.floor(t0);
+    const endS = Math.floor(t1);
+    const colLen = endS - startS;
+    if (colLen <= 0) continue;
+
+    const atkS = Math.min(attackSamples, colLen * 0.5);
+    const relS = Math.min(releaseSamples, colLen * 0.5);
+
+    for (let y = 0; y < height; y++) {
+      const pIdx = (y * width + x) * 3;
+      let brightness = (pixels[pIdx] + pixels[pIdx+1] + pixels[pIdx+2]) / 3;
+      if (cfg.invertBrightness) brightness = 255 - brightness;
+      if (brightness < threshold) continue;
+
+      const normY = (height - 1 - y) / (height - 1);
+      let baseFreq = getFreq(normY, cfg) + freqShift;
+      if (baseFreq <= 0) continue;
+
+      const chaosOffset = chaos_rng[y * width + x] * chaosScale * baseFreq * 0.15;
+      baseFreq = Math.max(1, baseFreq + chaosOffset);
+      baseFreq = quantizeFreq(baseFreq, cfg.pitchQuantize);
+
+      const amplitude = (brightness / 255) * gainFactor;
+
+      for (let h = 1; h <= harmonics; h++) {
+        const hFreq = baseFreq * h;
+        if (hFreq >= sr / 2) continue;
+        const hAmp = amplitude * Math.pow(rolloff, h - 1);
+        const phOffset = phaseOffsets ? phaseOffsets[y] * h : 0;
+        const phInc = TWOPI * hFreq / sr;
+        let phase = TWOPI * hFreq * (startS + startSampleOffset) / sr + phOffset;
+        const vibPhInc = vibRate > 0 ? TWOPI * vibRate / sr : 0;
+        let vibPh = TWOPI * vibRate * (startS + startSampleOffset) / sr;
+
+        // Stereo pan factor
+        let panL = 1, panR = 1;
+        if (stereo) {
+          if (cfg.stereoMode === 'lh') {
+            panL = normY < 0.5 ? 1 : 0;
+            panR = normY >= 0.5 ? 1 : 0;
+          } else if (cfg.stereoMode === 'pan') {
+            const panPos = x / width; // 0=left, 1=right
+            panL = Math.cos(panPos * Math.PI / 2);
+            panR = Math.sin(panPos * Math.PI / 2);
+          } else if (cfg.stereoMode === 'freq') {
+            panL = Math.cos(normY * Math.PI / 2);
+            panR = Math.sin(normY * Math.PI / 2);
+          }
+        }
+
+        for (let i = 0; i < colLen; i++) {
+          const si = startS + i;
+
+          let env = 1;
+          if (atkS > 0 && i < atkS) env = i / atkS;
+          if (relS > 0 && i >= colLen - relS) env = Math.min(env, (colLen - i) / relS);
+
+          let vibMod = 0;
+          if (vibDepth > 0 && vibRate > 0) {
+            vibMod = vibDepth * fsin(vibPh) / hFreq; // fractional phase shift
+            vibPh += vibPhInc;
+          }
+
+          const sample = hAmp * env * waveAt(wf, phase + vibMod);
+          chL[si] += sample * panL;
+          if (chR) chR[si] += sample * panR;
+          phase += phInc;
+        }
+      }
+    }
+
+    if (x % 32 === 0) {
+      self.postMessage({ type: 'progress', pct: x / width });
+    }
+  }
+
+  // Normalize
+  let maxAmp = 0;
+  for (let i = 0; i < totalSamples; i++) maxAmp = Math.max(maxAmp, Math.abs(chL[i]));
+  if (chR) for (let i = 0; i < totalSamples; i++) maxAmp = Math.max(maxAmp, Math.abs(chR[i]));
+
+  if (maxAmp > 1e-8) {
+    if (cfg.useDynamicRange) {
+      const dbScale = Math.pow(10, cfg.dynamicRange / 20);
+      const scale = dbScale / maxAmp;
+      const minAmp = 1 / dbScale;
+      for (let i = 0; i < totalSamples; i++) {
+        const s = chL[i] * scale;
+        chL[i] = Math.sign(s) * Math.max(minAmp, Math.abs(s));
+        if (chR) {
+          const sr2 = chR[i] * scale;
+          chR[i] = Math.sign(sr2) * Math.max(minAmp, Math.abs(sr2));
+        }
+      }
+    } else {
+      const scale = 0.85 / maxAmp;
+      for (let i = 0; i < totalSamples; i++) {
+        chL[i] *= scale;
+        if (chR) chR[i] *= scale;
+      }
+    }
+  }
+
+  return chR ? [chL, chR] : [chL];
+}
+
+self.onmessage = function(e) {
+  const { pixels, width, height, cfg, startSampleOffset = 0 } = e.data;
+  const channels = synthesize(pixels, width, height, cfg, startSampleOffset);
+  self.postMessage({ type: 'done', channels }, channels.map(c => c.buffer));
+};
+`;
+
+// ═══════════════════════════════════════════════════════════════════
+// WAV BLOB CREATOR
+// ═══════════════════════════════════════════════════════════════════
+function writeString(view, offset, str) {
+  for (let i = 0; i < str.length; i++) view.setUint8(offset + i, str.charCodeAt(i));
+}
+
+DataView.prototype.setInt24 = function(pos, val) {
+  this.setUint8(pos, val & 0xff);
+  this.setUint8(pos + 1, (val >> 8) & 0xff);
+  this.setUint8(pos + 2, (val >> 16) & 0xff);
+};
+
+function createWavBlob(channels, sampleRate, bitDepth) {
+  const numChannels = channels.length;
+  const totalSamples = channels[0].length;
+  const bytesPerSample = bitDepth / 8;
+  const dataSize = totalSamples * numChannels * bytesPerSample;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  writeString(view, 0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(view, 8, 'WAVE');
+  writeString(view, 12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * numChannels * bytesPerSample, true);
+  view.setUint16(32, numChannels * bytesPerSample, true);
+  view.setUint16(34, bitDepth, true);
+  writeString(view, 36, 'data');
+  view.setUint32(40, dataSize, true);
+
+  let offset = 44;
+  for (let i = 0; i < totalSamples; i++) {
+    for (let ch = 0; ch < numChannels; ch++) {
+      const s = Math.max(-1, Math.min(1, channels[ch][i]));
+      if (bitDepth === 8) {
+        view.setUint8(offset++, Math.floor((s + 1) * 127.5));
+      } else if (bitDepth === 16) {
+        view.setInt16(offset, s * 32767, true); offset += 2;
+      } else if (bitDepth === 24) {
+        view.setInt24(offset, Math.floor(s * 8388607)); offset += 3;
+      } else {
+        view.setInt32(offset, Math.floor(s * 2147483647), true); offset += 4;
+      }
+    }
+  }
+  return new Blob([buffer], { type: 'audio/wav' });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// WORKER RUNNER
+// ═══════════════════════════════════════════════════════════════════
+function makeWorker() {
+  const blob = new Blob([WORKER_CODE], { type: 'application/javascript' });
+  return new Worker(URL.createObjectURL(blob));
+}
+
+let activeWorker = null;
+
+function runWorker(pixels, width, height, cfg, onProgress, startSampleOffset = 0) {
+  return new Promise((resolve, reject) => {
+    if (activeWorker) { activeWorker.terminate(); activeWorker = null; }
+    const worker = makeWorker();
+    activeWorker = worker;
+    worker.onmessage = (e) => {
+      if (e.data.type === 'progress') {
+        onProgress(e.data.pct);
+      } else if (e.data.type === 'done') {
+        activeWorker = null;
+        resolve(e.data.channels);
+      }
+    };
+    worker.onerror = (e) => { activeWorker = null; reject(e); };
+    worker.postMessage({ pixels, width, height, cfg: JSON.parse(JSON.stringify(cfg)), startSampleOffset },
+      [pixels.buffer]);
+  });
+}
+
+function cancelWorker() {
+  if (activeWorker) { activeWorker.terminate(); activeWorker = null; }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// IMAGE PROCESSING
+// ═══════════════════════════════════════════════════════════════════
+const isMobile = () => window.matchMedia('(pointer: coarse)').matches || window.innerWidth < 700;
+function adaptiveMaxSize(durationHint) {
+  if (isMobile() || (durationHint && durationHint > 60)) return { maxW: 512, maxH: 256 };
+  return { maxW: 1024, maxH: 512 };
+}
+function processImageToData(img, maxW = 1024, maxH = 512) {
+  const canvas = document.createElement('canvas');
+  let w = img.width, h = img.height;
+  if (w > maxW || h > maxH) {
+    const r = Math.min(maxW / w, maxH / h);
+    w = Math.floor(w * r); h = Math.floor(h * r);
+  }
+  canvas.width = w; canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(img, 0, 0, w, h);
+  const imageData = ctx.getImageData(0, 0, w, h);
+  const pixels = new Uint8Array(w * h * 3);
+  for (let i = 0, j = 0; i < imageData.data.length; i += 4, j += 3) {
+    pixels[j] = imageData.data[i];
+    pixels[j+1] = imageData.data[i+1];
+    pixels[j+2] = imageData.data[i+2];
+  }
+  return { width: w, height: h, pixels };
+}
+
+function loadImageFile(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = reject;
+      img.src = e.target.result;
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+function reorientPixels(imgData, direction) {
+  const { width: W, height: H, pixels } = imgData;
+  if (direction === 'lr') return imgData;
+
+  let outW = W, outH = H;
+  if (direction === 'tb' || direction === 'bt') { outW = H; outH = W; }
+
+  const out = new Uint8Array(outW * outH * 3);
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      const srcIdx = (y * W + x) * 3;
+      let dx, dy;
+      switch (direction) {
+        case 'rl': dx = W - 1 - x; dy = y; break;
+        case 'tb': dx = y; dy = x; break;
+        case 'bt': dx = H - 1 - y; dy = x; break;
+        default: dx = x; dy = y;
+      }
+      const dstIdx = (dy * outW + dx) * 3;
+      out[dstIdx] = pixels[srcIdx];
+      out[dstIdx+1] = pixels[srcIdx+1];
+      out[dstIdx+2] = pixels[srcIdx+2];
+    }
+  }
+  return { width: outW, height: outH, pixels: out };
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// SPECTROGRAM PREVIEW
+// ═══════════════════════════════════════════════════════════════════
+function drawSpectrogramPreview(imgData, canvas, cfg) {
+  const W = Math.min(800, imgData.width);
+  const H = Math.min(256, imgData.height);
+  canvas.width = W; canvas.height = H;
+  const ctx = canvas.getContext('2d');
+  const id = ctx.createImageData(W, H);
+
+  for (let i = 0; i < id.data.length; i += 4) {
+    id.data[i] = 0; id.data[i+1] = 0; id.data[i+2] = 0; id.data[i+3] = 255;
+  }
+
+  const maxFreq = cfg.baseFrequency + cfg.frequencySpan;
+  const xRatio = imgData.width / W;
+  const yRatio = imgData.height / H;
+
+  for (let px = 0; px < W; px++) {
+    const srcX = Math.min(imgData.width - 1, Math.floor(px * xRatio));
+    for (let py = 0; py < H; py++) {
+      const srcY = Math.min(imgData.height - 1, Math.floor(py * yRatio));
+      const idx = (srcY * imgData.width + srcX) * 3;
+      let brightness = (imgData.pixels[idx] + imgData.pixels[idx+1] + imgData.pixels[idx+2]) / 3;
+      if (cfg.invertBrightness) brightness = 255 - brightness;
+      if (brightness < cfg.brightnessThreshold) continue;
+
+      const rawI = brightness / 255;
+      let displayI;
+      if (cfg.useDynamicRange) {
+        const db = 20 * Math.log10(Math.max(1e-6, rawI));
+        displayI = (Math.max(-cfg.dynamicRange, db) + cfg.dynamicRange) / cfg.dynamicRange;
+      } else {
+        displayI = rawI;
+      }
+
+      const displayY = H - 1 - py;
+      const dstIdx = (displayY * W + px) * 4;
+      const color = getColor(displayI, cfg.colormap);
+      id.data[dstIdx] = color[0];
+      id.data[dstIdx+1] = color[1];
+      id.data[dstIdx+2] = color[2];
+    }
+  }
+  ctx.putImageData(id, 0, 0);
+}
+
+function displayImageOnCanvas(imgData, canvas) {
+  const maxW = 400, maxH = 300;
+  let w = imgData.width, h = imgData.height;
+  if (w > maxW || h > maxH) {
+    const r = Math.min(maxW/w, maxH/h);
+    w = Math.floor(w*r); h = Math.floor(h*r);
+  }
+  canvas.width = w; canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  const id = ctx.createImageData(w, h);
+  const xr = imgData.width / w, yr = imgData.height / h;
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const si = (Math.floor(y*yr) * imgData.width + Math.floor(x*xr)) * 3;
+      const di = (y*w+x)*4;
+      id.data[di] = imgData.pixels[si];
+      id.data[di+1] = imgData.pixels[si+1];
+      id.data[di+2] = imgData.pixels[si+2];
+      id.data[di+3] = 255;
+    }
+  }
+  ctx.putImageData(id, 0, 0);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// TAB NAVIGATION
+// ═══════════════════════════════════════════════════════════════════
+document.querySelectorAll('.tab-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('active'));
+    btn.classList.add('active');
+    document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// SEGMENT CONTROL HELPER
+// ═══════════════════════════════════════════════════════════════════
+function initSegCtrl(id, configKey) {
+  const ctrl = document.getElementById(id);
+  ctrl.querySelectorAll('button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      ctrl.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      config[configKey] = btn.dataset.val;
+      composerOnChange();
+    });
+  });
+}
+
+function sliderLabel(sliderId, labelId, transform) {
+  const slider = document.getElementById(sliderId);
+  const label = document.getElementById(labelId);
+  slider.addEventListener('input', () => {
+    label.textContent = transform ? transform(slider.value) : slider.value;
+    composerOnChange();
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// COMPOSER TAB
+// ═══════════════════════════════════════════════════════════════════
+let composerImageData = null;
+let composerDebounce = null;
+
+function composerOnChange() {
+  clearTimeout(composerDebounce);
+  composerDebounce = setTimeout(() => {
+    if (composerImageData) {
+      const oriented = reorientPixels(composerImageData, config.imageDirection);
+      drawSpectrogramPreview(oriented, document.getElementById('spectrogramPreviewCanvas'), config);
+    }
+  }, 150);
+}
+
+function initComposer() {
+  // File drop
+  const drop = document.getElementById('composerDrop');
+  const fileInput = document.getElementById('imageInput');
+  drop.addEventListener('click', () => fileInput.click());
+  drop.addEventListener('dragover', e => { e.preventDefault(); drop.classList.add('drag-over'); });
+  drop.addEventListener('dragleave', () => drop.classList.remove('drag-over'));
+  drop.addEventListener('drop', e => {
+    e.preventDefault(); drop.classList.remove('drag-over');
+    if (e.dataTransfer.files[0]) loadComposerImage(e.dataTransfer.files[0]);
+  });
+  fileInput.addEventListener('change', () => { if (fileInput.files[0]) loadComposerImage(fileInput.files[0]); });
+
+  // Duration
+  const durSlider = document.getElementById('duration');
+  const durExact = document.getElementById('durationExact');
+  const durLabel = document.getElementById('durationValue');
+  durSlider.addEventListener('input', () => {
+    config.duration = parseFloat(durSlider.value);
+    durLabel.textContent = config.duration.toFixed(1);
+    durExact.value = config.duration.toFixed(1);
+    composerOnChange();
+  });
+  durExact.addEventListener('change', () => {
+    const v = Math.max(0.1, Math.min(300, parseFloat(durExact.value) || 5));
+    config.duration = v;
+    durSlider.value = v;
+    durLabel.textContent = v.toFixed(1);
+    composerOnChange();
+  });
+
+  // Checkboxes
+  document.getElementById('invertBrightness').addEventListener('change', function() {
+    config.invertBrightness = this.checked; composerOnChange();
+  });
+  document.getElementById('mirrorTime').addEventListener('change', function() {
+    config.mirrorTime = this.checked; composerOnChange();
+  });
+
+  // Seg ctrls
+  initSegCtrl('directionCtrl', 'imageDirection');
+  initSegCtrl('freqScaleCtrl', 'freqScale');
+  initSegCtrl('waveformCtrl', 'waveform');
+  initSegCtrl('stereoModeCtrl', 'stereoMode');
+
+  // Sliders
+  sliderLabel('baseFreq', 'baseFreqValue', v => { config.baseFrequency = parseInt(v); return v; });
+  sliderLabel('freqSpan', 'freqSpanValue', v => { config.frequencySpan = parseInt(v); return v; });
+  sliderLabel('frequencyShift', 'freqShiftValue', v => { config.frequencyShift = parseInt(v); return v; });
+  sliderLabel('harmonicCount', 'harmonicCountValue', v => { config.harmonicCount = parseInt(v); return v; });
+  sliderLabel('harmonicRolloff', 'harmonicRolloffValue', v => { config.harmonicRolloff = parseFloat(v); return parseFloat(v).toFixed(2); });
+  sliderLabel('chaos', 'chaosValue', v => { config.chaos = parseInt(v); return v; });
+  sliderLabel('vibratoRate', 'vibratoRateValue', v => { config.vibratoRate = parseFloat(v); return parseFloat(v).toFixed(1); });
+  sliderLabel('vibratoDepth', 'vibratoDepthValue', v => { config.vibratoDepth = parseInt(v); return v; });
+  sliderLabel('attackMs', 'attackValue', v => { config.attackMs = parseInt(v); return v; });
+  sliderLabel('releaseMs', 'releaseValue', v => { config.releaseMs = parseInt(v); return v; });
+  sliderLabel('brightnessThreshold', 'brightnessThresholdValue', v => { config.brightnessThreshold = parseInt(v); return v; });
+  sliderLabel('dynamicRange', 'dynamicRangeValue', v => { config.dynamicRange = parseInt(v); return v; });
+  sliderLabel('gain', 'gainValue', v => { config.gain = parseInt(v) / 100; return v; });
+
+  // Pitch quantize
+  document.getElementById('pitchQuantize').addEventListener('change', function() {
+    config.pitchQuantize = this.value; composerOnChange();
+  });
+
+  // Dynamic range toggle
+  document.getElementById('dynamicRangeToggle').addEventListener('change', function() {
+    config.useDynamicRange = this.checked;
+    document.getElementById('dynamicRangeControl').style.display = this.checked ? '' : 'none';
+    composerOnChange();
+  });
+
+  // Phase randomize
+  document.getElementById('phaseRandomize').addEventListener('change', function() {
+    config.phaseRandomize = this.checked;
+  });
+
+  // Sample rate / bit depth / colormap
+  document.getElementById('sampleRate').addEventListener('change', function() {
+    config.sampleRate = parseInt(this.value);
+  });
+  document.getElementById('bitDepth').addEventListener('change', function() {
+    config.bitDepth = parseInt(this.value);
+  });
+  document.getElementById('colormap').addEventListener('change', function() {
+    config.colormap = this.value; composerOnChange();
+  });
+
+  // Generate
+  document.getElementById('convertBtn').addEventListener('click', generateComposerAudio);
+  document.getElementById('cancelBtn').addEventListener('click', () => {
+    cancelWorker();
+    setComposerBusy(false);
+    setStatus('composerStatus', 'Cancelled.', 'err');
+  });
+}
+
+async function loadComposerImage(file) {
+  try {
+    const img = await loadImageFile(file);
+    const { maxW, maxH } = adaptiveMaxSize(config.duration);
+    composerImageData = processImageToData(img, maxW, maxH);
+    const oriented = reorientPixels(composerImageData, config.imageDirection);
+    displayImageOnCanvas(oriented, document.getElementById('imageCanvas'));
+    drawSpectrogramPreview(oriented, document.getElementById('spectrogramPreviewCanvas'), config);
+    setStatus('composerStatus', `Loaded: ${file.name} (${composerImageData.width}×${composerImageData.height})`, 'ok');
+  } catch (e) {
+    setStatus('composerStatus', 'Error loading image: ' + e.message, 'err');
+  }
+}
+
+function setComposerBusy(busy) {
+  document.getElementById('convertBtn').disabled = busy;
+  document.getElementById('cancelBtn').style.display = busy ? '' : 'none';
+  document.getElementById('composerProgressWrap').style.display = busy ? '' : 'none';
+  if (!busy) document.getElementById('composerProgress').style.width = '0%';
+}
+
+async function generateComposerAudio() {
+  if (!composerImageData) { setStatus('composerStatus', 'Load an image first.', 'err'); return; }
+  setComposerBusy(true);
+  setStatus('composerStatus', 'Synthesizing...');
+
+  try {
+    let imgData = reorientPixels(composerImageData, config.imageDirection);
+    if (config.mirrorTime) {
+      // flip X
+      const flipped = new Uint8Array(imgData.pixels.length);
+      for (let y = 0; y < imgData.height; y++) {
+        for (let x = 0; x < imgData.width; x++) {
+          const si = (y * imgData.width + (imgData.width - 1 - x)) * 3;
+          const di = (y * imgData.width + x) * 3;
+          flipped[di] = imgData.pixels[si];
+          flipped[di+1] = imgData.pixels[si+1];
+          flipped[di+2] = imgData.pixels[si+2];
+        }
+      }
+      imgData = { ...imgData, pixels: flipped };
+    }
+
+    const pixels = new Uint8Array(imgData.pixels);
+    const channels = await runWorker(pixels, imgData.width, imgData.height, config, (pct) => {
+      document.getElementById('composerProgress').style.width = (pct * 100).toFixed(0) + '%';
+    });
+
+    const blob = createWavBlob(channels, config.sampleRate, config.bitDepth);
+    const url = URL.createObjectURL(blob);
+    document.getElementById('audioPlayer').src = url;
+    const dlBtn = document.getElementById('downloadBtn');
+    dlBtn.disabled = false;
+    dlBtn.onclick = () => { const a = document.createElement('a'); a.href = url; a.download = 'sonivista.wav'; a.click(); };
+    document.getElementById('fileSizeLabel').textContent = `${(blob.size / 1024 / 1024).toFixed(2)} MB`;
+    setStatus('composerStatus', 'Done!', 'ok');
+  } catch (e) {
+    setStatus('composerStatus', 'Error: ' + (e.message || e), 'err');
+  } finally {
+    setComposerBusy(false);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// SEQUENCE TAB
+// ═══════════════════════════════════════════════════════════════════
+let seqImages = []; // [{file, img, imgData, duration, transpose}]
+
+function initSequence() {
+  document.getElementById('seqAddBtn').addEventListener('click', () =>
+    document.getElementById('seqFileInput').click());
+
+  document.getElementById('seqFileInput').addEventListener('change', async function() {
+    const defDur = parseFloat(document.getElementById('seqDefaultDur').value) || config.duration;
+    for (const file of this.files) {
+      try {
+        const img = await loadImageFile(file);
+        const { maxW, maxH } = adaptiveMaxSize(defDur);
+        const imgData = processImageToData(img, maxW, maxH);
+        seqImages.push({ file, img, imgData, duration: defDur, transpose: 0 });
+      } catch(e) { console.warn('Failed to load', file.name, e); }
+    }
+    this.value = '';
+    renderSeqList();
+  });
+
+  const transCtrl = document.getElementById('transitionTypeCtrl');
+  transCtrl.querySelectorAll('button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      transCtrl.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      updateSeqTotalLabel();
+    });
+  });
+
+  const transSlider = document.getElementById('transitionDur');
+  transSlider.addEventListener('input', () => {
+    document.getElementById('transitionDurValue').textContent = parseFloat(transSlider.value).toFixed(1);
+    updateSeqTotalLabel();
+  });
+
+  const defDurSlider = document.getElementById('seqDefaultDur');
+  defDurSlider.addEventListener('input', () => {
+    document.getElementById('seqDefaultDurValue').textContent = parseFloat(defDurSlider.value).toFixed(1);
+  });
+
+  document.getElementById('seqGenerateBtn').addEventListener('click', generateSequence);
+  document.getElementById('seqCancelBtn').addEventListener('click', () => {
+    cancelWorker();
+    setSeqBusy(false);
+    setStatus('seqStatus', 'Cancelled.', 'err');
+  });
+}
+
+function updateSeqTotalLabel() {
+  const lbl = document.getElementById('seqTotalDurLabel');
+  if (!lbl || seqImages.length === 0) { if (lbl) lbl.textContent = ''; return; }
+  const transType = document.getElementById('transitionTypeCtrl').querySelector('.active').dataset.val;
+  const xf = transType !== 'none' ? parseFloat(document.getElementById('transitionDur').value) : 0;
+  const rawTotal = seqImages.reduce((s, i) => s + i.duration, 0);
+  const total = Math.max(0, rawTotal - xf * Math.max(0, seqImages.length - 1));
+  lbl.textContent = `Total: ~${total.toFixed(1)}s across ${seqImages.length} image${seqImages.length !== 1 ? 's' : ''}`;
+}
+
+function renderSeqList() {
+  const list = document.getElementById('seqList');
+  if (seqImages.length === 0) {
+    list.innerHTML = '<div style="color:var(--muted);font-size:11px;padding:20px;text-align:center;border:1px dashed var(--border);border-radius:6px">No images added yet</div>';
+    updateSeqTotalLabel();
+    return;
+  }
+  list.innerHTML = '';
+  seqImages.forEach((item, idx) => {
+    const el = document.createElement('div');
+    el.className = 'seq-item';
+    el.draggable = true;
+
+    // Thumbnail
+    const thumbCanvas = document.createElement('canvas');
+    thumbCanvas.width = 48; thumbCanvas.height = 32;
+    thumbCanvas.className = 'seq-thumb';
+    thumbCanvas.getContext('2d').drawImage(item.img, 0, 0, 48, 32);
+    el.appendChild(thumbCanvas);
+
+    // Name
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'seq-name'; nameSpan.title = item.file.name;
+    nameSpan.textContent = item.file.name;
+    el.appendChild(nameSpan);
+
+    // Controls
+    const ctrls = document.createElement('div');
+    ctrls.className = 'seq-item-ctrls';
+
+    const durLbl = document.createElement('label'); durLbl.textContent = 'dur';
+    const durInp = document.createElement('input');
+    durInp.type = 'number'; durInp.value = item.duration.toFixed(1);
+    durInp.min = 0.1; durInp.max = 300; durInp.step = 0.5;
+    durInp.style.width = '58px';
+    durInp.addEventListener('change', () => { item.duration = Math.max(0.1, parseFloat(durInp.value) || 5); updateSeqTotalLabel(); });
+
+    const shiftLbl = document.createElement('label'); shiftLbl.textContent = 'shift';
+    const shiftInp = document.createElement('input');
+    shiftInp.type = 'number'; shiftInp.value = item.transpose;
+    shiftInp.min = -10000; shiftInp.max = 10000; shiftInp.step = 50;
+    shiftInp.style.width = '65px';
+    shiftInp.addEventListener('change', () => { item.transpose = parseFloat(shiftInp.value) || 0; });
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'btn danger sm'; delBtn.textContent = '✕';
+    delBtn.addEventListener('click', () => { seqImages.splice(idx, 1); renderSeqList(); });
+
+    // Up/Down buttons (work on all devices)
+    const moveBtns = document.createElement('div');
+    moveBtns.className = 'move-btns';
+    const upBtn = document.createElement('button'); upBtn.textContent = '↑'; upBtn.title = 'Move up';
+    const dnBtn = document.createElement('button'); dnBtn.textContent = '↓'; dnBtn.title = 'Move down';
+    upBtn.addEventListener('click', () => { if (idx > 0) { [seqImages[idx-1], seqImages[idx]] = [seqImages[idx], seqImages[idx-1]]; renderSeqList(); } });
+    dnBtn.addEventListener('click', () => { if (idx < seqImages.length-1) { [seqImages[idx], seqImages[idx+1]] = [seqImages[idx+1], seqImages[idx]]; renderSeqList(); } });
+    moveBtns.appendChild(upBtn); moveBtns.appendChild(dnBtn);
+
+    ctrls.append(durLbl, durInp, shiftLbl, shiftInp, delBtn, moveBtns);
+    el.appendChild(ctrls);
+
+    // Desktop drag-to-reorder
+    el.addEventListener('dragstart', e => { e.dataTransfer.setData('text/plain', idx); el.style.opacity = '.4'; });
+    el.addEventListener('dragend', () => { el.style.opacity = '1'; });
+    el.addEventListener('dragover', e => { e.preventDefault(); el.classList.add('drag-over'); });
+    el.addEventListener('dragleave', () => el.classList.remove('drag-over'));
+    el.addEventListener('drop', e => {
+      e.preventDefault(); el.classList.remove('drag-over');
+      const src = parseInt(e.dataTransfer.getData('text/plain'));
+      if (!isNaN(src) && src !== idx) {
+        const [moved] = seqImages.splice(src, 1);
+        seqImages.splice(idx, 0, moved);
+        renderSeqList();
+      }
+    });
+
+    list.appendChild(el);
+  });
+  updateSeqTotalLabel();
+}
+
+function setSeqBusy(busy) {
+  document.getElementById('seqGenerateBtn').disabled = busy;
+  document.getElementById('seqCancelBtn').style.display = busy ? '' : 'none';
+  document.getElementById('seqProgressWrap').style.display = busy ? '' : 'none';
+}
+
+async function generateSequence() {
+  if (seqImages.length === 0) { setStatus('seqStatus', 'Add images first.', 'err'); return; }
+  setSeqBusy(true);
+
+  const transType = document.getElementById('transitionTypeCtrl').querySelector('.active').dataset.val;
+  const xfadeDur = parseFloat(document.getElementById('transitionDur').value);
+  const sr = config.sampleRate;
+
+  try {
+    // ── Step 1: Render every image at its full specified duration ──────
+    const imageBuffers = [];
+    for (let i = 0; i < seqImages.length; i++) {
+      const item = seqImages[i];
+      setStatus('seqStatus', `Synthesizing image ${i + 1} / ${seqImages.length}…`);
+      const imgCfg = Object.assign({}, config, {
+        duration: item.duration,
+        frequencyShift: config.frequencyShift + (item.transpose || 0),
+      });
+      const imgData = reorientPixels(item.imgData, config.imageDirection);
+      const channels = await runWorker(
+        new Uint8Array(imgData.pixels), imgData.width, imgData.height, imgCfg,
+        pct => { document.getElementById('seqProgress').style.width = ((i + pct) / seqImages.length * 100).toFixed(0) + '%'; }
+      );
+      imageBuffers.push(channels);
+    }
+
+    const numCh = Math.max(...imageBuffers.map(b => b.length));
+
+    // ── Step 2: Assemble with chosen transition strategy ───────────────
+    let outChannels;
+
+    if (transType === 'none' || seqImages.length === 1) {
+      // Simple concatenation — no overlap
+      const total = imageBuffers.reduce((s, b) => s + b[0].length, 0);
+      outChannels = Array.from({ length: numCh }, () => new Float32Array(total));
+      let pos = 0;
+      for (const buf of imageBuffers) {
+        for (let ch = 0; ch < numCh; ch++) outChannels[ch].set(ch < buf.length ? buf[ch] : buf[0], pos);
+        pos += buf[0].length;
+      }
+
+    } else if (transType === 'crossfade') {
+      // Overlap-add with power-of-cosine amplitude envelopes
+      const minBufLen = Math.min(...imageBuffers.map(b => b[0].length));
+      const xf = Math.min(Math.floor(xfadeDur * sr), Math.floor(minBufLen * 0.45));
+      const total = Math.max(1, imageBuffers.reduce((s, b) => s + b[0].length, 0) - (imageBuffers.length - 1) * xf);
+      outChannels = Array.from({ length: numCh }, () => new Float32Array(total));
+      let pos = 0;
+      for (let i = 0; i < imageBuffers.length; i++) {
+        const buf = imageBuffers[i];
+        const len = buf[0].length;
+        const fadeIn  = i > 0                       ? xf : 0;
+        const fadeOut = i < imageBuffers.length - 1 ? xf : 0;
+        for (let ch = 0; ch < numCh; ch++) {
+          const src = ch < buf.length ? buf[ch] : buf[0];
+          for (let j = 0; j < len; j++) {
+            const si = pos + j;
+            if (si >= total) break;
+            let g = 1;
+            if (fadeIn  > 0 && j < fadeIn)          g = j / fadeIn;
+            if (fadeOut > 0 && j >= len - fadeOut)   g = Math.min(g, (len - j) / fadeOut);
+            outChannels[ch][si] += src[j] * g;
+          }
+        }
+        pos += len - (i < imageBuffers.length - 1 ? xf : 0);
+      }
+
+    } else if (transType === 'morph') {
+      // Render pixel-blended transition audio per boundary, then concatenate:
+      // [img0 body] [morph 0→1] [img1 body] [morph 1→2] [img2 body] …
+      // "body" = full render with half-xfade trimmed from each adjacent end
+      const MORPH_FRAMES = 8;
+      const frameDur = xfadeDur / MORPH_FRAMES;
+      const halfXf = Math.floor(xfadeDur * sr / 2);
+
+      const morphBuffers = [];
+      for (let i = 0; i < seqImages.length - 1; i++) {
+        setStatus('seqStatus', `Morphing ${i + 1}→${i + 2} (${MORPH_FRAMES} frames)…`);
+        const imgA = reorientPixels(seqImages[i].imgData, config.imageDirection);
+        const imgB = reorientPixels(seqImages[i + 1].imgData, config.imageDirection);
+        const tA = seqImages[i].transpose || 0, tB = seqImages[i + 1].transpose || 0;
+        const frameParts = Array.from({ length: numCh }, () => []);
+
+        for (let f = 0; f < MORPH_FRAMES; f++) {
+          const alpha = f / (MORPH_FRAMES - 1);
+          const blended = blendImageData(imgA, imgB, alpha);
+          const frameCfg = Object.assign({}, config, {
+            duration: frameDur,
+            frequencyShift: config.frequencyShift + tA * (1 - alpha) + tB * alpha,
+          });
+          const fCh = await runWorker(new Uint8Array(blended.pixels), blended.width, blended.height, frameCfg, () => {});
+          for (let ch = 0; ch < numCh; ch++) frameParts[ch].push(ch < fCh.length ? fCh[ch] : fCh[0]);
+        }
+        morphBuffers.push(frameParts.map(parts => {
+          const t = parts.reduce((s, p) => s + p.length, 0);
+          const out = new Float32Array(t);
+          let off = 0;
+          for (const p of parts) { out.set(p, off); off += p.length; }
+          return out;
+        }));
+      }
+
+      // Calculate total output length
+      let total = 0;
+      for (let i = 0; i < imageBuffers.length; i++) {
+        const len = imageBuffers[i][0].length;
+        const c0 = i > 0                       ? Math.min(halfXf, Math.floor(len * 0.4)) : 0;
+        const c1 = i < imageBuffers.length - 1 ? Math.min(halfXf, Math.floor(len * 0.4)) : 0;
+        total += Math.max(0, len - c0 - c1);
+        if (i < morphBuffers.length) total += morphBuffers[i][0].length;
+      }
+
+      outChannels = Array.from({ length: numCh }, () => new Float32Array(Math.max(1, total)));
+      let pos = 0;
+      for (let i = 0; i < imageBuffers.length; i++) {
+        const buf = imageBuffers[i];
+        const len = buf[0].length;
+        const c0 = i > 0                       ? Math.min(halfXf, Math.floor(len * 0.4)) : 0;
+        const c1 = i < imageBuffers.length - 1 ? Math.min(halfXf, Math.floor(len * 0.4)) : 0;
+        const wLen = Math.max(0, len - c0 - c1);
+        if (wLen > 0) {
+          for (let ch = 0; ch < numCh; ch++) {
+            const src = ch < buf.length ? buf[ch] : buf[0];
+            outChannels[ch].set(src.subarray(c0, c0 + wLen), pos);
+          }
+          pos += wLen;
+        }
+        if (i < morphBuffers.length) {
+          const morph = morphBuffers[i];
+          for (let ch = 0; ch < numCh; ch++) outChannels[ch].set(ch < morph.length ? morph[ch] : morph[0], pos);
+          pos += morphBuffers[i][0].length;
+        }
+      }
+    }
+
+    // ── Step 3: Normalize & export ─────────────────────────────────────
+    let maxA = 0;
+    outChannels.forEach(ch => { for (const s of ch) maxA = Math.max(maxA, Math.abs(s)); });
+    if (maxA > 0.85) {
+      const scale = 0.85 / maxA;
+      outChannels.forEach(ch => { for (let i = 0; i < ch.length; i++) ch[i] *= scale; });
+    }
+
+    const blob = createWavBlob(outChannels, sr, config.bitDepth);
+    const url = URL.createObjectURL(blob);
+    document.getElementById('seqAudioPlayer').src = url;
+    const dlBtn = document.getElementById('seqDownloadBtn');
+    dlBtn.disabled = false;
+    dlBtn.onclick = () => { const a = document.createElement('a'); a.href = url; a.download = 'sonivista-sequence.wav'; a.click(); };
+    const totalSec = outChannels[0].length / sr;
+    document.getElementById('seqFileSizeLabel').textContent = `${(blob.size / 1024 / 1024).toFixed(2)} MB · ${totalSec.toFixed(1)}s`;
+    setStatus('seqStatus', `Done! ${seqImages.length} image${seqImages.length !== 1 ? 's' : ''}, ${totalSec.toFixed(1)}s total`, 'ok');
+
+  } catch (e) {
+    setStatus('seqStatus', 'Error: ' + (e.message || e), 'err');
+  } finally {
+    setSeqBusy(false);
+  }
+}
+
+function blendImageData(a, b, alpha) {
+  const W = Math.min(a.width, b.width);
+  const H = Math.min(a.height, b.height);
+  const pixels = new Uint8Array(W * H * 3);
+  const xrA = a.width / W, yrA = a.height / H;
+  const xrB = b.width / W, yrB = b.height / H;
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      const siA = (Math.floor(y*yrA) * a.width + Math.floor(x*xrA)) * 3;
+      const siB = (Math.floor(y*yrB) * b.width + Math.floor(x*xrB)) * 3;
+      const di = (y*W+x)*3;
+      pixels[di]   = a.pixels[siA]   * (1-alpha) + b.pixels[siB]   * alpha;
+      pixels[di+1] = a.pixels[siA+1] * (1-alpha) + b.pixels[siB+1] * alpha;
+      pixels[di+2] = a.pixels[siA+2] * (1-alpha) + b.pixels[siB+2] * alpha;
+    }
+  }
+  return { width: W, height: H, pixels };
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// META COMPOSER TAB
+// ═══════════════════════════════════════════════════════════════════
+let metaTiles = [];      // [{id, file, img, imgData}]
+let metaPlacements = []; // [{tileId, x, y, w, h, weight, blend}]
+let metaSelectedTileId = null;
+let metaSelectedPlacementIdx = null;
+let metaTileIdCounter = 0;
+
+function initMeta() {
+  document.getElementById('metaAddTileBtn').addEventListener('click', () =>
+    document.getElementById('metaTileInput').click());
+
+  document.getElementById('metaTileInput').addEventListener('change', async function() {
+    for (const file of this.files) {
+      const img = await loadImageFile(file);
+      const imgData = processImageToData(img, 256, 256);
+      metaTiles.push({ id: metaTileIdCounter++, file, img, imgData });
+    }
+    this.value = '';
+    renderTileLibrary();
+  });
+
+  document.getElementById('metaClearBtn').addEventListener('click', () => {
+    metaPlacements = [];
+    metaSelectedPlacementIdx = null;
+    renderMetaCanvas();
+    hideTileProps();
+  });
+
+  document.getElementById('mosaicFillBtn').addEventListener('click', fillMosaic);
+  document.getElementById('metaGenerateBtn').addEventListener('click', generateMeta);
+  document.getElementById('metaCancelBtn').addEventListener('click', () => {
+    cancelWorker();
+    setMetaBusy(false);
+    setStatus('metaStatus', 'Cancelled.', 'err');
+  });
+  document.getElementById('deleteTileBtn').addEventListener('click', () => {
+    if (metaSelectedPlacementIdx !== null) {
+      metaPlacements.splice(metaSelectedPlacementIdx, 1);
+      metaSelectedPlacementIdx = null;
+      hideTileProps();
+      renderMetaCanvas();
+    }
+  });
+
+  // Meta canvas click
+  const mc = document.getElementById('metaCanvas');
+  mc.addEventListener('click', (e) => {
+    const rect = mc.getBoundingClientRect();
+    const cx = (e.clientX - rect.left) / rect.width * 100;
+    const cy = (e.clientY - rect.top) / rect.height * 100;
+
+    // Check if clicking on an existing placement
+    for (let i = metaPlacements.length - 1; i >= 0; i--) {
+      const p = metaPlacements[i];
+      if (cx >= p.x && cx <= p.x+p.w && cy >= p.y && cy <= p.y+p.h) {
+        metaSelectedPlacementIdx = i;
+        showTileProps(p);
+        renderMetaCanvas();
+        return;
+      }
+    }
+
+    // Place new tile
+    if (metaSelectedTileId === null) return;
+    const newPlacement = { tileId: metaSelectedTileId, x: Math.max(0, cx - 12.5), y: Math.max(0, cy - 12.5), w: 25, h: 25, weight: 1, blend: 'add' };
+    metaPlacements.push(newPlacement);
+    metaSelectedPlacementIdx = metaPlacements.length - 1;
+    showTileProps(newPlacement);
+    renderMetaCanvas();
+  });
+
+  // Tile property inputs
+  ['tileX','tileY','tileW','tileH'].forEach(id => {
+    document.getElementById(id).addEventListener('change', syncTileProps);
+  });
+  document.getElementById('tileWeight').addEventListener('input', function() {
+    document.getElementById('tileWeightValue').textContent = parseFloat(this.value).toFixed(2);
+    syncTileProps();
+  });
+  document.getElementById('tileBlend').addEventListener('change', syncTileProps);
+
+  // Meta canvas duration/freq sliders
+  const metaDurSlider = document.getElementById('metaDuration');
+  metaDurSlider.addEventListener('input', function() {
+    document.getElementById('metaDurValue').textContent = this.value;
+    document.getElementById('metaTimeLabel').textContent = this.value + 's';
+    renderMetaCanvas();
+  });
+  document.getElementById('metaBaseFreq').addEventListener('input', function() {
+    document.getElementById('metaBaseFreqValue').textContent = this.value;
+  });
+  document.getElementById('metaFreqSpan').addEventListener('input', function() {
+    document.getElementById('metaFreqSpanValue').textContent = this.value;
+  });
+
+  document.getElementById('metaTimeLabel').textContent = metaDurSlider.value + 's';
+  renderMetaCanvas();
+}
+
+function renderTileLibrary() {
+  const grid = document.getElementById('tileGrid');
+  grid.innerHTML = '';
+  metaTiles.forEach(tile => {
+    const el = document.createElement('div');
+    el.className = 'tile-item' + (tile.id === metaSelectedTileId ? ' selected' : '');
+    el.dataset.id = tile.id;
+    const img = document.createElement('img');
+    // Create thumbnail URL
+    const thumbCanvas = document.createElement('canvas');
+    thumbCanvas.width = 64; thumbCanvas.height = 64;
+    thumbCanvas.getContext('2d').drawImage(tile.img, 0, 0, 64, 64);
+    img.src = thumbCanvas.toDataURL();
+    const delBtn = document.createElement('button');
+    delBtn.className = 'tile-del';
+    delBtn.textContent = '✕';
+    delBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      metaTiles = metaTiles.filter(t => t.id !== tile.id);
+      metaPlacements = metaPlacements.filter(p => p.tileId !== tile.id);
+      if (metaSelectedTileId === tile.id) metaSelectedTileId = null;
+      renderTileLibrary();
+      renderMetaCanvas();
+    });
+    el.appendChild(img);
+    el.appendChild(delBtn);
+    el.addEventListener('click', () => {
+      metaSelectedTileId = tile.id;
+      renderTileLibrary();
+    });
+    grid.appendChild(el);
+  });
+}
+
+function showTileProps(p) {
+  document.getElementById('metaNoSelection').style.display = 'none';
+  const propsEl = document.getElementById('metaTileProps');
+  propsEl.style.display = 'flex';
+  document.getElementById('tileX').value = p.x.toFixed(1);
+  document.getElementById('tileY').value = p.y.toFixed(1);
+  document.getElementById('tileW').value = p.w.toFixed(1);
+  document.getElementById('tileH').value = p.h.toFixed(1);
+  document.getElementById('tileWeight').value = p.weight;
+  document.getElementById('tileWeightValue').textContent = p.weight.toFixed(2);
+  document.getElementById('tileBlend').value = p.blend;
+}
+
+function hideTileProps() {
+  document.getElementById('metaNoSelection').style.display = '';
+  document.getElementById('metaTileProps').style.display = 'none';
+}
+
+function syncTileProps() {
+  if (metaSelectedPlacementIdx === null) return;
+  const p = metaPlacements[metaSelectedPlacementIdx];
+  p.x = parseFloat(document.getElementById('tileX').value) || 0;
+  p.y = parseFloat(document.getElementById('tileY').value) || 0;
+  p.w = parseFloat(document.getElementById('tileW').value) || 25;
+  p.h = parseFloat(document.getElementById('tileH').value) || 25;
+  p.weight = parseFloat(document.getElementById('tileWeight').value) || 1;
+  p.blend = document.getElementById('tileBlend').value;
+  renderMetaCanvas();
+}
+
+function fillMosaic() {
+  const cols = parseInt(document.getElementById('mosaicCols').value) || 3;
+  const rows = parseInt(document.getElementById('mosaicRows').value) || 3;
+  if (metaTiles.length === 0) { setStatus('metaStatus', 'Add tiles first.', 'err'); return; }
+  metaPlacements = [];
+  const cw = 100 / cols, ch = 100 / rows;
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const tileIdx = (r * cols + c) % metaTiles.length;
+      metaPlacements.push({
+        tileId: metaTiles[tileIdx].id,
+        x: c * cw, y: r * ch, w: cw, h: ch,
+        weight: 1, blend: 'add'
+      });
+    }
+  }
+  metaSelectedPlacementIdx = null;
+  hideTileProps();
+  renderMetaCanvas();
+}
+
+function renderMetaCanvas() {
+  const canvas = document.getElementById('metaCanvas');
+  const W = canvas.width || canvas.clientWidth || 600;
+  canvas.width = W;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, 0, W, canvas.height);
+
+  const COLORS = ['#00e676','#ff6d00','#7c4dff','#00b0ff','#f44336','#ffcc00','#00bcd4','#e91e63'];
+
+  metaPlacements.forEach((p, idx) => {
+    const tile = metaTiles.find(t => t.id === p.tileId);
+    if (!tile) return;
+
+    const px = p.x / 100 * W;
+    const py = p.y / 100 * canvas.height;
+    const pw = p.w / 100 * W;
+    const ph = p.h / 100 * canvas.height;
+
+    // Draw thumbnail
+    ctx.save();
+    ctx.globalAlpha = Math.min(1, p.weight * 0.7);
+    const thumbCanvas = document.createElement('canvas');
+    thumbCanvas.width = Math.ceil(pw); thumbCanvas.height = Math.ceil(ph);
+    thumbCanvas.getContext('2d').drawImage(tile.img, 0, 0, thumbCanvas.width, thumbCanvas.height);
+    ctx.drawImage(thumbCanvas, px, py, pw, ph);
+    ctx.restore();
+
+    // Highlight selected
+    const color = COLORS[idx % COLORS.length];
+    ctx.strokeStyle = idx === metaSelectedPlacementIdx ? '#fff' : color;
+    ctx.lineWidth = idx === metaSelectedPlacementIdx ? 2 : 1;
+    ctx.strokeRect(px, py, pw, ph);
+
+    ctx.fillStyle = color;
+    ctx.font = '10px monospace';
+    ctx.fillText(tile.file.name.slice(0, 12), px + 3, py + 12);
+  });
+
+  if (metaPlacements.length === 0) {
+    ctx.fillStyle = '#333';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Select a tile from the library, then click here to place it', W/2, canvas.height/2);
+    ctx.textAlign = 'left';
+  }
+}
+
+function compositeMetaSpectrogram() {
+  const W = 512, H = 256;
+  const composite = new Float32Array(W * H); // brightness 0-1
+
+  metaPlacements.forEach(p => {
+    const tile = metaTiles.find(t => t.id === p.tileId);
+    if (!tile) return;
+
+    const x0 = Math.floor(p.x / 100 * W);
+    const y0 = Math.floor(p.y / 100 * H);
+    const x1 = Math.min(W, Math.ceil((p.x + p.w) / 100 * W));
+    const y1 = Math.min(H, Math.ceil((p.y + p.h) / 100 * H));
+
+    const tw = x1 - x0, th = y1 - y0;
+    if (tw <= 0 || th <= 0) return;
+
+    const xr = tile.imgData.width / tw;
+    const yr = tile.imgData.height / th;
+
+    for (let cy = 0; cy < th; cy++) {
+      for (let cx = 0; cx < tw; cx++) {
+        const si = (Math.floor(cy*yr) * tile.imgData.width + Math.floor(cx*xr)) * 3;
+        const brightness = (tile.imgData.pixels[si] + tile.imgData.pixels[si+1] + tile.imgData.pixels[si+2]) / 3 / 255;
+        const dstIdx = (y0+cy) * W + (x0+cx);
+        const val = brightness * p.weight;
+
+        switch (p.blend) {
+          case 'add':      composite[dstIdx] = Math.min(1, composite[dstIdx] + val); break;
+          case 'max':      composite[dstIdx] = Math.max(composite[dstIdx], val); break;
+          case 'multiply': composite[dstIdx] = composite[dstIdx] * val; break;
+          case 'screen':   composite[dstIdx] = 1 - (1-composite[dstIdx]) * (1-val); break;
+          default:         composite[dstIdx] = Math.min(1, composite[dstIdx] + val);
+        }
+      }
+    }
+  });
+
+  // Convert float composite to Uint8 RGB pixels
+  const pixels = new Uint8Array(W * H * 3);
+  for (let i = 0; i < W * H; i++) {
+    const v = Math.floor(composite[i] * 255);
+    pixels[i*3] = v; pixels[i*3+1] = v; pixels[i*3+2] = v;
+  }
+  return { width: W, height: H, pixels };
+}
+
+function setMetaBusy(busy) {
+  document.getElementById('metaGenerateBtn').disabled = busy;
+  document.getElementById('metaCancelBtn').style.display = busy ? '' : 'none';
+  document.getElementById('metaProgressWrap').style.display = busy ? '' : 'none';
+}
+
+async function generateMeta() {
+  if (metaPlacements.length === 0) { setStatus('metaStatus', 'Place some tiles first.', 'err'); return; }
+  setMetaBusy(true);
+  setStatus('metaStatus', 'Compositing...');
+
+  try {
+    const composed = compositeMetaSpectrogram();
+    const metaCfg = {
+      ...config,
+      duration: parseFloat(document.getElementById('metaDuration').value),
+      baseFrequency: parseInt(document.getElementById('metaBaseFreq').value),
+      frequencySpan: parseInt(document.getElementById('metaFreqSpan').value),
+    };
+
+    setStatus('metaStatus', 'Synthesizing...');
+    const channels = await runWorker(new Uint8Array(composed.pixels), composed.width, composed.height, metaCfg, (pct) => {
+      document.getElementById('metaProgress').style.width = (pct * 100).toFixed(0) + '%';
+    });
+
+    const blob = createWavBlob(channels, metaCfg.sampleRate, config.bitDepth);
+    const url = URL.createObjectURL(blob);
+    document.getElementById('metaAudioPlayer').src = url;
+    const dlBtn = document.getElementById('metaDownloadBtn');
+    dlBtn.disabled = false;
+    dlBtn.onclick = () => { const a = document.createElement('a'); a.href = url; a.download = 'sonivista-meta.wav'; a.click(); };
+    document.getElementById('metaFileSizeLabel').textContent = `${(blob.size / 1024 / 1024).toFixed(2)} MB`;
+    setStatus('metaStatus', 'Done!', 'ok');
+  } catch (e) {
+    setStatus('metaStatus', 'Error: ' + (e.message || e), 'err');
+  } finally {
+    setMetaBusy(false);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// UTIL
+// ═══════════════════════════════════════════════════════════════════
+function setStatus(id, msg, type) {
+  const el = document.getElementById(id);
+  el.textContent = msg;
+  el.className = 'status' + (type ? ' ' + type : '');
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// INIT
+// ═══════════════════════════════════════════════════════════════════
+document.addEventListener('DOMContentLoaded', () => {
+  initComposer();
+  initSequence();
+  initMeta();
+
+  // Resize meta canvas reactively
+  const metaCanvasParent = document.getElementById('metaCanvas').parentElement;
+  function resizeMetaCanvas() {
+    const mc = document.getElementById('metaCanvas');
+    const newW = metaCanvasParent ? metaCanvasParent.clientWidth : 600;
+    if (newW > 0) { mc.width = newW; renderMetaCanvas(); }
+  }
+  if (typeof ResizeObserver !== 'undefined') {
+    new ResizeObserver(resizeMetaCanvas).observe(metaCanvasParent);
+  } else {
+    window.addEventListener('resize', resizeMetaCanvas);
+    setTimeout(resizeMetaCanvas, 120);
+  }
+
+  // Also resize when switching to the meta tab
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => { if (btn.dataset.tab === 'meta') setTimeout(resizeMetaCanvas, 30); });
+  });
+
+  // SLIDE-style fill: paint the coloured portion left of the knob. One delegated
+  // listener handles every range input, so dragging stays instant (no per-frame
+  // redraw work on the slider itself — the heavy preview redraw is debounced).
+  const paintRange = (el) => {
+    const min = parseFloat(el.min) || 0;
+    const max = parseFloat(el.max);
+    const span = (isNaN(max) ? 100 : max) - min || 1;
+    el.style.setProperty('--fill', (((parseFloat(el.value) - min) / span) * 100) + '%');
+  };
+  document.addEventListener('input', (e) => {
+    if (e.target && e.target.matches && e.target.matches('input[type=range]')) paintRange(e.target);
+  });
+  document.querySelectorAll('input[type=range]').forEach(paintRange);
+});
+</script>
+
+</body>
+</html>

--- a/frontend/src/components/audio/AdvancedVisualizer.tsx
+++ b/frontend/src/components/audio/AdvancedVisualizer.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Zap, Target, Settings2, Maximize2 } from 'lucide-react';
 import { getAnalyser, getEngineCtx, samplePeakAndRMS } from '../../state/playerStore';
+import { QuantumLatticeView } from './QuantumLatticeView';
 
-type Mode = 'oscilloscope' | 'spectrum' | 'radial';
+type Mode = 'oscilloscope' | 'spectrum' | 'radial' | 'quantum';
 
 const OVERLAY_RESERVE_HEIGHT = 18;
 
@@ -95,7 +96,7 @@ export const AdvancedVisualizer: React.FC = () => {
           ctx2d.fillStyle = grad;
           ctx2d.fillRect(x + 0.5, floor - barH, Math.max(1, barWidth - 1), barH);
         }
-      } else {
+      } else if (mode === 'radial') {
         analyser.getByteFrequencyData(freqBuf);
         const cx = w / 2;
         const cy = h / 2;
@@ -134,8 +135,8 @@ export const AdvancedVisualizer: React.FC = () => {
     return () => cancelAnimationFrame(rafRef.current);
   }, [mode]);
 
-  const modeLabels: Record<Mode, string> = { oscilloscope: 'O', spectrum: 'S', radial: 'R' };
-  const modeTitles: Record<Mode, string> = { oscilloscope: 'Oscilloscope', spectrum: 'Spectrum', radial: 'Radial' };
+  const modeLabels: Record<Mode, string> = { oscilloscope: 'O', spectrum: 'S', radial: 'R', quantum: 'Q' };
+  const modeTitles: Record<Mode, string> = { oscilloscope: 'Oscilloscope', spectrum: 'Spectrum', radial: 'Radial', quantum: 'Quantum Lattice' };
 
   return (
     <div className="hardware-card h-full flex flex-col bg-black/40 relative overflow-hidden group">
@@ -152,9 +153,12 @@ export const AdvancedVisualizer: React.FC = () => {
       <div ref={wrapperRef} className="flex-1 min-h-0 relative">
         <canvas ref={canvasRef} className="absolute inset-0 w-full h-full" />
 
-        {/* O / S / R mode buttons — vertical column, top-left */}
+        {/* Quantum Lattice WebGL mode overlays the 2D canvas when selected */}
+        {mode === 'quantum' && <QuantumLatticeView />}
+
+        {/* O / S / R / Q mode buttons — vertical column, top-left */}
         <div className="absolute top-2 left-2 flex flex-col gap-1 z-10">
-          {(['oscilloscope', 'spectrum', 'radial'] as const).map((m) => (
+          {(['oscilloscope', 'spectrum', 'radial', 'quantum'] as const).map((m) => (
             <button
               key={m}
               onClick={() => setMode(m)}

--- a/frontend/src/components/audio/ArpeggiatorPanel.tsx
+++ b/frontend/src/components/audio/ArpeggiatorPanel.tsx
@@ -1,0 +1,393 @@
+/**
+ * ArpeggiatorPanel — the chord-progression arpeggiator UI (the MIDI tab's
+ * alternate face, shown when the roll's "Arp" toggle is on). A faithful React
+ * rebuild of Jake Albaugh's arpeggiator layout (keyboard strip, chord
+ * progression grid, key/mode/steps/type/style selectors, live output) rehosted
+ * on the app's Web Audio synth via `ArpPlayerEngine`. The current progression
+ * can be dumped into the piano roll's note model with one click.
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Play, Square, Piano, Music4 } from 'lucide-react';
+import {
+  ArpPlayerEngine,
+  DEFAULT_ARP_CONFIG,
+  noteNameToMidi,
+  type ArpConfig,
+  type PatternType,
+} from '../../lib/arpEngine';
+import { getEngineCtx } from '../../state/playerStore';
+import { usePianoRollStore, type PianoNote } from '../../state/pianoRollStore';
+import { InstrumentPicker } from './InstrumentPicker';
+
+const KEYS = 'C C# D D# E F F# G G# A A# B'.split(' ');
+const OCTAVES = [2, 3, 4, 5, 6, 7];
+const MODES = ['ionian', 'dorian', 'phrygian', 'lydian', 'mixolydian', 'aeolian', 'locrian', 'major', 'minor', 'melodic', 'harmonic'];
+const INTERVALS = 'i ii iii iv v vi vii'.split(' ');
+const STEP_OPTS = [3, 4, 5, 6];
+const BPM_MIN = 20;
+const BPM_MAX = 300;
+
+/** Tiny polyline thumbnail of one arpeggio index pattern (port of _genPatternSvg). */
+const PatternSvg: React.FC<{ pattern: number[] }> = ({ pattern }) => {
+  const spacing = 2;
+  const hi = Math.max(...pattern);
+  const width = pattern.length * spacing + spacing;
+  const height = hi + spacing * 2;
+  let x = spacing;
+  const pts = pattern.map((p) => {
+    const y = height - p - spacing;
+    const point = `${x},${y}`;
+    x += spacing;
+    return point;
+  });
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-auto pointer-events-none" aria-hidden="true">
+      <polyline points={pts.join(' ')} fill="none" stroke="currentColor" strokeWidth={0.6} strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+};
+
+const Section: React.FC<{ title: string; tip?: string; className?: string; children: React.ReactNode }> = ({ title, tip, className, children }) => (
+  <section className={`rounded-md border border-white/10 bg-black/30 p-2 ${className ?? ''}`}>
+    <h3 className="text-[10px] font-mono font-bold uppercase tracking-[0.15em] text-purple-300/80 mb-1.5" title={tip}>{title}</h3>
+    {children}
+  </section>
+);
+
+// purple accent to match the rest of theDAW (piano roll, MAKE, etc.)
+const cellBase =
+  'text-[11px] font-mono font-semibold uppercase tracking-wide rounded border transition-colors cursor-pointer select-none';
+const cellOn = 'border-purple-400 bg-purple-500 text-white font-bold';
+const cellOff = 'border-white/15 bg-white/8 text-zinc-100 hover:bg-white/15 hover:border-purple-500/40';
+
+export const ArpeggiatorPanel: React.FC = () => {
+  const engineRef = useRef<ArpPlayerEngine | null>(null);
+  if (!engineRef.current) engineRef.current = new ArpPlayerEngine();
+  const engine = engineRef.current;
+
+  const [cfg, setCfg] = useState<ArpConfig>({ ...DEFAULT_ARP_CONFIG });
+  const [playing, setPlaying] = useState(false);
+  const [activeChord, setActiveChord] = useState<number>(-1);
+  const [activeMidi, setActiveMidi] = useState<Set<number>>(new Set());
+  const timeoutsRef = useRef<number[]>([]);
+
+  // Patch engine + local mirror together so the UI and the scheduler agree.
+  const patch = (p: Partial<ArpConfig>): void => {
+    engine.setConfig(p);
+    setCfg({ ...engine.cfg });
+  };
+
+  const clearTimers = (): void => {
+    timeoutsRef.current.forEach((t) => window.clearTimeout(t));
+    timeoutsRef.current = [];
+  };
+
+  useEffect(() => {
+    engine.onTick = ({ when, chordIndex, trebleMidi, bassMidi }) => {
+      const ctx = getEngineCtx();
+      const delay = Math.max(0, (when - ctx.currentTime) * 1000);
+      const id = window.setTimeout(() => {
+        setActiveChord(chordIndex);
+        setActiveMidi((prev) => {
+          const next = new Set(prev);
+          next.add(trebleMidi);
+          if (bassMidi !== null) {
+            // a fresh bass note clears the prior held bass below its register
+            for (const m of next) if (m < 48) next.delete(m);
+            next.add(bassMidi);
+          }
+          // keep the held bass + only the latest treble: drop stale trebles
+          for (const m of next) if (m >= 48 && m !== trebleMidi) next.delete(m);
+          return next;
+        });
+      }, delay);
+      timeoutsRef.current.push(id);
+      // prune fired timers occasionally
+      if (timeoutsRef.current.length > 256) {
+        timeoutsRef.current = timeoutsRef.current.slice(-64);
+      }
+    };
+    engine.onStop = () => {
+      clearTimers();
+      setActiveChord(-1);
+      setActiveMidi(new Set());
+    };
+    return () => {
+      engine.dispose();
+      clearTimers();
+    };
+    // engine is stable (ref); run once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const togglePlay = (): void => {
+    if (playing) {
+      engine.stop();
+      setPlaying(false);
+    } else {
+      engine.start();
+      setPlaying(true);
+    }
+  };
+
+  const sendToRoll = (): void => {
+    const notes = engine.renderProgression();
+    const piano: PianoNote[] = notes.map((n, i) => ({
+      id: `arp-${i}-${n.step}-${n.midi}`,
+      note: n.midi,
+      step: n.step,
+      length: n.length,
+      velocity: n.velocity,
+    }));
+    usePianoRollStore.getState().importNotes(piano, cfg.bpm);
+  };
+
+  const out = engine.outputChords();
+  const scaleName = engine.MS._scale?.name ?? '';
+  const patternList = engine.AP.patterns[cfg.patternType];
+
+  // active note set for keyboard highlight, by midi
+  const trebleMidis = useMemo(() => activeMidi, [activeMidi]);
+
+  const setBpm = (v: number): void =>
+    patch({ bpm: Math.max(BPM_MIN, Math.min(BPM_MAX, Math.round(v) || BPM_MIN)) });
+
+  const qPct = Math.round(cfg.quantize * 100);
+  const ragPct = Math.round(cfg.swing * 100);
+  // small segmented pill (steps / type)
+  const pill = 'px-2 py-0.5 text-[11px] font-mono font-semibold rounded border transition-colors cursor-pointer select-none';
+  const fieldBox = 'flex items-center gap-1 px-1.5 py-0.5 bg-black/40 border border-white/5 rounded';
+
+  return (
+    <div className="h-full w-full flex flex-col bg-[#07050a] text-zinc-100 overflow-hidden">
+      {/* toolbar — same look/feel as the piano roll's toolbar */}
+      <div className="shrink-0 flex flex-wrap items-center gap-2 px-2 py-1 border-b border-white/5 bg-black/40">
+        <button
+          type="button"
+          onClick={togglePlay}
+          aria-label={playing ? 'Stop arpeggiator' : 'Play arpeggiator'}
+          title={playing ? 'Stop' : 'Play'}
+          className={`p-1 rounded transition-colors ${
+            playing
+              ? 'bg-red-500/20 text-red-300 border border-red-500/40'
+              : 'bg-purple-500/20 text-purple-300 border border-purple-500/40 hover:bg-purple-500/30'
+          }`}
+        >
+          {playing ? <Square className="w-3.5 h-3.5 fill-current" /> : <Play className="w-3.5 h-3.5 fill-current" />}
+        </button>
+        <span className="text-[11px] font-black uppercase tracking-widest text-purple-300" title="Chord-progression arpeggiator — pick a key, mode and chords; it arpeggiates them live through theDAW's synth.">Arp</span>
+        <span className="text-[10px] font-mono text-zinc-500" title="Current key + scale">{engine.MS.key} {scaleName}</span>
+
+        {/* BPM */}
+        <div className={fieldBox} title="Tempo in beats per minute. Type a value or use −/+ to step by 5.">
+          <span className="text-[7px] font-mono text-zinc-600 uppercase">BPM</span>
+          <button type="button" aria-label="Decrease BPM" title="−5 BPM" onClick={() => setBpm(cfg.bpm - 5)} className="text-zinc-500 hover:text-zinc-200 leading-none px-0.5">−</button>
+          <label htmlFor="arp-bpm" className="sr-only">BPM</label>
+          <input
+            id="arp-bpm" name="arp-bpm" type="number" min={BPM_MIN} max={BPM_MAX} value={cfg.bpm}
+            onChange={(e) => setBpm(parseInt(e.target.value, 10))}
+            className="bg-transparent border-none outline-none text-[10px] font-mono text-cyan-400 w-9 font-black text-center"
+          />
+          <button type="button" aria-label="Increase BPM" title="+5 BPM" onClick={() => setBpm(cfg.bpm + 5)} className="text-zinc-500 hover:text-zinc-200 leading-none px-0.5">+</button>
+        </div>
+
+        {/* Steps */}
+        <div className="flex items-center gap-1" title="Notes per arpeggio (3-6). More steps = busier, longer pattern.">
+          <span className="text-[7px] font-mono text-zinc-600 uppercase">Steps</span>
+          {STEP_OPTS.map((s) => {
+            const on = cfg.steps === s;
+            return (
+              <button key={s} type="button" aria-label={`Arpeggio steps ${s}`} aria-pressed={on}
+                onClick={() => patch({ steps: s })} title={`${s} notes per arpeggio (more steps = busier pattern)`} className={`${pill} ${on ? cellOn : cellOff}`}>
+                {s}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Type */}
+        <div className="flex items-center gap-1">
+          {(['straight', 'looped'] as PatternType[]).map((t) => {
+            const on = cfg.patternType === t;
+            return (
+              <button key={t} type="button" aria-label={`Arpeggio type ${t}`} aria-pressed={on}
+                onClick={() => patch({ patternType: t })}
+                title={t === 'straight' ? 'Straight: play the note order once per chord' : 'Looped: play the order then mirror back down'}
+                className={`${pill} capitalize ${on ? cellOn : cellOff}`}>
+                {t}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Quantize + Rag (live timing feel, same as the piano roll) */}
+        <div className={fieldBox} title="Quantize: 100% = dead-on grid; lower humanizes timing. Rag delays/pushes the off-16ths.">
+          <span className="text-[7px] font-mono text-zinc-600 uppercase">Q</span>
+          <label htmlFor="arp-quantize" className="sr-only">Quantize</label>
+          <input id="arp-quantize" name="arp-quantize" type="range" min={0} max={100} value={qPct}
+            onChange={(e) => patch({ quantize: (parseInt(e.target.value, 10) || 0) / 100 })} className="w-12 accent-cyan-400" />
+          <span className="text-[8px] font-mono text-cyan-300 w-7 text-right">{qPct}%</span>
+          <span className="text-[7px] font-mono text-zinc-600 uppercase ml-1">Rag</span>
+          <label htmlFor="arp-rag" className="sr-only">Rag (swing)</label>
+          <input id="arp-rag" name="arp-rag" type="range" min={-50} max={50} value={ragPct}
+            onChange={(e) => patch({ swing: (parseInt(e.target.value, 10) || 0) / 100 })} className="w-12 accent-purple-400" />
+          <span className="text-[8px] font-mono text-purple-300 w-8 text-right">{ragPct > 0 ? '+' : ''}{ragPct}%</span>
+        </div>
+
+        <InstrumentPicker />
+
+        {/* Bass */}
+        <button
+          type="button" aria-label="Toggle bass voice" aria-pressed={cfg.bassOn}
+          onClick={() => patch({ bassOn: !cfg.bassOn })} title="Bass voice"
+          className={`${pill} flex items-center gap-1 ${cfg.bassOn ? cellOn : cellOff}`}
+        >
+          <Music4 className="w-3 h-3" /> Bass
+        </button>
+
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={sendToRoll}
+          title="Render the progression into the piano roll's notes"
+          className="flex items-center gap-1 px-2 py-1 text-[10px] font-mono font-semibold uppercase tracking-wide rounded border border-purple-500/40 text-purple-200 hover:bg-purple-500/20 transition-colors"
+        >
+          <Piano className="w-3.5 h-3.5" /> Piano roll
+        </button>
+      </div>
+
+      {/* body: TONIC/MODE (left rail) · CHORDS + OUTPUT (center hero) · STYLES (right rail) */}
+      <div className="flex-1 min-h-0 p-2 grid gap-2" style={{ gridTemplateColumns: '196px minmax(0,1fr) 196px' }}>
+        {/* left rail: tonic + mode */}
+        <div className="flex flex-col gap-2 min-w-0 min-h-0 overflow-y-auto">
+          <Section title="Tonic / root" tip="The key center. Every chord is built from this root note plus the chosen mode.">
+            <div className="grid grid-cols-4 gap-1">
+              {KEYS.map((key) => {
+                const on = cfg.key === key;
+                return (
+                  <button key={key} type="button" aria-label={`Key ${key}`} aria-pressed={on}
+                    onClick={() => patch({ key })} title={`Set the tonic (root) to ${key}`} className={`${cellBase} w-full py-1 ${on ? cellOn : cellOff}`}>
+                    {key}
+                  </button>
+                );
+              })}
+            </div>
+          </Section>
+
+          <Section title="Mode" tip="The scale/mode that colors the chords (major, minor, dorian, …). Changes which chords are major/minor/diminished.">
+            <div className="grid grid-cols-2 gap-1">
+              {MODES.map((mode) => {
+                const on = cfg.mode === mode;
+                return (
+                  <button key={mode} type="button" aria-label={`Mode ${mode}`} aria-pressed={on}
+                    onClick={() => patch({ mode })} title={`Use the ${mode} scale/mode for the chords`} className={`${cellBase} w-full py-1 capitalize truncate ${on ? cellOn : cellOff}`}>
+                    {mode}
+                  </button>
+                );
+              })}
+            </div>
+          </Section>
+        </div>
+
+        {/* center hero: the chord progression fills the space; output aligns
+            directly beneath each chord column. */}
+        <div className="flex flex-col gap-2 min-w-0 min-h-0">
+          <Section title="Chord progression" tip="Eight progression slots, left to right. Each column is one slot — click a scale degree to set which chord plays there. The lit column is playing now." className="flex-1 min-h-0 flex flex-col">
+            <div className="flex-1 min-h-0 flex gap-1.5">
+              {cfg.chords.map((sel, c) => (
+                <div key={c} className={`flex-1 min-w-0 flex flex-col gap-1 rounded ${activeChord === c ? 'ring-2 ring-purple-400' : ''}`}>
+                  {INTERVALS.map((_label, i) => {
+                    const on = sel === i;
+                    const interval = engine.MS.notes[i]?.triad.interval ?? INTERVALS[i];
+                    return (
+                      <button
+                        key={i}
+                        type="button"
+                        aria-label={`Chord ${c + 1} degree ${interval}`}
+                        aria-pressed={on}
+                        onClick={() => {
+                          const chords = [...cfg.chords];
+                          chords[c] = i;
+                          patch({ chords });
+                        }}
+                        title={`Slot ${c + 1}: play the ${interval} chord (scale degree ${i + 1}) here`}
+                        className={`flex-1 min-h-0 text-[13px] font-mono font-bold rounded border transition-colors cursor-pointer ${on ? cellOn : cellOff}`}
+                      >
+                        {interval}
+                      </button>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </Section>
+
+          <Section title="Output" tip="The actual chord in each slot (note + quality), lit as it plays. Each chip sits under its progression column." className="shrink-0">
+            <div className="flex gap-1.5">
+              {out.map((chord, i) => (
+                <div
+                  key={i}
+                  className={`flex-1 min-w-0 text-center px-1 py-1 rounded border text-[11px] font-mono ${
+                    activeChord === i ? 'border-purple-400 bg-purple-500/15 text-purple-200' : 'border-white/10 bg-white/5 text-zinc-200'
+                  }`}
+                  title={`${chord.note}${chord.type} · ${chord.interval}`}
+                >
+                  <span className="font-bold">{chord.note}</span>
+                  <span className="text-zinc-400 lowercase">{chord.type}</span>
+                </div>
+              ))}
+            </div>
+          </Section>
+        </div>
+
+        {/* right rail: arpeggio styles (the only scroller) */}
+        <div className="flex flex-col gap-2 min-w-0 min-h-0">
+          <Section title={`Style (${patternList.length})`} tip="The order each chord's notes are arpeggiated through. Each thumbnail is one note-order; click to choose." className="flex-1 min-h-0 flex flex-col">
+            <div className="flex-1 min-h-0 overflow-y-auto grid gap-1 text-zinc-200" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(30px, 1fr))' }}>
+              {patternList.map((pattern, i) => {
+                const on = cfg.patternId === i;
+                return (
+                  <button
+                    key={i}
+                    type="button"
+                    aria-label={`Arpeggio style ${pattern.join('')}`}
+                    aria-pressed={on}
+                    onClick={() => patch({ patternId: i })}
+                    title={`Note order ${pattern.map((n) => n + 1).join('-')}`}
+                    className={`rounded border p-0.5 transition-colors ${
+                      on ? 'border-purple-400 bg-purple-500/25 text-purple-200' : 'border-white/15 bg-white/8 hover:border-purple-500/40'
+                    }`}
+                  >
+                    <PatternSvg pattern={pattern} />
+                  </button>
+                );
+              })}
+            </div>
+          </Section>
+        </div>
+      </div>
+
+      {/* keyboard strip — anchored to the bottom of the panel */}
+      <div className="shrink-0 px-2 pb-2 pt-1">
+        <div className="flex gap-px rounded overflow-hidden border border-white/10 bg-black/40">
+          {OCTAVES.map((octave) =>
+            KEYS.map((key) => {
+              const midi = noteNameToMidi(key, octave);
+              const black = key.includes('#');
+              const on = trebleMidis.has(midi);
+              return (
+                <div
+                  key={`${key}${octave}`}
+                  aria-hidden="true"
+                  className={`${black ? 'flex-2' : 'flex-3'} h-9 ${
+                    on ? (black ? 'bg-purple-500' : 'bg-purple-400') : black ? 'bg-zinc-800' : 'bg-zinc-200/85'
+                  } transition-colors`}
+                />
+              );
+            }),
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/audio/QuantumControls.tsx
+++ b/frontend/src/components/audio/QuantumControls.tsx
@@ -1,0 +1,152 @@
+/**
+ * QuantumControls — the full parameter surface for the Quantum Lattice visual
+ * (Visualize tab). A compact, grouped drawer: shape buttons, palette, master
+ * audio drive, and every QUANTUM_PARAMS slider with a per-param audio-band
+ * selector (none/bass/mid/high/volume), mirroring the VJ shader control deck.
+ * Values + bands are lifted to QuantumLatticeView, which feeds them to the
+ * engine via resolveQuantumParams.
+ */
+import React from 'react';
+import { Donut, Box, Star, Grid3x3, X, RotateCcw } from 'lucide-react';
+import {
+  QUANTUM_PARAMS,
+  QUANTUM_GROUPS,
+  QUANTUM_GEOMETRY_NAMES,
+  QUANTUM_PALETTES,
+  type QuantumAudioBand,
+} from '../../lib/quantumLattice';
+
+const SHAPE_ICONS = [Donut, Box, Star, Grid3x3];
+
+interface Props {
+  shape: number;
+  onShape: (n: number) => void;
+  paletteIdx: number; // -1 = auto (follows shape)
+  onPalette: (n: number) => void;
+  audioDrive: number;
+  onDrive: (n: number) => void;
+  values: Record<string, number>;
+  onValue: (id: string, v: number) => void;
+  audio: Record<string, QuantumAudioBand>;
+  onAudio: (id: string, b: QuantumAudioBand) => void;
+  onReset: () => void;
+  onClose: () => void;
+}
+
+const BANDS: { v: QuantumAudioBand; t: string }[] = [
+  { v: 'none', t: '—' },
+  { v: 'bass', t: 'BAS' },
+  { v: 'mid', t: 'MID' },
+  { v: 'high', t: 'HI' },
+  { v: 'volume', t: 'VOL' },
+];
+
+export const QuantumControls: React.FC<Props> = ({
+  shape, onShape, paletteIdx, onPalette, audioDrive, onDrive, values, onValue, audio, onAudio, onReset, onClose,
+}) => {
+  return (
+    <div className="absolute top-7 right-1 bottom-8 w-48 z-20 flex flex-col rounded-md border border-cyan-500/25 bg-black/85 backdrop-blur-sm text-zinc-200 overflow-hidden">
+      {/* header */}
+      <div className="shrink-0 flex items-center justify-between px-2 py-1 border-b border-white/10">
+        <span className="text-[8px] font-mono uppercase tracking-[0.25em] text-cyan-300/80">Quantum</span>
+        <div className="flex items-center gap-1">
+          <button type="button" onClick={onReset} title="Reset all to defaults" aria-label="Reset Quantum parameters"
+            className="p-0.5 rounded text-zinc-500 hover:text-zinc-200 hover:bg-white/10">
+            <RotateCcw className="w-3 h-3" />
+          </button>
+          <button type="button" onClick={onClose} title="Close controls" aria-label="Close Quantum controls"
+            className="p-0.5 rounded text-zinc-500 hover:text-zinc-200 hover:bg-white/10">
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto p-1.5 space-y-2">
+        {/* shape */}
+        <div>
+          <span className="block text-[7px] font-mono uppercase tracking-widest text-zinc-500 mb-1">Geometry</span>
+          <div className="grid grid-cols-4 gap-1">
+            {QUANTUM_GEOMETRY_NAMES.map((name, i) => {
+              const Icon = SHAPE_ICONS[i];
+              const on = shape === i;
+              return (
+                <button key={i} type="button" onClick={() => onShape(i)} title={name} aria-label={`Morph to ${name}`} aria-pressed={on}
+                  className={`h-6 grid place-items-center rounded border transition-colors ${
+                    on ? 'border-cyan-400 bg-cyan-500/25 text-cyan-200' : 'border-white/10 bg-white/5 text-zinc-500 hover:text-zinc-200 hover:border-white/25'
+                  }`}>
+                  <Icon className="w-3 h-3" />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* palette + master drive */}
+        <div className="space-y-1">
+          <div className="flex items-center gap-1">
+            <label htmlFor="q-palette" className="w-16 shrink-0 text-[8px] font-mono uppercase tracking-wide text-zinc-400">Palette</label>
+            <select id="q-palette" name="q-palette" value={paletteIdx} onChange={(e) => onPalette(parseInt(e.target.value, 10))}
+              className="flex-1 min-w-0 bg-zinc-800 border border-zinc-600 rounded text-[8px] font-mono text-zinc-100 px-1 py-0.5">
+              <option value={-1}>Auto</option>
+              {QUANTUM_PALETTES.map((p, i) => (
+                <option key={p} value={i}>{p}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-1">
+            <label htmlFor="q-drive" className="w-16 shrink-0 text-[8px] font-mono uppercase tracking-wide text-zinc-400" title="Master audio reactivity">Audio Drive</label>
+            <input id="q-drive" name="q-drive" type="range" min={0} max={2} step={0.05} value={audioDrive}
+              onChange={(e) => onDrive(parseFloat(e.target.value))} className="flex-1 min-w-0 accent-cyan-500" />
+            <span className="w-7 shrink-0 text-right text-[8px] font-mono text-zinc-500 tabular-nums">{audioDrive.toFixed(2)}</span>
+          </div>
+        </div>
+
+        {/* param groups */}
+        {QUANTUM_GROUPS.map((group, gi) => (
+          <details key={group} open={gi < 2} className="rounded border border-white/8 bg-white/3">
+            <summary className="cursor-pointer select-none px-1.5 py-1 text-[7px] font-mono uppercase tracking-widest text-zinc-400 hover:text-zinc-200">
+              {group}
+            </summary>
+            <div className="px-1.5 pb-1.5 space-y-1">
+              {QUANTUM_PARAMS.filter((p) => p.group === group).map((p) => {
+                const val = values[p.id] ?? p.default;
+                const band = audio[p.id] ?? p.audio ?? 'none';
+                return (
+                  <div key={p.id} className="flex items-center gap-1">
+                    <label htmlFor={`q-${p.id}`} className="w-14 shrink-0 text-[8px] font-mono uppercase tracking-wide text-zinc-400 truncate" title={p.label}>
+                      {p.label}
+                    </label>
+                    <input
+                      id={`q-${p.id}`}
+                      name={`q-${p.id}`}
+                      type="range"
+                      min={p.min}
+                      max={p.max}
+                      step={p.step}
+                      value={val}
+                      onChange={(e) => onValue(p.id, parseFloat(e.target.value))}
+                      className="flex-1 min-w-0 accent-cyan-500"
+                    />
+                    <label htmlFor={`q-${p.id}-aud`} className="sr-only">{p.label} audio band</label>
+                    <select
+                      id={`q-${p.id}-aud`}
+                      name={`q-${p.id}-aud`}
+                      value={band}
+                      onChange={(e) => onAudio(p.id, e.target.value as QuantumAudioBand)}
+                      title={`${p.label}: audio band that drives it`}
+                      className="shrink-0 w-10 bg-zinc-800 border border-zinc-600 rounded text-[7px] font-mono text-zinc-100 px-0.5 py-0.5"
+                    >
+                      {BANDS.map((b) => (
+                        <option key={b.v} value={b.v}>{b.t}</option>
+                      ))}
+                    </select>
+                  </div>
+                );
+              })}
+            </div>
+          </details>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/audio/QuantumLatticeView.tsx
+++ b/frontend/src/components/audio/QuantumLatticeView.tsx
@@ -1,0 +1,178 @@
+/**
+ * QuantumLatticeView — in-app host for the Quantum Lattice shader engine, used
+ * as the "Q" mode of the Visualize tab. Owns a canvas, drives the engine from
+ * the shared playback analyser (so the lattice reacts to whatever is playing),
+ * and exposes the full parameter surface through a collapsible controls drawer
+ * (QuantumControls): shape, palette, master audio drive, and every param with a
+ * per-param audio band. Sizing goes through getBoundingClientRect so it stays
+ * correct under the app's CSS-zoom scaling.
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Donut, Box, Star, Grid3x3, SlidersHorizontal, Activity } from 'lucide-react';
+import {
+  QuantumLatticeEngine,
+  QUANTUM_GEOMETRY_NAMES,
+  resolveQuantumParams,
+  type QuantumLevels,
+  type QuantumAudioBand,
+} from '../../lib/quantumLattice';
+import { getAnalyser } from '../../state/playerStore';
+import { QuantumControls } from './QuantumControls';
+
+const SHAPES: { idx: number; label: string; Icon: typeof Box }[] = [
+  { idx: 0, label: 'Torus', Icon: Donut },
+  { idx: 1, label: 'Cube', Icon: Box },
+  { idx: 2, label: 'Star', Icon: Star },
+  { idx: 3, label: 'Cage', Icon: Grid3x3 },
+];
+
+/** Read the shared analyser into 4 bands the engine consumes. */
+const makeGetLevels = (): (() => QuantumLevels) => {
+  const analyser = getAnalyser();
+  const buf = new Uint8Array(analyser.frequencyBinCount);
+  return () => {
+    analyser.getByteFrequencyData(buf);
+    let bass = 0, mid = 0, high = 0;
+    const bassEnd = Math.min(6, buf.length);
+    const midEnd = Math.min(40, buf.length);
+    for (let i = 0; i < bassEnd; i++) bass += buf[i];
+    for (let i = bassEnd; i < midEnd; i++) mid += buf[i];
+    for (let i = midEnd; i < buf.length; i++) high += buf[i];
+    const bassN = bass / Math.max(1, bassEnd) / 255;
+    const midN = mid / Math.max(1, midEnd - bassEnd) / 255;
+    const highN = high / Math.max(1, buf.length - midEnd) / 255;
+    return { bass: bassN, mid: midN, high: highN, volume: (bassN + midN + highN) / 3 };
+  };
+};
+
+export const QuantumLatticeView: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const engineRef = useRef<QuantumLatticeEngine | null>(null);
+
+  const [shape, setShape] = useState(0);
+  const [geomName, setGeomName] = useState(QUANTUM_GEOMETRY_NAMES[0]);
+  const [beatCycle, setBeatCycle] = useState(true); // hard hits cycle the geometry
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [paletteIdx, setPaletteIdx] = useState(-1); // -1 = auto
+  const [audioDrive, setAudioDrive] = useState(1);
+  const [values, setValues] = useState<Record<string, number>>({});
+  const [audioBands, setAudioBands] = useState<Record<string, QuantumAudioBand>>({});
+
+  const resolved = useMemo(() => resolveQuantumParams(values, audioBands), [values, audioBands]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    if (!container || !canvas) return;
+    const rect = container.getBoundingClientRect();
+    const engine = new QuantumLatticeEngine({
+      canvas,
+      width: rect.width || 320,
+      height: rect.height || 240,
+      interactive: true,
+      getLevels: makeGetLevels(),
+      onStats: (s) => setGeomName(s.geomName),
+      // beat-cycle advances the geometry internally; mirror it so the shape
+      // buttons highlight the live shape.
+      onShape: (idx) => setShape(idx),
+    });
+    engineRef.current = engine;
+
+    const ro = new ResizeObserver(() => {
+      const r = container.getBoundingClientRect();
+      engine.resize(r.width, r.height);
+    });
+    ro.observe(container);
+
+    return () => {
+      ro.disconnect();
+      engine.dispose();
+      engineRef.current = null;
+    };
+  }, []);
+
+  // Push live state into the engine.
+  useEffect(() => { engineRef.current?.setParams(resolved); }, [resolved]);
+  useEffect(() => { engineRef.current?.setAudioDrive(audioDrive); }, [audioDrive]);
+  useEffect(() => { engineRef.current?.setPaletteIndex(paletteIdx < 0 ? null : paletteIdx); }, [paletteIdx]);
+  useEffect(() => { engineRef.current?.setShape(shape); }, [shape]);
+  useEffect(() => { engineRef.current?.setBeatCycle(beatCycle); }, [beatCycle]);
+
+  return (
+    <div ref={containerRef} className="absolute inset-0 overflow-hidden bg-[#020005]">
+      <canvas ref={canvasRef} className="w-full h-full block" />
+
+      {/* shape selector — top-right column */}
+      <div className="absolute top-2 right-2 flex flex-col gap-1 z-10">
+        {SHAPES.map(({ idx, label, Icon }) => (
+          <button
+            key={idx}
+            type="button"
+            onClick={() => setShape(idx)}
+            title={label}
+            aria-label={`Morph to ${label}`}
+            aria-pressed={shape === idx}
+            className={`w-5 h-5 rounded grid place-items-center transition-colors ${
+              shape === idx
+                ? 'bg-cyan-500 text-black shadow-[0_0_6px_rgba(0,255,255,0.6)]'
+                : 'bg-black/50 text-zinc-500 border border-white/10 hover:text-zinc-200 hover:border-white/25'
+            }`}
+          >
+            <Icon className="w-3 h-3" />
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => setBeatCycle((v) => !v)}
+          title={beatCycle ? 'Hard hits cycle shapes (on)' : 'Hard hits cycle shapes (off)'}
+          aria-label="Toggle hard-hit shape cycling"
+          aria-pressed={beatCycle}
+          className={`w-5 h-5 rounded grid place-items-center transition-colors ${
+            beatCycle
+              ? 'bg-cyan-500 text-black shadow-[0_0_6px_rgba(0,255,255,0.6)]'
+              : 'bg-black/50 text-zinc-500 border border-white/10 hover:text-zinc-200 hover:border-white/25'
+          }`}
+        >
+          <Activity className="w-3 h-3" />
+        </button>
+        <button
+          type="button"
+          onClick={() => setPanelOpen((v) => !v)}
+          title="Quantum controls"
+          aria-label="Toggle Quantum controls"
+          aria-pressed={panelOpen}
+          className={`w-5 h-5 rounded grid place-items-center transition-colors ${
+            panelOpen
+              ? 'bg-cyan-500 text-black shadow-[0_0_6px_rgba(0,255,255,0.6)]'
+              : 'bg-black/50 text-zinc-500 border border-white/10 hover:text-zinc-200 hover:border-white/25'
+          }`}
+        >
+          <SlidersHorizontal className="w-3 h-3" />
+        </button>
+      </div>
+
+      {panelOpen && (
+        <QuantumControls
+          shape={shape}
+          onShape={setShape}
+          paletteIdx={paletteIdx}
+          onPalette={setPaletteIdx}
+          audioDrive={audioDrive}
+          onDrive={setAudioDrive}
+          values={values}
+          onValue={(id, v) => setValues((p) => ({ ...p, [id]: v }))}
+          audio={audioBands}
+          onAudio={(id, b) => setAudioBands((p) => ({ ...p, [id]: b }))}
+          onReset={() => { setValues({}); setAudioBands({}); setPaletteIdx(-1); setAudioDrive(1); }}
+          onClose={() => setPanelOpen(false)}
+        />
+      )}
+
+      {/* geometry name lamp, bottom-left */}
+      <div className="absolute bottom-1.5 left-2 z-10 text-[8px] font-mono uppercase tracking-[0.25em] text-cyan-300/70 pointer-events-none">
+        {geomName}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/audio/vocal2midi/AssistantOrb.tsx
+++ b/frontend/src/components/audio/vocal2midi/AssistantOrb.tsx
@@ -1,0 +1,282 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Sparkles, Send, X, Play, Square } from 'lucide-react';
+import type { ProcessingConfig, NoteEvent, ScaleType } from './types';
+import { askAssistant, type AssistantContext, type AssistantResponse } from './geminiAssistant';
+
+interface PianoRollControls {
+    notes: NoteEvent[];
+    bpm: number;
+    rootNote: number;
+    scale: ScaleType;
+    isPlaying: boolean;
+    onNotesChange: (notes: NoteEvent[]) => void;
+    onBpmChange: (bpm: number) => void;
+    onKeyChange: (rootNote: number, scale: ScaleType) => void;
+    onPlay: () => void;
+    onStop: () => void;
+    onInstrumentChange: (instrument: string) => void;
+}
+
+interface AssistantOrbProps {
+    currentConfig: ProcessingConfig;
+    onConfigUpdate: (updates: Partial<ProcessingConfig>) => void;
+    pianoRollControls: PianoRollControls;
+}
+
+export const AssistantOrb: React.FC<AssistantOrbProps> = ({
+    currentConfig,
+    onConfigUpdate,
+    pianoRollControls
+}) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [messages, setMessages] = useState<{ role: 'user' | 'ai', text: string, actions?: string[] }[]>([
+        { role: 'ai', text: "I am the Architect. I can control all settings, edit your MIDI notes, change tempo, transpose keys, and preview your work. What would you like me to do?" }
+    ]);
+    const [input, setInput] = useState('');
+    const [isThinking, setIsThinking] = useState(false);
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+
+    const scrollToBottom = () => {
+        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    };
+
+    useEffect(() => {
+        scrollToBottom();
+    }, [messages, isOpen]);
+
+    const handleSend = async () => {
+        if (!input.trim()) return;
+
+        const userMsg = input;
+        setInput('');
+        setMessages(prev => [...prev, { role: 'user', text: userMsg }]);
+        setIsThinking(true);
+
+        // Build context for the assistant
+        const context: AssistantContext = {
+            config: currentConfig,
+            pianoRoll: {
+                notes: pianoRollControls.notes,
+                bpm: pianoRollControls.bpm,
+                rootNote: pianoRollControls.rootNote,
+                scale: pianoRollControls.scale,
+                isPlaying: pianoRollControls.isPlaying
+            }
+        };
+
+        const response = await askAssistant(userMsg, context);
+
+        setIsThinking(false);
+
+        // Track what actions were taken
+        const actions: string[] = [];
+
+        // Apply all the response updates
+        if (response.configUpdates) {
+            onConfigUpdate(response.configUpdates);
+            actions.push('Updated settings');
+        }
+
+        if (response.notesUpdate !== undefined) {
+            console.log('[AssistantOrb] Updating notes:', response.notesUpdate.length, 'notes');
+            console.log('[AssistantOrb] First note before:', pianoRollControls.notes[0]);
+            console.log('[AssistantOrb] First note after:', response.notesUpdate[0]);
+            pianoRollControls.onNotesChange(response.notesUpdate);
+            if (response.notesUpdate.length === 0) {
+                actions.push('Cleared all notes');
+            } else {
+                actions.push(`Modified ${response.notesUpdate.length} notes`);
+            }
+        }
+
+        if (response.bpmUpdate !== undefined) {
+            pianoRollControls.onBpmChange(response.bpmUpdate);
+            actions.push(`Set BPM to ${response.bpmUpdate}`);
+        }
+
+        if (response.keyUpdate) {
+            pianoRollControls.onKeyChange(response.keyUpdate.rootNote, response.keyUpdate.scale);
+            const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+            actions.push(`Changed key to ${noteNames[response.keyUpdate.rootNote % 12]} ${response.keyUpdate.scale}`);
+        }
+
+        if (response.playbackAction === 'play') {
+            pianoRollControls.onPlay();
+            actions.push('Started playback');
+        } else if (response.playbackAction === 'stop') {
+            pianoRollControls.onStop();
+            actions.push('Stopped playback');
+        }
+
+        if (response.instrumentUpdate) {
+            pianoRollControls.onInstrumentChange(response.instrumentUpdate);
+            actions.push(`Changed instrument to ${response.instrumentUpdate}`);
+        }
+
+        setMessages(prev => [...prev, {
+            role: 'ai',
+            text: response.text,
+            actions: actions.length > 0 ? actions : undefined
+        }]);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleSend();
+        }
+    };
+
+    // Quick action buttons
+    const quickActions = [
+        { label: 'Play', action: 'play the preview', icon: Play },
+        { label: 'Stop', action: 'stop playback', icon: Square },
+    ];
+
+    return (
+        <>
+            {/* The Orb Trigger */}
+            <div
+                className={`fixed bottom-8 right-8 z-50 transition-all duration-300 ${isOpen ? 'scale-0 opacity-0' : 'scale-100 opacity-100'}`}
+            >
+                <button
+                    onClick={() => setIsOpen(true)}
+                    title="Open AI Assistant"
+                    className="relative w-16 h-16 rounded-full bg-black border border-violet-500 shadow-[0_0_30px_rgba(139,92,246,0.5)] flex items-center justify-center group overflow-hidden"
+                >
+                    <div className="absolute inset-0 bg-linear-to-tr from-violet-500/20 to-cyan-500/20 animate-pulse" />
+                    <Sparkles className="text-violet-400 group-hover:text-white transition-colors relative z-10" size={24} />
+                </button>
+            </div>
+
+            {/* Chat Interface */}
+            <div
+                className={`fixed bottom-8 right-8 w-80 md:w-96 h-[550px] bg-zinc-900 border border-white/10 rounded-2xl shadow-2xl z-50 flex flex-col transition-all duration-300 origin-bottom-right ${isOpen ? 'scale-100 opacity-100' : 'scale-90 opacity-0 pointer-events-none'
+                    }`}
+            >
+                {/* Header */}
+                <div className="p-4 border-b border-white/10 flex justify-between items-center bg-black/40 rounded-t-2xl">
+                    <div className="flex items-center gap-2">
+                        <Sparkles size={16} className="text-violet-400" />
+                        <span className="font-bold text-sm tracking-wide">ARCHITECT_AI</span>
+                        <span className="text-[9px] text-gray-500 bg-zinc-950 px-2 py-0.5 rounded">FULL CONTROL</span>
+                    </div>
+                    <button
+                        onClick={() => setIsOpen(false)}
+                        title="Close assistant"
+                        className="text-gray-500 hover:text-white transition-colors"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+
+                {/* Status Bar */}
+                <div className="px-4 py-2 bg-black/20 border-b border-white/10 flex items-center justify-between text-[10px] font-mono">
+                    <span className="text-gray-500">
+                        {pianoRollControls.notes.length} notes | {pianoRollControls.bpm} BPM
+                    </span>
+                    <span className={pianoRollControls.isPlaying ? 'text-cyan-400' : 'text-gray-600'}>
+                        {pianoRollControls.isPlaying ? '▶ PLAYING' : '■ STOPPED'}
+                    </span>
+                </div>
+
+                {/* Messages */}
+                <div className="flex-1 overflow-y-auto p-4 space-y-4">
+                    {messages.map((m, i) => (
+                        <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                            <div className={`max-w-[85%] rounded-lg p-3 text-xs leading-relaxed ${m.role === 'user'
+                                    ? 'bg-violet-500/20 text-white border border-violet-500/30'
+                                    : 'bg-black border border-white/10 text-gray-300'
+                                }`}>
+                                {m.text}
+                                {m.actions && m.actions.length > 0 && (
+                                    <div className="mt-2 pt-2 border-t border-white/5">
+                                        <div className="text-[9px] text-cyan-400 font-mono">
+                                            {m.actions.map((action, j) => (
+                                                <div key={j}>✓ {action}</div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                    {isThinking && (
+                        <div className="flex justify-start">
+                            <div className="bg-black border border-white/10 rounded-lg p-3 flex gap-1">
+                                <div className="w-1.5 h-1.5 bg-violet-500 rounded-full animate-bounce" />
+                                <div className="w-1.5 h-1.5 bg-violet-500 rounded-full animate-bounce delay-150" />
+                                <div className="w-1.5 h-1.5 bg-violet-500 rounded-full animate-bounce delay-300" />
+                            </div>
+                        </div>
+                    )}
+                    <div ref={messagesEndRef} />
+                </div>
+
+                {/* Quick Commands */}
+                <div className="px-3 py-2 border-t border-white/10 bg-black/20">
+                    <div className="flex gap-1 flex-wrap">
+                        <button
+                            onClick={() => { setInput('play the preview'); }}
+                            className="text-[9px] px-2 py-1 bg-zinc-800 hover:bg-cyan-500 hover:text-black rounded transition-colors"
+                        >
+                            ▶ Play
+                        </button>
+                        <button
+                            onClick={() => { setInput('stop'); }}
+                            className="text-[9px] px-2 py-1 bg-zinc-800 hover:bg-cyan-500 hover:text-black rounded transition-colors"
+                        >
+                            ■ Stop
+                        </button>
+                        <button
+                            onClick={() => { setInput('quantize to 1/16'); }}
+                            className="text-[9px] px-2 py-1 bg-zinc-800 hover:bg-cyan-500 hover:text-black rounded transition-colors"
+                        >
+                            Quantize
+                        </button>
+                        <button
+                            onClick={() => { setInput('transpose up one octave'); }}
+                            className="text-[9px] px-2 py-1 bg-zinc-800 hover:bg-cyan-500 hover:text-black rounded transition-colors"
+                        >
+                            +Octave
+                        </button>
+                        <button
+                            onClick={() => { setInput('set tempo to 140 bpm'); }}
+                            className="text-[9px] px-2 py-1 bg-zinc-800 hover:bg-cyan-500 hover:text-black rounded transition-colors"
+                        >
+                            140 BPM
+                        </button>
+                        <button
+                            onClick={() => { setInput('change to A minor'); }}
+                            className="text-[9px] px-2 py-1 bg-zinc-800 hover:bg-cyan-500 hover:text-black rounded transition-colors"
+                        >
+                            A minor
+                        </button>
+                    </div>
+                </div>
+
+                {/* Input */}
+                <div className="p-3 border-t border-white/10 bg-black/40 rounded-b-2xl">
+                    <div className="flex gap-2">
+                        <input
+                            type="text"
+                            value={input}
+                            onChange={(e) => setInput(e.target.value)}
+                            onKeyDown={handleKeyDown}
+                            placeholder="Try: 'make it faster' or 'change to E major'"
+                            className="flex-1 bg-zinc-950 border border-white/10 rounded-lg px-3 py-2 text-xs focus:outline-none focus:border-violet-500 transition-colors"
+                        />
+                        <button
+                            onClick={handleSend}
+                            disabled={!input.trim() || isThinking}
+                            title="Send message"
+                            className="bg-violet-500 hover:bg-violet-400 text-white p-2 rounded-lg transition-colors disabled:opacity-50"
+                        >
+                            <Send size={16} />
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+};

--- a/frontend/src/components/audio/vocal2midi/BpmTapper.tsx
+++ b/frontend/src/components/audio/vocal2midi/BpmTapper.tsx
@@ -1,0 +1,148 @@
+import React, { useState, useRef, useCallback } from 'react';
+
+interface BpmTapperProps {
+  onBpmSet: (bpm: number) => void;
+  currentBpm: number;
+}
+
+export const BpmTapper: React.FC<BpmTapperProps> = ({ onBpmSet, currentBpm }) => {
+  const [taps, setTaps] = useState<number[]>([]);
+  const [calculatedBpm, setCalculatedBpm] = useState<number | null>(null);
+  const [isActive, setIsActive] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const calculateBpm = useCallback((tapTimes: number[]): number | null => {
+    if (tapTimes.length < 2) return null;
+
+    // Calculate intervals between consecutive taps
+    const intervals: number[] = [];
+    for (let i = 1; i < tapTimes.length; i++) {
+      intervals.push(tapTimes[i] - tapTimes[i - 1]);
+    }
+
+    // Filter out outliers (too fast or too slow - outside 30-300 BPM range)
+    const validIntervals = intervals.filter(interval => {
+      const bpm = 60000 / interval;
+      return bpm >= 30 && bpm <= 300;
+    });
+
+    if (validIntervals.length === 0) return null;
+
+    // Calculate average interval
+    const avgInterval = validIntervals.reduce((a, b) => a + b, 0) / validIntervals.length;
+
+    // Convert to BPM
+    const bpm = Math.round(60000 / avgInterval);
+
+    return Math.max(30, Math.min(300, bpm));
+  }, []);
+
+  const handleTap = useCallback(() => {
+    const now = performance.now();
+
+    // Clear existing timeout
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    setTaps(prevTaps => {
+      // Just add the new tap (no auto-reset, user must click Reset)
+      const newTaps = [...prevTaps, now];
+
+      // Keep only last 10 taps for rolling average
+      const trimmedTaps = newTaps.slice(-10);
+
+      // Calculate BPM
+      const bpm = calculateBpm(trimmedTaps);
+      setCalculatedBpm(bpm);
+      setIsActive(true);
+
+      return trimmedTaps;
+    });
+
+    // Auto-pause (not reset) after 2 seconds of inactivity
+    timeoutRef.current = setTimeout(() => {
+      setIsActive(false);
+    }, 2000);
+  }, [calculateBpm]);
+
+  const handleReset = useCallback(() => {
+    setTaps([]);
+    setCalculatedBpm(null);
+    setIsActive(false);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+  }, []);
+
+  const handleApply = useCallback(() => {
+    if (calculatedBpm) {
+      onBpmSet(calculatedBpm);
+    }
+  }, [calculatedBpm, onBpmSet]);
+
+  return (
+    <div className="bg-zinc-900 border border-white/10 rounded-xl p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider">Tap Tempo</h3>
+        {calculatedBpm && (
+          <button
+            onClick={handleReset}
+            className="text-[10px] text-gray-500 hover:text-white transition-colors"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+
+      {/* Tap Button */}
+      <button
+        onClick={handleTap}
+        className={`w-full h-20 rounded-lg font-bold text-lg transition-all ${
+          isActive
+            ? 'bg-cyan-500/20 border-2 border-cyan-400 text-cyan-400 shadow-[0_0_20px_rgba(6,182,212,0.3)]'
+            : 'bg-black/50 border-2 border-white/10 text-gray-400 hover:border-gray-600'
+        }`}
+      >
+        {calculatedBpm ? (
+          <span className="text-2xl">{calculatedBpm} <span className="text-sm">BPM</span></span>
+        ) : (
+          <span>TAP</span>
+        )}
+      </button>
+
+      {/* Tap count indicator */}
+      <div className="flex justify-between items-center mt-2">
+        <span className="text-[10px] text-gray-500">
+          {taps.length > 0 ? `${taps.length} taps` : 'Tap to start'}
+        </span>
+        {taps.length >= 2 && (
+          <div className="flex gap-1">
+            {Array.from({ length: Math.min(taps.length, 8) }).map((_, i) => (
+              <div
+                key={i}
+                className={`w-1.5 h-1.5 rounded-full ${
+                  i < taps.length ? 'bg-cyan-400' : 'bg-gray-700'
+                }`}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Apply button */}
+      {calculatedBpm && (
+        <button
+          onClick={handleApply}
+          className="w-full mt-3 py-2 rounded-lg bg-cyan-500/20 border border-cyan-400 text-cyan-400 text-xs font-medium hover:bg-cyan-500 hover:text-black transition-all"
+        >
+          Set BPM to {calculatedBpm} (current: {currentBpm})
+        </button>
+      )}
+
+      <p className="text-[9px] text-gray-600 mt-2 text-center">
+        Tap along with your beat. Best accuracy with 4-8 taps.
+      </p>
+    </div>
+  );
+};

--- a/frontend/src/components/audio/vocal2midi/RecordingHistory.tsx
+++ b/frontend/src/components/audio/vocal2midi/RecordingHistory.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import { Trash2, Download, Upload, Clock, Music, FolderOpen } from 'lucide-react';
+import type { RecordingEntry, NoteEvent, ScaleType, Genre } from './types';
+import { NOTE_NAMES } from './constants';
+
+interface RecordingHistoryProps {
+  recordings: RecordingEntry[];
+  onLoad: (recording: RecordingEntry) => void;
+  onDelete: (id: string) => void;
+  onClearAll: () => void;
+  onExportAll: () => void;
+  onImport: (recordings: RecordingEntry[]) => void;
+}
+
+export const RecordingHistory: React.FC<RecordingHistoryProps> = ({
+  recordings,
+  onLoad,
+  onDelete,
+  onClearAll,
+  onExportAll,
+  onImport
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const formatDate = (timestamp: number) => {
+    const date = new Date(timestamp);
+    return date.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  const getKeyName = (rootNote: number, scale: ScaleType) => {
+    return `${NOTE_NAMES[rootNote % 12]} ${scale}`;
+  };
+
+  const handleImportClick = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+    input.onchange = async (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+
+      try {
+        const text = await file.text();
+        const data = JSON.parse(text);
+
+        // Validate it's an array of recordings
+        if (Array.isArray(data) && data.every(r => r.id && r.notes && r.timestamp)) {
+          onImport(data);
+        } else if (data.id && data.notes && data.timestamp) {
+          // Single recording
+          onImport([data]);
+        } else {
+          alert('Invalid recording file format');
+        }
+      } catch (err) {
+        alert('Failed to parse recording file');
+      }
+    };
+    input.click();
+  };
+
+  if (recordings.length === 0 && !isExpanded) {
+    return (
+      <div className="bg-zinc-900 border border-white/10 rounded-xl p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Clock size={14} className="text-gray-500" />
+            <span className="text-xs text-gray-400">Recording History</span>
+          </div>
+          <button
+            onClick={handleImportClick}
+            className="text-[10px] text-gray-500 hover:text-cyan-400 transition-colors flex items-center gap-1"
+          >
+            <Upload size={10} /> Import
+          </button>
+        </div>
+        <p className="text-[10px] text-gray-600 mt-2">No recordings saved yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-white/10 rounded-xl p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+        >
+          <Clock size={14} />
+          <span className="text-xs font-medium">Recording History</span>
+          <span className="text-[10px] text-cyan-400 bg-cyan-500/20 px-1.5 py-0.5 rounded">
+            {recordings.length}
+          </span>
+        </button>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleImportClick}
+            className="text-[10px] text-gray-500 hover:text-cyan-400 transition-colors"
+            title="Import recordings"
+          >
+            <Upload size={12} />
+          </button>
+          {recordings.length > 0 && (
+            <>
+              <button
+                onClick={onExportAll}
+                className="text-[10px] text-gray-500 hover:text-emerald-400 transition-colors"
+                title="Export all recordings"
+              >
+                <Download size={12} />
+              </button>
+              <button
+                onClick={onClearAll}
+                className="text-[10px] text-gray-500 hover:text-red-400 transition-colors"
+                title="Clear all recordings"
+              >
+                <Trash2 size={12} />
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Recording List */}
+      {isExpanded && (
+        <div className="space-y-2 max-h-48 overflow-y-auto">
+          {recordings.map((recording) => (
+            <div
+              key={recording.id}
+              className="bg-black/30 border border-white/10 rounded-lg p-2 hover:border-gray-600 transition-colors group"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Music size={10} className="text-cyan-400 shrink-0" />
+                    <span className="text-xs text-white truncate">{recording.name}</span>
+                  </div>
+                  <div className="flex items-center gap-2 mt-1 text-[9px] text-gray-500">
+                    <span>{formatDate(recording.timestamp)}</span>
+                    <span>|</span>
+                    <span>{recording.notes.length} notes</span>
+                    <span>|</span>
+                    <span>{recording.bpm} BPM</span>
+                    <span>|</span>
+                    <span>{getKeyName(recording.rootNote, recording.scale)}</span>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <button
+                    onClick={() => onLoad(recording)}
+                    className="p-1.5 text-gray-400 hover:text-cyan-400 hover:bg-cyan-500/10 rounded transition-colors"
+                    title="Load recording"
+                  >
+                    <FolderOpen size={12} />
+                  </button>
+                  <button
+                    onClick={() => onDelete(recording.id)}
+                    className="p-1.5 text-gray-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors"
+                    title="Delete recording"
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!isExpanded && recordings.length > 0 && (
+        <button
+          onClick={() => setIsExpanded(true)}
+          className="text-[10px] text-gray-500 hover:text-white transition-colors"
+        >
+          Click to expand ({recordings.length} recordings)
+        </button>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/audio/vocal2midi/Visualizer.tsx
+++ b/frontend/src/components/audio/vocal2midi/Visualizer.tsx
@@ -1,0 +1,94 @@
+import React, { useRef, useEffect } from 'react';
+
+interface VisualizerProps {
+  analyser: AnalyserNode | null;
+  isRecording: boolean;
+  threshold?: number; // 0.0 - 1.0 representing the gate level
+}
+
+export const Visualizer: React.FC<VisualizerProps> = ({ analyser, isRecording, threshold = 0.01 }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (!canvasRef.current || !analyser) return;
+
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const bufferLength = analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    let animationId: number;
+
+    const draw = () => {
+      animationId = requestAnimationFrame(draw);
+
+      analyser.getByteTimeDomainData(dataArray);
+
+      // 1. Clear Background
+      ctx.fillStyle = '#0f0f11'; // Match DAW bg
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      const centerY = canvas.height / 2;
+
+      // 2. Draw Threshold / Gate Lines
+      // We scale the threshold visually so it's visible.
+      // The threshold passed is usually RMS (small), so we multiply for visual clarity relative to peaks.
+      const visualGateScale = 4.0;
+      const gateOffset = Math.min((canvas.height / 2) * 0.9, (threshold * 255 * visualGateScale) / 2);
+
+      ctx.fillStyle = 'rgba(239, 68, 68, 0.1)'; // Red fill for "ignore zone"
+      ctx.fillRect(0, centerY - gateOffset, canvas.width, gateOffset * 2);
+
+      ctx.beginPath();
+      ctx.strokeStyle = 'rgba(239, 68, 68, 0.5)'; // Red lines
+      ctx.lineWidth = 1;
+      ctx.setLineDash([5, 5]);
+      // Top Gate
+      ctx.moveTo(0, centerY - gateOffset);
+      ctx.lineTo(canvas.width, centerY - gateOffset);
+      // Bottom Gate
+      ctx.moveTo(0, centerY + gateOffset);
+      ctx.lineTo(canvas.width, centerY + gateOffset);
+      ctx.stroke();
+      ctx.setLineDash([]); // Reset dash
+
+      // 3. Draw Waveform
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = isRecording ? '#06b6d4' : '#52525b'; // Cyan if recording, Gray if idle
+      ctx.beginPath();
+
+      const sliceWidth = (canvas.width * 1.0) / bufferLength;
+      let x = 0;
+
+      for (let i = 0; i < bufferLength; i++) {
+        const v = dataArray[i] / 128.0;
+        const y = (v * canvas.height) / 2;
+
+        if (i === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+
+        x += sliceWidth;
+      }
+
+      ctx.lineTo(canvas.width, canvas.height / 2);
+      ctx.stroke();
+    };
+
+    draw();
+
+    return () => cancelAnimationFrame(animationId);
+  }, [analyser, isRecording, threshold]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={600}
+      height={150}
+      className="w-full h-32 md:h-48 rounded-lg border border-white/10 bg-black shadow-[inset_0_2px_4px_rgba(0,0,0,0.6)]"
+    />
+  );
+};

--- a/frontend/src/components/audio/vocal2midi/Vocal2MidiPanel.tsx
+++ b/frontend/src/components/audio/vocal2midi/Vocal2MidiPanel.tsx
@@ -1,0 +1,629 @@
+/**
+ * Vocal2MidiPanel — the full vocal2midi-architect suite, natively integrated into
+ * theDAW's MIDI tab as a compact, collapsible control column. The ported recorder
+ * runs YIN pitch detection (exact sensitivity/threshold math from the source); the
+ * resulting notes are written into theDAW's EXISTING piano roll (pianoRollStore).
+ * Every control from the suite is here: capture (mic + level visualizer +
+ * sensitivity + cleanup), musical settings (key/scale/genre/profile/quantize),
+ * editor tools (quantize/transpose/snap/change-key/related-keys), AI (analyze on
+ * record, smart cleanup, assistant orb) on theDAW's Gemini, export (MIDI/WAV),
+ * tap tempo, and recording history. Instrument selection uses theDAW's full GM
+ * soundfont picker. AI calls convert audio to WAV first (gemini-3.5-flash audio).
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Mic, Square, ChevronDown, ChevronRight, Download, Wand2, Loader2, Trash2,
+  Activity, Music4, Save,
+} from 'lucide-react';
+
+import {
+  type NoteEvent,
+  type ProcessingConfig,
+  type AudioAnalysisResult,
+  type RecordingEntry,
+  QuantizeValue,
+  ScaleType,
+  Genre,
+} from './types';
+import { NOTE_NAMES, SOUND_PROFILES, GENRE_PROFILES } from './constants';
+import {
+  detectPitch, frequencyToMidi, cleanupNotes, snapToScale, processNotesWithProfile, generateMidiFile,
+} from './audioProcessing';
+import { quantizeNotes, transposeNotes, snapNotesToScale, changeKey, getKeyName } from './midiEditor';
+import { detectKeyAndScale, getRelatedKeys } from './musicTheory';
+import { getMidiSynth } from './midiSynth';
+import { analyzeAudioWithGemini, smartCleanupMidi, type AnalysisContext } from './geminiService';
+import { Visualizer } from './Visualizer';
+import { BpmTapper } from './BpmTapper';
+import { RecordingHistory } from './RecordingHistory';
+import { AssistantOrb } from './AssistantOrb';
+
+import { usePianoRollStore, type PianoNote } from '../../../state/pianoRollStore';
+import { encodeWav } from '../../../lib/wavEncode';
+import { logInfo, logWarn } from '../../../state/logStore';
+import { InstrumentPicker } from '../InstrumentPicker';
+
+const HISTORY_KEY = 'vocal2midi_recordings';
+
+const DEFAULT_CONFIG: ProcessingConfig = {
+  rootNote: 60,
+  scale: ScaleType.CHROMATIC,
+  genre: Genre.NONE,
+  quantizeMode: 'AUTO',
+  manualQuantizeValue: QuantizeValue.OFF,
+  useGeminiForBpm: true,
+  manualBpm: 120,
+  prompt: '',
+  autoKeyDetection: true,
+  activeProfileId: 'DEFAULT',
+  sensitivity: 35,
+  experimentalPitchBend: false,
+  enableCleanup: true,
+};
+
+/* ── helpers ──────────────────────────────────────────────────────────────── */
+
+const stepSec = (bpm: number): number => 60 / Math.max(1, bpm) / 4;
+
+/** Bridge: vocal2midi NoteEvent[] (absolute seconds) -> theDAW step-based notes. */
+const toPianoNotes = (notes: NoteEvent[], bpm: number): PianoNote[] => {
+  const ss = stepSec(bpm);
+  return notes.map((n, i) => ({
+    id: `v2m-${i}-${n.startTime.toFixed(3)}-${n.midiNote}`,
+    note: Math.max(0, Math.min(127, Math.round(n.midiNote))),
+    step: Math.max(0, Math.round(n.startTime / ss)),
+    length: Math.max(1, Math.round(n.duration / ss)),
+    velocity: Math.max(1, Math.min(127, Math.round(n.velocity))),
+  }));
+};
+
+/** gemini-3.5-flash accepts wav/mp3/ogg/flac (not webm) — convert before AI. */
+async function toWavBlob(blob: Blob): Promise<Blob> {
+  const ab = await blob.arrayBuffer();
+  const ctx = new AudioContext();
+  try {
+    const buf = await ctx.decodeAudioData(ab.slice(0));
+    return encodeWav(buf);
+  } finally {
+    void ctx.close().catch(() => {});
+  }
+}
+
+const QUANT_BUTTONS: { label: string; value: QuantizeValue }[] = [
+  { label: '1/4', value: QuantizeValue.Q_1_4 },
+  { label: '1/8', value: QuantizeValue.Q_1_8 },
+  { label: '1/16', value: QuantizeValue.Q_1_16 },
+  { label: '1/32', value: QuantizeValue.Q_1_32 },
+];
+
+const Section: React.FC<{ title: string; defaultOpen?: boolean; children: React.ReactNode }> = ({
+  title, defaultOpen = true, children,
+}) => (
+  <details open={defaultOpen} className="rounded border border-white/10 bg-black/30">
+    <summary className="cursor-pointer select-none px-2 py-1 text-[9px] font-mono font-bold uppercase tracking-widest text-cyan-300/80 hover:text-cyan-200">
+      {title}
+    </summary>
+    <div className="px-2 pb-2 pt-1 space-y-1.5">{children}</div>
+  </details>
+);
+
+const labelCls = 'text-[9px] font-mono uppercase tracking-wide text-zinc-400';
+const selectCls = 'w-full bg-zinc-800 border border-zinc-600 rounded text-[10px] font-mono text-zinc-100 px-1 py-0.5';
+const chip = 'px-1.5 py-0.5 text-[10px] font-mono rounded border transition-colors cursor-pointer';
+const chipOff = 'border-white/15 bg-white/5 text-zinc-200 hover:border-cyan-500/40';
+const chipOn = 'border-cyan-400 bg-cyan-500 text-black font-bold';
+
+/* ── component ────────────────────────────────────────────────────────────── */
+
+export const Vocal2MidiPanel: React.FC = () => {
+  const [collapsed, setCollapsed] = useState(false);
+  const [config, setConfig] = useState<ProcessingConfig>({ ...DEFAULT_CONFIG });
+  const [capturedNotes, setCapturedNotes] = useState<NoteEvent[]>([]);
+  const [processedNotes, setProcessedNotes] = useState<NoteEvent[]>([]);
+  const [audioAnalysis, setAudioAnalysis] = useState<AudioAnalysisResult | null>(null);
+  const [detectedKeyString, setDetectedKeyString] = useState('');
+  const [isRecording, setIsRecording] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [isSmartCleaning, setIsSmartCleaning] = useState(false);
+  const [lastCleanupSummary, setLastCleanupSummary] = useState<string | null>(null);
+  const [status, setStatus] = useState('ready');
+  const [analyser, setAnalyser] = useState<AnalyserNode | null>(null);
+  const [recordings, setRecordings] = useState<RecordingEntry[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]');
+    } catch {
+      return [];
+    }
+  });
+
+  // recorder refs (ported from the source App)
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const isRecordingRef = useRef(false);
+  const currentNoteRef = useRef<{ note: number; startTime: number } | null>(null);
+  const startTimeRef = useRef(0);
+  const bufferRef = useRef<NoteEvent[]>([]);
+  const sensitivityRef = useRef(config.sensitivity);
+  const lastBlobRef = useRef<Blob | null>(null);
+
+  useEffect(() => { sensitivityRef.current = config.sensitivity; }, [config.sensitivity]);
+  useEffect(() => { localStorage.setItem(HISTORY_KEY, JSON.stringify(recordings)); }, [recordings]);
+
+  const bpm = audioAnalysis?.detectedBpm || config.manualBpm || 120;
+
+  /** Write notes into theDAW's existing piano roll. */
+  const applyToRoll = useCallback((notes: NoteEvent[], atBpm: number) => {
+    usePianoRollStore.getState().importNotes(toPianoNotes(notes, atBpm), atBpm);
+  }, []);
+
+  /* ── recorder (ported YIN capture) ─────────────────────────────────────── */
+  const startRecording = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const ctx = new (window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
+      audioCtxRef.current = ctx;
+
+      const an = ctx.createAnalyser();
+      an.fftSize = 2048;
+      analyserRef.current = an;
+      setAnalyser(an);
+
+      const src = ctx.createMediaStreamSource(stream);
+      sourceRef.current = src;
+      src.connect(an);
+
+      const proc = ctx.createScriptProcessor(2048, 1, 1);
+      processorRef.current = proc;
+      src.connect(proc);
+      proc.connect(ctx.destination);
+
+      startTimeRef.current = ctx.currentTime;
+      bufferRef.current = [];
+      currentNoteRef.current = null;
+      isRecordingRef.current = true;
+      setIsRecording(true);
+      setAudioAnalysis(null);
+      setProcessedNotes([]);
+      setDetectedKeyString('');
+      setStatus('listening...');
+
+      proc.onaudioprocess = (e) => {
+        if (!isRecordingRef.current) return;
+        const inputData = e.inputBuffer.getChannelData(0);
+        const sampleRate = ctx.sampleRate;
+        const currentTime = ctx.currentTime - startTimeRef.current;
+        const s = sensitivityRef.current / 100;
+        const gateThreshold = 0.05 - s * 0.049;
+        const minConfidence = 0.9 - s * 0.5;
+        const minDuration = 0.04 - s * 0.03;
+        const frequency = detectPitch(inputData, sampleRate, minConfidence);
+        let sum = 0;
+        for (let i = 0; i < inputData.length; i++) sum += inputData[i] * inputData[i];
+        const rms = Math.sqrt(sum / inputData.length);
+        if (rms > gateThreshold && frequency) {
+          const midiNote = frequencyToMidi(frequency);
+          if (midiNote < 21 || midiNote > 108) return;
+          const pitchChangeThreshold = 2;
+          if (currentNoteRef.current) {
+            const pitchDiff = Math.abs(currentNoteRef.current.note - midiNote);
+            if (pitchDiff > pitchChangeThreshold) {
+              const duration = currentTime - currentNoteRef.current.startTime;
+              if (duration > minDuration) {
+                bufferRef.current.push({ midiNote: currentNoteRef.current.note, startTime: currentNoteRef.current.startTime, duration, velocity: 100 });
+              }
+              currentNoteRef.current = { note: midiNote, startTime: currentTime };
+            }
+          } else {
+            currentNoteRef.current = { note: midiNote, startTime: currentTime };
+          }
+        } else if (currentNoteRef.current) {
+          const duration = currentTime - currentNoteRef.current.startTime;
+          if (duration > minDuration) {
+            bufferRef.current.push({ midiNote: currentNoteRef.current.note, startTime: currentNoteRef.current.startTime, duration, velocity: 100 });
+          }
+          currentNoteRef.current = null;
+        }
+      };
+
+      const rec = new MediaRecorder(stream);
+      mediaRecorderRef.current = rec;
+      chunksRef.current = [];
+      rec.ondataavailable = (ev) => { if (ev.data.size) chunksRef.current.push(ev.data); };
+      rec.start();
+    } catch (err) {
+      logWarn('vocal2midi', `mic error: ${String(err)}`);
+      setStatus('mic error - check permission');
+    }
+  }, []);
+
+  const stopRecording = useCallback(async () => {
+    const rec = mediaRecorderRef.current;
+    const ctx = audioCtxRef.current;
+    if (!rec || !ctx) return;
+    isRecordingRef.current = false;
+    setIsRecording(false);
+    setIsProcessing(true);
+    setStatus('analyzing...');
+
+    const s = sensitivityRef.current / 100;
+    const minDuration = 0.04 - s * 0.03;
+    if (currentNoteRef.current) {
+      const currentTime = ctx.currentTime - startTimeRef.current;
+      const duration = currentTime - currentNoteRef.current.startTime;
+      if (duration > minDuration) {
+        bufferRef.current.push({ midiNote: currentNoteRef.current.note, startTime: currentNoteRef.current.startTime, duration, velocity: 100 });
+      }
+      currentNoteRef.current = null;
+    }
+
+    rec.stop();
+    sourceRef.current?.disconnect();
+    processorRef.current?.disconnect();
+    await new Promise<void>((resolve) => { rec.onstop = () => resolve(); });
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+
+    const webm = new Blob(chunksRef.current, { type: 'audio/webm' });
+    lastBlobRef.current = webm;
+
+    const rawUncleaned = [...bufferRef.current];
+    let rawNotes: NoteEvent[];
+    if (config.enableCleanup) {
+      rawNotes = cleanupNotes(rawUncleaned, 0.05, 0.1);
+    } else {
+      rawNotes = rawUncleaned;
+    }
+    if (rawNotes.length === 0) {
+      setStatus(`no notes detected (try raising sensitivity, now ${config.sensitivity}%)`);
+      setIsProcessing(false);
+      return;
+    }
+
+    // Gemini metadata (BPM/profile) — convert to WAV first (gemini-3.5-flash audio)
+    let analysis: AudioAnalysisResult;
+    if (config.useGeminiForBpm) {
+      try {
+        const wav = await toWavBlob(webm);
+        const aCtx: AnalysisContext = {
+          genre: config.genre, scale: config.scale, quantizeMode: config.quantizeMode,
+          manualQuantizeValue: config.manualQuantizeValue, sensitivity: config.sensitivity,
+          autoKeyDetection: config.autoKeyDetection,
+        };
+        analysis = await analyzeAudioWithGemini(wav, config.prompt, aCtx);
+      } catch (e) {
+        logWarn('vocal2midi', `Gemini analysis failed, using local defaults: ${String(e)}`);
+        analysis = { detectedBpm: config.manualBpm || 120, timeSignature: '4/4', suggestedInstrument: 'Grand Piano', description: 'Local (AI unavailable)', detectedProfileId: 'DEFAULT' };
+      }
+    } else {
+      analysis = { detectedBpm: config.manualBpm || 120, timeSignature: '4/4', suggestedInstrument: 'Unknown', description: 'Local processing', detectedProfileId: 'DEFAULT' };
+    }
+    setAudioAnalysis(analysis);
+
+    let finalRoot = config.rootNote;
+    let finalScale = config.scale;
+    if (config.autoKeyDetection) {
+      const k = detectKeyAndScale(rawNotes);
+      finalRoot = k.root + 60;
+      finalScale = k.scale;
+      setDetectedKeyString(`${NOTE_NAMES[k.root]} ${k.scale} (${Math.round(k.confidence * 100)}%)`);
+    }
+
+    const profileId = analysis.detectedProfileId && SOUND_PROFILES[analysis.detectedProfileId] ? analysis.detectedProfileId : 'DEFAULT';
+    const profile = SOUND_PROFILES[profileId];
+    const finalQuant = config.quantizeMode === 'AUTO' ? profile.suggestedQuantization : config.manualQuantizeValue;
+
+    setConfig((prev) => ({ ...prev, rootNote: finalRoot, scale: finalScale, activeProfileId: profileId }));
+
+    const scaled = rawNotes.map((n) => ({ ...n, midiNote: snapToScale(n.midiNote, finalRoot, finalScale) }));
+    const finalNotes = processNotesWithProfile(scaled, analysis.detectedBpm, finalQuant, profile);
+
+    setCapturedNotes(rawNotes);
+    setProcessedNotes(finalNotes);
+    applyToRoll(finalNotes, analysis.detectedBpm);
+
+    if (finalNotes.length > 0) {
+      setRecordings((prev) => [{
+        id: `rec_${Date.now()}`, timestamp: Date.now(), name: `Recording ${prev.length + 1}`,
+        notes: [...finalNotes], bpm: analysis.detectedBpm, rootNote: finalRoot, scale: finalScale,
+        genre: config.genre, profileId,
+      }, ...prev]);
+    }
+    setStatus(`captured ${finalNotes.length} notes -> piano roll`);
+    setIsProcessing(false);
+    logInfo('vocal2midi', `captured ${finalNotes.length} notes @ ${analysis.detectedBpm} BPM -> piano roll`);
+  }, [config, applyToRoll]);
+
+  // Re-process on setting change (mirrors the source effect; AUTO forces OFF).
+  useEffect(() => {
+    if (capturedNotes.length === 0) return;
+    const b = audioAnalysis?.detectedBpm || 120;
+    const scaled = capturedNotes.map((n) => ({ ...n, midiNote: snapToScale(n.midiNote, config.rootNote, config.scale) }));
+    const profile = SOUND_PROFILES[config.activeProfileId] || SOUND_PROFILES['DEFAULT'];
+    const q = config.quantizeMode === 'AUTO' ? QuantizeValue.OFF : config.manualQuantizeValue;
+    const finalNotes = processNotesWithProfile(scaled, b, q, profile);
+    setProcessedNotes(finalNotes);
+    applyToRoll(finalNotes, b);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [config.rootNote, config.scale, config.quantizeMode, config.manualQuantizeValue, config.activeProfileId, capturedNotes, audioAnalysis]);
+
+  /* ── editor tools (operate on processedNotes -> roll) ──────────────────── */
+  const pushNotes = useCallback((notes: NoteEvent[], atBpm = bpm) => {
+    setProcessedNotes(notes);
+    applyToRoll(notes, atBpm);
+  }, [applyToRoll, bpm]);
+
+  const doQuantize = (q: QuantizeValue) => pushNotes(quantizeNotes(processedNotes, bpm, q));
+  const doTranspose = (semis: number) => pushNotes(transposeNotes(processedNotes, semis));
+  const doSnap = () => pushNotes(snapNotesToScale(processedNotes, config.rootNote, config.scale));
+  const doChangeKey = (toRoot: number, toScale: ScaleType) => {
+    pushNotes(changeKey(processedNotes, config.rootNote, toRoot));
+    setConfig((p) => ({ ...p, rootNote: toRoot, scale: toScale }));
+  };
+
+  const handleSmartCleanup = useCallback(async () => {
+    if (!lastBlobRef.current || processedNotes.length === 0) return;
+    setIsSmartCleaning(true);
+    setStatus('AI cleaning...');
+    try {
+      const wav = await toWavBlob(lastBlobRef.current);
+      const res = await smartCleanupMidi(wav, processedNotes, config.prompt, bpm);
+      pushNotes(res.cleanedNotes);
+      setCapturedNotes(res.cleanedNotes);
+      setLastCleanupSummary(res.summary);
+      setStatus(`AI cleanup: ${res.summary}`);
+    } catch (e) {
+      setStatus(`AI cleanup failed: ${String(e)}`);
+    } finally {
+      setIsSmartCleaning(false);
+    }
+  }, [processedNotes, config.prompt, bpm, pushNotes]);
+
+  const handleExportMidi = () => {
+    if (processedNotes.length === 0) return;
+    const profile = SOUND_PROFILES[config.activeProfileId] || SOUND_PROFILES['DEFAULT'];
+    const blob = generateMidiFile(processedNotes, bpm, profile, { experimentalPitchBend: config.experimentalPitchBend });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `vocal2midi_${Date.now()}.mid`; a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 5000);
+  };
+
+  const handleExportWav = async () => {
+    if (processedNotes.length === 0) return;
+    setStatus('rendering WAV...');
+    try {
+      const blob = await getMidiSynth().renderToWav(processedNotes);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = `vocal2midi_${Date.now()}.wav`; a.click();
+      setTimeout(() => URL.revokeObjectURL(url), 8000);
+      setStatus('WAV exported');
+    } catch (e) {
+      setStatus(`WAV export failed: ${String(e)}`);
+    }
+  };
+
+  const playPreview = () => { void getMidiSynth().playNotes(processedNotes); };
+  const stopPreview = () => getMidiSynth().stop();
+
+  /* ── recording history ─────────────────────────────────────────────────── */
+  const loadRecording = (r: RecordingEntry) => {
+    setCapturedNotes(r.notes);
+    setProcessedNotes(r.notes);
+    setAudioAnalysis((prev) => ({ detectedBpm: r.bpm, timeSignature: prev?.timeSignature || '4/4', suggestedInstrument: prev?.suggestedInstrument || '', description: 'loaded from history', detectedProfileId: r.profileId }));
+    setConfig((p) => ({ ...p, rootNote: r.rootNote, scale: r.scale, genre: r.genre, activeProfileId: r.profileId }));
+    applyToRoll(r.notes, r.bpm);
+    setStatus(`loaded "${r.name}" -> piano roll`);
+  };
+
+  const patch = (p: Partial<ProcessingConfig>) => setConfig((prev) => ({ ...prev, ...p }));
+  const relatedKeys = config.scale !== ScaleType.CHROMATIC ? getRelatedKeys(config.rootNote, config.scale).slice(0, 4) : [];
+
+  /* ── render ────────────────────────────────────────────────────────────── */
+  if (collapsed) {
+    return (
+      <div className="h-full w-9 shrink-0 border-l border-white/8 bg-zinc-950 flex flex-col items-center gap-2 py-2">
+        <button type="button" onClick={() => setCollapsed(false)} title="Expand Vocal2MIDI" aria-label="Expand Vocal2MIDI"
+          className="text-cyan-300 hover:text-cyan-200"><ChevronRight className="w-4 h-4 rotate-180" /></button>
+        <button type="button" onClick={() => (isRecording ? void stopRecording() : void startRecording())}
+          title={isRecording ? 'Stop' : 'Record'} aria-label={isRecording ? 'Stop recording' : 'Record'}
+          className={`grid place-items-center w-6 h-6 rounded border ${isRecording ? 'border-red-500 text-red-300 bg-red-600/25' : 'border-cyan-600 text-cyan-300 hover:bg-cyan-600/15'}`}>
+          {isRecording ? <Square className="w-3 h-3" /> : <Mic className="w-3 h-3" />}
+        </button>
+        <span className="text-[8px] font-mono text-zinc-600 [writing-mode:vertical-rl] rotate-180 tracking-widest">VOCAL2MIDI</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-72 shrink-0 border-l border-white/8 bg-zinc-950 flex flex-col min-h-0">
+      {/* header */}
+      <div className="shrink-0 flex items-center gap-2 px-2 py-1.5 border-b border-white/10">
+        <button type="button" onClick={() => setCollapsed(true)} title="Collapse" aria-label="Collapse Vocal2MIDI"
+          className="text-zinc-500 hover:text-zinc-200"><ChevronDown className="w-3.5 h-3.5 -rotate-90" /></button>
+        <span className="text-[10px] font-mono font-bold uppercase tracking-widest text-cyan-300">Vocal2MIDI</span>
+        <div className="flex-1" />
+        <button type="button" onClick={() => (isRecording ? void stopRecording() : void startRecording())}
+          disabled={isProcessing}
+          aria-label={isRecording ? 'Stop recording' : 'Record'}
+          className={`grid place-items-center w-7 h-7 rounded border transition-colors disabled:opacity-40 ${isRecording ? 'border-red-500 text-red-300 bg-red-600/25' : 'border-cyan-600 text-cyan-300 hover:bg-cyan-600/15'}`}>
+          {isProcessing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : isRecording ? <Square className="w-3.5 h-3.5" /> : <Mic className="w-3.5 h-3.5" />}
+        </button>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto p-2 space-y-2">
+        <Section title="Capture">
+          <Visualizer analyser={analyser} isRecording={isRecording} threshold={0.05 - (config.sensitivity / 100) * 0.049} />
+          <div className="flex items-center gap-2">
+            <label htmlFor="v2m-sens" className={labelCls}>Sensitivity</label>
+            <input id="v2m-sens" name="v2m-sens" type="range" min={0} max={100} value={config.sensitivity}
+              onChange={(e) => patch({ sensitivity: parseInt(e.target.value, 10) })} className="flex-1 accent-cyan-500" />
+            <span className="w-8 text-right text-[9px] font-mono text-cyan-300">{config.sensitivity}%</span>
+          </div>
+          <label className="flex items-center gap-1.5 text-[10px] text-zinc-300">
+            <input type="checkbox" name="v2m-cleanup" checked={config.enableCleanup} onChange={(e) => patch({ enableCleanup: e.target.checked })} className="accent-cyan-500" />
+            Note cleanup
+          </label>
+          <label className="flex items-center gap-1.5 text-[10px] text-zinc-300">
+            <input type="checkbox" name="v2m-pitchbend" checked={config.experimentalPitchBend} onChange={(e) => patch({ experimentalPitchBend: e.target.checked })} className="accent-cyan-500" />
+            Pitch bend (experimental)
+          </label>
+          <span className="block text-[9px] font-mono text-zinc-500 truncate" title={status}>{status}</span>
+        </Section>
+
+        <Section title="Musical">
+          <div className="flex items-center gap-2">
+            <label className="flex items-center gap-1.5 text-[10px] text-zinc-300 flex-1">
+              <input type="checkbox" name="v2m-autokey" checked={config.autoKeyDetection} onChange={(e) => patch({ autoKeyDetection: e.target.checked })} className="accent-cyan-500" />
+              Auto key
+            </label>
+            <label className="flex items-center gap-1.5 text-[10px] text-zinc-300 flex-1">
+              <input type="checkbox" name="v2m-autobpm" checked={config.useGeminiForBpm} onChange={(e) => patch({ useGeminiForBpm: e.target.checked })} className="accent-cyan-500" />
+              Auto BPM (AI)
+            </label>
+          </div>
+          {detectedKeyString && <span className="block text-[9px] font-mono text-emerald-400">key: {detectedKeyString}</span>}
+          <div className="grid grid-cols-2 gap-1.5">
+            <div>
+              <label htmlFor="v2m-root" className={labelCls}>Root</label>
+              <select id="v2m-root" name="v2m-root" className={selectCls} value={config.rootNote} onChange={(e) => patch({ rootNote: parseInt(e.target.value, 10) })} style={{ colorScheme: 'dark' }}>
+                {NOTE_NAMES.map((n, i) => <option key={n} value={60 + i}>{n}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="v2m-scale" className={labelCls}>Scale</label>
+              <select id="v2m-scale" name="v2m-scale" className={selectCls} value={config.scale} onChange={(e) => patch({ scale: e.target.value as ScaleType })} style={{ colorScheme: 'dark' }}>
+                {Object.values(ScaleType).map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="v2m-genre" className={labelCls}>Genre</label>
+              <select id="v2m-genre" name="v2m-genre" className={selectCls} value={config.genre}
+                onChange={(e) => { const g = e.target.value as Genre; patch({ genre: g, activeProfileId: GENRE_PROFILES[g].suggestedProfileId }); }} style={{ colorScheme: 'dark' }}>
+                {Object.values(Genre).map((g) => <option key={g} value={g}>{GENRE_PROFILES[g].name}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="v2m-profile" className={labelCls}>Profile</label>
+              <select id="v2m-profile" name="v2m-profile" className={selectCls} value={config.activeProfileId} onChange={(e) => patch({ activeProfileId: e.target.value })} style={{ colorScheme: 'dark' }}>
+                {Object.values(SOUND_PROFILES).map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            </div>
+          </div>
+          <div>
+            <span className={labelCls}>Quantize</span>
+            <div className="flex gap-1 mt-0.5">
+              <button type="button" onClick={() => patch({ quantizeMode: 'AUTO' })} className={`${chip} ${config.quantizeMode === 'AUTO' ? chipOn : chipOff}`}>Auto</button>
+              <button type="button" onClick={() => patch({ quantizeMode: 'MANUAL' })} className={`${chip} ${config.quantizeMode === 'MANUAL' ? chipOn : chipOff}`}>Manual</button>
+              {config.quantizeMode === 'MANUAL' && (
+                <>
+                  <button type="button" onClick={() => patch({ manualQuantizeValue: QuantizeValue.OFF })} className={`${chip} ${config.manualQuantizeValue === QuantizeValue.OFF ? chipOn : chipOff}`}>Off</button>
+                  {QUANT_BUTTONS.map((q) => (
+                    <button key={q.label} type="button" onClick={() => patch({ manualQuantizeValue: q.value })} className={`${chip} ${config.manualQuantizeValue === q.value ? chipOn : chipOff}`}>{q.label}</button>
+                  ))}
+                </>
+              )}
+            </div>
+          </div>
+          <div>
+            <span className={labelCls}>Instrument (theDAW soundfonts)</span>
+            <div className="mt-0.5"><InstrumentPicker /></div>
+          </div>
+        </Section>
+
+        <Section title="Edit tools" defaultOpen={false}>
+          <div className="flex flex-wrap gap-1">
+            <span className={`${labelCls} w-full`}>Re-quantize</span>
+            {QUANT_BUTTONS.map((q) => (
+              <button key={q.label} type="button" onClick={() => doQuantize(q.value)} className={`${chip} ${chipOff}`} disabled={processedNotes.length === 0}>{q.label}</button>
+            ))}
+          </div>
+          <div className="flex flex-wrap items-center gap-1">
+            <span className={labelCls}>Transpose</span>
+            <button type="button" onClick={() => doTranspose(-12)} className={`${chip} ${chipOff}`}>-12</button>
+            <button type="button" onClick={() => doTranspose(-1)} className={`${chip} ${chipOff}`}>-1</button>
+            <button type="button" onClick={() => doTranspose(1)} className={`${chip} ${chipOff}`}>+1</button>
+            <button type="button" onClick={() => doTranspose(12)} className={`${chip} ${chipOff}`}>+12</button>
+            <button type="button" onClick={doSnap} className={`${chip} ${chipOff}`} disabled={processedNotes.length === 0}>Snap to scale</button>
+          </div>
+          {relatedKeys.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1">
+              <span className={labelCls}>Change key</span>
+              {relatedKeys.map((rk) => (
+                <button key={rk.relationship} type="button" title={rk.relationship} onClick={() => doChangeKey(rk.midiNote, rk.scale)} className={`${chip} ${chipOff}`}>
+                  {NOTE_NAMES[rk.root]} {rk.scale}
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="text-[9px] font-mono text-zinc-500">current: {getKeyName(config.rootNote, config.scale)} · {processedNotes.length} notes</div>
+        </Section>
+
+        <Section title="AI">
+          <input name="v2m-prompt" type="text" value={config.prompt} onChange={(e) => patch({ prompt: e.target.value })}
+            placeholder="AI context / instruction (optional)" aria-label="AI prompt"
+            className="w-full bg-zinc-800 border border-zinc-600 rounded text-[10px] text-zinc-100 px-1.5 py-1" />
+          <button type="button" onClick={() => void handleSmartCleanup()} disabled={isSmartCleaning || !lastBlobRef.current || processedNotes.length === 0}
+            className="w-full flex items-center justify-center gap-1 px-2 py-1 text-[10px] font-mono uppercase tracking-wide rounded border border-violet-500/50 text-violet-200 hover:bg-violet-500/15 disabled:opacity-40">
+            {isSmartCleaning ? <Loader2 className="w-3 h-3 animate-spin" /> : <Wand2 className="w-3 h-3" />} Smart cleanup (AI)
+          </button>
+          {lastCleanupSummary && <span className="block text-[9px] text-zinc-400 wrap-break-word">{lastCleanupSummary}</span>}
+          <span className="block text-[8px] font-mono text-zinc-600">AI uses theDAW's Gemini (gemini-3.5-flash). Needs GEMINI_API_KEY set on the server.</span>
+        </Section>
+
+        <Section title="Play & export" defaultOpen={false}>
+          <div className="flex items-center gap-1">
+            <button type="button" onClick={playPreview} disabled={processedNotes.length === 0} className={`${chip} ${chipOff} flex items-center gap-1`}><Activity className="w-3 h-3" /> Play</button>
+            <button type="button" onClick={stopPreview} className={`${chip} ${chipOff} flex items-center gap-1`}><Square className="w-3 h-3" /> Stop</button>
+            <BpmTapper currentBpm={bpm} onBpmSet={(b) => { setAudioAnalysis((prev) => prev ? { ...prev, detectedBpm: b } : { detectedBpm: b, timeSignature: '4/4', suggestedInstrument: '', description: 'tap tempo', detectedProfileId: config.activeProfileId }); patch({ manualBpm: b }); if (capturedNotes.length) applyToRoll(processedNotes, b); }} />
+          </div>
+          <div className="flex items-center gap-1">
+            <button type="button" onClick={handleExportMidi} disabled={processedNotes.length === 0} className={`${chip} ${chipOff} flex items-center gap-1`}><Download className="w-3 h-3" /> MIDI</button>
+            <button type="button" onClick={() => void handleExportWav()} disabled={processedNotes.length === 0} className={`${chip} ${chipOff} flex items-center gap-1`}><Music4 className="w-3 h-3" /> WAV</button>
+            <button type="button" onClick={() => { setCapturedNotes([]); setProcessedNotes([]); usePianoRollStore.getState().clear(); setStatus('cleared'); }} className={`${chip} ${chipOff} flex items-center gap-1`}><Trash2 className="w-3 h-3" /> Clear</button>
+          </div>
+        </Section>
+
+        <Section title="History" defaultOpen={false}>
+          <RecordingHistory
+            recordings={recordings}
+            onLoad={loadRecording}
+            onDelete={(id) => setRecordings((p) => p.filter((r) => r.id !== id))}
+            onClearAll={() => setRecordings([])}
+            onExportAll={() => {
+              const blob = new Blob([JSON.stringify(recordings, null, 2)], { type: 'application/json' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a'); a.href = url; a.download = 'vocal2midi_recordings.json'; a.click();
+              setTimeout(() => URL.revokeObjectURL(url), 5000);
+            }}
+            onImport={(recs) => setRecordings((p) => [...recs, ...p])}
+          />
+        </Section>
+      </div>
+
+      {/* AI assistant orb — drives config + the piano-roll notes */}
+      <AssistantOrb
+        currentConfig={config}
+        onConfigUpdate={(updates) => patch(updates)}
+        pianoRollControls={{
+          notes: processedNotes,
+          bpm,
+          rootNote: config.rootNote,
+          scale: config.scale,
+          isPlaying: false,
+          onNotesChange: (notes) => pushNotes(notes),
+          onBpmChange: (b) => { setAudioAnalysis((prev) => prev ? { ...prev, detectedBpm: b } : { detectedBpm: b, timeSignature: '4/4', suggestedInstrument: '', description: '', detectedProfileId: config.activeProfileId }); patch({ manualBpm: b }); },
+          onKeyChange: (root, scale) => setConfig((p) => ({ ...p, rootNote: root, scale })),
+          onPlay: playPreview,
+          onStop: stopPreview,
+          onInstrumentChange: (inst) => { void getMidiSynth().setInstrument(inst as Parameters<ReturnType<typeof getMidiSynth>['setInstrument']>[0]); },
+        }}
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/audio/vocal2midi/audioProcessing.ts
+++ b/frontend/src/components/audio/vocal2midi/audioProcessing.ts
@@ -1,0 +1,402 @@
+import { type NoteEvent, QuantizeValue, ScaleType, type SoundProfile } from './types';
+import { SCALES, SOUND_PROFILES } from './constants';
+
+// --- Signal Processing Helpers ---
+
+// A simplified YIN algorithm for pitch detection
+// Now accepts a dynamic confidence threshold
+export const detectPitch = (float32AudioBuffer: Float32Array, sampleRate: number, minConfidence: number = 0.5): number | null => {
+  const bufferSize = float32AudioBuffer.length;
+  const yinBuffer = new Float32Array(bufferSize / 2);
+  let probability = 0.0;
+  // Dynamic threshold for difference calculation based on confidence requested
+  // If we want high confidence (strict), we lower the error threshold allowed
+  const threshold = minConfidence < 0.6 ? 0.2 : 0.15;
+
+  // Step 1: Difference function
+  for (let t = 0; t < yinBuffer.length; t++) {
+    yinBuffer[t] = 0;
+    for (let i = 0; i < yinBuffer.length; i++) {
+      const delta = float32AudioBuffer[i] - float32AudioBuffer[i + t];
+      yinBuffer[t] += delta * delta;
+    }
+  }
+
+  // Step 2: Cumulative mean normalized difference function
+  yinBuffer[0] = 1;
+  let runningSum = 0;
+  for (let t = 1; t < yinBuffer.length; t++) {
+    runningSum += yinBuffer[t];
+    yinBuffer[t] *= t / runningSum;
+  }
+
+  // Step 3: Absolute threshold
+  let tau = -1;
+  for (let t = 2; t < yinBuffer.length; t++) {
+    if (yinBuffer[t] < threshold) {
+      while (t + 1 < yinBuffer.length && yinBuffer[t + 1] < yinBuffer[t]) {
+        t++;
+      }
+      tau = t;
+      probability = 1 - yinBuffer[t];
+      break;
+    }
+  }
+
+  if (tau === -1 || probability < minConfidence) return null;
+
+  return sampleRate / tau;
+};
+
+export const frequencyToMidi = (freq: number): number => {
+  return Math.round(69 + 12 * Math.log2(freq / 440));
+};
+
+// Clean up and deduplicate notes - removes noise and merges close consecutive notes
+export const cleanupNotes = (notes: NoteEvent[], minNoteDuration: number = 0.05, mergeGap: number = 0.08): NoteEvent[] => {
+  if (notes.length === 0) return [];
+
+  // Sort by start time
+  const sorted = [...notes].sort((a, b) => a.startTime - b.startTime);
+
+  // Filter out very short notes (likely noise)
+  const filtered = sorted.filter(n => n.duration >= minNoteDuration);
+
+  if (filtered.length === 0) return [];
+
+  // Merge consecutive notes of the same pitch that are very close together
+  const merged: NoteEvent[] = [];
+  let current = { ...filtered[0] };
+
+  for (let i = 1; i < filtered.length; i++) {
+    const next = filtered[i];
+    const gapBetween = next.startTime - (current.startTime + current.duration);
+
+    // If same pitch and gap is very small, merge them
+    if (next.midiNote === current.midiNote && gapBetween < mergeGap && gapBetween >= -0.01) {
+      // Extend current note to include the next one
+      current.duration = (next.startTime + next.duration) - current.startTime;
+      current.velocity = Math.max(current.velocity, next.velocity);
+    } else {
+      // Different pitch or too far apart - save current and start new
+      merged.push(current);
+      current = { ...next };
+    }
+  }
+  // Don't forget the last note
+  merged.push(current);
+
+  return merged;
+};
+
+export const snapToScale = (midiNote: number, rootNote: number, scaleType: ScaleType): number => {
+  if (scaleType === ScaleType.CHROMATIC) return midiNote;
+
+  const scaleIntervals = SCALES[scaleType];
+  const normalizedNote = midiNote % 12;
+  const normalizedRoot = rootNote % 12;
+
+  // Find the closest note in the scale
+  let minDiff = Infinity;
+  let closestNote = midiNote;
+
+  // Check all octaves around
+  for (let i = -1; i <= 1; i++) {
+     const octaveOffset = i * 12;
+     for (const interval of scaleIntervals) {
+       const targetNote = (normalizedRoot + interval) % 12;
+       // Reconstruct absolute MIDI note
+       const absoluteTarget = (Math.floor(midiNote / 12) * 12) + targetNote + octaveOffset;
+
+       const diff = Math.abs(midiNote - absoluteTarget);
+       if (diff < minDiff) {
+         minDiff = diff;
+         closestNote = absoluteTarget;
+       }
+     }
+  }
+  return closestNote;
+};
+
+// Applies both quantization AND sound profile transformations
+export const processNotesWithProfile = (
+  notes: NoteEvent[],
+  bpm: number,
+  quantizeVal: QuantizeValue,
+  profile: SoundProfile
+): NoteEvent[] => {
+
+  const secondsPerBeat = 60 / bpm;
+  const gridUnit = quantizeVal !== QuantizeValue.OFF ? secondsPerBeat * (4 / quantizeVal) : 0;
+
+  // Sort first
+  const sortedNotes = [...notes].sort((a, b) => a.startTime - b.startTime);
+
+  return sortedNotes.map((note, index) => {
+    let { startTime, duration, velocity, midiNote } = note;
+
+    // 1. Quantization (Time Correction) - preserves gaps/rests
+    if (gridUnit > 0) {
+      // Apply quantization strength (mix between original and grid)
+      const targetStart = Math.round(startTime / gridUnit) * gridUnit;
+      const targetDuration = Math.round(duration / gridUnit) * gridUnit;
+
+      // Interpolate based on profile quantization strength
+      const qStr = profile.transformation.quantizeStrength;
+      startTime = startTime + (targetStart - startTime) * qStr;
+
+      // Keep original duration character - don't force to grid minimum
+      // Just apply quantization strength to duration
+      const quantizedDuration = duration + (targetDuration - duration) * qStr;
+      // Minimum 0.02s to prevent zero-length notes, but preserve short notes
+      duration = Math.max(0.02, quantizedDuration);
+    }
+
+    // 2. Profile Duration Handling - NEVER fill gaps, only adjust individual note lengths
+    if (profile.transformation.durationMode === 'gated') {
+      // Force short durations for percussive sounds
+      duration = Math.min(duration, profile.transformation.minDuration || 0.15);
+    } else if (profile.transformation.durationMode === 'legato') {
+      // Just apply minimum duration - NEVER extend to fill gaps
+      // Gaps are intentional rests and must be preserved
+      duration = Math.max(duration, profile.transformation.minDuration || 0.2);
+    }
+    // 'natural' mode: preserve exact recorded durations
+
+    // 3. Velocity Handling
+    let finalVelocity = velocity;
+    if (profile.transformation.velocityCurve === 'fixed-high') {
+      finalVelocity = profile.transformation.baseVelocity;
+    } else if (profile.transformation.velocityCurve === 'soft') {
+      finalVelocity = Math.min(velocity, profile.transformation.baseVelocity);
+    } else {
+      // Dynamic: center around baseVelocity but keep variance
+      const variance = velocity - 100; // range -100 to 27
+      finalVelocity = Math.max(1, Math.min(127, profile.transformation.baseVelocity + (variance * 0.8)));
+    }
+
+    return {
+      midiNote,
+      startTime,
+      duration,
+      velocity: Math.round(finalVelocity)
+    };
+  });
+};
+
+// --- MIDI File Generation (Binary) ---
+
+const numberToBytes = (num: number, bytes: number) => {
+  const result = [];
+  for (let i = bytes - 1; i >= 0; i--) {
+    result.push((num >> (8 * i)) & 0xFF);
+  }
+  return result;
+};
+
+// Correct VarInt implementation
+const toVarInt = (num: number): number[] => {
+  if (num === 0) return [0];
+  const bytes = [];
+  let n = num;
+  while (n > 0) {
+    bytes.unshift(n & 0x7F);
+    n >>= 7;
+  }
+  for (let i = 0; i < bytes.length - 1; i++) {
+    bytes[i] |= 0x80;
+  }
+  return bytes;
+};
+
+
+export interface MidiExportOptions {
+  experimentalPitchBend?: boolean;
+}
+
+export const generateMidiFile = (
+  notes: NoteEvent[],
+  bpm: number,
+  profile?: SoundProfile,
+  options?: MidiExportOptions
+): Blob => {
+  const { experimentalPitchBend = false } = options || {};
+
+  // MIDI Header
+  const ticksPerBeat = 480; // Standard PPQ
+  const header = [
+    0x4d, 0x54, 0x68, 0x64, // MThd
+    0x00, 0x00, 0x00, 0x06, // Chunk size
+    0x00, 0x01, // Format 1 (multi-track, though we use 1 here mostly)
+    0x00, 0x02, // 2 Tracks (1 for Tempo, 1 for Notes)
+    ...numberToBytes(ticksPerBeat, 2)
+  ];
+
+  // Track 1: Tempo
+  const microsecondsPerBeat = Math.round(60000000 / bpm);
+  const tempoEvent = [
+    0x00, // Delta time 0
+    0xFF, 0x51, 0x03, // Meta event: Set Tempo
+    ...numberToBytes(microsecondsPerBeat, 3)
+  ];
+  const endOfTrack1 = [0x00, 0xFF, 0x2F, 0x00];
+  const track1Data = [...tempoEvent, ...endOfTrack1];
+  const track1Header = [
+    0x4d, 0x54, 0x72, 0x6b, // MTrk
+    ...numberToBytes(track1Data.length, 4)
+  ];
+
+  // Track 2: Notes & Control Changes
+  let track2Data: number[] = [];
+
+  // Convert seconds to ticks
+  const secToTicks = (sec: number) => Math.round(sec * (bpm / 60) * ticksPerBeat);
+
+  // Define Event Type
+  interface MidiEvent {
+    tick: number;
+    type: 'on' | 'off' | 'cc' | 'pitchbend';
+    note?: number;
+    ccNum?: number;
+    val: number;
+    pitchBendVal?: number; // 0-16383, 8192 = center
+  }
+  let events: MidiEvent[] = [];
+
+  // 1. Inject CC messages at Tick 0 if profile has them
+  if (profile && profile.transformation.midiCC) {
+    const { attack, release, brightness, reverb } = profile.transformation.midiCC;
+    if (attack !== undefined) events.push({ tick: 0, type: 'cc', ccNum: 73, val: attack });
+    if (release !== undefined) events.push({ tick: 0, type: 'cc', ccNum: 72, val: release });
+    if (brightness !== undefined) events.push({ tick: 0, type: 'cc', ccNum: 74, val: brightness });
+    if (reverb !== undefined) events.push({ tick: 0, type: 'cc', ccNum: 91, val: reverb });
+  }
+
+  // 2. Add Note Events
+  const sortedNotes = [...notes].sort((a, b) => a.startTime - b.startTime);
+  sortedNotes.forEach(n => {
+    const startTick = secToTicks(n.startTime);
+    const endTick = secToTicks(n.startTime + n.duration);
+    events.push({ tick: startTick, type: 'on', note: n.midiNote, val: n.velocity });
+    events.push({ tick: endTick, type: 'off', note: n.midiNote, val: 0 });
+  });
+
+  // 3. EXPERIMENTAL: Add Pitch Bend for slides between consecutive notes
+  if (experimentalPitchBend && sortedNotes.length > 1) {
+    // Reset pitch bend at the start
+    events.push({ tick: 0, type: 'pitchbend', val: 0, pitchBendVal: 8192 });
+
+    for (let i = 0; i < sortedNotes.length - 1; i++) {
+      const currentNote = sortedNotes[i];
+      const nextNote = sortedNotes[i + 1];
+
+      const currentEnd = currentNote.startTime + currentNote.duration;
+      const gap = nextNote.startTime - currentEnd;
+
+      // Detect potential slide: notes are close (gap < 100ms) and different pitches
+      const isSlideCandidate = gap < 0.1 && gap >= -0.05; // Allow small overlap
+      const pitchDiff = nextNote.midiNote - currentNote.midiNote;
+
+      if (isSlideCandidate && pitchDiff !== 0 && Math.abs(pitchDiff) <= 12) {
+        // Calculate slide parameters
+        // Standard pitch bend range is ±2 semitones (can be set via RPN, we assume default)
+        // pitchBendVal: 0 = -2 semitones, 8192 = center, 16383 = +2 semitones
+        // For larger intervals, we'll bend as much as we can (±2 semitones) then jump
+
+        const bendSemitones = Math.min(Math.abs(pitchDiff), 2) * Math.sign(pitchDiff);
+        // Convert semitones to pitch bend value: 8192 + (semitones * 4096)
+        const targetBend = 8192 + (bendSemitones * 4096);
+
+        const slideStartTick = secToTicks(currentEnd - 0.05); // Start slide 50ms before note ends
+        const slideEndTick = secToTicks(nextNote.startTime);
+
+        // Generate slide events (interpolate pitch bend)
+        const numSteps = 8; // 8 steps for smooth-ish slide
+        for (let step = 0; step <= numSteps; step++) {
+          const t = step / numSteps;
+          const tick = Math.round(slideStartTick + (slideEndTick - slideStartTick) * t);
+          const bendVal = Math.round(8192 + (targetBend - 8192) * t);
+          events.push({
+            tick: Math.max(0, tick),
+            type: 'pitchbend',
+            val: 0,
+            pitchBendVal: Math.max(0, Math.min(16383, bendVal))
+          });
+        }
+
+        // Reset pitch bend shortly after the next note starts
+        events.push({
+          tick: secToTicks(nextNote.startTime + 0.02),
+          type: 'pitchbend',
+          val: 0,
+          pitchBendVal: 8192
+        });
+      }
+    }
+  }
+
+  // 4. Sort events (Tick -> Type Priority: CC/PitchBend first, then Note Off, then Note On)
+  events.sort((a, b) => {
+    if (a.tick !== b.tick) return a.tick - b.tick;
+    // Priority: CC/PitchBend -> Note Off -> Note On
+    const typePriority = { cc: 0, pitchbend: 1, off: 2, on: 3 };
+    return typePriority[a.type] - typePriority[b.type];
+  });
+
+  let lastTick = 0;
+
+  events.forEach(e => {
+    const delta = e.tick - lastTick;
+    const deltaBytes = toVarInt(delta);
+
+    if (e.type === 'pitchbend') {
+      // Pitch Bend: 0xE0, LSB, MSB (14-bit value split into two 7-bit bytes)
+      const bendVal = e.pitchBendVal ?? 8192;
+      const lsb = bendVal & 0x7F;
+      const msb = (bendVal >> 7) & 0x7F;
+      track2Data.push(...deltaBytes);
+      track2Data.push(0xE0, lsb, msb);
+    } else {
+      // Note On: 0x90, CC: 0xB0
+      // Using Note On with Velocity 0 for Note Off (maximum compatibility)
+      let statusByte = 0x90;
+      let data1 = 0;
+      let data2 = e.val;
+
+      if (e.type === 'cc') {
+        statusByte = 0xB0;
+        data1 = e.ccNum || 0;
+      } else if (e.type === 'off') {
+        statusByte = 0x90; // Use Note On
+        data1 = e.note || 0;
+        data2 = 0; // Velocity 0 = Off
+      } else {
+        statusByte = 0x90;
+        data1 = e.note || 0;
+      }
+
+      track2Data.push(...deltaBytes);
+      track2Data.push(statusByte, data1, data2);
+    }
+
+    lastTick = e.tick;
+  });
+
+  const endOfTrack2 = [0x00, 0xFF, 0x2F, 0x00];
+  track2Data.push(...endOfTrack2);
+
+  const track2Header = [
+    0x4d, 0x54, 0x72, 0x6b,
+    ...numberToBytes(track2Data.length, 4)
+  ];
+
+  const fileBytes = new Uint8Array([
+    ...header,
+    ...track1Header,
+    ...track1Data,
+    ...track2Header,
+    ...track2Data
+  ]);
+
+  return new Blob([fileBytes], { type: 'audio/midi' });
+};

--- a/frontend/src/components/audio/vocal2midi/constants.ts
+++ b/frontend/src/components/audio/vocal2midi/constants.ts
@@ -1,0 +1,261 @@
+import { type SoundProfile, QuantizeValue, Genre, type GenreProfile, ScaleType } from "./types";
+
+export const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+export const SCALES: Record<string, number[]> = {
+  Chromatic: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+  Major: [0, 2, 4, 5, 7, 9, 11],
+  Minor: [0, 2, 3, 5, 7, 8, 10], // Natural Minor
+  Pentatonic: [0, 3, 5, 7, 10] // Minor Pentatonic
+};
+
+// MIDI File Header Constants
+export const MIDI_HEADER = [0x4d, 0x54, 0x68, 0x64];
+export const MIDI_TRACK_HEADER = [0x4d, 0x54, 0x72, 0x6b];
+
+export const SOUND_PROFILES: Record<string, SoundProfile> = {
+  'DEFAULT': {
+    id: 'DEFAULT',
+    name: 'Natural Capture',
+    description: 'Preserves original performance dynamics.',
+    suggestedQuantization: QuantizeValue.Q_1_8, // Gentle correction
+    transformation: {
+      velocityCurve: 'dynamic',
+      durationMode: 'natural',
+      quantizeStrength: 0.5,
+      baseVelocity: 100,
+      midiCC: {
+        attack: 64, // Neutral
+        release: 64, // Neutral
+        brightness: 64,
+        reverb: 40
+      }
+    }
+  },
+  'DRIVING': {
+    id: 'DRIVING',
+    name: 'Driving / Percussive',
+    description: 'Short, punchy notes with high velocity. Sharpened Attack.',
+    suggestedQuantization: QuantizeValue.Q_1_16, // Tight grid for beats
+    transformation: {
+      velocityCurve: 'fixed-high',
+      durationMode: 'gated',
+      minDuration: 0.1, // Force staccato
+      quantizeStrength: 1.0, // Strict timing
+      baseVelocity: 120,
+      midiCC: {
+        attack: 0,   // Immediate attack (CC 73)
+        release: 20, // Short release (CC 72)
+        brightness: 110, // Open filter (CC 74)
+        reverb: 10
+      }
+    }
+  },
+  'SOARING': {
+    id: 'SOARING',
+    name: 'Soaring / Lead',
+    description: 'Legato sustain with slow attack and heavy reverb.',
+    suggestedQuantization: QuantizeValue.Q_1_8, // Melodic structure
+    transformation: {
+      velocityCurve: 'dynamic',
+      durationMode: 'legato',
+      minDuration: 0.25,
+      quantizeStrength: 0.6,
+      baseVelocity: 100,
+      midiCC: {
+        attack: 50,  // Softer attack
+        release: 70, // Longer tail
+        brightness: 90, // Bright lead
+        reverb: 80 // Epic hall
+      }
+    }
+  },
+  'ATMOSPHERIC': {
+    id: 'ATMOSPHERIC',
+    name: 'Atmospheric / Pad',
+    description: 'Swelling attacks, long releases, overlapping notes.',
+    suggestedQuantization: QuantizeValue.Q_1_4, // Very loose, anchored to beat
+    transformation: {
+      velocityCurve: 'soft',
+      durationMode: 'legato',
+      minDuration: 0.5,
+      quantizeStrength: 0.2, // Loose timing
+      baseVelocity: 75,
+      midiCC: {
+        attack: 90,  // Very slow swell
+        release: 100, // Very long fade
+        brightness: 40, // Darker filter
+        reverb: 110 // Massive space
+      }
+    }
+  }
+};
+
+// Genre profiles - affects how MIDI is structured for DAW export
+export const GENRE_PROFILES: Record<Genre, GenreProfile> = {
+  [Genre.NONE]: {
+    id: Genre.NONE,
+    name: 'No Genre',
+    description: 'No genre-specific processing. Use your own settings.',
+    suggestedQuantization: QuantizeValue.Q_1_8,
+    suggestedProfileId: 'DEFAULT',
+    midiHints: {
+      noteLengthBias: 'medium',
+      quantizeTightness: 'medium',
+      velocityStyle: 'dynamic',
+      typicalBpmRange: [60, 180],
+      commonScales: [ScaleType.CHROMATIC]
+    },
+    geminiPromptHint: ''
+  },
+  [Genre.DUBSTEP]: {
+    id: Genre.DUBSTEP,
+    name: 'Dubstep',
+    description: 'Heavy bass wobbles, half-time feel, long sustained notes for LFO modulation.',
+    suggestedQuantization: QuantizeValue.Q_1_8,
+    suggestedProfileId: 'SOARING',
+    midiHints: {
+      noteLengthBias: 'long',
+      quantizeTightness: 'loose',
+      velocityStyle: 'dynamic',
+      typicalBpmRange: [140, 150],
+      commonScales: [ScaleType.MINOR, ScaleType.CHROMATIC]
+    },
+    geminiPromptHint: 'Dubstep bass: Create LONG sustained notes suitable for wobble bass with LFO modulation. Half-time feel. Notes should be held, not staccato. Think Skrillex, Excision - bass notes that sustain and can be modulated with filters/LFOs in a DAW.'
+  },
+  [Genre.HOUSE]: {
+    id: Genre.HOUSE,
+    name: 'House',
+    description: 'Four-on-the-floor, tight quantization, punchy and consistent.',
+    suggestedQuantization: QuantizeValue.Q_1_16,
+    suggestedProfileId: 'DRIVING',
+    midiHints: {
+      noteLengthBias: 'short',
+      quantizeTightness: 'tight',
+      velocityStyle: 'consistent',
+      typicalBpmRange: [120, 130],
+      commonScales: [ScaleType.MINOR, ScaleType.MAJOR]
+    },
+    geminiPromptHint: 'House music: Tight to the grid, punchy short notes. 4/4 driving rhythm. Notes should be quantized precisely. Think disco-influenced, groovy but mechanical precision.'
+  },
+  [Genre.TECHNO]: {
+    id: Genre.TECHNO,
+    name: 'Techno',
+    description: 'Hypnotic, repetitive, mechanical precision with subtle variations.',
+    suggestedQuantization: QuantizeValue.Q_1_16,
+    suggestedProfileId: 'DRIVING',
+    midiHints: {
+      noteLengthBias: 'short',
+      quantizeTightness: 'tight',
+      velocityStyle: 'consistent',
+      typicalBpmRange: [125, 140],
+      commonScales: [ScaleType.MINOR, ScaleType.CHROMATIC]
+    },
+    geminiPromptHint: 'Techno: Mechanical, hypnotic, precisely quantized. Repetitive patterns with subtle velocity variations. Dark, industrial feel. Notes locked to grid.'
+  },
+  [Genre.DRUM_AND_BASS]: {
+    id: Genre.DRUM_AND_BASS,
+    name: 'Drum & Bass',
+    description: 'Fast breakbeats, rolling bass, very short punchy notes.',
+    suggestedQuantization: QuantizeValue.Q_1_32,
+    suggestedProfileId: 'DRIVING',
+    midiHints: {
+      noteLengthBias: 'short',
+      quantizeTightness: 'tight',
+      velocityStyle: 'punchy',
+      typicalBpmRange: [160, 180],
+      commonScales: [ScaleType.MINOR, ScaleType.PENTATONIC]
+    },
+    geminiPromptHint: 'Drum & Bass: Fast tempo, very short staccato notes. Reese bass with quick articulation. Rolling, syncopated patterns. High energy, notes should be tight and punchy.'
+  },
+  [Genre.TRANCE]: {
+    id: Genre.TRANCE,
+    name: 'Trance',
+    description: 'Uplifting, melodic, arpeggiated patterns with medium-length notes.',
+    suggestedQuantization: QuantizeValue.Q_1_16,
+    suggestedProfileId: 'SOARING',
+    midiHints: {
+      noteLengthBias: 'medium',
+      quantizeTightness: 'medium',
+      velocityStyle: 'dynamic',
+      typicalBpmRange: [135, 145],
+      commonScales: [ScaleType.MINOR, ScaleType.MAJOR]
+    },
+    geminiPromptHint: 'Trance: Euphoric, melodic, arpeggiated. Build-ups and breakdowns. Notes should flow melodically with emotional dynamics. Supersaw-friendly note lengths.'
+  },
+  [Genre.AMBIENT]: {
+    id: Genre.AMBIENT,
+    name: 'Ambient',
+    description: 'Atmospheric pads, very long notes, free-flowing timing.',
+    suggestedQuantization: QuantizeValue.OFF,
+    suggestedProfileId: 'ATMOSPHERIC',
+    midiHints: {
+      noteLengthBias: 'long',
+      quantizeTightness: 'free',
+      velocityStyle: 'soft',
+      typicalBpmRange: [60, 100],
+      commonScales: [ScaleType.MAJOR, ScaleType.PENTATONIC]
+    },
+    geminiPromptHint: 'Ambient: Ethereal, floating, no strict timing. Very long sustained notes for pads. Gentle velocity. Overlapping notes are fine. Think Brian Eno - textures, not beats.'
+  },
+  [Genre.HIPHOP]: {
+    id: Genre.HIPHOP,
+    name: 'Hip-Hop',
+    description: 'Laid-back groove, slightly behind the beat, varied note lengths.',
+    suggestedQuantization: QuantizeValue.Q_1_8,
+    suggestedProfileId: 'DEFAULT',
+    midiHints: {
+      noteLengthBias: 'varied',
+      quantizeTightness: 'loose',
+      velocityStyle: 'dynamic',
+      typicalBpmRange: [80, 100],
+      commonScales: [ScaleType.MINOR, ScaleType.PENTATONIC]
+    },
+    geminiPromptHint: 'Hip-Hop: Laid-back, swung groove. Notes can sit slightly behind the grid for that human feel. 808-style bass - some short, some sustained. Boom-bap influence.'
+  },
+  [Genre.TRAP]: {
+    id: Genre.TRAP,
+    name: 'Trap',
+    description: 'Hard-hitting 808s, mix of sustained bass and rapid hi-hat patterns.',
+    suggestedQuantization: QuantizeValue.Q_1_16,
+    suggestedProfileId: 'DRIVING',
+    midiHints: {
+      noteLengthBias: 'varied',
+      quantizeTightness: 'medium',
+      velocityStyle: 'punchy',
+      typicalBpmRange: [130, 170],
+      commonScales: [ScaleType.MINOR, ScaleType.PENTATONIC]
+    },
+    geminiPromptHint: 'Trap: Hard 808 bass - sustained low notes with punchy hits. Triplet hi-hat feel. Mix of long gliding bass notes and short percussive hits. Think Metro Boomin, Southside.'
+  },
+  [Genre.POP]: {
+    id: Genre.POP,
+    name: 'Pop',
+    description: 'Clean, melodic, moderate quantization with dynamic expression.',
+    suggestedQuantization: QuantizeValue.Q_1_8,
+    suggestedProfileId: 'DEFAULT',
+    midiHints: {
+      noteLengthBias: 'medium',
+      quantizeTightness: 'medium',
+      velocityStyle: 'dynamic',
+      typicalBpmRange: [100, 130],
+      commonScales: [ScaleType.MAJOR, ScaleType.MINOR]
+    },
+    geminiPromptHint: 'Pop: Clean, polished, singable melodies. Notes should be clear and well-defined. Natural dynamics. Radio-friendly structure and timing.'
+  },
+  [Genre.ROCK]: {
+    id: Genre.ROCK,
+    name: 'Rock',
+    description: 'Energetic, power chords feel, strong downbeats.',
+    suggestedQuantization: QuantizeValue.Q_1_8,
+    suggestedProfileId: 'DRIVING',
+    midiHints: {
+      noteLengthBias: 'medium',
+      quantizeTightness: 'medium',
+      velocityStyle: 'punchy',
+      typicalBpmRange: [110, 140],
+      commonScales: [ScaleType.MINOR, ScaleType.PENTATONIC]
+    },
+    geminiPromptHint: 'Rock: Energetic, guitar-influenced. Strong accents on downbeats. Power chord-friendly note groupings. Raw energy with some human feel in timing.'
+  }
+};

--- a/frontend/src/components/audio/vocal2midi/geminiAssistant.ts
+++ b/frontend/src/components/audio/vocal2midi/geminiAssistant.ts
@@ -1,0 +1,474 @@
+import { GoogleGenAI, Type } from "@google/genai";
+import type { FunctionDeclaration } from "@google/genai";
+import { QuantizeValue, ScaleType, Genre } from "./types";
+import type { ProcessingConfig, NoteEvent } from "./types";
+import { quantizeNotes, transposeNotes, changeKey, snapNotesToScale, deleteNote } from "./midiEditor";
+import { GENRE_PROFILES } from "./constants";
+
+// theDAW keeps API keys server-side; route all Gemini calls through the backend proxy.
+const PROXY_BASE = (typeof window !== 'undefined' ? window.location.origin : '') + '/api/genai-proxy';
+const ai = new GoogleGenAI({ apiKey: 'thedaw-proxy', httpOptions: { baseUrl: PROXY_BASE } });
+
+// Helper to convert config enums to string description for the prompt
+const getConfigDescription = (config: ProcessingConfig) => {
+    return JSON.stringify(config, null, 2);
+};
+
+const getNotesDescription = (notes: NoteEvent[]) => {
+    if (notes.length === 0) return "No notes recorded yet.";
+    const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+    return `${notes.length} notes: ${notes.slice(0, 10).map(n => {
+        const name = noteNames[n.midiNote % 12];
+        const octave = Math.floor(n.midiNote / 12) - 1;
+        return `${name}${octave}`;
+    }).join(', ')}${notes.length > 10 ? '...' : ''}`;
+};
+
+// Tool 1: Update app configuration settings
+const updateConfigTool: FunctionDeclaration = {
+    name: 'updateAppConfiguration',
+    description: 'Updates the processing/recording settings of the Vocal2Midi application.',
+    parameters: {
+        type: Type.OBJECT,
+        properties: {
+            rootNote: { type: Type.INTEGER, description: 'MIDI root note number (60=C4, 61=C#4, 62=D4, etc.). Only 60-71 for root selection.' },
+            scale: { type: Type.STRING, description: 'Scale type: "Chromatic", "Major", "Minor", "Pentatonic".' },
+            genre: { type: Type.STRING, description: 'Genre for MIDI structure: "None", "Dubstep", "House", "Techno", "Drum & Bass", "Trance", "Ambient", "Hip-Hop", "Trap", "Pop", "Rock". Affects note lengths, quantization style, and velocity.' },
+            quantizeMode: { type: Type.STRING, description: '"AUTO" or "MANUAL".' },
+            manualQuantizeValue: { type: Type.INTEGER, description: 'Quantize value: 4 (1/4), 8 (1/8), 16 (1/16), 32 (1/32), or 0 (OFF/Free).' },
+            sensitivity: { type: Type.INTEGER, description: 'Recording sensitivity 0-100. Higher = more sensitive, catches quieter notes.' },
+            activeProfileId: { type: Type.STRING, description: 'Sound Profile ID: "DEFAULT", "DRIVING", "SOARING", "ATMOSPHERIC".' },
+            autoKeyDetection: { type: Type.BOOLEAN, description: 'Enable automatic key detection on recording.' },
+            responseMessage: { type: Type.STRING, description: 'A short confirmation message to speak back to the user.' }
+        },
+        required: ['responseMessage']
+    }
+};
+
+// Tool 2: Modify the piano roll / MIDI notes (bulk operations)
+const modifyNotesTool: FunctionDeclaration = {
+    name: 'modifyMidiNotes',
+    description: 'Bulk operations on MIDI notes: quantize, transpose, change key, snap to scale, or delete.',
+    parameters: {
+        type: Type.OBJECT,
+        properties: {
+            action: {
+                type: Type.STRING,
+                description: 'Action to perform: "quantize", "transpose", "changeKey", "snapToScale", "deleteAll", "deleteByRange".'
+            },
+            quantizeValue: {
+                type: Type.INTEGER,
+                description: 'For quantize action: 4 (1/4), 8 (1/8), 16 (1/16), 32 (1/32).'
+            },
+            semitones: {
+                type: Type.INTEGER,
+                description: 'For transpose action: number of semitones to shift (+12 = up octave, -12 = down octave).'
+            },
+            targetKey: {
+                type: Type.INTEGER,
+                description: 'For changeKey action: target root note (0-11, where 0=C, 1=C#, 2=D, etc.).'
+            },
+            targetScale: {
+                type: Type.STRING,
+                description: 'For snapToScale action: "Chromatic", "Major", "Minor", "Pentatonic".'
+            },
+            pitchMin: {
+                type: Type.INTEGER,
+                description: 'For deleteByRange: minimum MIDI note to delete.'
+            },
+            pitchMax: {
+                type: Type.INTEGER,
+                description: 'For deleteByRange: maximum MIDI note to delete.'
+            },
+            responseMessage: { type: Type.STRING, description: 'A short confirmation message.' }
+        },
+        required: ['action', 'responseMessage']
+    }
+};
+
+// Tool 2b: Add a single MIDI note
+const addNoteTool: FunctionDeclaration = {
+    name: 'addNote',
+    description: 'Adds a single MIDI note to the piano roll. Use this when the user wants to add a specific note.',
+    parameters: {
+        type: Type.OBJECT,
+        properties: {
+            pitch: {
+                type: Type.INTEGER,
+                description: 'MIDI note number. Middle C (C4) = 60. C3=48, C5=72. Notes: C=0, C#=1, D=2, D#=3, E=4, F=5, F#=6, G=7, G#=8, A=9, A#=10, B=11 (add to octave*12).'
+            },
+            startBeat: {
+                type: Type.NUMBER,
+                description: 'Start position in beats (0 = beginning, 1 = beat 2, 4 = measure 2 in 4/4). Use decimals for sub-beats.'
+            },
+            durationBeats: {
+                type: Type.NUMBER,
+                description: 'Duration in beats. 1 = quarter note, 0.5 = eighth note, 0.25 = sixteenth note, 2 = half note.'
+            },
+            velocity: {
+                type: Type.INTEGER,
+                description: 'Note velocity/loudness 1-127. Default is 100. Soft=60, Medium=100, Loud=120.'
+            },
+            responseMessage: { type: Type.STRING, description: 'Confirmation message.' }
+        },
+        required: ['pitch', 'startBeat', 'durationBeats', 'responseMessage']
+    }
+};
+
+// Tool 2c: Delete a specific note by index
+const deleteNoteTool: FunctionDeclaration = {
+    name: 'deleteNote',
+    description: 'Deletes a specific note from the piano roll by its index (0-based) or by matching pitch and approximate time.',
+    parameters: {
+        type: Type.OBJECT,
+        properties: {
+            noteIndex: {
+                type: Type.INTEGER,
+                description: 'Index of the note to delete (0-based, in order of start time).'
+            },
+            matchPitch: {
+                type: Type.INTEGER,
+                description: 'Alternative: MIDI pitch to match for deletion.'
+            },
+            matchBeat: {
+                type: Type.NUMBER,
+                description: 'Alternative: Approximate beat position to match (used with matchPitch).'
+            },
+            responseMessage: { type: Type.STRING, description: 'Confirmation message.' }
+        },
+        required: ['responseMessage']
+    }
+};
+
+// Tool 3: Control playback and BPM
+const controlPlaybackTool: FunctionDeclaration = {
+    name: 'controlPlayback',
+    description: 'Controls the piano roll playback and tempo settings.',
+    parameters: {
+        type: Type.OBJECT,
+        properties: {
+            action: {
+                type: Type.STRING,
+                description: 'Action: "play", "stop", "setBpm".'
+            },
+            bpm: {
+                type: Type.INTEGER,
+                description: 'For setBpm action: tempo in beats per minute (20-300).'
+            },
+            instrument: {
+                type: Type.STRING,
+                description: 'Preview instrument: "synth", "piano", "kick", "bass", "guitar".'
+            },
+            responseMessage: { type: Type.STRING, description: 'A short confirmation message.' }
+        },
+        required: ['action', 'responseMessage']
+    }
+};
+
+// Tool 4: Get status/info about current state
+const getStatusTool: FunctionDeclaration = {
+    name: 'getStatus',
+    description: 'Gets information about the current state of the app, notes, or settings. Use this to answer questions about the current configuration.',
+    parameters: {
+        type: Type.OBJECT,
+        properties: {
+            query: {
+                type: Type.STRING,
+                description: 'What to query: "notes", "config", "bpm", "key", "all".'
+            },
+            responseMessage: { type: Type.STRING, description: 'Information to relay to the user.' }
+        },
+        required: ['query', 'responseMessage']
+    }
+};
+
+export interface PianoRollState {
+    notes: NoteEvent[];
+    bpm: number;
+    rootNote: number;
+    scale: ScaleType;
+    isPlaying: boolean;
+}
+
+export interface AssistantResponse {
+    text: string;
+    configUpdates?: Partial<ProcessingConfig>;
+    notesUpdate?: NoteEvent[];
+    bpmUpdate?: number;
+    keyUpdate?: { rootNote: number; scale: ScaleType };
+    playbackAction?: 'play' | 'stop';
+    instrumentUpdate?: string;
+}
+
+export interface AssistantContext {
+    config: ProcessingConfig;
+    pianoRoll: PianoRollState;
+}
+
+export const askAssistant = async (
+    message: string,
+    context: AssistantContext
+): Promise<AssistantResponse> => {
+    const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+    const currentKeyName = `${noteNames[context.pianoRoll.rootNote % 12]} ${context.pianoRoll.scale}`;
+
+    // Get genre-specific hints if a genre is selected
+    const genreProfile = context.config.genre !== Genre.NONE ? GENRE_PROFILES[context.config.genre] : null;
+    const genreContext = genreProfile ? `
+=== GENRE CONTEXT: ${genreProfile.name.toUpperCase()} ===
+${genreProfile.geminiPromptHint}
+
+MIDI Hints for ${genreProfile.name}:
+- Note Length Bias: ${genreProfile.midiHints.noteLengthBias}
+- Quantize Tightness: ${genreProfile.midiHints.quantizeTightness}
+- Velocity Style: ${genreProfile.midiHints.velocityStyle}
+- Typical BPM: ${genreProfile.midiHints.typicalBpmRange[0]}-${genreProfile.midiHints.typicalBpmRange[1]}
+- Common Scales: ${genreProfile.midiHints.commonScales.join(', ')}
+
+When modifying MIDI for this genre, consider these characteristics. The goal is to create MIDI that will sound authentic when loaded into a DAW with appropriate VSTs.
+` : '';
+
+    // Comprehensive system instruction
+    const systemInstruction = `
+You are the "Digital Architect", an intelligent AI assistant for the Vocal2Midi web application.
+You have full control over the application settings and the MIDI piano roll editor.
+The purpose of this app is to create MIDI files for export to DAWs (like Reaper, Ableton) where they will be used with VST instruments.
+${genreContext}
+=== CURRENT APPLICATION STATE ===
+
+Recording/Processing Config:
+${getConfigDescription(context.config)}
+
+Piano Roll State:
+- BPM: ${context.pianoRoll.bpm}
+- Key: ${currentKeyName}
+- Genre: ${context.config.genre}
+- Notes: ${getNotesDescription(context.pianoRoll.notes)}
+- Total Duration: ${context.pianoRoll.notes.length > 0 ? Math.max(...context.pianoRoll.notes.map(n => n.startTime + n.duration)).toFixed(2) : 0}s
+- Playing: ${context.pianoRoll.isPlaying}
+
+=== YOUR CAPABILITIES ===
+
+1. **updateAppConfiguration** - Change recording settings:
+   - sensitivity (0-100): Higher catches quieter notes
+   - scale: Chromatic, Major, Minor, Pentatonic
+   - rootNote: The key (60=C4, 61=C#4, 62=D4...)
+   - quantizeMode: AUTO or MANUAL
+   - manualQuantizeValue: 0 (free), 4, 8, 16, 32
+   - activeProfileId: DEFAULT, DRIVING, SOARING, ATMOSPHERIC
+   - autoKeyDetection: true/false
+
+2. **modifyMidiNotes** - Edit the MIDI notes:
+   - "quantize": Snap notes to grid (specify quantizeValue: 4, 8, 16, 32)
+   - "transpose": Shift all notes by semitones (+12 = up octave, -1 = down half step)
+   - "changeKey": Transpose to a new key (targetKey: 0-11 where 0=C)
+   - "snapToScale": Force notes to fit a scale (targetScale: Major, Minor, etc.)
+   - "deleteAll": Clear all notes
+   - "deleteByRange": Delete notes in pitch range (pitchMin, pitchMax)
+
+3. **controlPlayback** - Control the preview:
+   - "play": Start playback
+   - "stop": Stop playback
+   - "setBpm": Change tempo (bpm: 20-300)
+   - instrument: synth, piano, kick, bass, guitar
+
+4. **getStatus** - Answer questions about current state
+
+=== RESPONSE GUIDELINES ===
+
+- Be concise and professional
+- When changing settings, briefly explain WHY (e.g., "Increased sensitivity to catch softer notes")
+- For music theory questions, answer directly without tools
+- If user says "play it" or "preview", use controlPlayback with action "play"
+- If user says "stop", use controlPlayback with action "stop"
+- "Make it tighter" → quantize to 1/16 or change to DRIVING profile
+- "Transpose up" → transpose by +12 (octave) or specify semitones
+- "Change to A minor" → changeKey to 9 (A) and update scale to Minor
+- "Speed it up" → increase BPM
+- "Slow it down" → decrease BPM
+
+Always include a helpful responseMessage in your tool calls.
+`;
+
+    try {
+        const response = await ai.models.generateContent({
+            model: "gemini-3.5-flash",
+            contents: message,
+            config: {
+                systemInstruction: systemInstruction,
+                tools: [{
+                    functionDeclarations: [
+                        updateConfigTool,
+                        modifyNotesTool,
+                        addNoteTool,
+                        deleteNoteTool,
+                        controlPlaybackTool,
+                        getStatusTool
+                    ]
+                }],
+                thinkingConfig: {
+                    thinkingBudget: 4096
+                }
+            }
+        });
+
+        // Check for function calls
+        const functionCalls = response.functionCalls;
+
+        if (functionCalls && functionCalls.length > 0) {
+            const call = functionCalls[0];
+            const args = call.args as any;
+
+            switch (call.name) {
+                case 'updateAppConfiguration': {
+                    const { responseMessage, ...configChanges } = args;
+                    return {
+                        text: responseMessage || "Configuration updated.",
+                        configUpdates: configChanges
+                    };
+                }
+
+                case 'modifyMidiNotes': {
+                    const { action, responseMessage } = args;
+                    let newNotes = [...context.pianoRoll.notes];
+                    let keyUpdate: { rootNote: number; scale: ScaleType } | undefined;
+
+                    switch (action) {
+                        case 'quantize':
+                            const qValue = args.quantizeValue as QuantizeValue || QuantizeValue.Q_1_8;
+                            newNotes = quantizeNotes(newNotes, context.pianoRoll.bpm, qValue);
+                            break;
+
+                        case 'transpose':
+                            const semitones = args.semitones || 0;
+                            newNotes = transposeNotes(newNotes, semitones);
+                            break;
+
+                        case 'changeKey':
+                            const targetKey = (args.targetKey ?? 0) + 60; // Convert 0-11 to MIDI
+                            newNotes = changeKey(newNotes, context.pianoRoll.rootNote, targetKey);
+                            keyUpdate = { rootNote: targetKey, scale: context.pianoRoll.scale };
+                            break;
+
+                        case 'snapToScale':
+                            const targetScale = args.targetScale as ScaleType || ScaleType.MAJOR;
+                            newNotes = snapNotesToScale(newNotes, context.pianoRoll.rootNote, targetScale);
+                            keyUpdate = { rootNote: context.pianoRoll.rootNote, scale: targetScale };
+                            break;
+
+                        case 'deleteAll':
+                            newNotes = [];
+                            break;
+
+                        case 'deleteByRange':
+                            const pitchMin = args.pitchMin ?? 0;
+                            const pitchMax = args.pitchMax ?? 127;
+                            newNotes = newNotes.filter(n => n.midiNote < pitchMin || n.midiNote > pitchMax);
+                            break;
+                    }
+
+                    return {
+                        text: responseMessage || `Notes ${action} complete.`,
+                        notesUpdate: newNotes,
+                        keyUpdate
+                    };
+                }
+
+                case 'controlPlayback': {
+                    const { action, responseMessage, bpm, instrument } = args;
+
+                    const result: AssistantResponse = {
+                        text: responseMessage || `Playback ${action}.`
+                    };
+
+                    if (action === 'play') {
+                        result.playbackAction = 'play';
+                    } else if (action === 'stop') {
+                        result.playbackAction = 'stop';
+                    } else if (action === 'setBpm' && bpm) {
+                        result.bpmUpdate = Math.max(20, Math.min(300, bpm));
+                    }
+
+                    if (instrument) {
+                        result.instrumentUpdate = instrument;
+                    }
+
+                    return result;
+                }
+
+                case 'addNote': {
+                    const { pitch, startBeat, durationBeats, velocity = 100, responseMessage } = args;
+
+                    // Convert beats to seconds
+                    const secondsPerBeat = 60 / context.pianoRoll.bpm;
+                    const startTime = startBeat * secondsPerBeat;
+                    const duration = durationBeats * secondsPerBeat;
+
+                    const newNote: NoteEvent = {
+                        midiNote: pitch,
+                        startTime,
+                        duration,
+                        velocity: Math.max(1, Math.min(127, velocity))
+                    };
+
+                    // Add note and sort by start time
+                    const updatedNotes = [...context.pianoRoll.notes, newNote]
+                        .sort((a, b) => a.startTime - b.startTime);
+
+                    return {
+                        text: responseMessage || `Added note.`,
+                        notesUpdate: updatedNotes
+                    };
+                }
+
+                case 'deleteNote': {
+                    const { noteIndex, matchPitch, matchBeat, responseMessage } = args;
+                    let updatedNotes = [...context.pianoRoll.notes];
+
+                    if (noteIndex !== undefined && noteIndex >= 0 && noteIndex < updatedNotes.length) {
+                        // Delete by index
+                        updatedNotes.splice(noteIndex, 1);
+                    } else if (matchPitch !== undefined) {
+                        // Delete by pitch and optional beat match
+                        const secondsPerBeat = 60 / context.pianoRoll.bpm;
+                        const matchTime = matchBeat !== undefined ? matchBeat * secondsPerBeat : undefined;
+
+                        const indexToDelete = updatedNotes.findIndex(n => {
+                            if (n.midiNote !== matchPitch) return false;
+                            if (matchTime !== undefined) {
+                                // Allow 0.1 beat tolerance
+                                return Math.abs(n.startTime - matchTime) < (0.1 * secondsPerBeat);
+                            }
+                            return true; // Just match pitch
+                        });
+
+                        if (indexToDelete >= 0) {
+                            updatedNotes.splice(indexToDelete, 1);
+                        }
+                    }
+
+                    return {
+                        text: responseMessage || `Note deleted.`,
+                        notesUpdate: updatedNotes
+                    };
+                }
+
+                case 'getStatus': {
+                    // Just return the response message - the AI already has the context
+                    return {
+                        text: args.responseMessage || "Here's the current status."
+                    };
+                }
+            }
+        }
+
+        // Standard text response (no tool call)
+        return {
+            text: response.text || "I heard you, but I'm not sure how to help with that specific request."
+        };
+
+    } catch (error: any) {
+        console.error(`[Assistant] Request failed:`, error.message || error);
+        return { text: `Failed: ${error?.message || 'Unknown error'}` };
+    }
+};

--- a/frontend/src/components/audio/vocal2midi/geminiService.ts
+++ b/frontend/src/components/audio/vocal2midi/geminiService.ts
@@ -1,0 +1,351 @@
+import { GoogleGenAI, Type } from "@google/genai";
+import type { AudioAnalysisResult, NoteEvent, ScaleType, QuantizeValue } from "./types";
+import { Genre } from "./types";
+import { GENRE_PROFILES } from "./constants";
+
+// theDAW keeps API keys server-side: a single module-level client routes
+// every Gemini call through the backend proxy. No keys live in the browser.
+const PROXY_BASE = (typeof window !== 'undefined' ? window.location.origin : '') + '/api/genai-proxy';
+const ai = new GoogleGenAI({ apiKey: 'thedaw-proxy', httpOptions: { baseUrl: PROXY_BASE } });
+
+// ============================================
+// MIDI CLEANUP WITH GEMINI
+// ============================================
+// Reviews locally-detected notes and removes obvious errors
+
+export interface MidiCleanupResult {
+  cleanedNotes: NoteEvent[];
+  removedCount: number;
+  reason: string;
+}
+
+export const cleanupMidiWithGemini = async (
+  audioBlob: Blob,
+  detectedNotes: NoteEvent[],
+  userPrompt: string
+): Promise<MidiCleanupResult> => {
+  const base64Audio = await blobToBase64(audioBlob);
+
+  const notesJson = JSON.stringify(detectedNotes.map(n => ({
+    midi: n.midiNote,
+    start: n.startTime.toFixed(3),
+    dur: n.duration.toFixed(3)
+  })));
+
+  const promptText = `
+    You are a MIDI cleanup assistant. I have detected these notes from audio using pitch detection:
+    ${notesJson}
+
+    Listen to the audio and REMOVE any notes that are OBVIOUSLY WRONG:
+    - Notes during actual silence (no vocalization)
+    - Duplicate/redundant notes at the same time
+    - Notes that don't match what you hear in the audio
+    - Noise artifacts (very short spurious notes)
+
+    User context: "${userPrompt || "Vocal to MIDI"}"
+
+    IMPORTANT RULES:
+    - ONLY remove notes that are clearly errors
+    - If unsure, KEEP the note
+    - Return the indices (0-based) of notes to REMOVE
+    - If all notes are valid, return empty array
+
+    Return JSON with:
+    - removeIndices: array of note indices to remove (e.g., [0, 3, 5])
+    - reason: brief explanation of what was removed and why
+  `;
+
+  try {
+    const response = await ai.models.generateContent({
+      model: "gemini-3.5-flash",
+      contents: {
+        parts: [
+          { inlineData: { mimeType: audioBlob.type || 'audio/webm', data: base64Audio } },
+          { text: promptText }
+        ]
+      },
+      config: {
+        thinkingConfig: { thinkingBudget: 512 },
+        responseMimeType: "application/json",
+        responseSchema: {
+          type: Type.OBJECT,
+          properties: {
+            removeIndices: { type: Type.ARRAY, items: { type: Type.INTEGER } },
+            reason: { type: Type.STRING }
+          },
+          required: ['removeIndices', 'reason']
+        }
+      }
+    });
+
+    const result = JSON.parse(response.text || '{}');
+    const removeSet = new Set(result.removeIndices || []);
+    const cleanedNotes = detectedNotes.filter((_, idx) => !removeSet.has(idx));
+
+    console.log(`[Gemini Cleanup] Removed ${removeSet.size} notes: ${result.reason}`);
+
+    return {
+      cleanedNotes,
+      removedCount: removeSet.size,
+      reason: result.reason || 'No issues found'
+    };
+  } catch (error: any) {
+    console.error(`[Gemini Cleanup] failed:`, error.message || error);
+  }
+
+  // Fallback: return original notes unchanged
+  return {
+    cleanedNotes: detectedNotes,
+    removedCount: 0,
+    reason: 'Cleanup skipped (API unavailable)'
+  };
+};
+
+// ============================================
+// DEEP SMART CLEANUP WITH 8K THINKING TOKENS
+// ============================================
+// More thorough analysis - can modify notes, not just remove
+
+export interface SmartCleanupResult {
+  cleanedNotes: NoteEvent[];
+  changes: string[];
+  summary: string;
+}
+
+export const smartCleanupMidi = async (
+  audioBlob: Blob,
+  detectedNotes: NoteEvent[],
+  userPrompt: string,
+  bpm: number
+): Promise<SmartCleanupResult> => {
+  const base64Audio = await blobToBase64(audioBlob);
+
+  const notesJson = JSON.stringify(detectedNotes.map((n, i) => ({
+    idx: i,
+    midi: n.midiNote,
+    start: Number(n.startTime.toFixed(3)),
+    dur: Number(n.duration.toFixed(3)),
+    vel: n.velocity
+  })));
+
+  const promptText = `
+    You are an expert MIDI editor. Analyze this audio and the detected MIDI notes.
+
+    DETECTED NOTES (from pitch detection):
+    ${notesJson}
+
+    BPM: ${bpm}
+    User context: "${userPrompt || "Vocal to MIDI conversion"}"
+
+    LISTEN CAREFULLY to the audio and compare with the detected notes.
+
+    YOUR TASK - Return a CORRECTED note array:
+    1. REMOVE notes that occur during silence (no vocalization heard)
+    2. REMOVE duplicate/spurious notes
+    3. FIX incorrect pitches if you clearly hear a different note
+    4. MERGE fragmented notes that should be one sustained note
+    5. ADJUST timing if notes are clearly off
+
+    CRITICAL RULES:
+    - Be CONSERVATIVE - only change what's clearly wrong
+    - If you hear 3 sounds, return 3 notes. If you hear 5 sounds, return 5 notes.
+    - Silence = NO NOTE. Never add notes where there's silence.
+    - Preserve the user's intentional rhythm and gaps
+
+    Return JSON with:
+    - notes: array of corrected notes [{midiNote, startTime, duration, velocity}, ...]
+    - changes: array of strings describing each change made
+    - summary: one sentence summary of what was fixed
+  `;
+
+  try {
+    const response = await ai.models.generateContent({
+      model: "gemini-3.5-flash",
+      contents: {
+        parts: [
+          { inlineData: { mimeType: audioBlob.type || 'audio/webm', data: base64Audio } },
+          { text: promptText }
+        ]
+      },
+      config: {
+        // HIGH thinking budget for deep analysis
+        thinkingConfig: { thinkingBudget: 8192 },
+        responseMimeType: "application/json",
+        responseSchema: {
+          type: Type.OBJECT,
+          properties: {
+            notes: {
+              type: Type.ARRAY,
+              items: {
+                type: Type.OBJECT,
+                properties: {
+                  midiNote: { type: Type.INTEGER },
+                  startTime: { type: Type.NUMBER },
+                  duration: { type: Type.NUMBER },
+                  velocity: { type: Type.INTEGER }
+                },
+                required: ['midiNote', 'startTime', 'duration', 'velocity']
+              }
+            },
+            changes: { type: Type.ARRAY, items: { type: Type.STRING } },
+            summary: { type: Type.STRING }
+          },
+          required: ['notes', 'changes', 'summary']
+        }
+      }
+    });
+
+    const result = JSON.parse(response.text || '{}');
+    console.log(`[Smart Cleanup] ${result.summary}`);
+    console.log(`[Smart Cleanup] Changes:`, result.changes);
+
+    return {
+      cleanedNotes: result.notes || detectedNotes,
+      changes: result.changes || [],
+      summary: result.summary || 'Analysis complete'
+    };
+  } catch (error: any) {
+    console.error(`[Smart Cleanup] failed:`, error.message || error);
+  }
+
+  // Fallback
+  return {
+    cleanedNotes: detectedNotes,
+    changes: [],
+    summary: 'Smart cleanup unavailable (API limit reached)'
+  };
+};
+
+// Helper to convert Blob to Base64
+export const blobToBase64 = (blob: Blob): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = reader.result as string;
+      const base64 = result.split(',')[1];
+      resolve(base64);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+};
+
+// User configuration context for analysis
+export interface AnalysisContext {
+  genre: Genre;
+  scale: ScaleType;
+  quantizeMode: 'AUTO' | 'MANUAL';
+  manualQuantizeValue: QuantizeValue;
+  sensitivity: number;
+  autoKeyDetection: boolean;
+}
+
+export const analyzeAudioWithGemini = async (
+  audioBlob: Blob,
+  userPrompt: string,
+  context?: AnalysisContext
+): Promise<AudioAnalysisResult> => {
+  const base64Audio = await blobToBase64(audioBlob);
+
+  // Build context string from user's selected options (do this once)
+  let contextInfo = "";
+  if (context) {
+    const genreProfile = GENRE_PROFILES[context.genre];
+    contextInfo = `
+    USER'S SELECTED OPTIONS (Consider these in your analysis):
+    - Genre Selected: ${context.genre}${context.genre !== Genre.NONE ? ` (${genreProfile?.description || ''})` : ''}
+    - Typical BPM Range for Genre: ${genreProfile?.midiHints?.typicalBpmRange ? `${genreProfile.midiHints.typicalBpmRange[0]}-${genreProfile.midiHints.typicalBpmRange[1]} BPM` : 'N/A'}
+    - Scale Preference: ${context.scale}
+    - Quantization Mode: ${context.quantizeMode}${context.quantizeMode === 'MANUAL' ? ` (1/${context.manualQuantizeValue})` : ''}
+    - Auto Key Detection: ${context.autoKeyDetection ? 'Enabled' : 'Disabled'}
+    - Sensitivity: ${context.sensitivity}% (${context.sensitivity > 70 ? 'loose/permissive' : context.sensitivity < 30 ? 'strict/precise' : 'balanced'})
+
+    ${context.genre !== Genre.NONE ? `Genre Hints from ${context.genre}:
+    - Note Length Bias: ${genreProfile?.midiHints?.noteLengthBias || 'varied'}
+    - Quantize Tightness: ${genreProfile?.midiHints?.quantizeTightness || 'medium'}
+    - Velocity Style: ${genreProfile?.midiHints?.velocityStyle || 'dynamic'}
+    - Common Scales: ${genreProfile?.midiHints?.commonScales?.join(', ') || 'any'}` : ''}
+    `;
+  }
+
+  // Structured prompt - Gemini analyzes METADATA only (BPM, profile, instrument)
+  // NOTE DETECTION is done locally via YIN pitch detection algorithm
+  const promptText = `
+    Analyze this audio clip. The user wants to convert this vocalization into MIDI.
+
+    User Context/Prompt: "${userPrompt || "No specific prompt provided"}"
+    ${contextInfo}
+
+    Your Task (ANALYSIS ONLY - do NOT create notes):
+    1. Listen critically to the groove, swing, and timing nuances.
+    2. Determine the precise BPM (Beats Per Minute) based on the rhythm.
+    3. Identify the Time Signature (e.g., "4/4", "6/8").
+    4. Suggest the best Instrument timbre (e.g., "Deep House Kick", "Acid Bass", "Sawtooth Lead", "Grand Piano").
+    5. Analyze the dynamic profile and map it to one of the Profile IDs below.
+
+    Profile IDs:
+       - 'DRIVING': Short, punchy, percussive, staccato, rhythmic.
+       - 'SOARING': Long, connected, legato, melodic, sustained.
+       - 'ATMOSPHERIC': Soft, ambient, long release, loose timing.
+       - 'DEFAULT': Natural, generic, mixed.
+
+    Return the result in JSON format with: detectedBpm, timeSignature, suggestedInstrument, description, detectedProfileId.
+  `;
+
+  // Using Gemini 3 Flash Preview which supports Thinking
+  const model = "gemini-3.5-flash";
+
+  try {
+    const response = await ai.models.generateContent({
+      model: model,
+      contents: {
+        parts: [
+          {
+            inlineData: {
+              mimeType: audioBlob.type || 'audio/webm',
+              data: base64Audio
+            }
+          },
+          { text: promptText }
+        ]
+      },
+      config: {
+        // Enable Thinking Tokens for analysis
+        thinkingConfig: { thinkingBudget: 1024 },
+        responseMimeType: "application/json",
+        responseSchema: {
+          type: Type.OBJECT,
+          properties: {
+            detectedBpm: { type: Type.NUMBER },
+            timeSignature: { type: Type.STRING },
+            suggestedInstrument: { type: Type.STRING },
+            description: { type: Type.STRING },
+            detectedProfileId: { type: Type.STRING }
+            // NOTE: We do NOT ask Gemini to create notes anymore
+            // Local YIN pitch detection handles note creation (more accurate for silence)
+          },
+          required: ['detectedBpm', 'timeSignature']
+        }
+      }
+    });
+
+    const resultText = response.text;
+    if (!resultText) throw new Error("No response from Gemini");
+
+    const analysis = JSON.parse(resultText) as AudioAnalysisResult;
+    console.log(`[Gemini] Success! Detected ${analysis.detectedNotes?.length || 0} notes`);
+    return analysis;
+
+  } catch (error: any) {
+    console.error(`[Gemini] analysis failed:`, error.message || error);
+  }
+
+  // Return fallback
+  return {
+    detectedBpm: 120,
+    timeSignature: "4/4",
+    suggestedInstrument: "Grand Piano",
+    description: `Analysis failed: ${'Unknown error'}`,
+    detectedProfileId: "DEFAULT"
+  };
+};

--- a/frontend/src/components/audio/vocal2midi/midiEditor.ts
+++ b/frontend/src/components/audio/vocal2midi/midiEditor.ts
@@ -1,0 +1,273 @@
+/**
+ * MIDI Editor Utilities
+ * Provides quantization, transposition, and grid snapping for the piano roll editor
+ */
+
+import { type NoteEvent, QuantizeValue, ScaleType } from './types';
+import { SCALES } from './constants';
+
+/**
+ * Convert BPM and quantize value to seconds per grid unit
+ */
+export function getGridSize(bpm: number, quantize: QuantizeValue): number {
+  if (quantize === QuantizeValue.OFF) return 0;
+  const beatsPerSecond = bpm / 60;
+  const secondsPerBeat = 1 / beatsPerSecond;
+  return secondsPerBeat / (quantize / 4); // quantize is notes per bar (4, 8, 16, 32)
+}
+
+/**
+ * Get beat positions for the grid visualization
+ */
+export function getBeatPositions(
+  totalDuration: number,
+  bpm: number,
+  quantize: QuantizeValue = QuantizeValue.Q_1_4
+): { time: number; isMajor: boolean; label: string }[] {
+  const positions: { time: number; isMajor: boolean; label: string }[] = [];
+  const secondsPerBeat = 60 / bpm;
+  const gridSize = getGridSize(bpm, quantize);
+
+  if (gridSize === 0) {
+    // Just show beats when quantize is off
+    for (let beat = 0; beat * secondsPerBeat <= totalDuration + 0.5; beat++) {
+      const time = beat * secondsPerBeat;
+      const isMajor = beat % 4 === 0; // Every bar (4 beats)
+      const bar = Math.floor(beat / 4) + 1;
+      const beatInBar = (beat % 4) + 1;
+      positions.push({
+        time,
+        isMajor,
+        label: isMajor ? `${bar}` : `${bar}.${beatInBar}`
+      });
+    }
+  } else {
+    // Show grid divisions
+    const stepsPerBeat = (quantize / 4);
+    for (let step = 0; step * gridSize <= totalDuration + 0.5; step++) {
+      const time = step * gridSize;
+      const beat = Math.floor(step / stepsPerBeat);
+      const isMajor = step % (stepsPerBeat * 4) === 0; // Every bar
+      const isOnBeat = step % stepsPerBeat === 0;
+      const bar = Math.floor(beat / 4) + 1;
+      const beatInBar = (beat % 4) + 1;
+      positions.push({
+        time,
+        isMajor,
+        label: isOnBeat ? (isMajor ? `${bar}` : `${bar}.${beatInBar}`) : ''
+      });
+    }
+  }
+
+  return positions;
+}
+
+/**
+ * Snap a time value to the nearest grid position
+ */
+export function snapToGrid(time: number, bpm: number, quantize: QuantizeValue): number {
+  const gridSize = getGridSize(bpm, quantize);
+  if (gridSize === 0) return time;
+  return Math.round(time / gridSize) * gridSize;
+}
+
+/**
+ * Quantize all notes to the grid
+ */
+export function quantizeNotes(
+  notes: NoteEvent[],
+  bpm: number,
+  quantize: QuantizeValue
+): NoteEvent[] {
+  if (quantize === QuantizeValue.OFF) return notes;
+
+  const gridSize = getGridSize(bpm, quantize);
+
+  return notes.map(note => ({
+    ...note,
+    startTime: Math.round(note.startTime / gridSize) * gridSize,
+    duration: Math.max(gridSize, Math.round(note.duration / gridSize) * gridSize)
+  }));
+}
+
+/**
+ * Transpose notes by semitones
+ */
+export function transposeNotes(notes: NoteEvent[], semitones: number): NoteEvent[] {
+  return notes.map(note => ({
+    ...note,
+    midiNote: Math.max(0, Math.min(127, note.midiNote + semitones))
+  }));
+}
+
+/**
+ * Snap notes to a specific scale
+ */
+export function snapNotesToScale(
+  notes: NoteEvent[],
+  rootNote: number,
+  scale: ScaleType
+): NoteEvent[] {
+  const scaleNotes = SCALES[scale];
+  const root = rootNote % 12;
+
+  return notes.map(note => {
+    const noteClass = note.midiNote % 12;
+    const octave = Math.floor(note.midiNote / 12);
+
+    // Find the closest scale note
+    let minDistance = 12;
+    let closestScaleNote = noteClass;
+
+    for (const interval of scaleNotes) {
+      const scaleNoteClass = (root + interval) % 12;
+      const distance = Math.min(
+        Math.abs(noteClass - scaleNoteClass),
+        12 - Math.abs(noteClass - scaleNoteClass)
+      );
+      if (distance < minDistance) {
+        minDistance = distance;
+        closestScaleNote = scaleNoteClass;
+      }
+    }
+
+    // Calculate the new MIDI note
+    let newMidiNote = octave * 12 + closestScaleNote;
+
+    // Handle octave boundary
+    if (closestScaleNote < noteClass && noteClass - closestScaleNote > 6) {
+      newMidiNote += 12;
+    } else if (closestScaleNote > noteClass && closestScaleNote - noteClass > 6) {
+      newMidiNote -= 12;
+    }
+
+    return {
+      ...note,
+      midiNote: Math.max(0, Math.min(127, newMidiNote))
+    };
+  });
+}
+
+/**
+ * Change key (transpose to new root while maintaining scale relationships)
+ */
+export function changeKey(
+  notes: NoteEvent[],
+  fromRoot: number,
+  toRoot: number
+): NoteEvent[] {
+  const semitones = (toRoot % 12) - (fromRoot % 12);
+  return transposeNotes(notes, semitones);
+}
+
+/**
+ * Move a single note
+ */
+export function moveNote(
+  notes: NoteEvent[],
+  noteIndex: number,
+  newStartTime: number,
+  newMidiNote: number,
+  bpm: number,
+  quantize: QuantizeValue
+): NoteEvent[] {
+  const result = [...notes];
+  const snappedTime = snapToGrid(Math.max(0, newStartTime), bpm, quantize);
+  const clampedNote = Math.max(0, Math.min(127, newMidiNote));
+
+  result[noteIndex] = {
+    ...result[noteIndex],
+    startTime: snappedTime,
+    midiNote: clampedNote
+  };
+
+  return result;
+}
+
+/**
+ * Resize a note's duration
+ */
+export function resizeNote(
+  notes: NoteEvent[],
+  noteIndex: number,
+  newDuration: number,
+  bpm: number,
+  quantize: QuantizeValue
+): NoteEvent[] {
+  const result = [...notes];
+  const gridSize = getGridSize(bpm, quantize);
+  const minDuration = gridSize > 0 ? gridSize : 0.05;
+  const snappedDuration = gridSize > 0
+    ? Math.max(minDuration, Math.round(newDuration / gridSize) * gridSize)
+    : Math.max(minDuration, newDuration);
+
+  result[noteIndex] = {
+    ...result[noteIndex],
+    duration: snappedDuration
+  };
+
+  return result;
+}
+
+/**
+ * Delete a note
+ */
+export function deleteNote(notes: NoteEvent[], noteIndex: number): NoteEvent[] {
+  return notes.filter((_, i) => i !== noteIndex);
+}
+
+/**
+ * Add a new note
+ */
+export function addNote(
+  notes: NoteEvent[],
+  startTime: number,
+  midiNote: number,
+  duration: number,
+  velocity: number,
+  bpm: number,
+  quantize: QuantizeValue
+): NoteEvent[] {
+  const gridSize = getGridSize(bpm, quantize);
+  const snappedTime = snapToGrid(startTime, bpm, quantize);
+  const snappedDuration = gridSize > 0
+    ? Math.max(gridSize, Math.round(duration / gridSize) * gridSize)
+    : Math.max(0.1, duration);
+
+  return [
+    ...notes,
+    {
+      midiNote: Math.max(0, Math.min(127, midiNote)),
+      startTime: snappedTime,
+      duration: snappedDuration,
+      velocity: Math.max(1, Math.min(127, velocity))
+    }
+  ].sort((a, b) => a.startTime - b.startTime);
+}
+
+/**
+ * Get scale name from root and scale type
+ */
+export function getKeyName(rootNote: number, scale: ScaleType): string {
+  const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+  return `${noteNames[rootNote % 12]} ${scale}`;
+}
+
+/**
+ * Parse key string to root and scale
+ */
+export function parseKeyString(keyString: string): { root: number; scale: ScaleType } | null {
+  const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+  const parts = keyString.split(' ');
+  if (parts.length < 2) return null;
+
+  const noteName = parts[0];
+  const scaleName = parts.slice(1).join(' ') as ScaleType;
+
+  const rootIndex = noteNames.indexOf(noteName);
+  if (rootIndex === -1) return null;
+
+  if (!Object.values(ScaleType).includes(scaleName)) return null;
+
+  return { root: rootIndex + 60, scale: scaleName };
+}

--- a/frontend/src/components/audio/vocal2midi/midiSynth.ts
+++ b/frontend/src/components/audio/vocal2midi/midiSynth.ts
@@ -1,0 +1,153 @@
+/**
+ * vocal2midi synth shim — preserves the original MidiSynth public API the ported
+ * components rely on (play/playNotes/stop/setInstrument/renderToWav/getInstrumentList/
+ * getMidiSynth) but voices everything through theDAW's FULL soundfont library
+ * (SpessaSynth + the bundled General MIDI SF3) instead of the suite's CDN
+ * soundfont-player. Instrument selection maps onto General MIDI programs; the
+ * compact panel also exposes theDAW's own instrument picker for the full 128-program
+ * range. WAV export uses theDAW's offline soundfont render.
+ */
+import type { NoteEvent } from './types';
+import {
+  previewNoteSF,
+  renderNotesToBlobSF,
+  liveAllNotesOff,
+  useSoundfontStore,
+} from '../../../lib/soundfontEngine';
+import type { RenderNote } from '../../../lib/midiSynth';
+import { getEngineCtx } from '../../../state/playerStore';
+
+export type InstrumentType = 'synth' | 'piano' | 'kick' | 'bass' | 'guitar' | 'strings' | 'organ';
+
+/** Map the suite's 7 named instruments onto General MIDI programs in theDAW's
+ *  full soundfont. The panel's main instrument control is theDAW's own picker,
+ *  which can reach all 128 programs; this map keeps the assistant's
+ *  `controlPlayback` instrument argument and the legacy dropdown working. */
+const INSTRUMENT_GM: Record<InstrumentType, { name: string; program: number }> = {
+  piano: { name: 'Grand Piano', program: 0 },
+  synth: { name: 'Synth Lead', program: 80 },
+  bass: { name: 'Electric Bass', program: 33 },
+  guitar: { name: 'Acoustic Guitar', program: 24 },
+  kick: { name: 'Synth Drum', program: 118 },
+  strings: { name: 'String Ensemble', program: 48 },
+  organ: { name: 'Rock Organ', program: 18 },
+};
+
+const now = (): number => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+const toRenderNotes = (notes: NoteEvent[]): RenderNote[] =>
+  notes.map((n) => ({
+    midi: Math.round(n.midiNote),
+    startSec: Math.max(0, n.startTime),
+    durationSec: Math.max(0.05, n.duration),
+    velocity: Math.max(1, Math.min(127, Math.round(n.velocity))),
+  }));
+
+export class MidiSynth {
+  private instrument: InstrumentType = 'synth';
+  private volume = 0.5;
+  private timers: number[] = [];
+  private endTimer: number | null = null;
+  private playing = false;
+  private startedAt = 0;
+  private startOffset = 0;
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async setInstrument(instrument: InstrumentType): Promise<void> {
+    this.instrument = instrument;
+    const sf = useSoundfontStore.getState();
+    sf.setActiveProgram(INSTRUMENT_GM[instrument].program);
+    sf.setUseSoundfont(true);
+  }
+
+  getInstrument(): InstrumentType {
+    return this.instrument;
+  }
+
+  setVolume(v: number): void {
+    this.volume = Math.max(0, Math.min(1, v));
+  }
+
+  /**
+   * Schedule a note sequence through theDAW's soundfont. `startFromTime` seeks
+   * into the sequence (notes before it are skipped). Each note triggers a live
+   * soundfont voice at its absolute start, scaled by the synth volume.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async playNotes(notes: NoteEvent[], onEnd?: () => void, startFromTime = 0): Promise<void> {
+    this.stop();
+    const ctx = getEngineCtx();
+    if (ctx.state === 'suspended') void ctx.resume();
+    this.playing = true;
+    this.startOffset = startFromTime;
+    this.startedAt = now();
+    let maxEnd = 0;
+    for (const n of notes) {
+      const end = n.startTime + n.duration;
+      if (end > maxEnd) maxEnd = end;
+      const at = n.startTime - startFromTime;
+      if (at < 0) continue;
+      const vel = Math.max(1, Math.min(127, Math.round(n.velocity * (0.4 + this.volume * 0.6))));
+      const id = window.setTimeout(() => {
+        void previewNoteSF(n.midiNote, vel, n.duration);
+      }, Math.max(0, at * 1000));
+      this.timers.push(id);
+    }
+    const totalMs = Math.max(0, maxEnd - startFromTime) * 1000 + 250;
+    this.endTimer = window.setTimeout(() => {
+      this.playing = false;
+      this.endTimer = null;
+      onEnd?.();
+    }, totalMs);
+  }
+
+  /** Alias kept for callers that use `play(notes, bpm)`. */
+  async play(notes: NoteEvent[], _bpm?: number): Promise<void> {
+    return this.playNotes(notes);
+  }
+
+  stop(): void {
+    this.timers.forEach((t) => window.clearTimeout(t));
+    this.timers = [];
+    if (this.endTimer != null) {
+      window.clearTimeout(this.endTimer);
+      this.endTimer = null;
+    }
+    this.playing = false;
+    try {
+      liveAllNotesOff();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  isCurrentlyPlaying(): boolean {
+    return this.playing;
+  }
+
+  getPlaybackPosition(): number {
+    if (!this.playing) return 0;
+    return this.startOffset + (now() - this.startedAt) / 1000;
+  }
+
+  /** Render the notes to a WAV Blob through theDAW's offline soundfont render. */
+  async renderToWav(notes: NoteEvent[]): Promise<Blob> {
+    const { blob } = await renderNotesToBlobSF(toRenderNotes(notes));
+    return blob;
+  }
+
+  dispose(): void {
+    this.stop();
+  }
+}
+
+let singleton: MidiSynth | null = null;
+
+export function getMidiSynth(): MidiSynth {
+  if (!singleton) singleton = new MidiSynth();
+  return singleton;
+}
+
+export function getInstrumentList(): { id: InstrumentType; name: string }[] {
+  return (Object.keys(INSTRUMENT_GM) as InstrumentType[]).map((id) => ({ id, name: INSTRUMENT_GM[id].name }));
+}

--- a/frontend/src/components/audio/vocal2midi/musicTheory.ts
+++ b/frontend/src/components/audio/vocal2midi/musicTheory.ts
@@ -1,0 +1,233 @@
+import { type NoteEvent, type KeyDetectionResult, ScaleType } from './types';
+import { SCALES } from './constants';
+
+/**
+ * Analyzes a set of notes to determine the most likely Key (Root + Scale).
+ * Uses a weighted histogram approach based on note duration.
+ */
+export const detectKeyAndScale = (notes: NoteEvent[]): KeyDetectionResult => {
+  if (!notes.length) {
+    return { root: 0, scale: ScaleType.CHROMATIC, confidence: 0 };
+  }
+
+  // 1. Build a Pitch Class Histogram (weighted by duration)
+  // We care more about long sustained notes than passing grace notes.
+  const chromaProfile = new Array(12).fill(0);
+  let totalDuration = 0;
+
+  notes.forEach(note => {
+    const pitchClass = note.midiNote % 12;
+    chromaProfile[pitchClass] += note.duration;
+    totalDuration += note.duration;
+  });
+
+  // Normalize
+  if (totalDuration > 0) {
+    for (let i = 0; i < 12; i++) chromaProfile[i] /= totalDuration;
+  }
+
+  // 2. Score against Scale Templates
+  // We primarily check Major and Minor as they are the most common tonal centers.
+  let bestRoot = 0;
+  let bestScale = ScaleType.MAJOR;
+  let maxScore = -1;
+
+  // We only check Major and Minor for auto-detection logic to keep it robust
+  const templates = [
+    { type: ScaleType.MAJOR, intervals: SCALES.Major },
+    { type: ScaleType.MINOR, intervals: SCALES.Minor }
+  ];
+
+  for (let root = 0; root < 12; root++) {
+    for (const template of templates) {
+      let score = 0;
+
+      // Sum the chroma weights for all notes that fit in this scale
+      for (const interval of template.intervals) {
+        const pitchClass = (root + interval) % 12;
+        score += chromaProfile[pitchClass];
+      }
+
+      // Basic heuristic: penalize scales that miss high-weight notes
+      // (This assumes the user played *mostly* inside the key)
+      if (score > maxScore) {
+        maxScore = score;
+        bestRoot = root;
+        bestScale = template.type;
+      }
+    }
+  }
+
+  return {
+    root: bestRoot,
+    scale: bestScale,
+    confidence: maxScore // 0 to 1
+  };
+};
+
+export interface RelatedKey {
+  root: number; // 0-11 pitch class
+  midiNote: number; // 60-71 for dropdown
+  scale: ScaleType;
+  relationship: string;
+  priority: number; // 1 = highest priority (closest relationship)
+}
+
+/**
+ * Gets harmonically related keys based on music theory relationships.
+ * Returns keys sorted by harmonic closeness.
+ *
+ * @param rootNote - Current root (MIDI note, e.g. 60 for C4)
+ * @param scale - Current scale type
+ */
+export const getRelatedKeys = (rootNote: number, scale: ScaleType): RelatedKey[] => {
+  const root = rootNote % 12; // Get pitch class (0-11)
+  const results: RelatedKey[] = [];
+
+  if (scale === ScaleType.MAJOR) {
+    // Relative Minor (same key signature) - 3 semitones down
+    const relMinor = (root + 9) % 12;
+    results.push({
+      root: relMinor,
+      midiNote: relMinor + 60,
+      scale: ScaleType.MINOR,
+      relationship: 'Relative Minor',
+      priority: 1
+    });
+
+    // Parallel Minor (same root)
+    results.push({
+      root,
+      midiNote: root + 60,
+      scale: ScaleType.MINOR,
+      relationship: 'Parallel Minor',
+      priority: 2
+    });
+
+    // Dominant (V) - 7 semitones up / perfect 5th
+    const dominant = (root + 7) % 12;
+    results.push({
+      root: dominant,
+      midiNote: dominant + 60,
+      scale: ScaleType.MAJOR,
+      relationship: 'Dominant (V)',
+      priority: 3
+    });
+
+    // Subdominant (IV) - 5 semitones up / perfect 4th
+    const subdominant = (root + 5) % 12;
+    results.push({
+      root: subdominant,
+      midiNote: subdominant + 60,
+      scale: ScaleType.MAJOR,
+      relationship: 'Subdominant (IV)',
+      priority: 3
+    });
+
+    // Relative of Dominant (ii)
+    const relDom = (dominant + 9) % 12;
+    results.push({
+      root: relDom,
+      midiNote: relDom + 60,
+      scale: ScaleType.MINOR,
+      relationship: 'ii (Dorian)',
+      priority: 4
+    });
+
+    // Relative of Subdominant (vi already covered as relative minor)
+
+  } else if (scale === ScaleType.MINOR) {
+    // Relative Major (same key signature) - 3 semitones up
+    const relMajor = (root + 3) % 12;
+    results.push({
+      root: relMajor,
+      midiNote: relMajor + 60,
+      scale: ScaleType.MAJOR,
+      relationship: 'Relative Major',
+      priority: 1
+    });
+
+    // Parallel Major (same root)
+    results.push({
+      root,
+      midiNote: root + 60,
+      scale: ScaleType.MAJOR,
+      relationship: 'Parallel Major',
+      priority: 2
+    });
+
+    // Minor Dominant (v) - natural minor's fifth
+    const minorDom = (root + 7) % 12;
+    results.push({
+      root: minorDom,
+      midiNote: minorDom + 60,
+      scale: ScaleType.MINOR,
+      relationship: 'v (Minor)',
+      priority: 3
+    });
+
+    // Subdominant minor (iv)
+    const subdominant = (root + 5) % 12;
+    results.push({
+      root: subdominant,
+      midiNote: subdominant + 60,
+      scale: ScaleType.MINOR,
+      relationship: 'iv (Subdominant)',
+      priority: 3
+    });
+
+    // VII (natural 7th) - common in EDM/metal
+    const flatSeven = (root + 10) % 12;
+    results.push({
+      root: flatSeven,
+      midiNote: flatSeven + 60,
+      scale: ScaleType.MAJOR,
+      relationship: 'bVII (Mixolydian feel)',
+      priority: 4
+    });
+
+  } else if (scale === ScaleType.PENTATONIC) {
+    // Pentatonic usually implies minor pentatonic
+    // Relative major pent
+    const relMajor = (root + 3) % 12;
+    results.push({
+      root: relMajor,
+      midiNote: relMajor + 60,
+      scale: ScaleType.PENTATONIC,
+      relationship: 'Relative Pent (Major feel)',
+      priority: 1
+    });
+
+    // Up a 4th (common blues move)
+    const fourth = (root + 5) % 12;
+    results.push({
+      root: fourth,
+      midiNote: fourth + 60,
+      scale: ScaleType.PENTATONIC,
+      relationship: 'IV Pentatonic',
+      priority: 2
+    });
+
+    // Up a 5th
+    const fifth = (root + 7) % 12;
+    results.push({
+      root: fifth,
+      midiNote: fifth + 60,
+      scale: ScaleType.PENTATONIC,
+      relationship: 'V Pentatonic',
+      priority: 2
+    });
+
+    // Natural minor (same notes, different feel)
+    results.push({
+      root,
+      midiNote: root + 60,
+      scale: ScaleType.MINOR,
+      relationship: 'Full Minor Scale',
+      priority: 3
+    });
+  }
+
+  // Sort by priority
+  return results.sort((a, b) => a.priority - b.priority);
+};

--- a/frontend/src/components/audio/vocal2midi/types.ts
+++ b/frontend/src/components/audio/vocal2midi/types.ts
@@ -1,0 +1,121 @@
+export interface NoteEvent {
+  midiNote: number;
+  startTime: number; // in seconds
+  duration: number; // in seconds
+  velocity: number; // 0-127
+}
+
+export interface AudioAnalysisResult {
+  detectedBpm: number;
+  timeSignature: string;
+  suggestedInstrument: string;
+  description: string;
+  detectedProfileId?: string; // ID from our predefined library
+  detectedNotes?: NoteEvent[]; // MIDI notes detected by Gemini from the audio
+}
+
+export enum QuantizeValue {
+  OFF = 0,
+  Q_1_4 = 4,
+  Q_1_8 = 8,
+  Q_1_16 = 16,
+  Q_1_32 = 32
+}
+
+export type QuantizeMode = 'AUTO' | 'MANUAL';
+
+export enum ScaleType {
+  CHROMATIC = 'Chromatic',
+  MAJOR = 'Major',
+  MINOR = 'Minor',
+  PENTATONIC = 'Pentatonic'
+}
+
+export enum Genre {
+  NONE = 'None',
+  DUBSTEP = 'Dubstep',
+  HOUSE = 'House',
+  TECHNO = 'Techno',
+  DRUM_AND_BASS = 'Drum & Bass',
+  TRANCE = 'Trance',
+  AMBIENT = 'Ambient',
+  HIPHOP = 'Hip-Hop',
+  TRAP = 'Trap',
+  POP = 'Pop',
+  ROCK = 'Rock'
+}
+
+export interface ProcessingConfig {
+  rootNote: number; // MIDI note number (e.g., 60 for C4)
+  scale: ScaleType;
+  genre: Genre; // Genre affects MIDI structure (note lengths, quantization, velocity)
+  quantizeMode: QuantizeMode; // New explicit mode
+  manualQuantizeValue: QuantizeValue; // Value used when in Manual mode
+  useGeminiForBpm: boolean; // If false, uses manualBpm instead of AI detection
+  manualBpm: number; // BPM to use when useGeminiForBpm is false
+  prompt: string;
+  autoKeyDetection: boolean; // New toggle
+  activeProfileId: string; // New: selected sound profile
+  sensitivity: number; // 0-100
+  // EXPERIMENTAL: Pitch bend export for slides/glides
+  experimentalPitchBend: boolean;
+  // Toggle for note cleanup (filters short notes, merges fragments)
+  enableCleanup: boolean;
+}
+
+// Genre-specific MIDI processing hints for Gemini and processing
+export interface GenreProfile {
+  id: Genre;
+  name: string;
+  description: string;
+  suggestedQuantization: QuantizeValue;
+  suggestedProfileId: string; // Links to SoundProfile
+  midiHints: {
+    noteLengthBias: 'short' | 'medium' | 'long' | 'varied';
+    quantizeTightness: 'tight' | 'medium' | 'loose' | 'free';
+    velocityStyle: 'punchy' | 'consistent' | 'dynamic' | 'soft';
+    typicalBpmRange: [number, number];
+    commonScales: ScaleType[];
+  };
+  geminiPromptHint: string; // Extra context for Gemini
+}
+
+export interface KeyDetectionResult {
+  root: number; // 0-11 (C-B)
+  scale: ScaleType;
+  confidence: number;
+}
+
+// Recording history entry
+export interface RecordingEntry {
+  id: string;
+  timestamp: number;
+  name: string;
+  notes: NoteEvent[];
+  bpm: number;
+  rootNote: number;
+  scale: ScaleType;
+  genre: Genre;
+  profileId: string;
+}
+
+export interface SoundProfile {
+  id: string;
+  name: string;
+  description: string;
+  suggestedQuantization: QuantizeValue; // New: Auto-quantize setting
+  transformation: {
+    velocityCurve: 'fixed-high' | 'dynamic' | 'soft';
+    durationMode: 'gated' | 'legato' | 'natural';
+    minDuration?: number;
+    quantizeStrength: number; // 0-1
+    baseVelocity: number;
+    // MIDI Control Changes (0-127) to shape the synth sound
+    midiCC?: {
+      attack?: number;  // CC 73
+      release?: number; // CC 72
+      brightness?: number; // CC 74 (Cutoff)
+      reverb?: number; // CC 91
+    };
+  };
+}

--- a/frontend/src/components/layout/MidiPanel.tsx
+++ b/frontend/src/components/layout/MidiPanel.tsx
@@ -11,7 +11,7 @@
  * validate. No synthesis here.
  */
 
-import { Activity, Download, Drum, FileCheck2, Loader2, Mic, Square } from 'lucide-react';
+import { Activity, Download, Drum, FileCheck2, Loader2, Mic, Music4, Square } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { RenderNote } from '../../lib/midiSynth';
@@ -34,6 +34,8 @@ import { useLibraryStore } from '../../state/libraryStore';
 import { logInfo, logWarn } from '../../state/logStore';
 import { usePianoRollStore, type PianoNote } from '../../state/pianoRollStore';
 import { PianoRoll } from '../audio/PianoRoll';
+import { ArpeggiatorPanel } from '../audio/ArpeggiatorPanel';
+import { Vocal2MidiPanel } from '../audio/vocal2midi/Vocal2MidiPanel';
 
 const stepSec = (bpm: number): number => 60 / bpm / 4;
 
@@ -111,12 +113,17 @@ const MicMeter: React.FC<{ monitorRef: React.MutableRefObject<InputMonitor | nul
 
 export const MidiPanel: React.FC = () => {
   const selectedEntryId = useLibraryStore((s) => s.selectedEntryId);
+  const entries = useLibraryStore((s) => s.entries);
   const [assetId, setAssetId] = useState('');
+  // What the search box shows (a friendly title); the actual API uses assetId.
+  const [assetQuery, setAssetQuery] = useState('');
+  const [assetOpen, setAssetOpen] = useState(false);
   const [recording, setRecording] = useState(false);
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState('idle');
   const [artifact, setArtifact] = useState<VocalArtifactDoc | null>(null);
   const [validateMsg, setValidateMsg] = useState('');
+  const [arpOn, setArpOn] = useState(false);
   const [inputs, setInputs] = useState<MediaDeviceInfo[]>([]);
   const [deviceId, setDeviceId] = useState<string>(
     () => localStorage.getItem('vocal.inputDeviceId') ?? '',
@@ -126,10 +133,30 @@ export const MidiPanel: React.FC = () => {
   const recorderRef = useRef<MediaRecorder | null>(null);
   const recordStartRef = useRef(0);
 
-  // Default the asset field to the selected library item (override freely).
+  // Default the asset field to the selected library item (override freely). Show
+  // the friendly title in the box while keeping the real id for the API.
   useEffect(() => {
-    if (selectedEntryId && !assetId) setAssetId(selectedEntryId);
+    if (selectedEntryId && !assetId) {
+      setAssetId(selectedEntryId);
+      const sel = useLibraryStore.getState().entries.find((e) => e.id === selectedEntryId);
+      if (sel) setAssetQuery(sel.title);
+    }
   }, [selectedEntryId, assetId]);
+
+  // Pick a library entry into the asset field: store the real id, show the title.
+  const pickAsset = useCallback((id: string, title: string) => {
+    setAssetId(id);
+    setAssetQuery(title);
+    setAssetOpen(false);
+  }, []);
+
+  // Library entries whose title matches the current search text (cap the list).
+  const assetMatches = (() => {
+    const q = assetQuery.trim().toLowerCase();
+    const audio = entries.filter((e) => e.kind === 'audio');
+    const list = q ? audio.filter((e) => e.title.toLowerCase().includes(q)) : audio;
+    return list.slice(0, 12);
+  })();
 
   const refreshInputs = useCallback(async () => {
     setMicPerm(await queryMicPermission());
@@ -402,21 +429,69 @@ export const MidiPanel: React.FC = () => {
 
         <span className="w-px h-4 bg-white/10" aria-hidden="true" />
 
-        {/* Analyze a library vocal into the roll */}
-        <label htmlFor="midi-asset-id" className="sr-only">
-          Library asset id
-        </label>
-        <input
-          id="midi-asset-id"
-          name="midi-asset-id"
-          type="text"
-          value={assetId}
-          onChange={(e) => setAssetId(e.target.value.trim())}
-          placeholder="asset id"
-          aria-label="Library asset id"
-          title="Library item id to analyze or load (defaults to the selected library item)"
-          className="w-36 bg-zinc-800 border border-zinc-500 text-zinc-100 text-[10px] font-mono px-1.5 py-1 rounded"
-        />
+        {/* Analyze a library vocal into the roll — search by name or drop a
+            library item here instead of pasting a raw id. */}
+        <div
+          className="relative"
+          onDragOver={(e) => {
+            if (e.dataTransfer.types.includes('application/x-thedaw-library-id')) {
+              e.preventDefault();
+              e.dataTransfer.dropEffect = 'copy';
+            }
+          }}
+          onDrop={(e) => {
+            const id = e.dataTransfer.getData('application/x-thedaw-library-id');
+            if (!id) return;
+            e.preventDefault();
+            const dropped = entries.find((en) => en.id === id);
+            pickAsset(id, dropped?.title ?? id);
+          }}
+        >
+          <label htmlFor="midi-asset-id" className="sr-only">
+            Search library song
+          </label>
+          <input
+            id="midi-asset-id"
+            name="midi-asset-id"
+            type="text"
+            value={assetQuery}
+            onChange={(e) => {
+              setAssetQuery(e.target.value);
+              setAssetId(e.target.value.trim());
+              setAssetOpen(true);
+            }}
+            onFocus={() => setAssetOpen(true)}
+            onBlur={() => window.setTimeout(() => setAssetOpen(false), 150)}
+            placeholder="search song / drop here"
+            aria-label="Search library song"
+            aria-expanded={assetOpen}
+            title="Type a song name (or drop a library item here). Pick a result to use it — no need to paste a raw id."
+            className="w-44 bg-zinc-800 border border-zinc-500 text-zinc-100 text-[10px] font-mono px-1.5 py-1 rounded"
+          />
+          {assetOpen && assetMatches.length > 0 && (
+            <div
+              role="listbox"
+              className="absolute left-0 top-full mt-1 z-50 w-64 max-h-56 overflow-y-auto rounded border border-zinc-600 bg-zinc-900 shadow-2xl"
+            >
+              {assetMatches.map((e) => (
+                <button
+                  key={e.id}
+                  type="button"
+                  role="option"
+                  aria-selected={e.id === assetId}
+                  onMouseDown={(ev) => ev.preventDefault()}
+                  onClick={() => pickAsset(e.id, e.title)}
+                  className={`w-full text-left px-2 py-1.5 text-[10px] border-b border-white/5 last:border-0 hover:bg-purple-500/15 ${
+                    e.id === assetId ? 'bg-purple-500/10 text-purple-200' : 'text-zinc-200'
+                  }`}
+                >
+                  <span className="block truncate">{e.title}</span>
+                  <span className="block truncate text-[8px] font-mono text-zinc-500">{e.id}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
         <button
           type="button"
           onClick={analyze}
@@ -468,18 +543,42 @@ export const MidiPanel: React.FC = () => {
           <FileCheck2 className="w-3 h-3" />
           Validate
         </button>
+
+        <span className="w-px h-4 bg-white/10" aria-hidden="true" />
+
+        <button
+          type="button"
+          onClick={() => setArpOn((v) => !v)}
+          aria-pressed={arpOn}
+          title={arpOn ? 'Back to the piano roll' : 'Chord-progression arpeggiator'}
+          className={`${btn} ${
+            arpOn
+              ? 'border-amber-400 text-amber-200 bg-amber-400/20'
+              : 'border-amber-600 text-amber-300 hover:bg-amber-600/15'
+          }`}
+        >
+          <Music4 className="w-3 h-3" />
+          Arp
+        </button>
         <span className="text-[10px] font-mono text-zinc-500 truncate min-w-0 flex-1 text-right">
           {status}
         </span>
       </div>
 
-      {/* body: piano roll, plus a vocal rail only when an artifact is loaded */}
+      {/* body: piano roll (or the arpeggiator face), plus a vocal rail only when
+          an artifact is loaded. The arpeggiator stays mounted but hidden so its
+          transport keeps running when toggling back to the roll. */}
       <div className="flex-1 min-h-0 flex">
         <div className="flex-1 min-w-0 relative">
-          <PianoRoll />
+          <div className={arpOn ? 'hidden' : 'absolute inset-0'}>
+            <PianoRoll />
+          </div>
+          <div className={arpOn ? 'absolute inset-0' : 'hidden'}>
+            <ArpeggiatorPanel />
+          </div>
         </div>
 
-        {artifact && (
+        {!arpOn && artifact && (
           <div className="w-64 shrink-0 border-l border-white/8 overflow-y-auto p-2 space-y-3">
             <section>
               <h3 className="text-[8px] font-mono uppercase tracking-widest text-zinc-500 mb-1">
@@ -523,6 +622,10 @@ export const MidiPanel: React.FC = () => {
             )}
           </div>
         )}
+
+        {/* Vocal2MIDI suite — the full vocal-to-MIDI tool as a collapsible right
+            column. Its recorder/AI/editor write notes into the piano roll above. */}
+        {!arpOn && <Vocal2MidiPanel />}
       </div>
     </div>
   );

--- a/frontend/src/components/library/LineageModal.tsx
+++ b/frontend/src/components/library/LineageModal.tsx
@@ -292,7 +292,12 @@ function computeLineage(
 const lineageOpacity = (onPath: boolean): number => (onPath ? 1 : 0.12);
 
 const LINEAGE_HOVER_INTENT_MS = 200;
-const LINEAGE_FADE_MS = 3000;
+
+// Genealogy grid geometry (px). Square cards; the gaps come from the sliders.
+const NODE_W = 140;
+const NODE_H = 140;
+const PAD = 24;
+const TOP_MARGIN = 8;
 
 const EDGE_COLOR_BY_KIND: Record<string, string> = {
   chimera_source_of: '#a78bfa',
@@ -329,6 +334,8 @@ export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, o
   // Hydrated from localStorage so settings survive a reload.
   const [appearance, setAppearance] = useState<GraphAppearance>(loadStoredAppearance);
   const [appearanceOpen, setAppearanceOpen] = useState(false);
+  // Genealogy Fit/Reset live in this header but operate on the GenealogyView.
+  const genControls = useRef<{ fit: () => void; reset: () => void } | null>(null);
 
   // Persist appearance changes to localStorage (debounced via the
   // natural batching of React state updates — each setAppearance flushes
@@ -431,6 +438,24 @@ export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, o
             <TabButton active={tab === 'graph3d'} onClick={() => setTab('graph3d')} icon={<Workflow className="w-3 h-3" />}>
               3D graph
             </TabButton>
+            {tab === 'genealogy' && (
+              <>
+                <button
+                  onClick={() => genControls.current?.fit()}
+                  className="ml-1 flex items-center gap-1 px-2 py-1 rounded text-[9px] font-mono uppercase tracking-widest text-zinc-300 hover:text-purple-200 bg-purple-500/15 border border-purple-500/30 hover:border-purple-400/60"
+                  title="Fit the entire genealogy into the viewport"
+                >
+                  <Maximize className="w-2.5 h-2.5" /> Fit
+                </button>
+                <button
+                  onClick={() => genControls.current?.reset()}
+                  className="flex items-center px-2 py-1 rounded text-[9px] font-mono uppercase tracking-widest text-zinc-400 hover:text-zinc-200 bg-black/40 border border-white/10"
+                  title="Reset to native scale"
+                >
+                  Reset
+                </button>
+              </>
+            )}
             {tab === 'graph3d' && (
               <button
                 onClick={() => setAppearanceOpen((v) => !v)}
@@ -469,7 +494,7 @@ export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, o
             <TrackTreeView root={rootEntryId} payload={perTrack} />
           )}
           {tab === 'genealogy' && libraryGraph && (
-            <GenealogyView payload={libraryGraph} appearance={appearance} />
+            <GenealogyView payload={libraryGraph} appearance={appearance} controlsRef={genControls} />
           )}
           {tab === 'graph3d' && libraryGraph && (
             <Suspense fallback={<div className="absolute inset-0 flex items-center justify-center text-[10px] font-mono text-zinc-500">Loading 3D engine…</div>}>
@@ -500,8 +525,8 @@ export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, o
           ))}
           {tab === 'genealogy' && (
             <div className="ml-auto flex items-center gap-4 normal-case">
-              <FooterRange label="Gen gap" value={appearance.colGap} min={40} max={320} step={5} onChange={(v) => setAppearance({ ...appearance, colGap: v })} />
-              <FooterRange label="Row gap" value={appearance.rowGap} min={4} max={200} step={2} onChange={(v) => setAppearance({ ...appearance, rowGap: v })} />
+              <FooterRange label="Gen gap" value={appearance.colGap} min={40} max={1200} step={5} onChange={(v) => setAppearance({ ...appearance, colGap: v })} />
+              <FooterRange label="Row gap" value={appearance.rowGap} min={4} max={800} step={2} onChange={(v) => setAppearance({ ...appearance, rowGap: v })} />
             </div>
           )}
         </div>
@@ -631,9 +656,10 @@ const Column: React.FC<{ title: string; nodes: GraphNode[]; accent: string; high
  *  flips re-render. This is what kills the per-hover lag and flash; the outer
  *  <g> (opacity/transform/handlers) stays in the parent and is cheap to diff. */
 const GenNodeBody = React.memo(function GenNodeBody({
-  n, sourceColor, strong, w, h,
+  n, title, sourceColor, strong, w, h,
 }: {
   n: GraphNode;
+  title: string;
   sourceColor: string;
   strong: boolean;
   w: number;
@@ -653,7 +679,7 @@ const GenNodeBody = React.memo(function GenNodeBody({
       />
       <rect width={w} height={4} rx={2} ry={2} fill={sourceColor} opacity={0.85} />
       <text x={10} y={24} fill="#f4f4f5" fontSize={12} fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontWeight={700}>
-        {truncate(n.title ?? n.id, 21)}
+        {truncate(title, 18)}
       </text>
       <line x1={10} y1={31} x2={w - 10} y2={31} stroke="#ffffff" strokeOpacity={0.08} />
       {(
@@ -704,7 +730,12 @@ const GenEdgeBody = React.memo(function GenEdgeBody({
   );
 });
 
-const GenealogyView: React.FC<{ payload: GraphPayload; appearance: GraphAppearance }> = ({ payload, appearance }) => {
+const GenealogyView: React.FC<{
+  payload: GraphPayload;
+  appearance: GraphAppearance;
+  /** Lets the parent header drive Fit/Reset (moved out of the canvas corner). */
+  controlsRef?: React.MutableRefObject<{ fit: () => void; reset: () => void } | null>;
+}> = ({ payload, appearance, controlsRef }) => {
   // Hover lights up a node's full lineage (uniform brightness both ways).
   const [hovered, setHovered] = useState<string | null>(null);
   // Hover is smoothed: moving the cursor straight from one node to the next
@@ -742,6 +773,9 @@ const GenealogyView: React.FC<{ payload: GraphPayload; appearance: GraphAppearan
   }, [clearHoverIntent]);
   // Click opens the detail/analytics inspector for that node.
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Viewport size — the grid uses the panel's aspect ratio to choose its row
+  // count so it fills the window (see fillRows).
+  const [containerSize, setContainerSize] = useState({ w: 0, h: 0 });
   // -- Filter to the connected subgraph --------------------------------
   const connected = useMemo(() => {
     const involved = new Set<string>();
@@ -862,82 +896,53 @@ const GenealogyView: React.FC<{ payload: GraphPayload; appearance: GraphAppearan
   }, [connected, nodeMap, layers, parentsOf, childrenOf]);
 
   // -- Step 3: coordinate assignment ----------------------------------
-  // Layout is LEFT→RIGHT: each generation is a vertical column of
-  // stacked sub-rows. When a generation has many nodes we split it
-  // across multiple SUB-COLUMNS (brick pattern) so a single generation
-  // doesn't run off the bottom of the modal. Alternating sub-columns
-  // are offset vertically by NODE_H/2 to stagger like the user's
-  // reference screenshot.
-  // Cards are a 4:3 landscape block (was a long 3.5:1 strip) so they can show
-  // more per-entry info without overlapping.
-  const NODE_W = 168;
-  const NODE_H = 126;
-  const COL_GAP = appearance.colGap;                          // gap between GENERATIONS
-  const SUBCOL_GAP = Math.max(8, Math.round(appearance.colGap * 0.31)); // sub-columns within a generation
-  const ROW_GAP = appearance.rowGap;                          // gap between stacked nodes in a sub-column
-  const PAD = 32;
-  const STAGGER_PX = NODE_H * 0.5;
-  const MAX_NODES_PER_SUBCOL = 14;
+  // Square cards pack into a grid that fills the panel; gaps come from sliders.
+  const ROW_GAP = appearance.rowGap;            // vertical gap between nodes
+  const SUBCOL_GAP = ROW_GAP;                    // uniform horizontal gap inside a generation
+  const GEN_GAP = appearance.colGap;            // larger gap BETWEEN generations
+
+  // Row count chosen so the layout's aspect ratio matches the panel's — that is
+  // what fills the window instead of leaving tall empty bands above and below.
+  // For N nodes in an A:1 panel with ~square cells the space-optimal grid is
+  // R = sqrt(N / A) rows × ~N/R columns (e.g. 144 nodes @ 16:9 → 9×16). Each
+  // generation packs its nodes column-major into R rows.
+  const fillRows = useMemo(() => {
+    const n = connected.nodes.length;
+    if (n <= 1) return 1;
+    const A = containerSize.w > 0 && containerSize.h > 0 ? containerSize.w / containerSize.h : 16 / 9;
+    const cellW = NODE_W + SUBCOL_GAP;
+    const cellH = NODE_H + ROW_GAP;
+    const r = Math.round(Math.sqrt((n * cellW) / (A * cellH)));
+    return Math.max(1, Math.min(n, r));
+  }, [connected.nodes.length, containerSize.w, containerSize.h, SUBCOL_GAP, ROW_GAP]);
 
   const generationLayouts = useMemo(() => {
-    type SubCol = { startX: number; ids: string[]; offset: number };
-    const layouts: Array<{
-      layer: number;
-      subCols: SubCol[];
-      genStartX: number;
-      genEndX: number;
-      colCount: number;
-    }> = [];
+    const layouts: Array<{ layer: number; ids: string[]; subColCount: number; genStartX: number; genEndX: number }> = [];
     let cursorX = PAD;
     orderedRows.forEach((row) => {
-      // Split row.ids across N sub-columns; brick-stagger alternating
-      // sub-columns by half a node height so neighbors don't form a
-      // perfect grid.
-      const nSub = Math.max(1, Math.ceil(row.ids.length / MAX_NODES_PER_SUBCOL));
-      const perSub = Math.ceil(row.ids.length / nSub);
-      const subCols: SubCol[] = [];
-      for (let s = 0; s < nSub; s += 1) {
-        const slice = row.ids.slice(s * perSub, (s + 1) * perSub);
-        subCols.push({
-          startX: cursorX + s * (NODE_W + SUBCOL_GAP),
-          ids: slice,
-          offset: s % 2 === 1 ? STAGGER_PX : 0,
-        });
-      }
-      const colCount = nSub;
+      const subColCount = Math.max(1, Math.ceil(row.ids.length / fillRows));
       const genStartX = cursorX;
-      const genEndX = cursorX + colCount * NODE_W + (colCount - 1) * SUBCOL_GAP;
-      layouts.push({ layer: row.layer, subCols, genStartX, genEndX, colCount });
-      cursorX = genEndX + COL_GAP;
+      const genEndX = genStartX + subColCount * NODE_W + (subColCount - 1) * SUBCOL_GAP;
+      layouts.push({ layer: row.layer, ids: row.ids, subColCount, genStartX, genEndX });
+      cursorX = genEndX + GEN_GAP;
     });
     return layouts;
-  }, [orderedRows, COL_GAP, SUBCOL_GAP]);
+  }, [orderedRows, fillRows, SUBCOL_GAP, GEN_GAP]);
 
   const positions = useMemo(() => {
     const pos: Record<string, { x: number; y: number }> = {};
-    // Vertical centering: find the tallest sub-column across the
-    // whole layout, then center smaller sub-columns to it.
-    let tallestPx = 0;
-    generationLayouts.forEach((g) =>
-      g.subCols.forEach((sc) => {
-        const px = sc.ids.length * NODE_H + (sc.ids.length - 1) * ROW_GAP;
-        if (px > tallestPx) tallestPx = px;
-      }),
-    );
     generationLayouts.forEach((g) => {
-      g.subCols.forEach((sc) => {
-        const colPx = sc.ids.length * NODE_H + (sc.ids.length - 1) * ROW_GAP;
-        const startY = PAD + (tallestPx - colPx) / 2 + sc.offset;
-        sc.ids.forEach((id, rowIdx) => {
-          pos[id] = {
-            x: sc.startX,
-            y: startY + rowIdx * (NODE_H + ROW_GAP),
-          };
-        });
+      g.ids.forEach((id, i) => {
+        const subcol = Math.floor(i / fillRows);
+        const r = i % fillRows;
+        pos[id] = {
+          x: g.genStartX + subcol * (NODE_W + SUBCOL_GAP),
+          y: TOP_MARGIN + PAD + r * (NODE_H + ROW_GAP),
+        };
       });
     });
     return pos;
-  }, [generationLayouts, ROW_GAP]);
+  }, [generationLayouts, fillRows, SUBCOL_GAP, ROW_GAP]);
 
   // -- Bounds for the SVG ---------------------------------------------
   const bounds = useMemo(() => {
@@ -964,6 +969,17 @@ const GenealogyView: React.FC<{ payload: GraphPayload; appearance: GraphAppearan
   const draggingRef = useRef<{ x: number; y: number; vx: number; vy: number } | null>(null);
   const draggedRef = useRef(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Keep the panel size current so the grid can size itself to fill it.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const measure = () => setContainerSize({ w: el.clientWidth, h: el.clientHeight });
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   // Snap view + target together (Fit / Reset / autofit) — no animation.
   const setViewImmediate = React.useCallback((v: { x: number; y: number; k: number }) => {
@@ -1003,14 +1019,18 @@ const GenealogyView: React.FC<{ payload: GraphPayload; appearance: GraphAppearan
     const gw = bounds.maxX - bounds.minX;
     const gh = bounds.maxY - bounds.minY;
     if (cw <= 0 || ch <= 0 || gw <= 0 || gh <= 0) return;
-    const margin = 40;
+    // Reserve a top strip for the generation numbers, then scale to fill the
+    // rest. No 1.0 cap so a small graph zooms up; the grid layout already makes
+    // the aspect ratio match the panel, so both axes fill with little waste.
+    const margin = 12;
+    const topReserve = 34;
     const k = Math.min(
       (cw - margin) / gw,
-      (ch - margin) / gh,
-      1.0,
+      (ch - margin - topReserve) / gh,
+      4,
     );
     const x = (cw - gw * k) / 2 - bounds.minX * k;
-    const y = (ch - gh * k) / 2 - bounds.minY * k;
+    const y = topReserve + (ch - topReserve - gh * k) / 2 - bounds.minY * k;
     setViewImmediate({ x, y, k });
   }, [bounds, setViewImmediate]);
 
@@ -1019,6 +1039,13 @@ const GenealogyView: React.FC<{ payload: GraphPayload; appearance: GraphAppearan
     fitToView();
   }, [fitToView]);
 
+  // Publish Fit/Reset to the parent so they can live in the Lineage header.
+  useEffect(() => {
+    if (!controlsRef) return;
+    controlsRef.current = { fit: fitToView, reset: () => setViewImmediate({ x: 0, y: 0, k: 1 }) };
+    return () => { controlsRef.current = null; };
+  }, [controlsRef, fitToView, setViewImmediate]);
+
   // Esc closes the inspector.
   useEffect(() => {
     if (!selectedId) return;
@@ -1026,6 +1053,103 @@ const GenealogyView: React.FC<{ payload: GraphPayload; appearance: GraphAppearan
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [selectedId]);
+
+  // Stems / MIDI nodes are titled "bass" / "piano" etc — show the TRACK they
+  // were derived from. Find a non-derived neighbor (the source track) and prefix
+  // its title.
+  const displayTitle = useCallback((n: GraphNode): string => {
+    const own = n.title ?? n.id;
+    const derived = (x?: GraphNode) =>
+      !!x && (x.source === 'stem' || x.source === 'midi' || x.kind === 'stem' || x.kind === 'midi');
+    if (!derived(n)) return own;
+    const nbrs = [...(parentsOf[n.id] ?? []), ...(childrenOf[n.id] ?? [])];
+    for (const id of nbrs) {
+      const src = nodeMap[id];
+      if (src && !derived(src) && src.title) return `${src.title} · ${own}`;
+    }
+    return own;
+  }, [parentsOf, childrenOf, nodeMap]);
+
+  // The whole SVG is memoized on graph/hover/selection/layout — NOT on `view`.
+  // Pan/zoom only updates the wrapper div's transform, so dragging/zooming no
+  // longer rebuilds hundreds of node/edge elements every frame (the old hot path).
+  const svgContent = useMemo(() => (
+    <svg
+      width={bounds.maxX - bounds.minX}
+      height={bounds.maxY - bounds.minY}
+      viewBox={`${bounds.minX} ${bounds.minY} ${bounds.maxX - bounds.minX} ${bounds.maxY - bounds.minY}`}
+      style={{ display: 'block' }}
+    >
+      {/* Generation bands: plain alternating grey / darker-grey, full height.
+          The gen NUMBER lives in a screen-space strip above the nodes (below the
+          header) — not stamped here. */}
+      {generationLayouts.map((g) => (
+        <rect
+          key={`genbg-${g.layer}`}
+          x={g.genStartX - GEN_GAP / 2}
+          y={bounds.minY}
+          width={g.genEndX - g.genStartX + GEN_GAP}
+          height={bounds.maxY - bounds.minY}
+          fill={g.layer % 2 === 0 ? '#17171c' : '#0d0d11'}
+        />
+      ))}
+
+      {/* Edges under nodes. Hovering a node lights up its WHOLE lineage: the
+          lineage edges stay full and thicken, off-path edges fade — without
+          dimming any nodes. */}
+      {connected.edges.map((edge, i) => {
+        const from = positions[edge.from_id];
+        const to = positions[edge.to_id];
+        if (!from || !to) return null;
+        const x1 = from.x + NODE_W;
+        const y1 = from.y + NODE_H / 2;
+        const x2 = to.x;
+        const y2 = to.y + NODE_H / 2;
+        const dx = (x2 - x1) * 0.5;
+        const d = `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`;
+        const color = EDGE_COLOR_BY_KIND[edge.kind] ?? '#71717a';
+        const onPath = lineage.has(edge.from_id) && lineage.has(edge.to_id);
+        const eOp = !hovered ? 0.85 : onPath ? 1 : 0.07;
+        return (
+          <g key={i} opacity={eOp} style={{ transition: 'opacity 240ms ease' }}>
+            <GenEdgeBody d={d} color={color} x2={x2} y2={y2} strong={!!hovered && onPath} />
+          </g>
+        );
+      })}
+
+      {/* Nodes are never dimmed. Hovering glows the hovered node strongly and the
+          rest of its lineage softly, in each node's source color. */}
+      {connected.nodes.map((n) => {
+        const p = positions[n.id];
+        if (!p) return null;
+        const sourceColor = pickNodeColor(n);
+        const isHovered = hovered === n.id;
+        const isSelected = selectedId === n.id;
+        const inLineage = !!hovered && lineage.has(n.id);
+        const glow = isHovered
+          ? `drop-shadow(0 0 14px ${sourceColor}) drop-shadow(0 0 5px ${sourceColor})`
+          : inLineage
+            ? `drop-shadow(0 0 8px ${sourceColor})`
+            : undefined;
+        return (
+          <g
+            key={n.id}
+            transform={`translate(${p.x}, ${p.y})`}
+            style={{ cursor: 'pointer', filter: glow, transition: 'filter 160ms ease' }}
+            onMouseEnter={() => enterNode(n.id)}
+            onMouseLeave={leaveNode}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (draggedRef.current) return;
+              setSelectedId((cur) => (cur === n.id ? null : n.id));
+            }}
+          >
+            <GenNodeBody n={n} title={displayTitle(n)} sourceColor={sourceColor} strong={isHovered || isSelected || inLineage} w={NODE_W} h={NODE_H} />
+          </g>
+        );
+      })}
+    </svg>
+  ), [bounds, generationLayouts, GEN_GAP, connected, positions, lineage, hovered, selectedId, enterNode, leaveNode, displayTitle]);
 
   if (connected.nodes.length === 0) {
     return (
@@ -1106,21 +1230,22 @@ const GenealogyView: React.FC<{ payload: GraphPayload; appearance: GraphAppearan
       onPointerUp={onPointerUp}
       onClick={() => { if (!draggedRef.current) setSelectedId(null); }}
     >
-      <div className="absolute top-2 right-2 z-10 flex gap-1">
-        <button
-          onClick={fitToView}
-          className="text-[9px] font-mono uppercase tracking-widest text-zinc-300 hover:text-purple-200 bg-purple-500/15 border border-purple-500/30 hover:border-purple-400/60 px-2 py-1 rounded flex items-center gap-1"
-          title="Fit the entire genealogy into the viewport"
-        >
-          <Maximize className="w-2.5 h-2.5" /> Fit
-        </button>
-        <button
-          onClick={() => setViewImmediate({ x: 0, y: 0, k: 1 })}
-          className="text-[9px] font-mono uppercase tracking-widest text-zinc-400 hover:text-zinc-200 bg-black/40 border border-white/10 px-2 py-1 rounded"
-          title="Reset to native scale"
-        >
-          Reset
-        </button>
+      {/* Generation numbers — a screen-space strip just below the header that
+          tracks the canvas horizontally so each number floats above its
+          generation's column. Fit reserves the top margin so these stay clear. */}
+      <div className="absolute top-0 left-0 right-0 h-8 z-10 overflow-hidden pointer-events-none">
+        {generationLayouts.map((g) => {
+          const centerX = ((g.genStartX + g.genEndX) / 2) * view.k + view.x;
+          return (
+            <span
+              key={g.layer}
+              className="absolute top-2 -translate-x-1/2 text-[12px] font-mono font-bold tracking-widest text-zinc-300"
+              style={{ left: centerX }}
+            >
+              {g.layer}
+            </span>
+          );
+        })}
       </div>
 
       <div
@@ -1129,103 +1254,7 @@ const GenealogyView: React.FC<{ payload: GraphPayload; appearance: GraphAppearan
           transformOrigin: '0 0',
         }}
       >
-        <svg
-          width={bounds.maxX - bounds.minX}
-          height={bounds.maxY - bounds.minY}
-          viewBox={`${bounds.minX} ${bounds.minY} ${bounds.maxX - bounds.minX} ${bounds.maxY - bounds.minY}`}
-          style={{ display: 'block' }}
-        >
-          {/* Per-generation background bands: a subtle, alternating shade behind
-              each generation's nodes so the gen-0 / gen-1 / … columns read as
-              distinct zones (gentle variations of the canvas color). */}
-          {generationLayouts.map((g) => (
-            <rect
-              key={`genbg-${g.layer}`}
-              x={g.genStartX - appearance.colGap / 2}
-              y={bounds.minY}
-              width={g.genEndX - g.genStartX + appearance.colGap}
-              height={bounds.maxY - bounds.minY}
-              fill={`hsl(258 38% ${3.4 + (g.layer % 2) * 2.4}%)`}
-            />
-          ))}
-
-          {/* Edges next so nodes paint on top. Flow is left-to-right:
-              parent on the left, child on the right of the next column. */}
-          {connected.edges.map((edge, i) => {
-            const from = positions[edge.from_id];
-            const to = positions[edge.to_id];
-            if (!from || !to) return null;
-            const x1 = from.x + NODE_W;          // parent's right edge
-            const y1 = from.y + NODE_H / 2;
-            const x2 = to.x;                      // child's left edge
-            const y2 = to.y + NODE_H / 2;
-            // Smooth cubic Bezier curving across the column gap.
-            const dx = (x2 - x1) * 0.5;
-            const d = `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`;
-            const color = EDGE_COLOR_BY_KIND[edge.kind] ?? '#71717a';
-            // Lineage hover: an edge is "on the path" when both endpoints are in
-            // the highlighted set; off-path edges fade right back.
-            const onPath = lineage.has(edge.from_id) && lineage.has(edge.to_id);
-            const eOp = !hovered ? 1 : onPath ? 1 : 0.06;
-            return (
-              <g key={i} opacity={eOp} style={{ transition: `opacity ${LINEAGE_FADE_MS}ms cubic-bezier(0.4, 0, 0.2, 1)` }}>
-                <GenEdgeBody d={d} color={color} x2={x2} y2={y2} strong={!!hovered && onPath} />
-              </g>
-            );
-          })}
-
-          {/* Nodes. */}
-          {connected.nodes.map((n) => {
-            const p = positions[n.id];
-            if (!p) return null;
-            const sourceColor = pickNodeColor(n);
-            const onPath = lineage.has(n.id);
-            const nOp = !hovered ? 1 : lineageOpacity(onPath);
-            const isHovered = hovered === n.id;
-            const isSelected = selectedId === n.id;
-            return (
-              <g
-                key={n.id}
-                transform={`translate(${p.x}, ${p.y})`}
-                opacity={nOp}
-                style={{ cursor: 'pointer', transition: `opacity ${LINEAGE_FADE_MS}ms cubic-bezier(0.4, 0, 0.2, 1)` }}
-                onMouseEnter={() => enterNode(n.id)}
-                onMouseLeave={leaveNode}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  // Suppress the click that ends a pan-drag.
-                  if (draggedRef.current) return;
-                  setSelectedId((cur) => (cur === n.id ? null : n.id));
-                }}
-              >
-                <GenNodeBody n={n} sourceColor={sourceColor} strong={isHovered || isSelected} w={NODE_W} h={NODE_H} />
-              </g>
-            );
-          })}
-        </svg>
-      </div>
-
-      {/* Generation column headers — each one spans its (possibly
-          multi-sub-column) generation width and follows the canvas in
-          screen-space so they don't pan/zoom with content. */}
-      <div className="absolute top-0 left-0 z-10 text-[9px] font-mono uppercase tracking-widest text-zinc-500 pointer-events-none">
-        {generationLayouts.map((g) => {
-          const centerWorldX = (g.genStartX + g.genEndX) / 2;
-          return (
-            <div
-              key={g.layer}
-              style={{
-                position: 'absolute',
-                left: centerWorldX * view.k + view.x,
-                top: 8,
-                transform: 'translateX(-50%)',
-              }}
-              className="bg-purple-500/20 border border-purple-500/40 rounded px-2 py-0.5 text-purple-200"
-            >
-              gen {g.layer}
-            </div>
-          );
-        })}
+        {svgContent}
       </div>
 
       {/* Help hint */}

--- a/frontend/src/lib/arpEngine.ts
+++ b/frontend/src/lib/arpEngine.ts
@@ -1,0 +1,503 @@
+/**
+ * Chord-progression arpeggiator engine.
+ *
+ * A faithful TypeScript port of Jake Albaugh's "Musical Chord Progression
+ * Arpeggiator" (the MusicalScale scale generator + ArpeggioPatterns permutation
+ * generator), rehosted on this app's Web Audio stack instead of Tone.js. The
+ * original Tone.Transport.scheduleRepeat loop is replaced by a lookahead clock
+ * on the shared engine AudioContext, and notes are voiced through the same
+ * `triggerActiveVoice` synth the piano roll uses — so the arpeggiator shares the
+ * app's instrument, master gain and effect rack, and its progression can be
+ * dumped straight into the piano roll's note model.
+ *
+ * No Tone.js, no CDN: pure data + the standard AudioContext surface.
+ */
+import { getEngineCtx, getMasterGain } from '../state/playerStore';
+import { triggerActiveVoice } from './midiSynth';
+import { isSoundfontActive, getActiveProgram } from './soundfontEngine';
+import { previewNoteSF } from './soundfontEngine';
+
+/* ── music theory ─────────────────────────────────────────────────────────── */
+
+export interface TriadNote {
+  note: string;
+  rel_octave: number;
+}
+export interface Triad {
+  type: string;
+  interval: string;
+  notes: TriadNote[];
+}
+export interface ScaleNote {
+  step: number;
+  note: string;
+  rel_octave: number;
+  triad: Triad;
+}
+
+interface ScaleDef {
+  name: string;
+  steps: number[];
+  dominance: number[];
+  triads: string[];
+}
+interface ScaleDict {
+  keys: string[];
+  scales: Record<string, ScaleDef>;
+  modes: string[];
+  flat_sharp: Record<string, string>;
+  triads: Record<string, number[]>;
+}
+
+/**
+ * Generate a scale and its diatonic triads for a key + mode.
+ * Port of https://codepen.io/jakealbaugh/pen/NrdEYL/
+ */
+export class MusicalScale {
+  dict: ScaleDict;
+  key = 'C';
+  mode = 'ionian';
+  notes: ScaleNote[] = [];
+  _scale!: ScaleDef;
+
+  constructor(params: { key: string; mode: string }) {
+    this.dict = MusicalScale._loadDictionary();
+    this._loadScale(params);
+  }
+
+  updateScale(params: { key: string; mode: string }): void {
+    this._loadScale(params);
+  }
+
+  private _loadScale(params: { key: string; mode: string }): void {
+    this.key = this._paramKey(params.key);
+    this.mode = params.mode;
+    this.notes = [];
+    this._scale = this.dict.scales[this._paramMode(this.mode)];
+
+    const keys = this.dict.keys;
+    const offset = keys.indexOf(this.key);
+    for (let s = 0; s < this._scale.steps.length; s++) {
+      const step = this._scale.steps[s];
+      const idx = (offset + step) % keys.length;
+      const rel_octave = offset + step > keys.length - 1 ? 1 : 0;
+      const triad = this._genTriad(s, idx, rel_octave, this._scale.triads[s]);
+      this.notes.push({ step: s, note: keys[idx], rel_octave, triad });
+    }
+  }
+
+  private _genTriad(s: number, offset: number, octave: number, t: string): Triad {
+    const steps = this.dict.triads[t];
+    const chord: Triad = { type: t, interval: this._intervalFromType(s, t), notes: [] };
+    const keys = this.dict.keys;
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i];
+      const idx = (offset + step) % keys.length;
+      const rel_octave = offset + step > keys.length - 1 ? octave + 1 : octave;
+      chord.notes.push({ note: keys[idx], rel_octave });
+    }
+    return chord;
+  }
+
+  private _intervalFromType(step: number, type: string): string {
+    const steps = 'i ii iii iv v vi vii'.split(' ');
+    let s = steps[step];
+    switch (type) {
+      case 'maj':
+        s = s.toUpperCase();
+        break;
+      case 'aug':
+        s = s.toUpperCase() + '+';
+        break;
+      case 'dim':
+        s = s + '°';
+        break;
+    }
+    return s;
+  }
+
+  private _paramMode(mode: string): string {
+    return (
+      {
+        minor: 'aeo',
+        major: 'ion',
+        ionian: 'ion',
+        dorian: 'dor',
+        phrygian: 'phr',
+        lydian: 'lyd',
+        mixolydian: 'mix',
+        aeolian: 'aeo',
+        locrian: 'loc',
+        melodic: 'mel',
+        harmonic: 'har',
+      } as Record<string, string>
+    )[mode];
+  }
+
+  private _paramKey(key: string): string {
+    if (this.dict.flat_sharp[key]) return this.dict.flat_sharp[key];
+    return key;
+  }
+
+  private static _genTriads(offset: number): string[] {
+    const base = 'maj min min maj maj min dim'.split(' ');
+    const triads: string[] = [];
+    for (let i = 0; i < base.length; i++) triads.push(base[(i + offset) % base.length]);
+    return triads;
+  }
+
+  private static _genSteps(steps_str: string): number[] {
+    const arr = steps_str.split(' ');
+    const steps = [0];
+    let step = 0;
+    for (let i = 0; i < arr.length - 1; i++) {
+      let inc = 0;
+      switch (arr[i]) {
+        case 'W':
+          inc = 2;
+          break;
+        case 'H':
+          inc = 1;
+          break;
+        case 'WH':
+          inc = 3;
+          break;
+      }
+      step += inc;
+      steps.push(step);
+    }
+    return steps;
+  }
+
+  private static _loadDictionary(): ScaleDict {
+    return {
+      keys: 'C C# D D# E F F# G G# A A# B'.split(' '),
+      scales: {
+        ion: { name: 'Ionian', steps: MusicalScale._genSteps('W W H W W W H'), dominance: [3, 0, 1, 0, 2, 0, 1], triads: MusicalScale._genTriads(0) },
+        dor: { name: 'Dorian', steps: MusicalScale._genSteps('W H W W W H W'), dominance: [3, 0, 1, 0, 2, 2, 1], triads: MusicalScale._genTriads(1) },
+        phr: { name: 'Phrygian', steps: MusicalScale._genSteps('H W W W H W W'), dominance: [3, 2, 1, 0, 2, 0, 1], triads: MusicalScale._genTriads(2) },
+        lyd: { name: 'Lydian', steps: MusicalScale._genSteps('W W W H W W H'), dominance: [3, 0, 1, 2, 2, 0, 1], triads: MusicalScale._genTriads(3) },
+        mix: { name: 'Mixolydian', steps: MusicalScale._genSteps('W W H W W H W'), dominance: [3, 0, 1, 0, 2, 0, 2], triads: MusicalScale._genTriads(4) },
+        aeo: { name: 'Aeolian', steps: MusicalScale._genSteps('W H W W H W W'), dominance: [3, 0, 1, 0, 2, 0, 1], triads: MusicalScale._genTriads(5) },
+        loc: { name: 'Locrian', steps: MusicalScale._genSteps('H W W H W W W'), dominance: [3, 0, 1, 0, 3, 0, 0], triads: MusicalScale._genTriads(6) },
+        mel: { name: 'Melodic Minor', steps: MusicalScale._genSteps('W H W W W W H'), dominance: [3, 0, 1, 0, 3, 0, 0], triads: 'min min aug maj maj dim dim'.split(' ') },
+        har: { name: 'Harmonic Minor', steps: MusicalScale._genSteps('W H W W H WH H'), dominance: [3, 0, 1, 0, 3, 0, 0], triads: 'min dim aug min maj maj dim'.split(' ') },
+      },
+      modes: ['ionian', 'dorian', 'phrygian', 'lydian', 'mixolydian', 'aeolian', 'locrian', 'major', 'minor', 'melodic', 'harmonic'],
+      flat_sharp: { Cb: 'B', Db: 'C#', Eb: 'D#', Fb: 'E', Gb: 'F#', Ab: 'G#', Bb: 'A#' },
+      triads: { maj: [0, 4, 7], min: [0, 3, 7], dim: [0, 3, 6], aug: [0, 4, 8] },
+    };
+  }
+}
+
+/**
+ * All arpeggio index patterns for a given number of steps.
+ * Port of https://codepen.io/jakealbaugh/pen/PzpzEO/
+ */
+export class ArpeggioPatterns {
+  steps: number;
+  patterns: { straight: number[][]; looped: number[][] } = { straight: [], looped: [] };
+  private arr: number[] = [];
+  private _used: number[] = [];
+  private permutations: number[][] = [];
+
+  constructor(params: { steps: number }) {
+    this.steps = params.steps;
+    this._loadPatterns();
+  }
+
+  updatePatterns(params: { steps: number }): void {
+    this.steps = params.steps;
+    this._loadPatterns();
+  }
+
+  private _loadPatterns(): void {
+    this.arr = [];
+    for (let i = 0; i < this.steps; i++) this.arr.push(i);
+    this._used = [];
+    this.permutations = this._permute(this.arr);
+    this.patterns = { straight: this.permutations, looped: this._loop() };
+  }
+
+  private _permute(input: number[], permutations: number[][] = []): number[][] {
+    for (let i = 0; i < input.length; i++) {
+      const ch = input.splice(i, 1)[0];
+      this._used.push(ch);
+      if (input.length === 0) permutations.push(this._used.slice());
+      this._permute(input, permutations);
+      input.splice(i, 0, ch);
+      this._used.pop();
+    }
+    return permutations;
+  }
+
+  private _loop(): number[][] {
+    const looped: number[][] = [];
+    for (let p = 0; p < this.permutations.length; p++) {
+      const perm = this.permutations[p];
+      const arr = Array.from(perm);
+      for (let x = 1; x < perm.length - 1; x++) arr.push(perm[perm.length - 1 - x]);
+      looped.push(arr);
+    }
+    return looped;
+  }
+}
+
+/* ── note naming ──────────────────────────────────────────────────────────── */
+
+const KEYS = 'C C# D D# E F F# G G# A A# B'.split(' ');
+
+/** "C#4" / chord note + absolute octave -> MIDI number (C4 = 60). */
+export const noteNameToMidi = (note: string, octave: number): number => {
+  const pc = KEYS.indexOf(note);
+  if (pc < 0) return 60;
+  return (octave + 1) * 12 + pc;
+};
+
+/* ── live engine ──────────────────────────────────────────────────────────── */
+
+export type PatternType = 'straight' | 'looped';
+
+export interface ArpConfig {
+  chords: number[]; // scale-degree index per progression slot
+  key: string;
+  mode: string;
+  steps: number; // arpeggio note count (3-6)
+  patternType: PatternType;
+  patternId: number;
+  bpm: number;
+  octaveBase: number;
+  arpRepeat: number;
+  bassOn: boolean; // whether to voice the bass synth
+  /** Timing feel (mirrors the piano roll): 1 = dead-on grid, <1 humanizes the
+   *  note timing; swing delays the off-16ths (+) or pushes them early (-). */
+  quantize: number; // 0..1
+  swing: number; // -0.5..0.5
+}
+
+export const DEFAULT_ARP_CONFIG: ArpConfig = {
+  chords: [0, 2, 6, 3, 4, 2, 5, 1],
+  key: 'G',
+  mode: 'locrian',
+  steps: 6,
+  patternType: 'straight',
+  patternId: 0,
+  bpm: 135,
+  octaveBase: 4,
+  arpRepeat: 2,
+  bassOn: true,
+  quantize: 1,
+  swing: 0,
+};
+
+/** A scheduled highlight event the UI can react to (keyboard + chord lamps). */
+export interface ArpTick {
+  when: number; // AudioContext time the note sounds
+  chordIndex: number; // active progression slot
+  trebleMidi: number;
+  bassMidi: number | null; // non-null only on the tick the bass (re)triggers
+}
+
+/** Convert one progression pass to absolute-seconds piano-roll-style notes. */
+export interface ArpRenderNote {
+  midi: number;
+  step: number; // 16th-note step
+  length: number; // in 16th-note steps
+  velocity: number;
+}
+
+const LOOKAHEAD_MS = 25;
+const SCHEDULE_AHEAD = 0.12; // seconds
+
+export class ArpPlayerEngine {
+  cfg: ArpConfig;
+  MS: MusicalScale;
+  AP: ArpeggioPatterns;
+  arpeggio: number[] = [];
+
+  private playing = false;
+  private timer: number | null = null;
+  private nextNoteTime = 0;
+  private step = 0;
+  private chordStep = 0;
+  private bassActive = false;
+
+  onTick: ((t: ArpTick) => void) | null = null;
+  onStop: (() => void) | null = null;
+
+  constructor(cfg: Partial<ArpConfig> = {}) {
+    this.cfg = { ...DEFAULT_ARP_CONFIG, ...cfg };
+    this.MS = new MusicalScale({ key: this.cfg.key, mode: this.cfg.mode });
+    this.AP = new ArpeggioPatterns({ steps: this.cfg.steps });
+    this._refreshArpeggio();
+  }
+
+  get isPlaying(): boolean {
+    return this.playing;
+  }
+
+  private _refreshArpeggio(): void {
+    const list = this.AP.patterns[this.cfg.patternType];
+    if (this.cfg.patternId > list.length - 1) this.cfg.patternId = 0;
+    this.arpeggio = list[this.cfg.patternId] ?? [];
+  }
+
+  /** Patch config; rebuilds scale/patterns as needed. Safe while playing. */
+  setConfig(patch: Partial<ArpConfig>): void {
+    const prev = this.cfg;
+    this.cfg = { ...prev, ...patch };
+    if (patch.key !== undefined || patch.mode !== undefined) {
+      this.MS.updateScale({ key: this.cfg.key, mode: this.cfg.mode });
+    }
+    if (patch.steps !== undefined) {
+      this.AP.updatePatterns({ steps: this.cfg.steps });
+    }
+    this._refreshArpeggio();
+  }
+
+  /** The "Output" view: the chosen chords as {note, type, interval}. */
+  outputChords(): { note: string; type: string; interval: string }[] {
+    return this.cfg.chords.map((c) => {
+      const n = this.MS.notes[c] ?? this.MS.notes[0];
+      return { note: n.note, type: n.triad.type, interval: n.triad.interval };
+    });
+  }
+
+  private stepDur(): number {
+    return 60 / this.cfg.bpm / 4;
+  }
+
+  start(): void {
+    if (this.playing) return;
+    const ctx = getEngineCtx();
+    if (ctx.state === 'suspended') void ctx.resume();
+    this.playing = true;
+    this.step = 0;
+    this.chordStep = 0;
+    this.bassActive = false;
+    this.nextNoteTime = ctx.currentTime + 0.06;
+    this._tick();
+  }
+
+  stop(): void {
+    if (!this.playing) return;
+    this.playing = false;
+    if (this.timer !== null) {
+      window.clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.onStop?.();
+  }
+
+  private _voice(midi: number, when: number, duration: number, velocity: number): void {
+    const ctx = getEngineCtx();
+    if (isSoundfontActive()) {
+      const delayMs = Math.max(0, (when - ctx.currentTime) * 1000);
+      window.setTimeout(() => void previewNoteSF(midi, velocity, duration), delayMs);
+      return;
+    }
+    void getActiveProgram();
+    triggerActiveVoice(ctx, getMasterGain(), midi, velocity, when, duration, 0.85);
+  }
+
+  /** Schedule one 16th step, mirroring the original scheduleRepeat body. */
+  private _scheduleStep(when: number): void {
+    const chordCount = this.cfg.chords.length;
+    const arpLen = Math.max(1, this.arpeggio.length);
+    const currChord = this.chordStep % chordCount;
+    const chord = this.MS.notes[this.cfg.chords[currChord]] ?? this.MS.notes[0];
+
+    // Build the arpeggiable note pool: the triad, stacked up by octaves.
+    let pool: TriadNote[] = chord.triad.notes;
+    const octaveLifts = Math.ceil(this.cfg.steps / 3);
+    for (let i = 0; i < octaveLifts; i++) {
+      pool = pool.concat(pool.map((n) => ({ note: n.note, rel_octave: n.rel_octave + (i + 1) })));
+    }
+    const arpNote = pool[this.arpeggio[this.step % arpLen]] ?? pool[0];
+
+    let bassMidi: number | null = null;
+    if (this.cfg.bassOn && !this.bassActive) {
+      this.bassActive = true;
+      const bassOctave = chord.rel_octave + 2;
+      const bassMidiVal = noteNameToMidi(chord.note, bassOctave);
+      const bassDur = arpLen * this.cfg.arpRepeat * this.stepDur();
+      this._voice(bassMidiVal, when, bassDur * 0.96, 96);
+      bassMidi = bassMidiVal;
+    }
+
+    this.step++;
+    if (this.step % (arpLen * this.cfg.arpRepeat) === 0) {
+      this.chordStep++;
+      this.bassActive = false;
+    }
+
+    const trebleMidi = noteNameToMidi(arpNote.note, arpNote.rel_octave + this.cfg.octaveBase);
+    this._voice(trebleMidi, when, this.stepDur() * 0.9, 104);
+
+    this.onTick?.({ when, chordIndex: currChord, trebleMidi, bassMidi });
+  }
+
+  private _tick = (): void => {
+    if (this.timer === null) {
+      this.timer = window.setInterval(this._tick, LOOKAHEAD_MS);
+    }
+    if (!this.playing) return;
+    const ctx = getEngineCtx();
+    while (this.nextNoteTime < ctx.currentTime + SCHEDULE_AHEAD) {
+      const dur = this.stepDur();
+      // Swing delays the off-16ths; lower quantize adds a touch of humanized
+      // jitter. `this.step` is the upcoming step (incremented inside _scheduleStep).
+      const swingOff = this.step % 2 === 1 ? this.cfg.swing * dur : 0;
+      const humanize = (1 - this.cfg.quantize) * (Math.random() - 0.5) * dur * 0.5;
+      this._scheduleStep(this.nextNoteTime + swingOff + humanize);
+      this.nextNoteTime += dur;
+    }
+  };
+
+  /**
+   * Render the full progression (all chords, one arp_repeat pass each) to
+   * step-grid notes for the piano roll. Treble arp notes only; the grid is
+   * 16th-note steps so it lines up with the roll's bpm.
+   */
+  renderProgression(): ArpRenderNote[] {
+    const out: ArpRenderNote[] = [];
+    const chordCount = this.cfg.chords.length;
+    const arpLen = Math.max(1, this.arpeggio.length);
+    const stepsPerChord = arpLen * this.cfg.arpRepeat;
+    let gridStep = 0;
+    for (let c = 0; c < chordCount; c++) {
+      const chord = this.MS.notes[this.cfg.chords[c]] ?? this.MS.notes[0];
+      let pool: TriadNote[] = chord.triad.notes;
+      const octaveLifts = Math.ceil(this.cfg.steps / 3);
+      for (let i = 0; i < octaveLifts; i++) {
+        pool = pool.concat(pool.map((n) => ({ note: n.note, rel_octave: n.rel_octave + (i + 1) })));
+      }
+      // bass for the whole chord span
+      if (this.cfg.bassOn) {
+        out.push({
+          midi: noteNameToMidi(chord.note, chord.rel_octave + 2),
+          step: gridStep,
+          length: stepsPerChord,
+          velocity: 88,
+        });
+      }
+      for (let s = 0; s < stepsPerChord; s++) {
+        const arpNote = pool[this.arpeggio[s % arpLen]] ?? pool[0];
+        out.push({
+          midi: noteNameToMidi(arpNote.note, arpNote.rel_octave + this.cfg.octaveBase),
+          step: gridStep + s,
+          length: 1,
+          velocity: 104,
+        });
+      }
+      gridStep += stepsPerChord;
+    }
+    return out;
+  }
+
+  dispose(): void {
+    this.stop();
+    this.onTick = null;
+    this.onStop = null;
+  }
+}

--- a/frontend/src/lib/quantumLattice.ts
+++ b/frontend/src/lib/quantumLattice.ts
@@ -1,0 +1,847 @@
+/**
+ * Quantum Lattice engine — a framework-agnostic port of the "Quantum Sacred
+ * Geometry" high-energy shader engine (instanced node/beam lattice that morphs
+ * between Torus / Cube / Star / Cage, with bloom + dithering post). The original
+ * was a single-file three.js page bound to window/document; this class owns a
+ * caller-supplied canvas, takes its own width/height, and exposes a full live
+ * parameter surface so it can drive both the in-app Visualize tab and (copied
+ * into the VJ tree) a captureStream camera source.
+ *
+ * Parameters: every control is declared once in QUANTUM_PARAMS (id/label/group/
+ * range/default + optional default audio band). `resolveQuantumParams()` merges
+ * UI overrides into a flat config the engine consumes each frame. Audio
+ * reactivity mirrors the VJ shader system: bands are envelope-followed (fast
+ * attack / slow release), each param eases toward `base + range*amt*level*drive`,
+ * clamped to its range. With no audio the params sit at their slider value.
+ */
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+
+export interface QuantumLevels {
+  bass: number;
+  mid: number;
+  high: number;
+  volume: number;
+}
+
+export interface QuantumStats {
+  geomName: string;
+  stability: number;
+  fps: number;
+  resonance: number;
+  phasePercent: number;
+  /** Currently active geometry index (may auto-advance when beat-cycle is on). */
+  shape: number;
+}
+
+export interface QuantumOptions {
+  canvas: HTMLCanvasElement;
+  width: number;
+  height: number;
+  /** Device pixel ratio cap. Defaults to min(devicePixelRatio, 2); offscreen
+   *  capture sources pass 1 to keep the captured buffer at its nominal size. */
+  pixelRatio?: number;
+  /** Attach OrbitControls (in-app interactive view). Off for offscreen capture. */
+  interactive?: boolean;
+  /** Optional audio drive; returns 0..1 bands. */
+  getLevels?: () => QuantumLevels;
+  /** Optional HUD callback (geometry name, stability %, fps, resonance). */
+  onStats?: (s: QuantumStats) => void;
+  /** Fired the instant a hard hit auto-advances the geometry (beat-cycle on). */
+  onShape?: (shapeIndex: number) => void;
+}
+
+export const QUANTUM_GEOMETRY_NAMES = ['Grand Torus', 'Cubic Frame', 'Merkabah Star', 'Cosmos Cage'];
+export const QUANTUM_PALETTES = ['Quantum', 'Oceanic', 'Inferno', 'Glacier'];
+
+/* ── parameter catalogue ──────────────────────────────────────────────────── */
+
+export type QuantumAudioBand = 'none' | 'bass' | 'mid' | 'high' | 'volume';
+
+export interface QuantumParamDef {
+  id: string;
+  label: string;
+  group: string;
+  min: number;
+  max: number;
+  step: number;
+  default: number;
+  /** Default audio band that modulates this param (user can override). */
+  audio?: QuantumAudioBand;
+  /** Audio depth as a fraction of (max-min). Default 0.3. */
+  audioAmt?: number;
+  /** Bipolar slider (centre = 0), e.g. auto-rotate direction. */
+  bipolar?: boolean;
+}
+
+/** Every live-tunable parameter, grouped. Audio defaults make it react out of
+ *  the box; OFF bands leave a param as a plain slider. */
+export const QUANTUM_PARAMS: QuantumParamDef[] = [
+  // Motion
+  { id: 'waveSpeed', label: 'Wave Speed', group: 'Motion', min: 0.2, max: 3.5, step: 0.05, default: 1.2, audio: 'mid', audioAmt: 0.35 },
+  { id: 'morphAmount', label: 'Morph Push', group: 'Motion', min: 0, max: 0.6, step: 0.01, default: 0.15, audio: 'bass', audioAmt: 0.5 },
+  { id: 'autoRotate', label: 'Auto-Spin', group: 'Motion', min: -1.5, max: 1.5, step: 0.05, default: 0, audio: 'none', bipolar: true },
+  // Glow & Post
+  { id: 'bloomStrength', label: 'Bloom', group: 'Glow & Post', min: 0, max: 2.5, step: 0.05, default: 0.2, audio: 'volume', audioAmt: 0.35 },
+  { id: 'bloomRadius', label: 'Bloom Radius', group: 'Glow & Post', min: 0, max: 1, step: 0.05, default: 0.35, audio: 'none' },
+  { id: 'bloomThreshold', label: 'Bloom Thresh', group: 'Glow & Post', min: 0, max: 1, step: 0.05, default: 0.82, audio: 'none' },
+  { id: 'dither', label: 'Dither', group: 'Glow & Post', min: 0, max: 0.06, step: 0.002, default: 0.012, audio: 'high', audioAmt: 0.3 },
+  { id: 'exposure', label: 'Exposure', group: 'Glow & Post', min: 0.4, max: 2.2, step: 0.05, default: 0.85, audio: 'none' },
+  { id: 'vignette', label: 'Vignette', group: 'Glow & Post', min: 0, max: 2, step: 0.05, default: 1.1, audio: 'none' },
+  { id: 'fog', label: 'Fog', group: 'Glow & Post', min: 0, max: 0.1, step: 0.005, default: 0.025, audio: 'none' },
+  // Structure
+  { id: 'nodeScale', label: 'Node Size', group: 'Structure', min: 0.2, max: 2.5, step: 0.05, default: 1, audio: 'bass', audioAmt: 0.3 },
+  { id: 'beamScale', label: 'Beam Width', group: 'Structure', min: 0.2, max: 3, step: 0.05, default: 1, audio: 'none' },
+  { id: 'coreScale', label: 'Core Size', group: 'Structure', min: 0.3, max: 2.2, step: 0.05, default: 1, audio: 'none' },
+  // Camera
+  { id: 'cameraDist', label: 'Camera Dist', group: 'Camera', min: 0.4, max: 2.5, step: 0.05, default: 1, audio: 'none' },
+  { id: 'cameraFov', label: 'Field of View', group: 'Camera', min: 20, max: 90, step: 1, default: 45, audio: 'none' },
+  // Detail (promoted GLSL uniforms)
+  { id: 'gridIntensity', label: 'Grid Glow', group: 'Detail', min: 0, max: 1.2, step: 0.05, default: 0.45, audio: 'high', audioAmt: 0.4 },
+  { id: 'waveDetail', label: 'Filament Detail', group: 'Detail', min: 0.3, max: 3, step: 0.05, default: 1, audio: 'mid', audioAmt: 0.3 },
+  { id: 'beamFresnel', label: 'Beam Edge', group: 'Detail', min: 1, max: 5, step: 0.25, default: 3, audio: 'none' },
+  { id: 'nodeFresnel', label: 'Node Edge', group: 'Detail', min: 1, max: 4, step: 0.25, default: 2.5, audio: 'none' },
+  { id: 'heartbeat', label: 'Core Pulse', group: 'Detail', min: 1, max: 15, step: 0.5, default: 6.5, audio: 'bass', audioAmt: 0.3 },
+];
+
+/** The ordered group names, for laying out a control panel. */
+export const QUANTUM_GROUPS = ['Motion', 'Glow & Post', 'Structure', 'Camera', 'Detail'];
+
+export interface QuantumParamConfig {
+  id: string;
+  base: number;
+  min: number;
+  max: number;
+  audio: QuantumAudioBand;
+  amt: number;
+}
+
+/** Merge UI overrides (by param id) with the declared defaults into the flat
+ *  config the engine consumes each frame. */
+export function resolveQuantumParams(
+  values?: Record<string, number>,
+  audio?: Record<string, QuantumAudioBand>,
+): QuantumParamConfig[] {
+  return QUANTUM_PARAMS.map((p) => ({
+    id: p.id,
+    base: values?.[p.id] ?? p.default,
+    min: p.min,
+    max: p.max,
+    audio: audio?.[p.id] ?? p.audio ?? 'none',
+    amt: p.audioAmt ?? 0.3,
+  }));
+}
+
+/* ── shaders ──────────────────────────────────────────────────────────────── */
+
+const CustomVertexShader = `
+  varying vec2 vUv;
+  varying vec3 vNormal;
+  varying vec3 vViewPosition;
+  varying vec3 vWorldPosition;
+  void main() {
+    vUv = uv;
+    vec4 localNormal = instanceMatrix * vec4(normal, 0.0);
+    vNormal = normalize(normalMatrix * localNormal.xyz);
+    vec4 localPosition = instanceMatrix * vec4(position, 1.0);
+    vec4 mvPosition = modelViewMatrix * localPosition;
+    vViewPosition = -mvPosition.xyz;
+    vec4 worldPosition = modelMatrix * localPosition;
+    vWorldPosition = worldPosition.xyz;
+    gl_Position = projectionMatrix * mvPosition;
+  }
+`;
+
+const TubeFragmentShader = `
+  varying vec2 vUv;
+  varying vec3 vNormal;
+  varying vec3 vViewPosition;
+  varying vec3 vWorldPosition;
+  uniform float uTime;
+  uniform float uSpeed;
+  uniform float uGridIntensity;
+  uniform float uFresnelPow;
+  uniform float uWaveScale;
+  uniform vec3 uColorCyan;
+  uniform vec3 uColorMagenta;
+  uniform vec3 uColorGold;
+  uniform vec3 uColorWhite;
+  void main() {
+    vec3 normal = normalize(vNormal);
+    vec3 viewDir = normalize(vViewPosition + vec3(0.0, 0.0, 0.0001));
+    float fresnel = pow(clamp(1.0 - abs(dot(viewDir, normal)), 0.0, 1.0), uFresnelPow);
+    float speedFactor = uTime * uSpeed * 4.0;
+    float wave1 = sin(vUv.y * 18.0 * uWaveScale - speedFactor);
+    float wave2 = cos(vUv.y * 36.0 * uWaveScale + speedFactor * 0.8);
+    float wave3 = sin(vUv.y * 90.0 * uWaveScale - speedFactor * 1.5) * 0.4;
+    float energyFlux = smoothstep(0.2, 0.8, (wave1 * wave2 + wave3) * 0.5 + 0.5);
+    float wireX = sin(vUv.x * 3.14159265 * 4.0);
+    float dWireX = max(fwidth(wireX), 0.0001);
+    float lineX = smoothstep(dWireX * 1.5, 0.0, abs(wireX));
+    float wireY = sin(vUv.y * 3.14159265 * 30.0);
+    float dWireY = max(fwidth(wireY), 0.0001);
+    float lineY = smoothstep(dWireY * 1.5, 0.0, abs(wireY));
+    float grid = max(lineX, lineY);
+    vec3 surfaceColor = mix(uColorMagenta * 0.2, uColorCyan, fresnel);
+    vec3 activeFilament = mix(surfaceColor, uColorMagenta * 1.8, energyFlux);
+    vec3 finalColor = mix(activeFilament, uColorGold * 1.5, grid * uGridIntensity);
+    float burst = smoothstep(0.96, 1.0, sin(vUv.y * 6.0 - speedFactor * 1.8));
+    finalColor = mix(finalColor, uColorWhite, burst * 0.85);
+    float alpha = mix(0.12 + fresnel * 0.65, 1.0, (grid * 0.75) + (energyFlux * 0.35));
+    gl_FragColor = vec4(clamp(finalColor, vec3(0.0), vec3(8.0)), clamp(alpha, 0.0, 1.0));
+  }
+`;
+
+const NodeFragmentShader = `
+  varying vec2 vUv;
+  varying vec3 vNormal;
+  varying vec3 vViewPosition;
+  varying vec3 vWorldPosition;
+  uniform float uTime;
+  uniform float uSpeed;
+  uniform float uFresnelPow;
+  uniform float uHeartbeat;
+  uniform vec3 uColorCyan;
+  uniform vec3 uColorMagenta;
+  uniform vec3 uColorGold;
+  uniform vec3 uColorWhite;
+  void main() {
+    vec3 normal = normalize(vNormal);
+    vec3 viewDir = normalize(vViewPosition + vec3(0.0, 0.0, 0.0001));
+    float fresnel = pow(clamp(1.0 - abs(dot(viewDir, normal)), 0.0, 1.0), uFresnelPow);
+    float speedFactor = uTime * uSpeed * 3.2;
+    float distFromCenter = length(vUv - vec2(0.5));
+    float thermalWave = sin(distFromCenter * 28.0 - speedFactor) * 0.5 + 0.5;
+    float stormNoise = sin(vUv.x * 24.0 + speedFactor) * cos(vUv.y * 24.0 - speedFactor);
+    float activeSolar = smoothstep(0.3, 0.9, stormNoise * thermalWave);
+    vec3 basePlasma = mix(uColorMagenta, uColorCyan, fresnel);
+    vec3 solarLatticeColor = mix(basePlasma, uColorGold * 1.8, activeSolar);
+    float centralReactor = smoothstep(0.28, 0.0, distFromCenter);
+    vec3 finalColor = mix(solarLatticeColor, uColorWhite, centralReactor * 0.95);
+    float heartbeat = sin(uTime * uHeartbeat) * 0.5 + 0.5;
+    finalColor += uColorGold * (fresnel * heartbeat * 0.4);
+    float alpha = mix(0.3 + fresnel * 0.7, 1.0, activeSolar * 0.5 + centralReactor * 0.5);
+    gl_FragColor = vec4(clamp(finalColor, vec3(0.0), vec3(8.0)), clamp(alpha, 0.0, 1.0));
+  }
+`;
+
+const DitheringShader = {
+  name: 'DitheringShader',
+  uniforms: {
+    tDiffuse: { value: null as THREE.Texture | null },
+    uTime: { value: 0 },
+    uNoiseAmount: { value: 0.012 },
+    uVignetteDarkness: { value: 1.1 },
+    uVignetteOffset: { value: 1.1 },
+  },
+  vertexShader: `
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: `
+    uniform sampler2D tDiffuse;
+    uniform float uTime;
+    uniform float uNoiseAmount;
+    uniform float uVignetteDarkness;
+    uniform float uVignetteOffset;
+    varying vec2 vUv;
+    float random(vec2 coords) {
+      return fract(sin(dot(coords, vec2(12.9898, 78.233))) * 43758.5453);
+    }
+    void main() {
+      vec4 texel = texture2D(tDiffuse, vUv);
+      float noise = (random(vUv + sin(uTime)) - 0.5) * uNoiseAmount;
+      vec3 color = texel.rgb + vec3(noise);
+      vec2 uv = vUv - 0.5;
+      float dist = length(uv);
+      float vignette = smoothstep(uVignetteOffset, uVignetteOffset - 0.55, dist);
+      color = mix(color, color * vignette, uVignetteDarkness);
+      gl_FragColor = vec4(clamp(color, 0.0, 1.0), texel.a);
+    }
+  `,
+};
+
+const N_POINTS = 120;
+const STRANDS = 3;
+const R_BASE = 3.0;
+const r_base = 1.0;
+
+export class QuantumLatticeEngine {
+  private opts: QuantumOptions;
+  private width: number;
+  private height: number;
+
+  private renderer: THREE.WebGLRenderer;
+  private scene: THREE.Scene;
+  private camera: THREE.PerspectiveCamera;
+  private controls: OrbitControls | null = null;
+  private composer: EffectComposer;
+  private bloomPass: UnrealBloomPass;
+  private ditherPass: ShaderPass;
+
+  private nodeMaterial: THREE.ShaderMaterial;
+  private beamMaterial: THREE.ShaderMaterial;
+  private nodeMesh: THREE.InstancedMesh;
+  private beamMesh: THREE.InstancedMesh;
+  private sphereGeometry: THREE.SphereGeometry;
+  private cylinderGeometry: THREE.CylinderGeometry;
+
+  private config = {
+    activeShape: 0,
+    waveSpeed: 1.2,
+    coreScale: 1.25,
+    nodesCount: 373,
+    beamsCount: 756,
+  };
+  private morphEnergy = 0;
+  private currentBloomMultiplier = 1.0;
+  private currentScaleFactor = 1.0;
+
+  // live parameter state
+  private params: QuantumParamConfig[] = resolveQuantumParams();
+  private cur: Record<string, number> = {};
+  private audioDrive = 1;
+  private paletteOverride: number | null = null;
+  // resolved param fields read by the per-frame logic
+  private morphAmount = 0.15;
+  private bloomBase = 0.2;
+  private ditherBase = 0.012;
+  private nodeScaleMul = 1;
+  private beamScaleMul = 1;
+  private coreScaleMul = 1;
+  private cameraDistMul = 1;
+  private autoRotateSpeed = 0;
+  private baseCameraZ = 9.5;
+  private curFov = 45;
+  // envelope-smoothed audio bands
+  private sm = { bass: 0, mid: 0, high: 0, vol: 0 };
+  // hard-hit -> next-shape cycling (bass transient detector with hysteresis)
+  private beatCycle = false;
+  private beatArmed = true;
+  private beatCooldown = 0;
+
+  private latticePositions: THREE.Vector3[][] = [];
+  private coreVertices: THREE.Vector3[] = [];
+  private baseCuboctahedron: THREE.Vector3[];
+  private coreEdges: number[][] = [];
+  private centerPoint = new THREE.Vector3(0, 0, 0);
+
+  private palettes: { cyan: THREE.Color; magenta: THREE.Color; gold: THREE.Color; white: THREE.Color }[];
+  private activePalette: { cyan: THREE.Color; magenta: THREE.Color; gold: THREE.Color; white: THREE.Color };
+
+  private tempMatrix = new THREE.Matrix4();
+  private tempObject = new THREE.Object3D();
+  private scratchDir = new THREE.Vector3();
+  private upVector = new THREE.Vector3(0, 1, 0);
+  private idealTargetVector = new THREE.Vector3();
+
+  private clock = new THREE.Clock();
+  private prevTime = 0;
+  private rafId = 0;
+  private disposed = false;
+  private lastTime = 0;
+  private frameCount = 0;
+  private fps = 0;
+
+  constructor(opts: QuantumOptions) {
+    this.opts = opts;
+    this.width = Math.max(1, opts.width);
+    this.height = Math.max(1, opts.height);
+    this.baseCameraZ = this.width < 768 ? 11.5 : 9.5;
+
+    this.renderer = new THREE.WebGLRenderer({ canvas: opts.canvas, antialias: true, alpha: false, powerPreference: 'high-performance' });
+    this.renderer.setPixelRatio(opts.pixelRatio ?? Math.min(window.devicePixelRatio, 2));
+    this.renderer.setSize(this.width, this.height, false);
+    this.renderer.setClearColor('#020005', 1.0);
+    this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    this.renderer.toneMappingExposure = 0.85;
+
+    this.scene = new THREE.Scene();
+    this.scene.fog = new THREE.FogExp2(new THREE.Color('#020005'), 0.025);
+
+    this.camera = new THREE.PerspectiveCamera(45, this.width / this.height, 0.1, 100);
+    this.camera.position.set(0, 0, this.baseCameraZ);
+
+    if (opts.interactive) {
+      this.controls = new OrbitControls(this.camera, opts.canvas);
+      this.controls.enableDamping = true;
+      this.controls.dampingFactor = 0.05;
+      this.controls.minDistance = 3.0;
+      this.controls.maxDistance = 25.0;
+      this.controls.target.set(0, 0, 0);
+    }
+
+    // lattice state
+    for (let s = 0; s < STRANDS; s++) {
+      this.latticePositions[s] = [];
+      for (let i = 0; i < N_POINTS; i++) this.latticePositions[s].push(new THREE.Vector3());
+    }
+    this.baseCuboctahedron = [
+      new THREE.Vector3(1, 1, 0), new THREE.Vector3(1, -1, 0), new THREE.Vector3(-1, 1, 0), new THREE.Vector3(-1, -1, 0),
+      new THREE.Vector3(1, 0, 1), new THREE.Vector3(1, 0, -1), new THREE.Vector3(-1, 0, 1), new THREE.Vector3(-1, 0, -1),
+      new THREE.Vector3(0, 1, 1), new THREE.Vector3(0, 1, -1), new THREE.Vector3(0, -1, 1), new THREE.Vector3(0, -1, -1),
+    ];
+    this.baseCuboctahedron.forEach(() => this.coreVertices.push(new THREE.Vector3()));
+    const distSqMin = 1.9, distSqMax = 2.1;
+    for (let i = 0; i < this.baseCuboctahedron.length; i++) {
+      for (let j = i + 1; j < this.baseCuboctahedron.length; j++) {
+        const dSq = this.baseCuboctahedron[i].distanceToSquared(this.baseCuboctahedron[j]);
+        if (dSq > distSqMin && dSq < distSqMax) this.coreEdges.push([i, j]);
+      }
+    }
+
+    this.palettes = [
+      { cyan: new THREE.Color('#00ffff'), magenta: new THREE.Color('#ff007f'), gold: new THREE.Color('#ffaa00'), white: new THREE.Color('#ffffff') },
+      { cyan: new THREE.Color('#00ff66'), magenta: new THREE.Color('#0055ff'), gold: new THREE.Color('#a800ff'), white: new THREE.Color('#ffffff') },
+      { cyan: new THREE.Color('#ff3c00'), magenta: new THREE.Color('#ffcc00'), gold: new THREE.Color('#ff0055'), white: new THREE.Color('#ffffdd') },
+      { cyan: new THREE.Color('#00aaff'), magenta: new THREE.Color('#00ffff'), gold: new THREE.Color('#9d4edd'), white: new THREE.Color('#e0f2fe') },
+    ];
+    this.activePalette = {
+      cyan: this.palettes[0].cyan.clone(),
+      magenta: this.palettes[0].magenta.clone(),
+      gold: this.palettes[0].gold.clone(),
+      white: this.palettes[0].white.clone(),
+    };
+
+    this.nodeMaterial = new THREE.ShaderMaterial({
+      vertexShader: CustomVertexShader,
+      fragmentShader: NodeFragmentShader,
+      uniforms: {
+        uTime: { value: 0 }, uSpeed: { value: this.config.waveSpeed },
+        uFresnelPow: { value: 2.5 }, uHeartbeat: { value: 6.5 },
+        uColorCyan: { value: this.activePalette.cyan }, uColorMagenta: { value: this.activePalette.magenta },
+        uColorGold: { value: this.activePalette.gold }, uColorWhite: { value: this.activePalette.white },
+      },
+      transparent: true, depthWrite: false, blending: THREE.AdditiveBlending, side: THREE.DoubleSide,
+    });
+    this.beamMaterial = new THREE.ShaderMaterial({
+      vertexShader: CustomVertexShader,
+      fragmentShader: TubeFragmentShader,
+      uniforms: {
+        uTime: { value: 0 }, uSpeed: { value: this.config.waveSpeed },
+        uGridIntensity: { value: 0.45 }, uFresnelPow: { value: 3.0 }, uWaveScale: { value: 1.0 },
+        uColorCyan: { value: this.activePalette.cyan }, uColorMagenta: { value: this.activePalette.magenta },
+        uColorGold: { value: this.activePalette.gold }, uColorWhite: { value: this.activePalette.white },
+      },
+      transparent: true, depthWrite: false, blending: THREE.AdditiveBlending, side: THREE.DoubleSide,
+    });
+
+    this.sphereGeometry = new THREE.SphereGeometry(1, 16, 16);
+    this.cylinderGeometry = new THREE.CylinderGeometry(1, 1, 1, 8, 1, false);
+    this.nodeMesh = new THREE.InstancedMesh(this.sphereGeometry, this.nodeMaterial, this.config.nodesCount);
+    this.nodeMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+    this.scene.add(this.nodeMesh);
+    this.beamMesh = new THREE.InstancedMesh(this.cylinderGeometry, this.beamMaterial, this.config.beamsCount);
+    this.beamMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+    this.scene.add(this.beamMesh);
+
+    this.composer = new EffectComposer(this.renderer);
+    this.composer.addPass(new RenderPass(this.scene, this.camera));
+    this.bloomPass = new UnrealBloomPass(new THREE.Vector2(this.width, this.height), 0.2, 0.35, 0.82);
+    this.composer.addPass(this.bloomPass);
+    this.ditherPass = new ShaderPass(DitheringShader);
+    this.ditherPass.uniforms.uNoiseAmount.value = 0.012;
+    this.composer.addPass(this.ditherPass);
+    this.composer.addPass(new OutputPass());
+    this.composer.setSize(this.width, this.height);
+
+    this.initializeLatticeCoordinates();
+    this.lastTime = performance.now();
+    this.animate();
+  }
+
+  /* ── public param API ───────────────────────────────────────────────────── */
+
+  setShape(shapeIndex: number): void {
+    const idx = Math.max(0, Math.min(3, Math.round(shapeIndex)));
+    if (idx === this.config.activeShape) return; // no-op: don't re-kick the morph
+    this.config.activeShape = idx;
+    this.morphEnergy = 1.0;
+  }
+
+  get activeShape(): number {
+    return this.config.activeShape;
+  }
+
+  /** When on, a hard bass hit advances to the next geometry (Torus->...->Cage->Torus). */
+  setBeatCycle(on: boolean): void {
+    this.beatCycle = on;
+    this.beatArmed = true;
+    this.beatCooldown = 0;
+  }
+
+  /** Replace the live param config (already resolved from UI + defaults). */
+  setParams(params: QuantumParamConfig[]): void {
+    this.params = params;
+  }
+
+  /** Master audio reactivity amount (0 = static, >1 = exaggerated). */
+  setAudioDrive(drive: number): void {
+    this.audioDrive = Math.max(0, drive);
+  }
+
+  /** Force a palette index, or null to follow the active shape (default). */
+  setPaletteIndex(index: number | null): void {
+    this.paletteOverride = index === null || index < 0 ? null : Math.min(3, Math.round(index));
+  }
+
+  resize(width: number, height: number): void {
+    this.width = Math.max(1, width);
+    this.height = Math.max(1, height);
+    this.baseCameraZ = this.width < 768 ? 11.5 : 9.5;
+    this.camera.aspect = this.width / this.height;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(this.width, this.height, false);
+    this.composer.setSize(this.width, this.height);
+  }
+
+  /* ── lattice geometry (unchanged maths) ─────────────────────────────────── */
+
+  private computeTargetCoordinate(shapeIndex: number, s: number, i: number, time: number, targetVector: THREE.Vector3): void {
+    const alpha = (s * Math.PI * 2) / STRANDS;
+    const phi = (i / N_POINTS) * Math.PI * 2;
+    if (shapeIndex === 0) {
+      const p = 3, q = 7;
+      const delta_r = Math.sin(5.0 * phi - time * this.config.waveSpeed) * Math.cos(3.0 * phi + time * this.config.waveSpeed) * 0.15;
+      const r_current = r_base + delta_r;
+      const x = (R_BASE + r_current * Math.cos(q * phi + alpha)) * Math.cos(p * phi);
+      const y = (R_BASE + r_current * Math.cos(q * phi + alpha)) * Math.sin(p * phi);
+      const z = r_current * Math.sin(q * phi + alpha);
+      targetVector.set(x, y, z);
+    } else if (shapeIndex === 1) {
+      const scaleFactor = [3.3, 2.2, 1.1][s];
+      const edgeIdx = Math.floor(i / 10);
+      const lerpFactor = (i % 10) / 9.0;
+      const cubeVerts = [
+        new THREE.Vector3(-1, -1, -1), new THREE.Vector3(1, -1, -1), new THREE.Vector3(1, 1, -1), new THREE.Vector3(-1, 1, -1),
+        new THREE.Vector3(-1, -1, 1), new THREE.Vector3(1, -1, 1), new THREE.Vector3(1, 1, 1), new THREE.Vector3(-1, 1, 1),
+      ];
+      const cubeEdges = [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]];
+      const edge = cubeEdges[edgeIdx % 12];
+      targetVector.lerpVectors(cubeVerts[edge[0]], cubeVerts[edge[1]], lerpFactor);
+      targetVector.multiplyScalar(scaleFactor);
+      const pulse = 1.0 + Math.sin(time * 2.0 + i * 0.1) * 0.02;
+      targetVector.multiplyScalar(pulse);
+    } else if (shapeIndex === 2) {
+      if (s === 0) {
+        const verts = [new THREE.Vector3(1, 1, 1), new THREE.Vector3(1, -1, -1), new THREE.Vector3(-1, 1, -1), new THREE.Vector3(-1, -1, 1)];
+        const edges = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]];
+        const edgeIdx = Math.floor(i / 20) % 6;
+        const lerpFactor = (i % 20) / 19.0;
+        targetVector.lerpVectors(verts[edges[edgeIdx][0]], verts[edges[edgeIdx][1]], lerpFactor).multiplyScalar(2.6);
+      } else if (s === 1) {
+        const verts = [new THREE.Vector3(-1, -1, -1), new THREE.Vector3(-1, 1, 1), new THREE.Vector3(1, -1, 1), new THREE.Vector3(1, 1, -1)];
+        const edges = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]];
+        const edgeIdx = Math.floor(i / 20) % 6;
+        const lerpFactor = (i % 20) / 19.0;
+        targetVector.lerpVectors(verts[edges[edgeIdx][0]], verts[edges[edgeIdx][1]], lerpFactor).multiplyScalar(2.6);
+      } else {
+        const verts = [
+          new THREE.Vector3(1, 0, 0), new THREE.Vector3(-1, 0, 0), new THREE.Vector3(0, 1, 0),
+          new THREE.Vector3(0, -1, 0), new THREE.Vector3(0, 0, 1), new THREE.Vector3(0, 0, -1),
+        ];
+        const edges = [[0, 2], [2, 1], [1, 3], [3, 0], [0, 4], [1, 4], [2, 4], [3, 4], [0, 5], [1, 5], [2, 5], [3, 5]];
+        const edgeIdx = Math.floor(i / 10) % 12;
+        const lerpFactor = (i % 10) / 9.0;
+        targetVector.lerpVectors(verts[edges[edgeIdx][0]], verts[edges[edgeIdx][1]], lerpFactor).multiplyScalar(1.6);
+      }
+    } else {
+      const index = s * N_POINTS + i;
+      const totalPoints = STRANDS * N_POINTS;
+      const y = 1.0 - (index / (totalPoints - 1.0)) * 2.0;
+      const radiusAtY = Math.sqrt(Math.max(0.0, 1.0 - y * y));
+      const goldenRatio = (1.0 + Math.sqrt(5.0)) / 2.0;
+      const theta = 2.0 * Math.PI * goldenRatio * index;
+      const x = Math.cos(theta) * radiusAtY;
+      const z = Math.sin(theta) * radiusAtY;
+      const baseRad = 2.6 + Math.sin(time * 1.5 + index * 0.05) * 0.1;
+      targetVector.set(x, y, z).multiplyScalar(baseRad);
+    }
+  }
+
+  private initializeLatticeCoordinates(): void {
+    for (let s = 0; s < STRANDS; s++) {
+      for (let i = 0; i < N_POINTS; i++) this.computeTargetCoordinate(0, s, i, 0, this.latticePositions[s][i]);
+    }
+    const pulseScalar = this.config.coreScale;
+    for (let i = 0; i < this.baseCuboctahedron.length; i++) {
+      this.coreVertices[i].copy(this.baseCuboctahedron[i]).multiplyScalar(pulseScalar);
+    }
+  }
+
+  private getCylinderMatrix(vA: THREE.Vector3, vB: THREE.Vector3, radius: number, targetMatrix: THREE.Matrix4): void {
+    this.scratchDir.subVectors(vB, vA);
+    const length = this.scratchDir.length();
+    if (length < 0.0001) {
+      this.tempObject.position.copy(vA);
+      this.tempObject.scale.set(0, 0, 0);
+      this.tempObject.updateMatrix();
+      targetMatrix.copy(this.tempObject.matrix);
+      return;
+    }
+    this.scratchDir.normalize();
+    this.tempObject.position.addVectors(vA, vB).multiplyScalar(0.5);
+    this.tempObject.quaternion.setFromUnitVectors(this.upVector, this.scratchDir);
+    this.tempObject.scale.set(radius, length, radius);
+    this.tempObject.updateMatrix();
+    targetMatrix.copy(this.tempObject.matrix);
+  }
+
+  private computePositionsAndMorph(time: number, activeShapeIndex: number): number {
+    let totalDeviation = 0;
+    let count = 0;
+    const morphShockwave = Math.sin(time * 25.0) * this.morphEnergy * this.morphAmount;
+    for (let s = 0; s < STRANDS; s++) {
+      for (let i = 0; i < N_POINTS; i++) {
+        this.computeTargetCoordinate(activeShapeIndex, s, i, time, this.idealTargetVector);
+        if (this.morphEnergy > 0.001) {
+          const direction = this.idealTargetVector.clone().normalize();
+          this.idealTargetVector.addScaledVector(direction, morphShockwave);
+        }
+        totalDeviation += this.latticePositions[s][i].distanceTo(this.idealTargetVector);
+        count++;
+        this.latticePositions[s][i].lerp(this.idealTargetVector, 0.06);
+      }
+    }
+    const coreScaleTarget = [1.25, 0.75, 1.05, 0.6][activeShapeIndex];
+    const lerpedBaseScale = THREE.MathUtils.lerp(this.config.coreScale, coreScaleTarget, 0.06);
+    this.config.coreScale = lerpedBaseScale;
+    const pulseScalar = lerpedBaseScale * this.coreScaleMul + Math.sin(time * 2.5) * 0.08;
+    for (let i = 0; i < this.baseCuboctahedron.length; i++) {
+      this.idealTargetVector.copy(this.baseCuboctahedron[i]).multiplyScalar(pulseScalar);
+      this.coreVertices[i].lerp(this.idealTargetVector, 0.06);
+    }
+    const avgDeviation = totalDeviation / count;
+    return Math.max(100.0 - avgDeviation * 45.0, 0.0);
+  }
+
+  private updateLatticeSystem(time: number, activeShapeIndex: number): number {
+    const coherence = this.computePositionsAndMorph(time, activeShapeIndex);
+    let nodeIdx = 0;
+    for (let s = 0; s < STRANDS; s++) {
+      for (let i = 0; i < N_POINTS; i++) {
+        this.tempObject.position.copy(this.latticePositions[s][i]);
+        const scaleMult = 1.0 + this.morphEnergy * 0.45;
+        const baseNodeScale = 0.065 * this.currentScaleFactor * this.nodeScaleMul;
+        this.tempObject.scale.setScalar(baseNodeScale * scaleMult);
+        this.tempObject.updateMatrix();
+        this.nodeMesh.setMatrixAt(nodeIdx++, this.tempObject.matrix);
+      }
+    }
+    const coreNodeScaleFactor = [1.0, 0.8, 0.65, 0.5][activeShapeIndex];
+    for (let i = 0; i < this.coreVertices.length; i++) {
+      this.tempObject.position.copy(this.coreVertices[i]);
+      this.tempObject.scale.setScalar(0.115 * coreNodeScaleFactor * this.nodeScaleMul);
+      this.tempObject.updateMatrix();
+      this.nodeMesh.setMatrixAt(nodeIdx++, this.tempObject.matrix);
+    }
+    this.tempObject.position.copy(this.centerPoint);
+    const centerPulse = (0.2 + Math.sin(time * 5.0) * 0.05) * coreNodeScaleFactor * this.nodeScaleMul;
+    this.tempObject.scale.setScalar(centerPulse);
+    this.tempObject.updateMatrix();
+    this.nodeMesh.setMatrixAt(nodeIdx++, this.tempObject.matrix);
+    this.nodeMesh.instanceMatrix.needsUpdate = true;
+
+    let beamIdx = 0;
+    const primaryBeamRadius = 0.015 * this.currentScaleFactor * this.beamScaleMul;
+    for (let s = 0; s < STRANDS; s++) {
+      for (let i = 0; i < N_POINTS; i++) {
+        const pA = this.latticePositions[s][i];
+        const pB = this.latticePositions[s][(i + 1) % N_POINTS];
+        this.getCylinderMatrix(pA, pB, primaryBeamRadius, this.tempMatrix);
+        this.beamMesh.setMatrixAt(beamIdx++, this.tempMatrix);
+      }
+    }
+    for (let i = 0; i < N_POINTS; i++) {
+      for (let s = 0; s < STRANDS; s++) {
+        const sNext = (s + 1) % STRANDS;
+        const pA = this.latticePositions[s][i];
+        const pB = this.latticePositions[sNext][i];
+        this.getCylinderMatrix(pA, pB, primaryBeamRadius * 0.65, this.tempMatrix);
+        this.beamMesh.setMatrixAt(beamIdx++, this.tempMatrix);
+      }
+    }
+    for (let e = 0; e < this.coreEdges.length; e++) {
+      const edge = this.coreEdges[e];
+      this.getCylinderMatrix(this.coreVertices[edge[0]], this.coreVertices[edge[1]], primaryBeamRadius * 1.6, this.tempMatrix);
+      this.beamMesh.setMatrixAt(beamIdx++, this.tempMatrix);
+    }
+    for (let i = 0; i < this.coreVertices.length; i++) {
+      this.getCylinderMatrix(this.coreVertices[i], this.centerPoint, primaryBeamRadius * 0.8, this.tempMatrix);
+      this.beamMesh.setMatrixAt(beamIdx++, this.tempMatrix);
+    }
+    this.beamMesh.instanceMatrix.needsUpdate = true;
+    return coherence;
+  }
+
+  /* ── per-frame parameter + audio application ────────────────────────────── */
+
+  private band(b: QuantumAudioBand): number {
+    return b === 'bass' ? this.sm.bass : b === 'mid' ? this.sm.mid : b === 'high' ? this.sm.high : b === 'volume' ? this.sm.vol : 0;
+  }
+
+  private applyParams(dt: number): void {
+    const tcPar = 1 - Math.exp(-dt / 0.08);
+    for (const pm of this.params) {
+      const level = this.band(pm.audio) * this.audioDrive;
+      let target = pm.base + (pm.max - pm.min) * pm.amt * level;
+      if (target < pm.min) target = pm.min;
+      else if (target > pm.max) target = pm.max;
+      const prev = this.cur[pm.id];
+      const val = prev === undefined ? target : prev + (target - prev) * tcPar;
+      this.cur[pm.id] = val;
+      this.dispatch(pm.id, val);
+    }
+  }
+
+  private dispatch(id: string, v: number): void {
+    switch (id) {
+      case 'waveSpeed':
+        this.config.waveSpeed = v;
+        this.nodeMaterial.uniforms.uSpeed.value = v;
+        this.beamMaterial.uniforms.uSpeed.value = v;
+        break;
+      case 'morphAmount': this.morphAmount = v; break;
+      case 'autoRotate': this.autoRotateSpeed = v; break;
+      case 'bloomStrength': this.bloomBase = v; break;
+      case 'bloomRadius': this.bloomPass.radius = v; break;
+      case 'bloomThreshold': this.bloomPass.threshold = v; break;
+      case 'dither': this.ditherBase = v; break;
+      case 'exposure': this.renderer.toneMappingExposure = v; break;
+      case 'vignette': this.ditherPass.uniforms.uVignetteDarkness.value = v; break;
+      case 'fog': (this.scene.fog as THREE.FogExp2).density = v; break;
+      case 'nodeScale': this.nodeScaleMul = v; break;
+      case 'beamScale': this.beamScaleMul = v; break;
+      case 'coreScale': this.coreScaleMul = v; break;
+      case 'cameraDist': this.cameraDistMul = v; break;
+      case 'cameraFov':
+        if (Math.abs(v - this.curFov) > 0.01) {
+          this.curFov = v;
+          this.camera.fov = v;
+          this.camera.updateProjectionMatrix();
+        }
+        break;
+      case 'gridIntensity': this.beamMaterial.uniforms.uGridIntensity.value = v; break;
+      case 'waveDetail': this.beamMaterial.uniforms.uWaveScale.value = v; break;
+      case 'beamFresnel': this.beamMaterial.uniforms.uFresnelPow.value = v; break;
+      case 'nodeFresnel': this.nodeMaterial.uniforms.uFresnelPow.value = v; break;
+      case 'heartbeat': this.nodeMaterial.uniforms.uHeartbeat.value = v; break;
+    }
+  }
+
+  private animate = (): void => {
+    if (this.disposed) return;
+    this.rafId = requestAnimationFrame(this.animate);
+    if (this.renderer.getContext().isContextLost?.()) return;
+
+    const time = this.clock.getElapsedTime();
+    const dt = Math.min(0.1, Math.max(0.001, time - this.prevTime));
+    this.prevTime = time;
+
+    // envelope-follow audio bands (fast attack / slow release)
+    if (this.opts.getLevels) {
+      const lv = this.opts.getLevels();
+      const tcUp = 1 - Math.exp(-dt / 0.025);
+      const tcDn = 1 - Math.exp(-dt / 0.18);
+      const sm = this.sm;
+      const rb = Math.min(1, Math.max(0, lv.bass)), rm = Math.min(1, Math.max(0, lv.mid));
+      const rh = Math.min(1, Math.max(0, lv.high)), rv = Math.min(1, Math.max(0, lv.volume));
+      sm.bass += (rb - sm.bass) * (rb > sm.bass ? tcUp : tcDn);
+      sm.mid += (rm - sm.mid) * (rm > sm.mid ? tcUp : tcDn);
+      sm.high += (rh - sm.high) * (rh > sm.high ? tcUp : tcDn);
+      sm.vol += (rv - sm.vol) * (rv > sm.vol ? tcUp : tcDn);
+      // bass also kicks the morph shockwave (the on-beat pulse)
+      this.morphEnergy = Math.max(this.morphEnergy, sm.bass * 0.6 * this.audioDrive);
+
+      // hard hit -> advance geometry. Hysteresis gate: bass must dip below the
+      // low threshold (re-arm) before a rise past the high threshold fires, so
+      // one kick triggers one step, not a burst. Cooldown caps the rate.
+      if (this.beatCycle) {
+        this.beatCooldown = Math.max(0, this.beatCooldown - dt);
+        if (sm.bass < 0.3) this.beatArmed = true;
+        if (this.beatArmed && this.beatCooldown <= 0 && sm.bass > 0.55) {
+          this.config.activeShape = (this.config.activeShape + 1) % 4;
+          this.morphEnergy = 1.0;
+          this.beatArmed = false;
+          this.beatCooldown = 0.18;
+          this.opts.onShape?.(this.config.activeShape);
+        }
+      }
+    }
+
+    this.applyParams(dt);
+
+    const pIdx = this.paletteOverride ?? this.config.activeShape;
+    const targetPalette = this.palettes[pIdx] ?? this.palettes[0];
+    this.activePalette.cyan.lerp(targetPalette.cyan, 0.06);
+    this.activePalette.magenta.lerp(targetPalette.magenta, 0.06);
+    this.activePalette.gold.lerp(targetPalette.gold, 0.06);
+    this.activePalette.white.lerp(targetPalette.white, 0.06);
+
+    this.morphEnergy += (0.0 - this.morphEnergy) * 0.05;
+
+    const targetBloomMultiplier = [1.0, 0.78, 0.42, 0.32][this.config.activeShape];
+    this.currentBloomMultiplier = THREE.MathUtils.lerp(this.currentBloomMultiplier, targetBloomMultiplier, 0.06);
+    const targetScaleFactor = [1.0, 0.8, 0.55, 0.45][this.config.activeShape];
+    this.currentScaleFactor = THREE.MathUtils.lerp(this.currentScaleFactor, targetScaleFactor, 0.06);
+
+    this.bloomPass.strength = this.bloomBase * this.currentBloomMultiplier + this.morphEnergy * 0.5;
+    this.ditherPass.uniforms.uNoiseAmount.value = this.ditherBase + this.morphEnergy * 0.04;
+
+    this.nodeMaterial.uniforms.uTime.value = time;
+    this.beamMaterial.uniforms.uTime.value = time;
+    this.ditherPass.uniforms.uTime.value = time;
+
+    if (Math.abs(this.autoRotateSpeed) > 0.001) this.scene.rotation.y += this.autoRotateSpeed * dt;
+    if (!this.controls) this.camera.position.z = this.baseCameraZ * this.cameraDistMul;
+
+    const coherence = this.updateLatticeSystem(time, this.config.activeShape);
+
+    this.controls?.update();
+    this.composer.render();
+
+    const now = performance.now();
+    this.frameCount++;
+    if (now - this.lastTime >= 500) {
+      this.fps = (this.frameCount * 1000) / (now - this.lastTime);
+      this.frameCount = 0;
+      this.lastTime = now;
+      if (this.opts.onStats) {
+        const shapeMultiplier = [1.0, 1.35, 1.82, 2.25][this.config.activeShape];
+        const resonance = 3 * 7 * 0.077 * (1 + this.config.waveSpeed * 0.12) * shapeMultiplier;
+        this.opts.onStats({
+          geomName: QUANTUM_GEOMETRY_NAMES[this.config.activeShape],
+          stability: coherence,
+          fps: this.fps,
+          resonance,
+          phasePercent: Math.max(0, Math.min(100, Math.round((coherence / 100.0) * 100.0))),
+          shape: this.config.activeShape,
+        });
+      }
+    }
+  };
+
+  dispose(): void {
+    this.disposed = true;
+    cancelAnimationFrame(this.rafId);
+    this.controls?.dispose();
+    this.scene.traverse((obj) => {
+      const mesh = obj as THREE.Mesh;
+      if (mesh.geometry) mesh.geometry.dispose();
+    });
+    this.sphereGeometry.dispose();
+    this.cylinderGeometry.dispose();
+    this.nodeMaterial.dispose();
+    this.beamMaterial.dispose();
+    this.composer.dispose();
+    this.renderer.dispose();
+  }
+}

--- a/frontend/src/state/studioStore.ts
+++ b/frontend/src/state/studioStore.ts
@@ -255,14 +255,18 @@ export const useStudioStore = create<StudioStoreState>()((set, get) => ({
           metadata: { title, prompt: chainLabel, source: 'studio', tags: ['effects-chain'] },
         });
         await usePlayerStore.getState().load(finalBlob, { label: title, entryId: entry.id });
+        useStatusBarStore.getState().setText(`MIX CHAIN COMPLETE: ${chainLabel}`);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         logError('studio', `Chain library save failed: ${msg}`);
+        set({ error: `Library save failed: ${msg}` });
+        useStatusBarStore
+          .getState()
+          .setText(`MIX CHAIN LIBRARY SAVE FAILED — check Processing Log: ${msg}`);
         try {
           await usePlayerStore.getState().load(finalBlob, { label: title, entryId: `chain-fail-${Date.now()}` });
         } catch { /* swallow */ }
       }
-      useStatusBarStore.getState().setText(`MIX CHAIN COMPLETE: ${chainLabel}`);
     } finally {
       set({ isChainProcessing: false });
     }

--- a/frontend/src/views/AdvancedGenPanel.tsx
+++ b/frontend/src/views/AdvancedGenPanel.tsx
@@ -4,7 +4,7 @@ import {
   Scissors, Mic2, Search, ChevronDown,
   LayoutList, AudioWaveform, Volume2, Sliders,
   Wand2, Loader2, BookOpen, Layers, Sparkles, Download,
-  Music2, Dice5, Repeat,
+  Music2, Dice5, Repeat, Aperture,
 } from 'lucide-react';
 import { useGenerateParamsStore, type GenerateParamsState } from '../state/generateParamsStore';
 import { useGenerateStore } from '../state/generateStore';
@@ -356,8 +356,9 @@ export const AdvancedGenPanel: React.FC<{
   const [spectrograms, setSpectrograms] = useState<{mel:string,stft:string,chromagram:string,cqt:string}|null>(null);
   const [specLoading, setSpecLoading] = useState(false);
 
-  // Center hero tab — Chimera (setup) ↔ Compare (post-gen inspection).
-  const [heroTab, setHeroTab] = useState<'chimera' | 'compare'>('chimera');
+  // Center hero tab — Chimera (setup) ↔ Compare (post-gen inspection) ↔
+  // Synesteez (image → spectrogram audio composer).
+  const [heroTab, setHeroTab] = useState<'chimera' | 'compare' | 'synesteez'>('chimera');
   const prevAudioRef = useRef<string | null>(null);
   useEffect(() => {
     if (lastAudioUrl && lastAudioUrl !== prevAudioRef.current) setHeroTab('compare');
@@ -795,6 +796,9 @@ export const AdvancedGenPanel: React.FC<{
             <button onClick={() => setHeroTab('chimera')} className={`relative z-10 ${tabBtn(heroTab === 'chimera')}`}>
               <Layers className="w-3 h-3" /> Chimera
             </button>
+            <button onClick={() => setHeroTab('synesteez')} className={`relative z-10 ${tabBtn(heroTab === 'synesteez')}`}>
+              <Aperture className="w-3 h-3" /> Synesteez
+            </button>
             <button onClick={() => lastAudioUrl && setHeroTab('compare')} disabled={!lastAudioUrl}
               className={`relative z-10 ${tabBtn(heroTab === 'compare')} disabled:opacity-30 disabled:cursor-not-allowed`}>
               <AudioWaveform className="w-3 h-3" /> Compare
@@ -813,6 +817,18 @@ export const AdvancedGenPanel: React.FC<{
               <div className="flex-1 px-1 min-h-0 overflow-y-auto" data-chimera-anchor="init-audio">
                 <ChimeraStack />
               </div>
+            </div>
+          )}
+
+          {/* SYNESTEEZ tab — image → spectrogram audio composer, a self-contained
+              same-origin app vendored under /synesteez (Composer/Sequence/Meta). */}
+          {heroTab === 'synesteez' && (
+            <div className="relative z-10 flex-1 min-h-0 overflow-hidden rounded-lg border border-white/5 bg-[#0d0d0f]">
+              <iframe
+                src="/synesteez/index.html"
+                title="Synesteez — image to spectrogram audio"
+                className="w-full h-full border-0 block"
+              />
             </div>
           )}
 

--- a/frontend/src/views/MixView.tsx
+++ b/frontend/src/views/MixView.tsx
@@ -10,6 +10,7 @@ import { useLibraryStore } from '../state/libraryStore';
 import { usePlayerStore } from '../state/playerStore';
 import { useGenerateParamsStore } from '../state/generateParamsStore';
 import { useAppUiStore } from '../state/appUiStore';
+import { logError } from '../state/logStore';
 import { SlideKnob } from '../components/audio/SlideKnob';
 import { SlideRow } from '../components/audio/SlideRow';
 import { MixVizRow, type MixVizMode } from '../components/audio/MixVizRow';
@@ -771,7 +772,23 @@ export const MixView: React.FC = () => {
       src.connect(inGain);
       src.start(0);
       const rendered = await offline.startRendering();
-      setOutputUrl(URL.createObjectURL(encodeWav(rendered)));
+      const wav = encodeWav(rendered);
+      setOutputUrl(URL.createObjectURL(wav));
+      // Persist the rendered result to the library (mirrors the backend chain's
+      // save). Without this the rack output only appears in the Output viz and
+      // is never saved.
+      const label = chainNow.filter((e) => e.enabled).map((e) => e.effect).join(' + ') || 'rack';
+      const title = `rack-${label.slice(0, 40)}.wav`;
+      try {
+        await useLibraryStore.getState().importEntry({
+          blob: wav,
+          filename: title,
+          mimeType: 'audio/wav',
+          metadata: { title, prompt: `Psychoacoustic rack: ${label}`, source: 'studio', tags: ['psychoacoustic-rack'] },
+        });
+      } catch (e) {
+        logError('studio', `Rack library save failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
     } catch { /* non-fatal: leave the prior output in place */ } finally {
       decodeCtx.close().catch(() => {});
       setApplyingRack(false);


### PR DESCRIPTION
Large multi-area session. Frontend builds clean (tsc + vite); backend ruff check + format clean.

vocal2midi: native port of the whole vocal2midi-architect suite
- New module frontend/src/components/audio/vocal2midi/ (types, constants, audioProcessing YIN, midiEditor, musicTheory, midiSynth, Visualizer, BpmTapper, RecordingHistory, AssistantOrb, geminiService, geminiAssistant, Vocal2MidiPanel). Ported verbatim where possible; nothing dropped.
- Mounted in the MIDI tab (MidiPanel) as a compact collapsible right column. The recorder runs the original YIN capture and exact sensitivity/threshold math; captured notes are written into theDAW's existing piano roll via a NoteEvent(seconds) to step-based PianoNote bridge.
- Synth delegates to theDAW's full General MIDI soundfont library (SpessaSynth
  + gm.sf3) for playback, instrument selection, and WAV export.
- AI (analyze, smart cleanup, assistant) reuses theDAW's Gemini: services kept verbatim and pointed at a new backend proxy (backend/modules/genaiproxy) that injects the server-side GEMINI_API_KEY, so the browser never sees it.
- Model upgraded from gemini-3-flash-preview to gemini-3.5-flash, verified against the live Gemini docs to support audio input and structured output. Recordings are converted to WAV before any Gemini call.
- The prior basic-pitch vocal toolbar and the lyrics/inpaint rail are left intact for now (separate vocal-engine feature) pending a retirement decision.

Arpeggiator (ArpeggiatorPanel, arpEngine)
- Rebuilt layout: chord progression is the large center hero, tonic/mode in a left rail, arpeggio styles in a right rail, output chips beneath the chords.
- BPM field plus steppers, Steps, Type, Quantize, Rag, Bass, and theDAW instrument picker moved into the header; play button matches the piano roll.
- Engine gained live swing (Rag) and quantize (humanize) in the scheduler.
- Full mode names, larger high-contrast font, purple theme coherent with theDAW, uniform Tonic/Mode grids, and tooltips on every control.

Quantum Lattice (quantumLattice, QuantumLatticeView, QuantumControls)
- Hard bass hits cycle the geometry (onset detector with hysteresis), exposed via a toggle and synced to the shape buttons.
- Lowered default bloom (0.45 to 0.20) and exposure (1.15 to 0.85) and tamed the per-hit bloom flash since it was blown out.

Synesteez (public/synesteez/index.html)
- Removed the branded header and the footer, kept a slim tab strip.
- Compacted spacing and restyled the range inputs to the SLIDE glass-capsule look with a live colored fill via one delegated listener (no lag).

LEARN Genealogy 2D (LineageModal)
- Generation identity is now grey alternating bands; gen numbers moved to a screen-space strip above the nodes; Fit and Reset moved to the lineage header with a reserved top margin.
- Aspect-ratio fill grid so the layout fills the panel (rows derived from panel aspect); square node cards; stems/MIDI show the source track name.
- Hover lights the whole lineage without dimming nodes (colored back-glow, off-path edges fade); the SVG is memoized off pan/zoom for performance.

MIX library save (studioStore, MixView)
- Psychoacoustic rack output now imports to the library.
- PROCESS CHAIN save failures are surfaced to the status bar and log instead of being swallowed.

Vocal asset resolver (backend/modules/vocal/service.py)
- Resolve an asset by entry id or by track title (exact then case-insensitive) so analyze/load work when given a song name, not just a raw id.

MidiPanel asset field
- Searchable, drag-and-drop song picker (shows title, sends the real id) instead of requiring the long asset id.