### PR TITLE
style(frontend): use Tailwind v4 canonical scale tokens

### DIFF
--- a/frontend/src/components/layout/WorldsCollidePanel.tsx
+++ b/frontend/src/components/layout/WorldsCollidePanel.tsx
@@ -176,7 +176,7 @@ const Knob: React.FC<{ label: string; value: number; onChange: (v: number) => vo
           aria-valuenow={value}
         >
           <div className="absolute inset-0 rounded-full" style={{ background: arcBg }} />
-          <div className="absolute inset-[4px] rounded-full bg-zinc-900 border border-white/10" />
+          <div className="absolute inset-1 rounded-full bg-zinc-900 border border-white/10" />
           <div className="absolute inset-0" style={{ transform: `rotate(${225 + sweep}deg)` }}>
             <span className="absolute left-1/2 top-1 -translate-x-1/2 w-1 h-2.5 rounded-full bg-fuchsia-100 shadow-[0_0_6px_rgba(217,70,239,0.8)]" />
           </div>

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -1574,7 +1574,7 @@ const DeckRack: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cyan'; entryId: 
             </div>
           )}
           {stemNames.length > 0 ? (
-            <div className="max-h-[88px] min-h-0 overflow-y-auto pr-0.5">
+            <div className="max-h-22 min-h-0 overflow-y-auto pr-0.5">
               <div className="grid gap-1 place-items-center" style={{ gridTemplateColumns: `repeat(${Math.min(stemNames.length, 4)}, minmax(0,1fr))` }}>
                 {stemNames.map((name) => (
                   <SlideKnob key={name} label={stemLabel(name)} value={stemLevels[name] ?? 1} onChange={(v) => onStem(name, v)} min={0} max={1} step={0.01} size={28} centerReadout />


### PR DESCRIPTION
inset-[4px] -> inset-1 (WorldsCollidePanel), max-h-[88px] -> max-h-22 (DJView). Clears the tailwindcss-intellisense suggestCanonicalClasses warnings.