### PR TITLE
feat(genealogy+edit+mix): stable 2D glow, 3D hover accuracy, clip mute/FX, stage restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,42 @@ In-tree sidecars under `sidecars/` (`questcast`, `queststitch`, `magenta`) and t
 | **theDAW interface** | `frontend/` | React 19, Vite 7, Tailwind 4, Zustand 5. Eight workspaces (MAKE, EDIT, PERFORM, MIX, DJ, VJ, TRAIN, LEARN) plus the library, the Catalogue, and the live tools. The dev server on port 5173 proxies `/api/*` to the backend. |
 | **Sidecars** | `sidecars/` | The vendored `magenta-rt2-nvidia` port, the `questcast` and `queststitch` Quest bridges, and the `magenta` studio sidecar. |
 
+### Folder map
+
+The table above maps the components; the tree below is the same root as it looks on a first run, with the folders a new user actually touches called out.
+
+```
+stable-audio-3/
+|-- theDAW.bat        <-- double-click this to install everything and launch (backend :8600, UI :5173)
+|-- backend/          <-- FastAPI server and the plugin modules behind /api/*
+|-- frontend/         <-- the React / Vite workspace served at http://localhost:5173
+|-- stable_audio_3/   <-- the Stable Audio 3 inference library (DiT, SAME autoencoder, LoRA)
+|-- sidecars/
+|   |-- magenta-rt2-nvidia/   <-- run Setup-MRT2.bat in here once to install the Magenta RT2 engine
+|   |-- magenta/              <-- the Magenta studio sidecar
+|   \-- questcast/            <-- the Quest video bridge
+|-- electron-ui/      <-- the optional desktop (Electron) shell, chosen in Settings > Startup
+|-- install/          <-- setup.ps1, the consent-based installer theDAW.bat runs when a tool is missing
+|-- docs/             <-- the User Guide, setup guides, and workflow docs
+|-- data/             <-- created at runtime; the personal library (gitignored, safe to back up)
+|   |-- generations/            <-- every render and import, plus the library.db metadata
+|   |-- plugins/                <-- installed .gan web-plugins
+|   |-- settings.json           <-- app settings
+|   \-- local_checkpoints.json  <-- checkpoints registered in Settings > Models
+|-- models/           <-- OPTIONAL: create this folder and drop checkpoint subfolders here (see below)
+|-- local_models.txt  <-- OPTIONAL: extra checkpoint folders to search, one path per line
+|-- tests/            <-- the pytest suite for the inference library
+|-- scripts/          <-- automation that captures the screenshots and the feature tour
+\-- .venv/            <-- created by uv sync; the Python environment (no need to touch it)
+```
+
+**Where do models go?**
+
+- **The built-in models need no manual placement.** Every load resolves local-first: local model folders, then the Hugging Face cache at `%USERPROFILE%\.cache\huggingface\hub\` (relocatable by setting `HF_HOME` before launch), then a one-time download into that cache. **Local only (never download)** is on by default for fresh installs, so nothing fetches until it is allowed in **Settings → Models**; once allowed, the weights download automatically on the first generation that needs them (the `medium` checkpoint is roughly 17 GB), and the T5Gemma text encoder fetches into the same cache.
+- **A checkpoint already on disk** registers through **Settings → Models → Add a checkpoint you already have**: Browse to the folder (or the `.safetensors` file itself) and it appears in the MAKE model picker. Entries persist in `data/local_checkpoints.json`, and removing one never touches the files.
+- **The folder convention** works without the UI: create `models/` at the repo root (or list extra directories in `local_models.txt`, one path per line, or in the `SA3_LOCAL_MODELS_DIR` environment variable, `;`-separated on Windows) and give each checkpoint a subfolder named after its Hugging Face repo, for example `models/stable-audio-3-medium/` holding the config JSON and the `.safetensors`. [User Guide §21.2](docs/USER_GUIDE.md#212-manual-model-placement-download-links-and-folder-tree) has the full download table.
+- **Magenta RealTime 2 models are not placed by hand.** `sidecars/magenta-rt2-nvidia/Setup-MRT2.bat` installs the WSL2 engine and its assets in one pass.
+
 ---
 
 ## Models

--- a/backend/modules/project/tasmo_project.py
+++ b/backend/modules/project/tasmo_project.py
@@ -57,6 +57,9 @@ class Clip(BaseModel):
     channels: int = 2
     midi_notes: list[dict] | None = None
     midi_file: str | None = None
+    # Per-clip mute (the clip is skipped by playback and bounces). Defaulted so
+    # .tasmo files written before this field existed still validate.
+    muted: bool = False
     generation_prompt: str | None = None
     generation_seed: int | None = None
     generation_params: dict | None = None

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-07-02T09:38:02.566Z · Git revision: `2f6878ab7601` · Repomix tracked: **no**
+> Generated: 2026-07-02T12:46:22.544Z · Git revision: `14346f68c3a0` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-02T09:38:02.566Z",
-  "repoRevision": "2f6878ab7601",
+  "generatedAt": "2026-07-02T12:46:22.544Z",
+  "repoRevision": "14346f68c3a0",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/frontend/src/components/audio/VstEmbedHost.tsx
+++ b/frontend/src/components/audio/VstEmbedHost.tsx
@@ -16,12 +16,24 @@ import { vstApi, getContentBounds } from '../../lib/vstClient';
 // same in every view that mounts it.
 const sectionTitle = 'text-[10px] font-black uppercase tracking-widest text-purple-300';
 
-export const VstEmbedHost: React.FC<{ pluginPath: string; pluginName: string; error?: string; onClose: () => void }> = ({ pluginPath, pluginName, error, onClose }) => {
+export const VstEmbedHost: React.FC<{
+  pluginPath: string;
+  pluginName: string;
+  error?: string;
+  onClose: () => void;
+  /** Reports the plugin's natural editor size (CSS px) whenever it changes, so
+   *  a hosting popup can size itself to the plugin instead of a fixed box. */
+  onNaturalSize?: (w: number, h: number) => void;
+}> = ({ pluginPath, pluginName, error, onClose, onNaturalSize }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [expanded, setExpanded] = useState(false);
   // Plugin's natural size in CSS px (from the backend, which knows the real
   // window size); drives the scrollable inner spacer.
   const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
+  // The callback rides a ref so the polling effect below keeps its
+  // [pluginPath, error] dependency list even when the parent re-creates it.
+  const onNaturalSizeRef = useRef(onNaturalSize);
+  onNaturalSizeRef.current = onNaturalSize;
 
   useEffect(() => {
     const el = ref.current;
@@ -71,12 +83,22 @@ export const VstEmbedHost: React.FC<{ pluginPath: string; pluginName: string; er
     if (error) return;
     let alive = true;
     const dpr = window.devicePixelRatio || 1;
+    let last: { w: number; h: number } | null = null;
     const poll = () => {
       vstApi.editorSize(pluginPath)
         .then((res) => {
           if (!alive) return;
           if (res.status === 'ok' && res.w && res.h) {
-            setNatural({ w: Math.round(res.w / dpr), h: Math.round(res.h / dpr) });
+            const w = Math.round(res.w / dpr);
+            const h = Math.round(res.h / dpr);
+            // Only propagate a real change; the poll fires every second and a
+            // fresh object each tick would re-render the host (and the parent
+            // popup) for nothing.
+            if (!last || last.w !== w || last.h !== h) {
+              last = { w, h };
+              setNatural((prev) => (prev && prev.w === w && prev.h === h ? prev : { w, h }));
+              onNaturalSizeRef.current?.(w, h);
+            }
           }
           if (alive) window.setTimeout(poll, 1000);
         })

--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   Scissors, Play, Pause, Square, ZoomIn, ZoomOut,
   Magnet, Trash2, Move, Plus, Volume2, Upload, Save, Piano, Paintbrush, X, Wand2, Layers,
@@ -43,6 +44,7 @@ import { logError, logInfo } from '../../state/logStore';
 import { registerEditorPlayback, unregisterEditorPlayback } from '../../state/editorPlaybackBridge';
 import { publishSelectedTracks } from '../../state/editorSelectionBridge';
 import * as liveMixer from '../../state/liveMixer';
+import { useDjAnalysisStore } from '../../state/djAnalysisStore';
 import { ContextMenu, useContextMenu, type ContextMenuItem } from '../ui/ContextMenu';
 
 const TRACK_HEADER_PX = 180;
@@ -188,6 +190,56 @@ const MidiClipNotes: React.FC<{ clip: AudioClip; zoom: number; selected: boolean
         );
       })}
     </div>
+  );
+};
+
+/**
+ * Floating popover portaled to document.body, mirroring ContextMenu's pattern:
+ * the Shell scales the DAW with CSS `zoom` (`.dense-layout`), so a fixed panel
+ * rendered INSIDE the zoomed tree drifts away from raw clientX/Y anchors. The
+ * body portal escapes the zoom, so the coords land at the click. After mount
+ * we measure the panel and nudge it to stay inside the viewport (right/bottom
+ * edge clicks would overflow otherwise). When no coords are given the panel
+ * renders at `anchorClassName` (the legacy fixed position) instead.
+ */
+const PopoverPortal: React.FC<{
+  x?: number;
+  y?: number;
+  anchorClassName?: string;
+  className: string;
+  /** Optional external ref (outside-click dismissal needs the panel node). */
+  innerRef?: React.RefObject<HTMLDivElement | null>;
+  children: React.ReactNode;
+}> = ({ x, y, anchorClassName = '', className, innerRef, children }) => {
+  const localRef = useRef<HTMLDivElement | null>(null);
+  const ref = innerRef ?? localRef;
+  const hasCoords = x != null && y != null;
+  const [adjusted, setAdjusted] = useState<{ x: number; y: number } | null>(null);
+  useLayoutEffect(() => {
+    if (x == null || y == null || !ref.current) {
+      setAdjusted(null);
+      return;
+    }
+    const rect = ref.current.getBoundingClientRect();
+    const pad = 8;
+    let nx = x;
+    let ny = y;
+    if (nx + rect.width + pad > window.innerWidth) nx = Math.max(pad, window.innerWidth - rect.width - pad);
+    if (ny + rect.height + pad > window.innerHeight) ny = Math.max(pad, window.innerHeight - rect.height - pad);
+    setAdjusted((prev) => (prev && prev.x === nx && prev.y === ny ? prev : { x: nx, y: ny }));
+  }, [x, y, ref]);
+  // While measuring (first paint) the panel renders off-screen, exactly like
+  // ContextMenu, so the un-clamped position never flashes.
+  const shown = hasCoords ? adjusted ?? { x: -9999, y: -9999 } : null;
+  return createPortal(
+    <div
+      ref={ref}
+      className={`${className}${shown ? '' : ` ${anchorClassName}`}`}
+      style={shown ? { left: shown.x, top: shown.y } : undefined}
+    >
+      {children}
+    </div>,
+    document.body,
   );
 };
 
@@ -420,6 +472,10 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   const getTotalDurationSec = useEditorStore((s) => s.getTotalDurationSec);
   const masterGain = usePlaybackStore((s) => (s.muted ? 0 : s.volume / 100));
   const inpaintSelection = useEditorStore((s) => s.inpaintSelection);
+  // BPM/key per clip: audio clips resolve through the DJ analysis cache via
+  // their originating library entry (same source the DJ decks read); MIDI
+  // clips report their own render BPM. Read-only — nothing is queued here.
+  const djAnalysisById = useDjAnalysisStore((s) => s.byId);
   const setInpaintSelection = useEditorStore((s) => s.setInpaintSelection);
   const clearInpaintSelection = useEditorStore((s) => s.clearInpaintSelection);
   const masterFxChain = useEditorStore((s) => s.masterFxChain);
@@ -623,7 +679,10 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   const [magentaToolId, setMagentaToolId] = useState<string | null>(null);
   const magentaTool: MagentaTool | null = magentaToolId ? magentaToolById[magentaToolId] ?? null : null;
   const [showMetamorph, setShowMetamorph] = useState(false);
-  const [fxPanelTrackId, setFxPanelTrackId] = useState<string | null>(null);
+  // Per-track FX rack popover. x/y anchor it at the opening click (clip FX
+  // button, track-header F, context menu); both undefined falls back to the
+  // legacy right-4 top-28 position.
+  const [fxPanel, setFxPanel] = useState<{ trackId: string; x?: number; y?: number } | null>(null);
   // The app-wide embedded native VST editor session (vstEditorStore hosts ONE
   // editor window; leaving the owning tab closes it). EDIT hosts it in a
   // floating popup only while EDIT owns it; MIX hosts it in its Effect Stage.
@@ -632,6 +691,16 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   const vstSessionName = useVstEditorStore((s) => s.pluginName);
   const vstSessionError = useVstEditorStore((s) => s.error);
   const vstSessionOwnerTab = useVstEditorStore((s) => s.ownerTab);
+  // Natural editor size the loaded plugin reported (CSS px); sizes the floating
+  // popup to the plugin. Reset when the session switches plugins so a small
+  // editor never inherits the previous plugin's large box.
+  const [vstNatural, setVstNatural] = useState<{ w: number; h: number } | null>(null);
+  useEffect(() => {
+    setVstNatural(null);
+  }, [vstSessionPath]);
+  const onVstNaturalSize = useCallback((w: number, h: number) => {
+    setVstNatural((prev) => (prev && prev.w === w && prev.h === h ? prev : { w, h }));
+  }, []);
   // Open a VST entry's REAL native GUI; the sink stores the captured raw_state
   // on the right chain (a track's fxChain or the master VST chain).
   const openVstEditor = (entry: ChainEntry, sink: (entryId: string, rawState: string) => void) =>
@@ -1098,6 +1167,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
       }
 
       for (const clip of selection) {
+        if (clip.muted) continue; // muted clips are excluded from the mashup, matching commitEdit and live playback
         const track = trackById.get(clip.trackId);
         if (!track || track.mute) continue;
         const buf = blobCache.get(clip.audioBlob);
@@ -1437,6 +1507,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
       }
 
       for (const c of clips) {
+        if (c.muted) continue; // muted clips are excluded from the bounce, matching live playback
         const tn = trackNodeById.get(c.trackId);
         if (!tn) continue; // track muted or hidden by an active solo
         const buf = blobCache.get(c.audioBlob);
@@ -1478,7 +1549,8 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
         );
         if (teleEntries.length === 0) continue;
         const insts = tn.fx.instances();
-        const trackClips = clips.filter((c) => c.trackId === track.id);
+        // Muted clips render no audio, so their onsets must not drive jumps.
+        const trackClips = clips.filter((c) => c.trackId === track.id && !c.muted);
         for (const entry of teleEntries) {
           const li = insts.find((x) => x.id === entry.id);
           if (!li?.inst.scheduleTeleport) continue;
@@ -1615,8 +1687,10 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   // Signature of everything that affects the rendered master, so a frozen render
   // can be flagged stale after edits (and re-renders are skipped when unchanged).
   const freezeSig = useMemo(() => {
+    // A clip's muted flag is part of the shape because commitEdit drops muted
+    // clips from the bounce, so toggling mute changes the rendered master.
     const clipPart = clips
-      .map((c) => `${c.id}:${c.trackId}:${c.startSec}:${c.durationSec}:${c.offsetIntoSource}:${c.fadeInSec ?? 0}:${c.fadeOutSec ?? 0}:${c.audioBlob.size}`)
+      .map((c) => `${c.id}:${c.trackId}:${c.startSec}:${c.durationSec}:${c.offsetIntoSource}:${c.fadeInSec ?? 0}:${c.fadeOutSec ?? 0}:${c.muted ? 1 : 0}:${c.audioBlob.size}`)
       .join('|');
     const trackPart = tracks
       .map((t) => `${t.id}:${t.volume}:${t.pan}:${t.mute}:${t.solo}:${JSON.stringify(t.fxChain ?? [])}`)
@@ -1754,6 +1828,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
       const trackInput = offline.createGain();
       const fx = buildEffectChain(offline, trackInput, offline.destination, rackChain);
       for (const c of trackClips) {
+        if (c.muted) continue; // muted clips stay out of the printed stem, matching live playback
         const buf = blobCache.get(c.audioBlob);
         if (!buf) continue;
         const safeOffset = Math.min(c.offsetIntoSource, Math.max(0, buf.duration - 0.01));
@@ -2706,18 +2781,24 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
         </div>
       )}
 
-      {/* Per-track FX rack (floating; fixed so it escapes the card's overflow clip) */}
-      {fxPanelTrackId && (() => {
-        const t = tracks.find((tr) => tr.id === fxPanelTrackId);
+      {/* Per-track FX rack (floating popover, portaled to body so it opens AT
+          the click even under the .dense-layout CSS zoom) */}
+      {fxPanel && (() => {
+        const t = tracks.find((tr) => tr.id === fxPanel.trackId);
         if (!t) return null;
         return (
-          <div className="fixed right-4 top-28 z-50 w-90 max-h-[70vh] overflow-y-auto hardware-card bg-black/90 border border-purple-500/30 rounded-lg shadow-2xl shadow-purple-900/40 p-3 flex flex-col gap-2">
+          <PopoverPortal
+            x={fxPanel.x}
+            y={fxPanel.y}
+            anchorClassName="right-4 top-28"
+            className="fixed z-50 w-90 max-h-[70vh] overflow-y-auto hardware-card bg-black/90 border border-purple-500/30 rounded-lg shadow-2xl shadow-purple-900/40 p-3 flex flex-col gap-2"
+          >
             <div className="flex items-center justify-between gap-2 border-b border-white/10 pb-2">
               <span className="text-[10px] font-mono uppercase tracking-wider text-zinc-400 truncate">
                 Track FX — <span style={{ color: t.color }}>{t.name}</span>
               </span>
               <button
-                onClick={() => setFxPanelTrackId(null)}
+                onClick={() => setFxPanel(null)}
                 aria-label="Close track FX rack"
                 title="Close"
                 className="p-0.5 rounded text-zinc-500 hover:text-white hover:bg-white/10 shrink-0"
@@ -2738,26 +2819,43 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               onOpenVst={(entry) => openVstEditor(entry, (entryId, raw) => setTrackVstRawState(t.id, entryId, raw))}
               onOpenSurface={(entry) => openAresSurface({ kind: 'track', trackId: t.id }, entry)}
             />
-          </div>
+          </PopoverPortal>
         );
       })()}
 
       {/* Embedded native VST editor (floating hardware-card popup, offset below
           the top-28 FX panels so both can be open). Rendered only while EDIT
           owns the ONE app-wide embed session; the same VstEmbedHost drives the
-          native OS window in MIX's Effect Stage. */}
-      {vstSessionEntryId && vstSessionPath && vstSessionName && vstSessionOwnerTab === 'edit' && (
+          native OS window in MIX's Effect Stage. Portaled to document.body:
+          outside the CSS-zoomed .dense-layout one CSS px equals one viewport
+          px, so the plugin's reported natural size maps 1:1 onto the popup with
+          no zoom-factor division. Sized to the plugin once it reports (plus the
+          host chrome), clamped to the viewport with the host's inner scroll for
+          oversized editors; 640x480 is the pre-report fallback. */}
+      {vstSessionEntryId && vstSessionPath && vstSessionName && vstSessionOwnerTab === 'edit' && createPortal(
         <div
           className="fixed left-1/2 -translate-x-1/2 top-36 z-50 hardware-card bg-black/95 border border-teal-500/30 rounded-lg shadow-2xl shadow-teal-900/40 overflow-hidden"
-          style={{ width: 'min(640px, 92vw)', height: 'min(480px, 72vh)' }}
+          style={
+            vstNatural
+              ? {
+                  // Host chrome around the plugin viewport: popup border (2),
+                  // VstEmbedHost padding (16) + inner border (2) horizontally;
+                  // plus the header row (~18) and its gap (8) vertically.
+                  width: `min(${vstNatural.w + 20}px, 92vw)`,
+                  height: `min(${vstNatural.h + 46}px, 85vh)`,
+                }
+              : { width: 'min(640px, 92vw)', height: 'min(480px, 72vh)' }
+          }
         >
           <VstEmbedHost
             pluginPath={vstSessionPath}
             pluginName={vstSessionName}
             error={vstSessionError ?? undefined}
             onClose={() => useVstEditorStore.getState().close()}
+            onNaturalSize={onVstNaturalSize}
           />
-        </div>
+        </div>,
+        document.body,
       )}
 
       {/* Ares control surface (floating popup); its .gan drives the picked
@@ -2855,17 +2953,17 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
         </div>
       )}
 
-      {/* Per-clip instrument override (floating; MIDI clips only) */}
+      {/* Per-clip instrument override (floating; MIDI clips only). Portaled to
+          body so the click-position anchor holds under the layout zoom. */}
       {instrPanel && (() => {
         const clip = clips.find((c) => c.id === instrPanel.clipId);
         if (!clip) return null;
-        const left = Math.max(8, Math.min(instrPanel.x, window.innerWidth - 280));
-        const top = Math.max(8, Math.min(instrPanel.y, window.innerHeight - 96));
         return (
-          <div
-            ref={instrPanelRef}
+          <PopoverPortal
+            x={instrPanel.x}
+            y={instrPanel.y}
+            innerRef={instrPanelRef}
             className="fixed z-50 w-66 hardware-card bg-black/90 border border-purple-500/30 rounded-lg shadow-2xl shadow-purple-900/40 p-3 flex flex-col gap-2"
-            style={{ left, top }}
           >
             <div className="flex items-center justify-between gap-2 border-b border-white/10 pb-2">
               <span className="text-[10px] font-mono uppercase tracking-wider text-zinc-400 truncate">
@@ -2881,21 +2979,21 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               </button>
             </div>
             <ClipInstrumentSelect clip={clip} />
-          </div>
+          </PopoverPortal>
         );
       })()}
 
-      {/* Per-clip Time / Pitch popover (audio clips) */}
+      {/* Per-clip Time / Pitch popover (audio clips). Portaled to body so the
+          click-position anchor holds under the layout zoom. */}
       {timePitchPanel && (() => {
         const clip = clips.find((c) => c.id === timePitchPanel.clipId);
         if (!clip) return null;
-        const left = Math.max(8, Math.min(timePitchPanel.x, window.innerWidth - 300));
-        const top = Math.max(8, Math.min(timePitchPanel.y, window.innerHeight - 170));
         return (
-          <div
-            ref={timePitchRef}
+          <PopoverPortal
+            x={timePitchPanel.x}
+            y={timePitchPanel.y}
+            innerRef={timePitchRef}
             className="fixed z-50 w-72 hardware-card bg-black/90 border border-purple-500/30 rounded-lg shadow-2xl shadow-purple-900/40 p-3 flex flex-col gap-2"
-            style={{ left, top }}
           >
             <div className="flex items-center justify-between gap-2 border-b border-white/10 pb-2">
               <span className="text-[10px] font-mono uppercase tracking-wider text-zinc-400 truncate">
@@ -2914,7 +3012,7 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               busy={timePitchBusy}
               onApply={(tempo, semitones) => { void applyTimePitch(timePitchPanel.clipId, tempo, semitones).then(() => setTimePitchPanel(null)); }}
             />
-          </div>
+          </PopoverPortal>
         );
       })()}
 
@@ -2957,18 +3055,26 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
                     </button>
                     <button
                       onClick={() => updateTrack(t.id, { mute: !t.mute })}
+                      aria-label={`Mute track ${t.name}`}
+                      aria-pressed={t.mute}
                       className={`w-4 h-4 rounded text-[8px] font-bold flex items-center justify-center ${t.mute ? 'bg-red-500/20 text-red-400 border border-red-500/50' : 'bg-black/40 text-zinc-500 border border-white/5 hover:text-white'}`}
                     >M</button>
                     <button
                       onClick={() => toggleSolo(t.id)}
+                      aria-label={`Solo track ${t.name}`}
+                      aria-pressed={t.solo}
                       className={`w-4 h-4 rounded text-[8px] font-bold flex items-center justify-center ${t.solo ? 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/50' : 'bg-black/40 text-zinc-500 border border-white/5 hover:text-white'}`}
                     >S</button>
                     <button
-                      onClick={() => setFxPanelTrackId((cur) => (cur === t.id ? null : t.id))}
+                      onClick={(e) =>
+                        setFxPanel((cur) =>
+                          cur?.trackId === t.id ? null : { trackId: t.id, x: e.clientX, y: e.clientY },
+                        )
+                      }
                       aria-label={`Track ${t.name} insert FX`}
-                      aria-pressed={fxPanelTrackId === t.id}
+                      aria-pressed={fxPanel?.trackId === t.id}
                       title="Track insert FX rack"
-                      className={`w-4 h-4 rounded text-[8px] font-bold flex items-center justify-center ${(t.fxChain?.length ?? 0) > 0 || fxPanelTrackId === t.id ? 'bg-purple-500/20 text-purple-300 border border-purple-500/50' : 'bg-black/40 text-zinc-500 border border-white/5 hover:text-white'}`}
+                      className={`w-4 h-4 rounded text-[8px] font-bold flex items-center justify-center ${(t.fxChain?.length ?? 0) > 0 || fxPanel?.trackId === t.id ? 'bg-purple-500/20 text-purple-300 border border-purple-500/50' : 'bg-black/40 text-zinc-500 border border-white/5 hover:text-white'}`}
                     >F</button>
                     {(t.frozenOriginal || (t.fxChain ?? []).some((e) => e.effect === 'vst3' && e.vst)) && (
                       <button
@@ -3133,6 +3239,20 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               const selected = selectedClipIdSet.has(clip.id) || clip.id === selectedClipId;
               const peaks = clip.peaks;
               const isMidi = clip.sourceKind === 'piano-roll' && !!clip.sourcePianoRoll && clip.sourcePianoRoll.length > 0;
+              // Compact BPM/key readout: MIDI clips carry their render BPM; audio
+              // clips resolve through the DJ analysis cache. Hidden entirely on
+              // narrow clips or when neither value is known.
+              let bpmText: string | null = null;
+              let keyText: string | null = null;
+              if (clip.sourceKind === 'piano-roll') {
+                if (clip.sourceBpm) bpmText = String(Math.round(clip.sourceBpm));
+              } else if (clip.libraryEntryId) {
+                const d = djAnalysisById[clip.libraryEntryId]?.data;
+                if (d?.bpm) bpmText = String(Math.round(d.bpm));
+                if (d?.key) keyText = `${d.key}${(d.scale ?? '').toLowerCase().startsWith('min') ? 'm' : ''}`;
+              }
+              const bpmKeyReadout =
+                width >= 120 && (bpmText || keyText) ? [bpmText, keyText].filter(Boolean).join(' . ') : null;
               return (
                 <div
                   key={clip.id}
@@ -3156,13 +3276,46 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
                       )}
                       <span className="text-white truncate">{clip.label}</span>
                     </span>
-                    <span className="text-zinc-300">{clip.durationSec.toFixed(2)}s</span>
+                    <span className="flex items-center gap-1 shrink-0">
+                      {bpmKeyReadout && (
+                        <span className="text-zinc-400 normal-case tabular-nums">{bpmKeyReadout}</span>
+                      )}
+                      {/* Header buttons stop pointerdown so they never start a
+                          clip drag, and stop click so they never re-select. */}
+                      <button
+                        type="button"
+                        onPointerDown={(e) => e.stopPropagation()}
+                        onDoubleClick={(e) => e.stopPropagation()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setFxPanel({ trackId: clip.trackId, x: e.clientX, y: e.clientY });
+                        }}
+                        aria-label={`Open track FX for clip ${clip.label}`}
+                        className="px-0.5 h-3 rounded-sm text-[7px] font-bold leading-none flex items-center bg-black/40 text-zinc-400 border border-white/10 hover:text-purple-300 hover:border-purple-500/50"
+                      >FX</button>
+                      <button
+                        type="button"
+                        onPointerDown={(e) => e.stopPropagation()}
+                        onDoubleClick={(e) => e.stopPropagation()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          updateClip(clip.id, { muted: !clip.muted });
+                        }}
+                        aria-label={`Mute clip ${clip.label}`}
+                        aria-pressed={!!clip.muted}
+                        className={`px-0.5 h-3 rounded-sm text-[7px] font-bold leading-none flex items-center ${clip.muted ? 'bg-red-500/20 text-red-400 border border-red-500/50' : 'bg-black/40 text-zinc-400 border border-white/10 hover:text-white'}`}
+                      >M</button>
+                      <span className="text-zinc-300">{clip.durationSec.toFixed(2)}s</span>
+                    </span>
                   </div>
-                  {/* Body: MIDI clips show their notes (FL-style); audio clips show peaks */}
+                  {/* Body: MIDI clips show their notes (FL-style); audio clips show
+                      peaks. A muted clip's body is dimmed (the red M is the flag). */}
                   {isMidi ? (
-                    <MidiClipNotes clip={clip} zoom={zoom} selected={selected} />
+                    <div className={clip.muted ? 'opacity-30' : ''}>
+                      <MidiClipNotes clip={clip} zoom={zoom} selected={selected} />
+                    </div>
                   ) : (
-                    <div className="absolute inset-x-0 bottom-0 top-3.5 flex items-center gap-[0.5px] px-1">
+                    <div className={`absolute inset-x-0 bottom-0 top-3.5 flex items-center gap-[0.5px] px-1 ${clip.muted ? 'opacity-30' : ''}`}>
                       {peaks ? (
                         Array.from(peaks).map((v, i) => (
                           <div
@@ -3513,7 +3666,9 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
             type: 'item',
             icon: <SlidersHorizontal className="w-3 h-3" />,
             label: 'Open FX rack',
-            onSelect: () => setFxPanelTrackId(t.id),
+            // Anchor the rack at the right-click that opened this menu; the
+            // legacy right-4 top-28 spot is the no-coords fallback.
+            onSelect: () => setFxPanel({ trackId: t.id, x: trackMenu.position?.x, y: trackMenu.position?.y }),
           },
           { type: 'separator' },
           { type: 'header', label: 'Add insert' },

--- a/frontend/src/components/layout/DAWCenterPanel.tsx
+++ b/frontend/src/components/layout/DAWCenterPanel.tsx
@@ -47,12 +47,13 @@ export const DAWCenterPanel: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   const centerTab = useAppUiStore((s) => s.centerTab);
 
   // Track which heavy live-performance tabs have been opened at least
-  // once. We only mount DJ / VJ after first visit (so a user who never
-  // touches them pays nothing), then keep them mounted permanently and
-  // toggle visibility — preserving deck state + the warm VJ iframe.
+  // once. We only mount DJ / VJ / LEARN after first visit (so a user who
+  // never touches them pays nothing), then keep them mounted permanently
+  // and toggle visibility — preserving deck state, the warm VJ iframe,
+  // and the LEARN genealogy graph's fetch + layout + pan/zoom.
   const [warmedTabs, setWarmedTabs] = useState<Set<string>>(() => new Set());
   useEffect(() => {
-    if (centerTab === 'dj' || centerTab === 'vj') {
+    if (centerTab === 'dj' || centerTab === 'vj' || centerTab === 'learn') {
       setWarmedTabs((prev) => {
         if (prev.has(centerTab)) return prev;
         const next = new Set(prev);
@@ -98,8 +99,19 @@ export const DAWCenterPanel: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               <Suspense fallback={<TabFallback />}><MixView /></Suspense>
             </div>
           )}
-          {centerTab === 'learn' && (
-            <Suspense fallback={<TabFallback />}><LineageView rootEntryId={null} /></Suspense>
+          {/* LEARN stays mounted once warmed (same pattern as DJ/VJ below)
+              so tab switches preserve the fetched graph, the computed
+              layout, the DOM, and the user's pan/zoom. The `visible` prop
+              tells the view when it is re-shown so it can refetch the
+              cheap bulk graph endpoint and rebuild only if the library
+              actually changed. */}
+          {warmedTabs.has('learn') && (
+            <div
+              className="absolute inset-0"
+              style={{ display: centerTab === 'learn' ? undefined : 'none' }}
+            >
+              <Suspense fallback={<TabFallback />}><LineageView rootEntryId={null} visible={centerTab === 'learn'} /></Suspense>
+            </div>
           )}
 
           {/* DJ + VJ stay mounted once warmed; visibility toggles with

--- a/frontend/src/components/library/LineageModal.tsx
+++ b/frontend/src/components/library/LineageModal.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, lazy, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Network, X, GitBranch, GitFork, Workflow, Maximize2, Minimize2, Sliders, Maximize, Copy, Crosshair, Package, GitMerge, Library as LibraryIcon, Home, Rocket } from 'lucide-react';
 import { ContextMenu, useContextMenu, type ContextMenuItem } from '../ui/ContextMenu';
@@ -41,6 +41,11 @@ interface LineageModalProps {
    *  new center bar. Defaults to 'modal' so existing callers don't
    *  change behaviour. */
   mode?: 'modal' | 'embedded';
+  /** For the warm-mounted embedded view: whether the hosting tab is
+   *  currently shown. A false->true flip triggers a freshness refetch
+   *  of the bulk graph endpoint (rebuild only if the payload changed).
+   *  Defaults to true so modal callers keep their behaviour. */
+  visible?: boolean;
 }
 
 type VizPreset =
@@ -319,7 +324,7 @@ const CLUSTER_TINT_BY_SOURCE: Record<string, string> = {
   other: '#94a3b8',
 };
 
-export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, onClose, mode = 'modal' }) => {
+export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, onClose, mode = 'modal', visible = true }) => {
   const embedded = mode === 'embedded';
   const [tab, setTab] = useState<LineageTab>('track');
   const [perTrack, setPerTrack] = useState<GraphPayload | null>(null);
@@ -371,17 +376,51 @@ export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, o
   }, [active, rootEntryId]);
 
   // Fetch the full library graph for the family-tree + 3D-graph views.
-  useEffect(() => {
-    if (!active) return;
-    if (tab !== 'genealogy' && tab !== 'graph3d') return;
-    if (libraryGraph !== null) return;
-    setLoading(true);
+  // The bulk endpoint is cheap (~60ms), so it is re-hit every time the
+  // view is (re-)shown; the payload only replaces state — and thereby
+  // rebuilds the layout/DOM, discarding pan/zoom — when its signature
+  // (node/edge counts + byte length) differs from the last build. An
+  // unchanged library keeps the warm graph exactly as the user left it
+  // while new entries still appear without a manual reload.
+  const graphSigRef = useRef<string | null>(null);
+  const fetchLibraryGraph = useCallback(() => {
+    // Only the very first load shows the loading overlay; freshness
+    // refetches on re-show run silently behind the warm graph.
+    const initial = graphSigRef.current === null;
+    if (initial) setLoading(true);
     void fetch('/api/library/_graph/all')
       .then((r) => r.json())
-      .then((j: GraphPayload) => setLibraryGraph(j))
-      .catch(() => setLibraryGraph({ nodes: [], edges: [] }))
-      .finally(() => setLoading(false));
-  }, [active, tab, libraryGraph]);
+      .then((j: GraphPayload) => {
+        const sig = `${j?.nodes?.length ?? 0}:${j?.edges?.length ?? 0}:${JSON.stringify(j).length}`;
+        if (graphSigRef.current === sig) return;
+        graphSigRef.current = sig;
+        setLibraryGraph(j);
+      })
+      .catch(() => {
+        // Keep any prior graph on a failed refresh; only seed the empty
+        // placeholder when nothing was ever loaded. graphSigRef stays
+        // null so the next attempt is still treated as the initial one.
+        setLibraryGraph((cur) => cur ?? { nodes: [], edges: [] });
+      })
+      .finally(() => {
+        if (initial) setLoading(false);
+      });
+  }, []);
+  useEffect(() => {
+    if (!active || !visible) return;
+    if (tab !== 'genealogy' && tab !== 'graph3d') return;
+    fetchLibraryGraph();
+  }, [active, visible, tab, fetchLibraryGraph]);
+
+  // The embedded fullscreen overlay portals to document.body, so it
+  // escapes the warm-mounted tab's display:none wrapper. A programmatic
+  // tab switch (a DAW import jumping to EDIT, an automix jumping to DJ)
+  // would otherwise leave the z-200 overlay covering the new tab with no
+  // close affordance. Exiting fullscreen whenever the host tab is hidden
+  // keeps the overlay scoped to the tab that opened it.
+  useEffect(() => {
+    if (!visible) setFullscreen(false);
+  }, [visible]);
 
   if (!active) return null;
 
@@ -479,36 +518,55 @@ export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, o
           </div>
         </div>
 
-        {/* Body */}
+        {/* Body. The inline-embedded (LEARN tab) case sits inside the
+            Shell's `.dense-layout` CSS zoom, which breaks the graph
+            libraries' pointer math (three-render-objects raycasts and the
+            SVG pan/drag both assume unzoomed CSS pixels). The inner
+            wrapper counter-zooms by 1/zoom and pre-scales its box by zoom
+            so the graph area runs at an effective scale of 1 — matching
+            the portaled modal and fullscreen paths, which stay untouched
+            (they get a plain full-size wrapper). */}
         <div className="flex-1 min-h-0 relative">
-          {loading && (
-            <div className="absolute inset-0 flex items-center justify-center text-[10px] font-mono text-zinc-500">
-              Loading lineage…
-            </div>
-          )}
-          {tab === 'track' && rootEntryId && perTrack && (
-            <TrackTreeView root={rootEntryId} payload={perTrack} />
-          )}
-          {tab === 'genealogy' && libraryGraph && (
-            <GenealogyView payload={libraryGraph} appearance={appearance} controlsRef={genControls} />
-          )}
-          {tab === 'graph3d' && libraryGraph && (
-            <Suspense fallback={<div className="absolute inset-0 flex items-center justify-center text-[10px] font-mono text-zinc-500">Loading 3D engine…</div>}>
-              <Graph3DView
-                payload={libraryGraph}
-                highlight={rootEntryId}
-                appearance={appearance}
-              />
-            </Suspense>
-          )}
+          <div
+            className="relative"
+            style={useInlineLayout
+              ? {
+                  zoom: 'calc(1 / var(--layout-zoom, 1))',
+                  width: 'calc(100% * var(--layout-zoom, 1))',
+                  height: 'calc(100% * var(--layout-zoom, 1))',
+                }
+              : { width: '100%', height: '100%' }}
+          >
+            {loading && (
+              <div className="absolute inset-0 flex items-center justify-center text-[10px] font-mono text-zinc-500">
+                Loading lineage…
+              </div>
+            )}
+            {tab === 'track' && rootEntryId && perTrack && (
+              <TrackTreeView root={rootEntryId} payload={perTrack} />
+            )}
+            {tab === 'genealogy' && libraryGraph && (
+              <GenealogyView payload={libraryGraph} appearance={appearance} controlsRef={genControls} />
+            )}
+            {tab === 'graph3d' && libraryGraph && (
+              <Suspense fallback={<div className="absolute inset-0 flex items-center justify-center text-[10px] font-mono text-zinc-500">Loading 3D engine…</div>}>
+                <Graph3DView
+                  payload={libraryGraph}
+                  highlight={rootEntryId}
+                  appearance={appearance}
+                  visible={visible}
+                />
+              </Suspense>
+            )}
 
-          {tab === 'graph3d' && appearanceOpen && (
-            <AppearancePanel
-              value={appearance}
-              onChange={setAppearance}
-              onClose={() => setAppearanceOpen(false)}
-            />
-          )}
+            {tab === 'graph3d' && appearanceOpen && (
+              <AppearancePanel
+                value={appearance}
+                onChange={setAppearance}
+                onClose={() => setAppearanceOpen(false)}
+              />
+            )}
+          </div>
         </div>
 
         {/* Footer: edge-kind color key (left) + genealogy spacing (right). */}
@@ -542,11 +600,14 @@ export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, o
 
 /** Embedded variant of LineageModal — mounts the lineage UI inline
  *  (no backdrop, no portal, no close button) for use as the LEARN tab
- *  in the new center bar. Always-live; doesn't take an `open` prop. */
-export const LineageView: React.FC<{ rootEntryId?: string | null }> = ({ rootEntryId = null }) => (
+ *  in the new center bar. Always-live; doesn't take an `open` prop.
+ *  `visible` mirrors whether the warm-mounted host tab is shown so the
+ *  view can refresh its data on re-show. */
+export const LineageView: React.FC<{ rootEntryId?: string | null; visible?: boolean }> = ({ rootEntryId = null, visible = true }) => (
   <LineageModal
     mode="embedded"
     open={true}
+    visible={visible}
     rootEntryId={rootEntryId}
     onClose={() => {
       /* no-op in embedded mode */
@@ -761,7 +822,13 @@ const GenealogyView: React.FC<{
     if (zoomingRef.current) return;
     clearHoverIntent();
     if (hoverClearRef.current != null) { window.clearTimeout(hoverClearRef.current); hoverClearRef.current = null; }
-    setHovered(null);
+    // Grace timer: clearing after a short delay lets the cursor cross the
+    // gap between adjacent cards without the highlight blinking off —
+    // enterNode cancels this pending clear when the next card is reached.
+    hoverClearRef.current = window.setTimeout(() => {
+      setHovered(null);
+      hoverClearRef.current = null;
+    }, 150);
   }, [clearHoverIntent]);
   useEffect(() => () => {
     clearHoverIntent();
@@ -863,27 +930,36 @@ const GenealogyView: React.FC<{
 
     // Median-of-parents heuristic, sweeping top-down then bottom-up
     // a few times. This is the simplest crossing-reduction step in
-    // the Sugiyama framework.
-    const positionInRow = (id: string, row: string[]): number => row.indexOf(id);
+    // the Sugiyama framework. Rank Maps (id -> row index) replace the
+    // old repeated includes/indexOf scans, and each sweep precomputes
+    // one median value per id before sorting so the comparator is a
+    // pair of Map lookups. The resulting ordering is byte-identical to
+    // the scan-based version; only the cost changes.
     for (let iter = 0; iter < 12; iter += 1) {
       const topDown = iter % 2 === 0;
       const order = topDown ? layerKeys.slice(1) : layerKeys.slice(0, -1).reverse();
       order.forEach((d) => {
         const adjLayer = topDown ? d - 1 : d + 1;
-        const adjRow = grouped[adjLayer] || [];
         const adjMap = topDown ? parentsOf : childrenOf;
-        const newRow = [...grouped[d]];
-        const medianOf = (id: string): number => {
-          const refs = (adjMap[id] || []).filter((n) => adjRow.includes(n));
-          if (refs.length === 0) return positionInRow(id, grouped[d]);
-          const positions = refs
-            .map((r) => positionInRow(r, adjRow))
-            .filter((p) => p >= 0)
+        const adjIndex = new Map<string, number>();
+        (grouped[adjLayer] || []).forEach((id, i) => adjIndex.set(id, i));
+        const rowIndex = new Map<string, number>();
+        grouped[d].forEach((id, i) => rowIndex.set(id, i));
+        const medianVal = new Map<string, number>();
+        grouped[d].forEach((id) => {
+          const positions = (adjMap[id] || [])
+            .map((r) => adjIndex.get(r))
+            .filter((p): p is number => p !== undefined)
             .sort((a, b) => a - b);
-          if (positions.length === 0) return positionInRow(id, grouped[d]);
-          return positions[Math.floor(positions.length / 2)];
-        };
-        newRow.sort((a, b) => medianOf(a) - medianOf(b));
+          medianVal.set(
+            id,
+            positions.length === 0
+              ? (rowIndex.get(id) as number)
+              : positions[Math.floor(positions.length / 2)],
+          );
+        });
+        const newRow = [...grouped[d]];
+        newRow.sort((a, b) => (medianVal.get(a) as number) - (medianVal.get(b) as number));
         grouped[d] = newRow;
       });
     }
@@ -967,10 +1043,21 @@ const GenealogyView: React.FC<{
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   // Keep the panel size current so the grid can size itself to fill it.
-  useEffect(() => {
+  // useLayoutEffect seeds the size synchronously BEFORE first paint, so
+  // fillRows never runs with the 16:9 fallback and rebuilds the whole
+  // layout once the ResizeObserver fires — the old double build.
+  useLayoutEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-    const measure = () => setContainerSize({ w: el.clientWidth, h: el.clientHeight });
+    const measure = () => {
+      const w = el.clientWidth;
+      const h = el.clientHeight;
+      // Zero means hidden (the warm LEARN tab uses display:none); keep
+      // the last real size so the layout — and with it the user's
+      // pan/zoom — survives the hide/show round trip.
+      if (w <= 0 || h <= 0) return;
+      setContainerSize((cur) => (cur.w === w && cur.h === h ? cur : { w, h }));
+    };
     measure();
     const ro = new ResizeObserver(measure);
     ro.observe(el);
@@ -1071,6 +1158,10 @@ const GenealogyView: React.FC<{
   // longer rebuilds hundreds of node/edge elements every frame (the old hot path).
   const svgContent = useMemo(() => (
     <svg
+      // Stable class hook for the imperative hover-glow effect below and
+      // its scoped CSS in index.css. 'gen-hovering' is toggled via
+      // classList only, so React never fights the imperative writes.
+      className="genealogy-svg"
       width={bounds.maxX - bounds.minX}
       height={bounds.maxY - bounds.minY}
       viewBox={`${bounds.minX} ${bounds.minY} ${bounds.maxX - bounds.minX} ${bounds.maxY - bounds.minY}`}
@@ -1105,6 +1196,8 @@ const GenealogyView: React.FC<{
         const dx = (x2 - x1) * 0.5;
         const d = `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`;
         const color = EDGE_COLOR_BY_KIND[edge.kind] ?? '#71717a';
+        // No inline transition on this <g>: glow classes must apply and
+        // clear in one frame (transitioned filters caused a repaint storm).
         return (
           <g
             key={i}
@@ -1112,7 +1205,6 @@ const GenealogyView: React.FC<{
             data-edge-from={edge.from_id}
             data-edge-to={edge.to_id}
             data-edge-color={color}
-            style={{ transition: 'filter 200ms ease, opacity 200ms ease' }}
           >
             <GenEdgeBody d={d} color={color} x2={x2} y2={y2} strong={false} />
           </g>
@@ -1131,7 +1223,7 @@ const GenealogyView: React.FC<{
             transform={`translate(${p.x}, ${p.y})`}
             data-node-id={n.id}
             data-node-color={sourceColor}
-            style={{ cursor: 'pointer', transition: 'filter 160ms ease' }}
+            style={{ cursor: 'pointer' }}
             onMouseEnter={() => enterNode(n.id)}
             onMouseLeave={leaveNode}
             onClick={(e) => {
@@ -1149,52 +1241,49 @@ const GenealogyView: React.FC<{
 
   // Lineage hover glow, applied imperatively. The SVG above is referentially
   // stable across hover changes (hover is NOT in its memo deps), so React never
-  // touches the mounted graph while the mouse moves — this effect writes a
-  // filter onto just the hovered lineage's <g> elements and clears exactly the
-  // ones it lit last time. Off-lineage nodes/edges are left untouched (no dim,
-  // no fade, no remount).
+  // touches the mounted graph while the mouse moves. Instead of writing inline
+  // filter strings, the effect toggles classes + a --glow custom property (the
+  // rules live in index.css, all transition-free so the glow lands in ONE
+  // frame): 'gen-hovering' on the svg root dims everything off-lineage,
+  // 'gen-lit' + --glow lights each lineage node/edge <g>, and 'gen-lit-hot'
+  // marks the hovered node itself. Edge glow is stroke-based only — a
+  // drop-shadow on a bezier edge's <g> creates a filter surface spanning
+  // thousands of px, which Chromium drops/checkerboards (edges visibly
+  // flashed out of existence). litRef tracks exactly the touched elements so
+  // cleanup restores only them; svgContent stays in the deps so the glow
+  // re-applies onto freshly mounted elements after a rebuild.
   const litRef = useRef<SVGGElement[]>([]);
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
+    const svg = el.querySelector<SVGSVGElement>('svg.genealogy-svg');
     litRef.current.forEach((g) => {
-      g.style.filter = '';
-      g.style.opacity = '';
+      g.classList.remove('gen-lit', 'gen-lit-hot');
+      g.style.removeProperty('--glow');
     });
     litRef.current = [];
-    if (!hovered) return;
+    svg?.classList.remove('gen-hovering');
+    if (!hovered || !svg) return;
+    svg.classList.add('gen-hovering');
     const lit: SVGGElement[] = [];
     el.querySelectorAll<SVGGElement>('g[data-node-id]').forEach((g) => {
       const id = g.dataset.nodeId as string;
       if (!lineage.has(id)) return;
-      const color = g.dataset.nodeColor || '#a78bfa';
-      g.style.filter = id === hovered
-        ? `drop-shadow(0 0 16px ${color}) drop-shadow(0 0 6px ${color}) brightness(1.35)`
-        : `drop-shadow(0 0 9px ${color}) brightness(1.15)`;
+      g.style.setProperty('--glow', g.dataset.nodeColor || '#a78bfa');
+      g.classList.add('gen-lit');
+      if (id === hovered) g.classList.add('gen-lit-hot');
       lit.push(g);
     });
     el.querySelectorAll<SVGGElement>('g[data-edge-from]').forEach((g) => {
       const from = g.dataset.edgeFrom as string;
       const to = g.dataset.edgeTo as string;
       if (!lineage.has(from) || !lineage.has(to)) return;
-      const color = g.dataset.edgeColor || '#a78bfa';
-      g.style.filter = `drop-shadow(0 0 6px ${color}) brightness(1.6)`;
-      g.style.opacity = '1';
+      g.style.setProperty('--glow', g.dataset.edgeColor || '#a78bfa');
+      g.classList.add('gen-lit');
       lit.push(g);
     });
     litRef.current = lit;
   }, [hovered, lineage, svgContent]);
-
-  if (connected.nodes.length === 0) {
-    return (
-      <p className="absolute inset-0 flex items-center justify-center text-[10px] text-zinc-500 italic px-12 text-center">
-        No genealogy yet — entries become connected when you generate from
-        chimera sources, separate stems, convert to MIDI, or mark a
-        track as derived-from another. Right-click a track → "Show
-        lineage" to start populating relationships.
-      </p>
-    );
-  }
 
   // Wheel listener must be attached non-passively so we can preventDefault
   // and stop the parent (Shell) from scrolling. React's JSX wheel handler
@@ -1225,6 +1314,24 @@ const GenealogyView: React.FC<{
     el.addEventListener('wheel', onNativeWheel, { passive: false });
     return () => el.removeEventListener('wheel', onNativeWheel);
   }, [kick]);
+
+  // This early return must sit BELOW every hook in the component. The
+  // warm-mounted LEARN tab refetches the library graph in place, so
+  // connected.nodes.length can flip between zero and non-zero on an
+  // already-mounted component; a conditional return above any hook would
+  // then change the hook count between renders and React would tear down
+  // the whole tree ("Rendered more/fewer hooks than during the previous
+  // render").
+  if (connected.nodes.length === 0) {
+    return (
+      <p className="absolute inset-0 flex items-center justify-center text-[10px] text-zinc-500 italic px-12 text-center">
+        No genealogy yet — entries become connected when you generate from
+        chimera sources, separate stems, convert to MIDI, or mark a
+        track as derived-from another. Right-click a track → "Show
+        lineage" to start populating relationships.
+      </p>
+    );
+  }
 
   // Pan: capture only once a real drag begins (>4px) so a plain click still
   // reaches a node's onClick. `draggedRef` suppresses the click that ends a drag.
@@ -1547,15 +1654,45 @@ const SelectRow: React.FC<{ label: string; value: string; options: Array<{ value
 );
 
 
+/** Frees the geometries and materials under a detached overlay group
+ *  (cluster halos). three.js objects hold GPU resources that are not
+ *  garbage-collected on scene removal; they must be disposed explicitly. */
+function disposeLineageGroup(group: { traverse?: (cb: (o: unknown) => void) => void }) {
+  group.traverse?.((o) => {
+    const m = o as { geometry?: { dispose?: () => void }; material?: { dispose?: () => void } };
+    m.geometry?.dispose?.();
+    m.material?.dispose?.();
+  });
+}
+
+// ONE shared geometry + ONE shared invisible material back every node's
+// enlarged hover hit-proxy sphere (see the nodeThreeObject builder).
+// Module-cached so rebuilds never re-allocate them. The material is
+// invisible rather than transparent: three's raycaster still intersects
+// it (Mesh.raycast only skips undefined materials, and the recursive
+// traversal checks layers, not visibility) while the renderer skips
+// drawing it entirely. It deliberately carries NO userData.baseOpacity
+// so the lineage glow tween ignores the proxy meshes.
+let hitProxyGeo: import('three').SphereGeometry | null = null;
+let hitProxyMat: import('three').MeshBasicMaterial | null = null;
+
 /** Interactive 3D force-directed graph using react-force-graph-3d.
  *  Camera auto-fits to the connected subgraph on first render so the
  *  user lands on something usable instead of a dot in the distance.
- *  Appearance controlled via the AppearancePanel side drawer. */
-const Graph3DView: React.FC<{
+ *  Appearance controlled via the AppearancePanel side drawer.
+ *  Memoized: the parent re-renders on unrelated state (e.g. the silent
+ *  library-graph refresh toggling `loading`), and any re-render with
+ *  fresh accessor prop identities makes the library rebuild scene
+ *  objects wholesale — React.memo keeps those renders away entirely. */
+const Graph3DView = React.memo(function Graph3DViewBase({ payload, highlight, appearance, visible = true }: {
   payload: GraphPayload;
   highlight: string | null;
   appearance: GraphAppearance;
-}> = ({ payload, highlight, appearance }) => {
+  /** Mirrors whether the warm-mounted host tab is shown. The wrapper
+   *  hides this view with display:none instead of unmounting it, so the
+   *  render loops below must be paused explicitly while hidden. */
+  visible?: boolean;
+}) {
   // Same filter as Genealogy: drop nodes that don't participate in any
   // relation, otherwise 100+ disconnected dots dominate the view.
   const connected = useMemo(() => {
@@ -1644,6 +1781,49 @@ const Graph3DView: React.FC<{
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const fgRef = useRef<any>(null);
+
+  // Two-state load: three is lazy-imported so 2D users don't pay its
+  // bundle cost. Until it resolves, the component renders the engine-
+  // loading note INSTEAD of <ForceGraph3D> — mounting the graph earlier
+  // made nodeThreeObject return undefined for the first frames, so the
+  // library drew its default spheres (nodeRelSize 7, ~7x larger than
+  // the custom meshes) and then rebuilt everything post-import.
+  const threeRef = useRef<typeof import('three') | null>(null);
+  const [threeReady, setThreeReady] = useState(false);
+  useEffect(() => {
+    if (appearance.renderMode !== '3d') return;
+    let cancelled = false;
+    void import('three').then((mod) => {
+      threeRef.current = mod;
+      if (!cancelled) setThreeReady(true);
+    });
+    return () => { cancelled = true; };
+  }, [appearance.renderMode]);
+
+  // Explicit canvas size, measured from the container. Without these
+  // props react-force-graph sizes itself once from the window, so the
+  // canvas neither matches the hosting panel nor survives the
+  // fullscreen toggle. getBoundingClientRect works under the counter-
+  // zoomed embed (effective scale 1) and in the portaled paths alike.
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [dims, setDims] = useState({ w: 0, h: 0 });
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const measure = () => {
+      const r = el.getBoundingClientRect();
+      const w = Math.round(r.width);
+      const h = Math.round(r.height);
+      // Zero means hidden (warm tab display:none); keep the last real
+      // size so the canvas is not collapsed and re-expanded.
+      if (w <= 0 || h <= 0) return;
+      setDims((cur) => (cur.w === w && cur.h === h ? cur : { w, h }));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   // Hover state. Stored as state so the useEffect below can run a
   // Three.js scene traversal to dim per-node meshes on each hover
@@ -1734,6 +1914,36 @@ const Graph3DView: React.FC<{
   // disappears when the cursor moves); the hovered node and its lineage
   // brighten instead. The scene is traversed ONCE per hover change to collect
   // node meshes; the rAF tween then touches only that list until it settles.
+  //
+  // Lineage LINKS thicken 2.6x here too, imperatively: the linkWidth prop
+  // must stay a stable number because any linkWidth identity change makes
+  // three-forcegraph rebuild every link object from scratch. Straight
+  // links are unit cylinders whose radius is baked into a shared geometry
+  // and stretched via scale.z + lookAt — the library never writes
+  // scale.x/y, so a radial scale composes cleanly. Curved links are
+  // per-link TubeGeometry with the radius baked in; those are rebuilt in
+  // place with the boosted radius (matching what the library itself does
+  // on every position update). thickenedRef remembers exactly what was
+  // touched so the next hover change restores the base look first.
+  const thickenedRef = useRef<Array<{
+    mesh: {
+      parent?: unknown;
+      scale: { x: number; y: number };
+      geometry: { dispose?: () => void; type?: string };
+    };
+    mode: 'scale' | 'tube';
+    curve?: import('three').Curve<import('three').Vector3> | null;
+    baseRadius?: number;
+    /** The link record itself, kept so the 10Hz repair in the flight
+     *  loop can rebuild from the link's CURRENT curve after the engine
+     *  moves the nodes (the curve stored at hover time goes stale). */
+    link?: { __curve?: import('three').Curve<import('three').Vector3> | null };
+    /** The exact boosted TubeGeometry this code installed. The engine's
+     *  layout tick rebuilds curved-link tubes at base radius during
+     *  cooldown; a geometry identity mismatch is the cheap signal that
+     *  the boost was erased and must be re-applied. */
+    boostedGeo?: unknown;
+  }>>([]);
   useEffect(() => {
     if (appearance.renderMode !== '3d') return;
     type SceneLike = { traverse: (cb: (obj: unknown) => void) => void };
@@ -1742,6 +1952,60 @@ const Graph3DView: React.FC<{
       material?: { opacity?: number; userData?: { baseOpacity?: number } };
       parent?: { userData?: { nodeId?: string } };
     };
+    const THREE = threeRef.current;
+    // Restore the previous hover's thickened links before lighting the
+    // next set so a hover move never strands a thick link. The rebuild
+    // prefers the link's CURRENT curve: the engine may have moved the
+    // nodes since the hover started, and the curve captured at hover
+    // time would place the restored tube at stale positions.
+    for (const t of thickenedRef.current) {
+      if (!t.mesh.parent) continue; // already removed by a rebuild
+      if (t.mode === 'scale') {
+        t.mesh.scale.x = 1;
+        t.mesh.scale.y = 1;
+      } else if (THREE && typeof t.baseRadius === 'number') {
+        const curve = t.link?.__curve ?? t.curve;
+        if (curve) {
+          t.mesh.geometry.dispose?.();
+          (t.mesh as { geometry: unknown }).geometry = new THREE.TubeGeometry(curve, 30, t.baseRadius, 6, false);
+        }
+      }
+    }
+    thickenedRef.current = [];
+    if (hoveredId && THREE) {
+      // Mirror the library's width rounding so the restored tube radius
+      // is byte-identical to what a fresh layout pass would build.
+      const baseRadius = Math.ceil(appearance.linkWidth * 10) / 10 / 2;
+      type LinkLike = {
+        source?: { id?: string } | string;
+        target?: { id?: string } | string;
+        __lineObj?: { children?: unknown[]; isMesh?: boolean };
+        __curve?: import('three').Curve<import('three').Vector3> | null;
+      };
+      for (const l of dataRef.current.links as unknown as LinkLike[]) {
+        const srcId = typeof l.source === 'object' ? l.source?.id : l.source;
+        const tgtId = typeof l.target === 'object' ? l.target?.id : l.target;
+        if (!lineage.has(srcId ?? '') || !lineage.has(tgtId ?? '')) continue;
+        const lineObj = l.__lineObj;
+        const mesh = (lineObj?.children?.length ? lineObj.children[0] : lineObj) as {
+          isMesh?: boolean;
+          parent?: unknown;
+          scale: { x: number; y: number };
+          geometry?: { dispose?: () => void; type?: string };
+        } | undefined;
+        if (!mesh?.isMesh || !mesh.geometry) continue;
+        if (/^Cylinder/.test(mesh.geometry.type ?? '')) {
+          mesh.scale.x = 2.6;
+          mesh.scale.y = 2.6;
+          thickenedRef.current.push({ mesh: mesh as never, mode: 'scale' });
+        } else if (/^Tube/.test(mesh.geometry.type ?? '') && l.__curve) {
+          mesh.geometry.dispose?.();
+          const boosted = new THREE.TubeGeometry(l.__curve, 30, baseRadius * 2.6, 6, false);
+          (mesh as { geometry: unknown }).geometry = boosted;
+          thickenedRef.current.push({ mesh: mesh as never, mode: 'tube', curve: l.__curve, baseRadius, link: l, boostedGeo: boosted });
+        }
+      }
+    }
     let raf = 0;
     let meshes: Array<{ m: MeshLike; target: number }> | null = null;
     const collect = (): boolean => {
@@ -1777,17 +2041,34 @@ const Graph3DView: React.FC<{
     };
     raf = requestAnimationFrame(apply);
     return () => { if (raf) cancelAnimationFrame(raf); };
-  }, [hoveredId, lineage, appearance.renderMode, data]);
+  }, [hoveredId, lineage, appearance.renderMode, appearance.linkWidth, data]);
 
-  // Fit-to-view at three checkpoints so we catch both early- and late-
-  // settling force layouts. Without this the camera lingers at its
-  // default position and the user sees one disconnected dot far off
-  // in z-space.
+  // ONE fit-to-view per (re)layout, fired on the first onEngineStop with
+  // a fallback timer in case the engine is already cold. The old triple
+  // 350/1200/2500ms timeout visibly re-framed an on-screen graph twice;
+  // combined with warmupTicks (the layout settles before first paint)
+  // the framing now lands in a single move. Without any fit the camera
+  // lingers at its default position and the user sees one disconnected
+  // dot far off in z-space.
   //
   // Tighter padding (was 80 → 12) so the cluster fills the viewport.
   // d3Force tweaks pull nodes closer: weaker repulsive charge (was
   // ~-300 default → -90) and shorter link distance (was ~30 default →
   // 18) trade out-of-cluster breathing room for in-cluster density.
+  const fitDoneRef = useRef(false);
+  const runInitialFit = useCallback(() => {
+    if (fitDoneRef.current) return;
+    const r = fgRef.current as {
+      zoomToFit?: (ms: number, pad: number) => void;
+      centerAt?: (x: number, y: number, ms: number) => void;
+    } | null;
+    // Leave the fit pending while the graph is not mounted yet (the
+    // two-state load gate) so a later engine stop can still claim it.
+    if (!r?.zoomToFit) return;
+    fitDoneRef.current = true;
+    r.zoomToFit(600, 12);
+    if (r.centerAt) r.centerAt(0, 0, 600);
+  }, []);
   useEffect(() => {
     const ref = fgRef.current as {
       d3Force?: (forceName: string) => {
@@ -1799,18 +2080,10 @@ const Graph3DView: React.FC<{
       ref.d3Force('charge')?.strength?.(appearance.charge);
       ref.d3Force('link')?.distance?.(appearance.linkDistance);
     }
-    const timeouts = [350, 1200, 2500].map((ms) =>
-      setTimeout(() => {
-        const r = fgRef.current as {
-          zoomToFit?: (ms: number, pad: number) => void;
-          centerAt?: (x: number, y: number, ms: number) => void;
-        } | null;
-        if (r?.zoomToFit) r.zoomToFit(600, 12);
-        if (r?.centerAt) r.centerAt(0, 0, 600);
-      }, ms),
-    );
-    return () => timeouts.forEach(clearTimeout);
-  }, [data, appearance.renderMode, appearance.vizPreset, appearance.charge, appearance.linkDistance]);
+    fitDoneRef.current = false;
+    const fallback = setTimeout(runInitialFit, 2000);
+    return () => clearTimeout(fallback);
+  }, [data, appearance.renderMode, appearance.vizPreset, appearance.charge, appearance.linkDistance, threeReady, runInitialFit]);
 
   // Cluster tint: when ON (and 3D), add a translucent halo sphere
   // centered on each per-source centroid so the user can see source-
@@ -1833,7 +2106,11 @@ const Graph3DView: React.FC<{
       | null;
     if (!scene?.add) return;
     const prior = scene.getObjectByName?.('__lineage_clusters__');
-    if (prior) scene.remove?.(prior);
+    if (prior) {
+      scene.remove?.(prior);
+      // Each rebuild allocates fresh halo spheres; free the old ones.
+      disposeLineageGroup(prior);
+    }
 
     // react-force-graph stores resolved positions on the node objects
     // themselves (x/y/z). After settle they're populated.
@@ -1909,7 +2186,10 @@ const Graph3DView: React.FC<{
         | null;
       if (scene) {
         const prior = scene.getObjectByName?.('__lineage_clusters__');
-        if (prior) scene.remove?.(prior);
+        if (prior) {
+          scene.remove?.(prior);
+          disposeLineageGroup(prior);
+        }
       }
       return;
     }
@@ -1929,7 +2209,10 @@ const Graph3DView: React.FC<{
           })
         | null;
       const prior = scene?.getObjectByName?.('__lineage_clusters__');
-      if (prior && scene?.remove) scene.remove(prior);
+      if (prior && scene?.remove) {
+        scene.remove(prior);
+        disposeLineageGroup(prior);
+      }
     };
   }, [appearance.clusterColoring, appearance.renderMode, rebuildClusterHalos]);
 
@@ -1939,24 +2222,37 @@ const Graph3DView: React.FC<{
   //
   // Wrapped in a deferred handle so the heavy 1500-point geometry build
   // doesn't block the React commit phase — that pile-on is what triggers
-  // "[Violation] 'message' handler took Xms" on initial modal open.
+  // "[Violation] 'message' handler took Xms" on initial modal open. The
+  // deferral window is short (100ms) and the setup retries until the
+  // scene exists, so background + nodes + framing appear together
+  // instead of the stars trailing in seconds later (the old code both
+  // waited 500ms and silently gave up when the scene wasn't ready yet).
   useEffect(() => {
     if (appearance.renderMode !== '3d') return;
     let teardown: (() => void) | null = null;
     let cancelled = false;
+    let retryTimer: number | null = null;
+    let attempts = 0;
     type IdleCb = (cb: () => void, opts?: { timeout: number }) => number;
     const ric = (window as unknown as { requestIdleCallback?: IdleCb }).requestIdleCallback;
     const schedule = (fn: () => void) => {
-      if (typeof ric === 'function') ric(fn, { timeout: 500 });
+      if (typeof ric === 'function') ric(fn, { timeout: 100 });
       else setTimeout(fn, 0);
     };
-    schedule(() => {
+    const trySetup = () => {
       if (cancelled) return;
       const setup = setupStarfield();
-      if (setup) teardown = setup;
-    });
+      if (setup) {
+        teardown = setup;
+        return;
+      }
+      attempts += 1;
+      if (attempts < 40) retryTimer = window.setTimeout(trySetup, 50);
+    };
+    schedule(trySetup);
     return () => {
       cancelled = true;
+      if (retryTimer != null) window.clearTimeout(retryTimer);
       teardown?.();
     };
 
@@ -2027,7 +2323,9 @@ const Graph3DView: React.FC<{
       starsMat.dispose();
     };
     }
-  }, [appearance.renderMode, appearance.vizPreset, data]);
+    // threeReady re-runs the setup once the graph actually mounts (the
+    // two-state load gate keeps the scene from existing before then).
+  }, [appearance.renderMode, appearance.vizPreset, data, threeReady]);
 
   // Tron-grid preset: lay a glowing ground GridHelper under the nodes,
   // injected straight into the Three.js scene (like the starfield) and
@@ -2064,6 +2362,8 @@ const Graph3DView: React.FC<{
       teardown = () => {
         scene.remove(grid);
         grid.geometry.dispose();
+        // GridHelper's LineBasicMaterial holds GPU resources too.
+        mat.dispose();
       };
     };
     const t = setTimeout(() => void run(), 400);
@@ -2073,7 +2373,9 @@ const Graph3DView: React.FC<{
       teardown?.();
       removeExisting();
     };
-  }, [appearance.renderMode, appearance.vizPreset, data]);
+    // threeReady re-runs the injection once the graph mounts (before it
+    // the scene doesn't exist and run() would silently no-op).
+  }, [appearance.renderMode, appearance.vizPreset, data, threeReady]);
 
   // Selection "handle": scale the selected node's group up so both the
   // click target and the visual selection read clearly. Walks the scene
@@ -2098,6 +2400,22 @@ const Graph3DView: React.FC<{
     });
   }, [selectedId, appearance.renderMode, data]);
 
+  // The warm-mounted LEARN tab hides this view with display:none, which
+  // does NOT stop the graph library's internal render loop (the kapsule
+  // _animationCycle keeps requesting frames behind the hidden canvas).
+  // pauseAnimation / resumeAnimation are kapsule-exposed methods on the
+  // component ref; both react-force-graph-3d and react-force-graph-2d
+  // declare them in their .d.ts, and resuming while already running is a
+  // no-op, so the visible=true pass is safe on every mount. renderMode
+  // and threeReady stay in the deps so the effect re-runs once the
+  // actual graph instance behind fgRef mounts or is swapped.
+  useEffect(() => {
+    const r = fgRef.current as { pauseAnimation?: () => void; resumeAnimation?: () => void } | null;
+    if (!r) return;
+    if (visible) r.resumeAnimation?.();
+    else r.pauseAnimation?.();
+  }, [visible, appearance.renderMode, threeReady]);
+
   // Spaceship flight (3D). A single rAF loop integrates a velocity from the
   // held keys (W/S forward, A/D strafe, Q/E up-down, arrows too) with ease-in
   // acceleration and exponential drag, so holding a key accelerates and
@@ -2106,6 +2424,11 @@ const Graph3DView: React.FC<{
   // button FTLs back to the cluster. Ignored while typing in the search box.
   useEffect(() => {
     if (appearance.renderMode !== '3d') return;
+    // A hidden warm-mounted tab must not keep the flight rAF loop (and
+    // its ~10Hz hit-proxy scan) running behind display:none. Returning
+    // here tears the loop down via the cleanup; the effect re-runs and
+    // restarts it when the tab is shown again.
+    if (!visible) return;
     const FLY = new Set(['w', 'a', 's', 'd', 'q', 'e', 'arrowup', 'arrowdown', 'arrowleft', 'arrowright']);
     const keys = new Set<string>();
     let raf = 0;
@@ -2117,6 +2440,7 @@ const Graph3DView: React.FC<{
     let homeTween: null | { t: number; dur: number; px: number; py: number; pz: number; tx: number; ty: number; tz: number; mx: number; my: number; mz: number; lx: number; ly: number; lz: number } = null;
     let wasFar = false;
     let frame = 0;
+    let hitFrame = 0;
 
     type FgApi = {
       camera?: () => import('three').PerspectiveCamera;
@@ -2186,6 +2510,54 @@ const Graph3DView: React.FC<{
       raf = requestAnimationFrame(loop);
       const dt = last ? Math.min(0.05, (t - last) / 1000) : 0.016;
       last = t;
+      // Hit-proxy autoscale, throttled to ~10Hz and run BEFORE the idle
+      // gate (orbit/trackball dragging moves the camera without setting
+      // any flight state). Each node's invisible hover target grows with
+      // camera distance so far-away nodes stay hoverable, floored at its
+      // base radius and capped at 8 world units (~0.45x the default link
+      // rest length of 18) so proxies never swallow their neighbors.
+      hitFrame += 1;
+      if (hitFrame % 6 === 0) {
+        const hctx = getCtx();
+        if (hctx) {
+          const camPos = hctx.cam.position;
+          type ProxyNode = {
+            x?: number; y?: number; z?: number;
+            __threeObj?: { children?: Array<{ userData?: { hitProxy?: boolean; hitBaseRadius?: number }; scale?: { setScalar: (s: number) => void } }> };
+          };
+          for (const n of dataRef.current.nodes as unknown as ProxyNode[]) {
+            const grp = n.__threeObj;
+            if (!grp?.children || typeof n.x !== 'number') continue;
+            for (const child of grp.children) {
+              if (!child.userData?.hitProxy) continue;
+              const base = child.userData.hitBaseRadius ?? 1;
+              const dist = Math.hypot(n.x - camPos.x, (n.y ?? 0) - camPos.y, (n.z ?? 0) - camPos.z);
+              child.scale?.setScalar(Math.min(8, Math.max(base, dist * 0.02)));
+              break;
+            }
+          }
+          // While a hover lineage is active, the engine's layout tick
+          // rebuilds every curved link's TubeGeometry at base radius on
+          // each position update during the cooldown, erasing the 2.6x
+          // thickening the hover effect installed. Re-apply the boost to
+          // any lineage tube whose geometry identity no longer matches
+          // the one this code installed, rebuilding from the link's
+          // CURRENT curve so the tube tracks the still-moving nodes.
+          // Bounded cost: lineage links only, ~10Hz, and thickenedRef is
+          // empty whenever no hover is active; once the engine stops the
+          // identity check matches and this loop does no work.
+          for (const t of thickenedRef.current) {
+            if (t.mode !== 'tube' || !t.mesh.parent) continue;
+            const curve = t.link?.__curve ?? t.curve;
+            if (!curve || typeof t.baseRadius !== 'number') continue;
+            if ((t.mesh as { geometry?: unknown }).geometry === t.boostedGeo) continue;
+            t.mesh.geometry.dispose?.();
+            const reboosted = new hctx.THREE.TubeGeometry(curve, 30, t.baseRadius * 2.6, 6, false);
+            (t.mesh as { geometry: unknown }).geometry = reboosted;
+            t.boostedGeo = reboosted;
+          }
+        }
+      }
       // Idle-gate: when there's no flight input, residual motion, or warp active
       // (and the cluster centroid is already known), skip the entire per-frame
       // flight/centroid/warp computation. The rAF is already re-queued above, so
@@ -2328,7 +2700,7 @@ const Graph3DView: React.FC<{
       if (vignetteRef.current) vignetteRef.current.style.opacity = '0';
       flyRef.current = { flyHome: () => {}, flyForward: () => {} };
     };
-  }, [appearance.renderMode]);
+  }, [appearance.renderMode, visible]);
 
   // Dispose the streak mesh on unmount (three objects must be freed manually).
   useEffect(() => () => {
@@ -2339,6 +2711,140 @@ const Graph3DView: React.FC<{
     seg.material?.dispose?.();
     streakRef.current = null;
   }, []);
+
+  // Per-node Three.js object builder. Memoized (a stable function
+  // identity per generation) because ANY nodeThreeObject identity change
+  // makes three-forcegraph clear + rebuild every node object — the old
+  // inline function did that on every render, including each hover.
+  // A generation is cut when shape/wireframe change (different geometry)
+  // or when three finishes loading (first real build). The closure also
+  // carries the generation's geometry cache, keyed by (shape, size
+  // bucket): buckets are 0.05 world units wide — visually
+  // indistinguishable — and collapse the per-node allocations. The
+  // library _deallocate()s child geometries when it removes node
+  // objects; a disposed-but-cached geometry is transparently re-uploaded
+  // by three on next use, so the sharing stays safe.
+  const nodeGen = useMemo(() => {
+    const geoCache = new Map<string, import('three').BufferGeometry>();
+    const shape = appearance.nodeShape;
+    const wireframe = appearance.wireframe;
+    const getGeometry = (THREE: typeof import('three'), size: number): import('three').BufferGeometry => {
+      const bucket = Math.round(size * 20) / 20;
+      const key = `${shape}:${bucket}`;
+      const cached = geoCache.get(key);
+      if (cached) return cached;
+      let geometry: import('three').BufferGeometry;
+      switch (shape) {
+        case 'cube':
+          geometry = new THREE.BoxGeometry(bucket, bucket, bucket);
+          break;
+        case 'octahedron':
+          geometry = new THREE.OctahedronGeometry(bucket * 0.85);
+          break;
+        case 'tetrahedron':
+          geometry = new THREE.TetrahedronGeometry(bucket);
+          break;
+        case 'icosahedron':
+          geometry = new THREE.IcosahedronGeometry(bucket * 0.85);
+          break;
+        case 'torus':
+          geometry = new THREE.TorusGeometry(bucket * 0.7, bucket * 0.25, 8, 16);
+          break;
+        case 'sphere':
+        default:
+          geometry = new THREE.SphereGeometry(bucket, 16, 16);
+          break;
+      }
+      geoCache.set(key, geometry);
+      return geometry;
+    };
+    const getHaloGeometry = (THREE: typeof import('three'), size: number): import('three').BufferGeometry => {
+      const bucket = Math.round(size * 20) / 20;
+      const key = `halo:${shape}:${bucket}`;
+      const cached = geoCache.get(key);
+      if (cached) return cached;
+      const halo = getGeometry(THREE, size).clone();
+      halo.scale(1.45, 1.45, 1.45);
+      geoCache.set(key, halo);
+      return halo;
+    };
+    const build = (node: { id?: string; color?: string; val?: number }): unknown => {
+      const THREE = threeRef.current;
+      // The two-state load gate means the graph only mounts post-import,
+      // but the guard keeps the accessor safe if probed early.
+      if (!THREE) return undefined;
+      const size = Math.cbrt(node.val ?? 4);
+      const geometry = getGeometry(THREE, size);
+      const colorHex = node.color ?? '#a78bfa';
+      const baseColor = new THREE.Color(colorHex);
+      // Build a Group so we can stack a wireframe halo + inner solid for
+      // the glossy "neon" look the codepens go for.
+      const group = new THREE.Group();
+      // Tag the group with the node id so the hover-dim effect (which
+      // traverses the scene) can find which child meshes belong to which
+      // graph node. Each material also carries userData.baseOpacity so
+      // the dim/restore math knows the un-dimmed target value. Materials
+      // stay per-node on purpose: the lineage glow tween mutates opacity
+      // per mesh, so shared materials would couple unrelated nodes.
+      group.userData.nodeId = node.id;
+      if (wireframe) {
+        const wireMat = new THREE.MeshBasicMaterial({
+          color: baseColor,
+          wireframe: true,
+          transparent: true,
+          opacity: 0.95,
+        });
+        wireMat.userData.baseOpacity = 0.95;
+        group.add(new THREE.Mesh(geometry, wireMat));
+      } else {
+        // Solid inner core + slightly larger translucent "halo" that
+        // approximates a glow without needing a postprocessing pass.
+        const innerMat = new THREE.MeshBasicMaterial({
+          color: baseColor,
+          transparent: true,
+          opacity: 0.95,
+        });
+        innerMat.userData.baseOpacity = 0.95;
+        group.add(new THREE.Mesh(geometry, innerMat));
+        const haloMat = new THREE.MeshBasicMaterial({
+          color: baseColor,
+          transparent: true,
+          opacity: 0.22,
+          depthWrite: false,
+          blending: THREE.AdditiveBlending,
+        });
+        haloMat.userData.baseOpacity = 0.22;
+        group.add(new THREE.Mesh(getHaloGeometry(THREE, size), haloMat));
+      }
+      // Invisible hover hit-proxy: ONE shared unit-sphere geometry + ONE
+      // shared invisible material (module-cached), scaled per node to
+      // 2.5x the node size. Raycasting recurses into node-group children
+      // (getGraphObj walks back up to the group), so this widens the
+      // hover target at zero render cost. The flight loop re-scales it
+      // with camera distance.
+      if (!hitProxyGeo) hitProxyGeo = new THREE.SphereGeometry(1, 8, 6);
+      if (!hitProxyMat) hitProxyMat = new THREE.MeshBasicMaterial({ visible: false });
+      const hit = new THREE.Mesh(hitProxyGeo, hitProxyMat);
+      hit.userData.hitProxy = true;
+      hit.userData.hitBaseRadius = 2.5 * size;
+      hit.scale.setScalar(2.5 * size);
+      group.add(hit);
+      return group;
+    };
+    return { build, geoCache };
+  }, [appearance.nodeShape, appearance.wireframe, threeReady]);
+  const nodeThreeObject = nodeGen.build;
+
+  // Dispose the outgoing generation's cached geometries when a new one
+  // replaces it, and on unmount. Double-dispose (the library also
+  // deallocates on object removal) is harmless — dispose is idempotent.
+  useEffect(() => {
+    const cache = nodeGen.geoCache;
+    return () => {
+      cache.forEach((g) => g.dispose());
+      cache.clear();
+    };
+  }, [nodeGen]);
 
   if (connected.nodes.length === 0) {
     return (
@@ -2357,148 +2863,26 @@ const Graph3DView: React.FC<{
         <div style="color: #a3a3a3; font-size: 10px;">${escapeHtml(n.source)} · ${escapeHtml(n.model)}</div>
       </div>`;
 
-  // Build a Three.js mesh per node based on the chosen shape +
-  // wireframe flag. Lazy-imports three only when the 3D mode is on
-  // so 2D users don't pay the bundle cost.
-  const buildNodeObject = useMemo(() => {
-    let THREE: typeof import('three') | null = null;
-    return async (
-      node: { color?: string; val?: number },
-    ): Promise<unknown> => {
-      if (!THREE) {
-        THREE = await import('three');
-      }
-      const t = THREE;
-      const size = Math.cbrt(node.val ?? 4);
-      let geometry: import('three').BufferGeometry;
-      switch (appearance.nodeShape) {
-        case 'cube':
-          geometry = new t.BoxGeometry(size, size, size);
-          break;
-        case 'octahedron':
-          geometry = new t.OctahedronGeometry(size * 0.85);
-          break;
-        case 'tetrahedron':
-          geometry = new t.TetrahedronGeometry(size);
-          break;
-        case 'icosahedron':
-          geometry = new t.IcosahedronGeometry(size * 0.85);
-          break;
-        case 'torus':
-          geometry = new t.TorusGeometry(size * 0.7, size * 0.25, 8, 16);
-          break;
-        case 'sphere':
-        default:
-          geometry = new t.SphereGeometry(size, 12, 12);
-          break;
-      }
-      const color = new t.Color(node.color ?? '#a78bfa');
-      const material = new t.MeshBasicMaterial({
-        color,
-        wireframe: appearance.wireframe,
-        transparent: true,
-        opacity: appearance.wireframe ? 0.95 : 0.9,
-      });
-      const mesh = new t.Mesh(geometry, material);
-      return mesh;
-    };
-    // Re-build when shape OR wireframe toggle changes.
-  }, [appearance.nodeShape, appearance.wireframe]);
-
-  // Synchronous wrapper: react-force-graph calls nodeThreeObject
-  // synchronously, so we cache the lazy-import promise + render with
-  // a placeholder until three is loaded. In practice three loads in
-  // <100ms once the user opens the 3D tab.
-  const threeRef = useRef<typeof import('three') | null>(null);
-  useEffect(() => {
-    if (appearance.renderMode !== '3d') return;
-    void import('three').then((mod) => {
-      threeRef.current = mod;
-    });
-  }, [appearance.renderMode]);
-
-  const nodeThreeObject = (node: { id?: string; color?: string; val?: number }): unknown => {
-    void buildNodeObject;
-    const THREE = threeRef.current;
-    if (!THREE) return undefined; // first frame: fall through to default sphere
-    const size = Math.cbrt(node.val ?? 4);
-    let geometry: import('three').BufferGeometry;
-    switch (appearance.nodeShape) {
-      case 'cube':
-        geometry = new THREE.BoxGeometry(size, size, size);
-        break;
-      case 'octahedron':
-        geometry = new THREE.OctahedronGeometry(size * 0.85);
-        break;
-      case 'tetrahedron':
-        geometry = new THREE.TetrahedronGeometry(size);
-        break;
-      case 'icosahedron':
-        geometry = new THREE.IcosahedronGeometry(size * 0.85);
-        break;
-      case 'torus':
-        geometry = new THREE.TorusGeometry(size * 0.7, size * 0.25, 8, 16);
-        break;
-      case 'sphere':
-      default:
-        geometry = new THREE.SphereGeometry(size, 16, 16);
-        break;
-    }
-    const colorHex = node.color ?? '#a78bfa';
-    const baseColor = new THREE.Color(colorHex);
-    // Build a Group so we can stack a wireframe halo + inner solid for
-    // the glossy "neon" look the codepens go for.
-    const group = new THREE.Group();
-    // Tag the group with the node id so the hover-dim effect (which
-    // traverses the scene) can find which child meshes belong to which
-    // graph node. Each material also carries userData.baseOpacity so
-    // the dim/restore math knows the un-dimmed target value.
-    group.userData.nodeId = node.id;
-    if (appearance.wireframe) {
-      const wireMat = new THREE.MeshBasicMaterial({
-        color: baseColor,
-        wireframe: true,
-        transparent: true,
-        opacity: 0.95,
-      });
-      wireMat.userData.baseOpacity = 0.95;
-      group.add(new THREE.Mesh(geometry, wireMat));
-    } else {
-      // Solid inner core + slightly larger translucent "halo" that
-      // approximates a glow without needing a postprocessing pass.
-      const innerMat = new THREE.MeshBasicMaterial({
-        color: baseColor,
-        transparent: true,
-        opacity: 0.95,
-      });
-      innerMat.userData.baseOpacity = 0.95;
-      group.add(new THREE.Mesh(geometry, innerMat));
-      const haloGeo = geometry.clone();
-      haloGeo.scale(1.45, 1.45, 1.45);
-      const haloMat = new THREE.MeshBasicMaterial({
-        color: baseColor,
-        transparent: true,
-        opacity: 0.22,
-        depthWrite: false,
-        blending: THREE.AdditiveBlending,
-      });
-      haloMat.userData.baseOpacity = 0.22;
-      group.add(new THREE.Mesh(haloGeo, haloMat));
-    }
-    return group;
-  };
+  // Explicit canvas size once the container has been measured; before
+  // that the library would size itself from the window instead.
+  const graphDims = dims.w > 0 && dims.h > 0 ? { width: dims.w, height: dims.h } : {};
 
   return (
-    <div className="absolute inset-0" style={{ background: bgColor }}>
+    <div ref={containerRef} className="absolute inset-0" style={{ background: bgColor }}>
       {appearance.renderMode === '3d' ? (
+        threeReady ? (
         <ForceGraph3D
           ref={fgRef}
+          {...graphDims}
           graphData={data}
           nodeAutoColorBy="source"
           nodeRelSize={7}
           backgroundColor={bgColor}
           showNavInfo={false}
           controlType={appearance.controlType}
+          // Pre-run the force layout off-screen so the graph appears
+          // near-settled instead of exploding into place on mount.
+          warmupTicks={80}
           onNodeHover={handleNodeHover}
           onNodeClick={handleNodeClick}
           onNodeRightClick={handleNodeRightClick}
@@ -2511,14 +2895,10 @@ const Graph3DView: React.FC<{
             return onPath ? '#f3e8ff' : (l.color ?? '#a78bfa');
           }}
           linkOpacity={appearance.linkOpacity}
-          linkWidth={(l: { source?: { id?: string } | string; target?: { id?: string } | string }) => {
-            if (!hoveredId) return appearance.linkWidth;
-            const srcId = typeof l.source === 'object' ? l.source?.id : l.source;
-            const tgtId = typeof l.target === 'object' ? l.target?.id : l.target;
-            const onPath = lineage.has(srcId ?? '') && lineage.has(tgtId ?? '');
-            // Glow, don't hide: lineage links thicken, the rest stay unchanged.
-            return onPath ? appearance.linkWidth * 2.6 : appearance.linkWidth;
-          }}
+          // MUST stay a stable number: any linkWidth identity change makes
+          // three-forcegraph rebuild every link cylinder. The hover 2.6x
+          // lineage thickening is applied imperatively in the glow effect.
+          linkWidth={appearance.linkWidth}
           linkCurvature={appearance.edgeCurve}
           linkDirectionalArrowLength={5}
           linkDirectionalArrowRelPos={0.92}
@@ -2529,18 +2909,37 @@ const Graph3DView: React.FC<{
           nodeThreeObject={nodeThreeObject}
           nodeLabel={labelHtml}
           onEngineStop={() => {
-            // Re-anchor cluster halos around the new settled positions.
-            // The callback short-circuits if cluster coloring is off, so
-            // this is a no-op cost when the user isn't using the tint.
+            // First stop after a (re)layout = the settle point: claim the
+            // single initial camera fit here (the fallback timer covers a
+            // cold engine). Then re-anchor cluster halos around the new
+            // settled positions — that callback short-circuits if cluster
+            // coloring is off, so it costs nothing without the tint.
+            runInitialFit();
             void rebuildClusterHalos();
           }}
         />
+        ) : (
+          // Two-state load: keep the engine-loading note up until three
+          // finishes importing. Mounting <ForceGraph3D> earlier makes
+          // nodeThreeObject return undefined, so the library renders its
+          // default spheres (~7x larger) first and rebuilds moments later.
+          <div className="absolute inset-0 flex items-center justify-center text-[10px] font-mono text-zinc-500">Loading 3D engine…</div>
+        )
       ) : (
         <ForceGraph2D
           ref={fgRef}
+          {...graphDims}
           graphData={data}
           nodeRelSize={7}
           backgroundColor={bgColor}
+          // Pre-run the force layout off-screen so the graph appears
+          // near-settled instead of exploding into place on mount,
+          // matching the 3D branch above.
+          warmupTicks={80}
+          // First engine stop claims the single initial camera fit
+          // (runInitialFit is once-guarded via fitDoneRef); without it
+          // the 2D branch only fit via the 2s fallback timer.
+          onEngineStop={runInitialFit}
           // Node drag is on by default in ForceGraph2D — being explicit
           // here so a refactor doesn't silently disable it. Each node is
           // grabbable; the force layout updates around it in real time.
@@ -2804,7 +3203,7 @@ const Graph3DView: React.FC<{
       })()}
     </div>
   );
-};
+});
 
 function pickNodeColor(n: GraphNode): string {
   switch (n.source) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -185,3 +185,24 @@ select optgroup {
 .text-xs,   .text-xs\!   { font-size: calc(0.75rem  * var(--text-scale, 1)) !important; }
 .text-sm,   .text-sm\!   { font-size: calc(0.875rem * var(--text-scale, 1)) !important; }
 .text-base, .text-base\! { font-size: calc(1rem     * var(--text-scale, 1)) !important; }
+
+/* ---------------------------------------------------------------------------
+ * Genealogy graph hover glow (LineageModal's GenealogyView).
+ * The classes + the --glow custom property are toggled imperatively via
+ * classList so React never re-renders the mounted SVG while the mouse moves.
+ * Deliberately NO transitions on any of these rules: transitioned filters on
+ * hundreds of SVG groups forced a repaint storm; glow must apply and clear in
+ * a single frame.
+ * Node cards are small (140x140) so their drop-shadow filter surfaces stay
+ * cheap. Edges must NOT use drop-shadow: a bezier edge's <g> bounding box can
+ * span thousands of px, and the oversized filter surface makes Chromium drop
+ * or checkerboard the layer (edges visibly flash out of existence). Lit edges
+ * therefore glow via full opacity + a 3x stroke instead.
+ * ------------------------------------------------------------------------- */
+.genealogy-svg.gen-hovering g[data-node-id]:not(.gen-lit) { opacity: 0.35; }
+.genealogy-svg.gen-hovering g[data-edge-from]:not(.gen-lit) { opacity: 0.12; }
+.genealogy-svg g.gen-lit[data-node-id] { filter: drop-shadow(0 0 14px var(--glow)) brightness(1.3); }
+.genealogy-svg g.gen-lit-hot[data-node-id] { filter: drop-shadow(0 0 26px var(--glow)) drop-shadow(0 0 10px var(--glow)) brightness(1.6) saturate(1.35); }
+.genealogy-svg g.gen-lit-hot[data-node-id] > rect:first-of-type { stroke-width: 4; }
+.genealogy-svg g.gen-lit[data-edge-from] { opacity: 1; }
+.genealogy-svg g.gen-lit[data-edge-from] path { stroke-width: 4.5; }

--- a/frontend/src/lib/projectClient.ts
+++ b/frontend/src/lib/projectClient.ts
@@ -48,6 +48,8 @@ export interface TasmoClipInput {
   midi_notes?: unknown[] | null;
   loop_start?: number | null;
   loop_end?: number | null;
+  /** Per-clip mute; optional so pre-mute payloads stay valid. */
+  muted?: boolean;
 }
 
 export interface TasmoTrackInput {
@@ -89,6 +91,8 @@ export interface TasmoLoadedClip {
   audio_file: string | null;
   midi_notes?: Array<Record<string, number>> | null;
   instrument_program?: number;
+  /** Per-clip mute; absent in .tasmo files written before the field existed. */
+  muted?: boolean;
 }
 
 export interface TasmoLoadedTrack {

--- a/frontend/src/lib/projectImport.ts
+++ b/frontend/src/lib/projectImport.ts
@@ -242,6 +242,9 @@ const buildClip = async (
     sourceKind,
     sourcePianoRoll,
     sourceBpm: sourceKind ? bpm : undefined,
+    // Restore the per-clip mute; omit the field entirely for unmuted clips so
+    // pre-mute projects hydrate exactly as before.
+    muted: c.muted ? true : undefined,
   };
 };
 
@@ -389,6 +392,8 @@ export function captureEditorSession(): CapturedSession {
                   velocity: n.velocity,
                 }))
               : null,
+          // Per-clip mute survives the .tasmo round-trip (fades do not yet).
+          muted: c.muted ?? false,
         };
       });
     return {

--- a/frontend/src/state/editorStore.ts
+++ b/frontend/src/state/editorStore.ts
@@ -50,6 +50,10 @@ export interface AudioClip {
   fadeInSec?: number;
   /** Fade-out duration in seconds (0 = no fade). */
   fadeOutSec?: number;
+  /** Muted: the clip is skipped by playback and every offline bounce. This is
+   *  the ONE clip property liveMixer gates live mid-playback; all other clip
+   *  edits are structural and take effect on the next play. */
+  muted?: boolean;
 }
 
 export interface EditorTrack {

--- a/frontend/src/state/ganStore.ts
+++ b/frontend/src/state/ganStore.ts
@@ -23,6 +23,13 @@ interface GanState {
   close: () => void;
 }
 
+// In-flight ensureAres promise. package-ares rewrites the installed Ares
+// runtime files in place, so two concurrent ensures (or an openById racing
+// one) could serve half-written files to the stage iframe. All concurrent
+// callers await this single run; it resets when the run settles, so later
+// calls still repackage and pick up bundled-project edits.
+let ensureAresInflight: Promise<void> | null = null;
+
 export const useGanStore = create<GanState>()((set, get) => ({
   plugins: [],
   busy: false,
@@ -105,13 +112,22 @@ export const useGanStore = create<GanState>()((set, get) => ({
     // Always (re)package: package-ares is idempotent (rebuilds the .gan + extracts
     // a fresh runtime), so this guarantees edits to the bundled Ares project.json
     // ship even on a machine that already has an older ares.gan installed.
-    try {
-      await ganApi.packageAres();
-      await get().refresh();
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : 'Ares package failed';
-      logError('plugin', msg);
-    }
+    // Concurrent calls (MixView mounts fire two ensure paths in the same tick)
+    // share ONE in-flight run so the runtime is never rewritten by two
+    // package-ares requests at once.
+    if (ensureAresInflight) return ensureAresInflight;
+    ensureAresInflight = (async () => {
+      try {
+        await ganApi.packageAres();
+        await get().refresh();
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'Ares package failed';
+        logError('plugin', msg);
+      } finally {
+        ensureAresInflight = null;
+      }
+    })();
+    return ensureAresInflight;
   },
 
   close: () => set({ activeId: null, activeUrl: null, activeName: null }),

--- a/frontend/src/state/liveMixer.ts
+++ b/frontend/src/state/liveMixer.ts
@@ -25,9 +25,10 @@
  * The OFFLINE bounce is kept as-is for export / commit / send-to-init — those
  * genuinely need a rendered file. liveMixer only replaces the live PREVIEW.
  *
- * Honesty / scope: live updates cover the MIXER params (volume/pan/mute/solo).
- * Structural clip edits (add/remove/split/move) made WHILE playing take effect
- * on the next play, same as a hardware mixer wouldn't re-cut tape mid-take.
+ * Honesty / scope: live updates cover the MIXER params (volume/pan/mute/solo)
+ * plus per-clip mute (a retained gain gate per scheduled clip). Structural clip
+ * edits (add/remove/split/move) made WHILE playing take effect on the next
+ * play, same as a hardware mixer wouldn't re-cut tape mid-take.
  */
 import {
   useEditorStore,
@@ -94,6 +95,11 @@ let unsubEditor: (() => void) | null = null;
 let lastMixSig = '';
 let lastTimePush = 0; // throttle playerStore.currentTime writes
 let midiTimers: number[] = []; // setTimeout handles for scheduled MIDI note on/off
+// Per-clip mute gates retained at schedule time, keyed by clip id. Structural
+// clip edits still require a re-schedule; muted is the one clip property gated
+// live, so the editor-store subscription flips these gains mid-playback.
+let clipMuteGains = new Map<string, GainNode>();
+let lastClipMuteSig = '';
 let liveMidiActive = false; // true while MIDI clips play via the live synth (vs their bounce)
 let autoFxTimer = 0; // setInterval handle for the FX-param automation lookahead
 
@@ -144,6 +150,27 @@ function mixSignature(tracks: EditorTrack[]): string {
   let s = '';
   for (const t of tracks) s += `${t.id}:${t.volume}:${t.pan}:${t.mute}:${t.solo}|`;
   return s;
+}
+
+/** Signature of which clips are muted, so the clips-slice subscription (which
+ *  also fires on drags/resizes) only touches the live gates on a mute change. */
+function clipMuteSignature(clips: AudioClip[]): string {
+  let s = '';
+  for (const c of clips) if (c.muted) s += `${c.id}|`;
+  return s;
+}
+
+/** Push each scheduled clip's live mute gate (0 or 1, click-free). Clips muted
+ *  at schedule time were never scheduled, so unmuting those takes effect on the
+ *  next play; muting (and re-unmuting) a playing clip is audible immediately. */
+function applyClipMutesLive(): void {
+  if (clipMuteGains.size === 0) return;
+  const ctx = getEngineCtx();
+  for (const clip of useEditorStore.getState().clips) {
+    const gate = clipMuteGains.get(clip.id);
+    if (!gate) continue;
+    gate.gain.setTargetAtTime(clip.muted ? 0 : 1, ctx.currentTime, RAMP_TC);
+  }
 }
 
 /** Push current track volume/pan/mute/solo onto the live nodes (click-free).
@@ -285,7 +312,11 @@ function scheduleClips(clips: AudioClip[], fromSec: number): void {
   const ctx = getEngineCtx();
   const now = ctx.currentTime;
   sources = [];
+  clipMuteGains = new Map();
   for (const clip of clips) {
+    // Muted clips are not scheduled at all; a mute toggled DURING playback is
+    // handled live by the clip's mute gate (see applyClipMutesLive).
+    if (clip.muted) continue;
     // When the live synth drives MIDI, skip the clip's bounced audio so we don't
     // double up; scheduleMidiClips plays its notes instead.
     if (liveMidiActive && isMidiClip(clip)) continue;
@@ -330,12 +361,18 @@ function scheduleClips(clips: AudioClip[], fromSec: number): void {
       g.linearRampToValueAtTime(0, clipStartCtx + safeDur);
     }
 
+    // Live mute gate, kept separate from clipGain so a mid-playback mute toggle
+    // never clobbers the fade envelope's scheduled ramps.
+    const muteGate = ctx.createGain();
+    muteGate.gain.value = 1;
+    clipMuteGains.set(clip.id, muteGate);
+
     const src = ctx.createBufferSource();
     src.buffer = buf;
-    src.connect(clipGain).connect(nodes.gain);
+    src.connect(clipGain).connect(muteGate).connect(nodes.gain);
     src.start(when, safeOffset + into, remaining);
     src.onended = () => {
-      try { src.disconnect(); clipGain.disconnect(); } catch { /* already gone */ }
+      try { src.disconnect(); clipGain.disconnect(); muteGate.disconnect(); } catch { /* already gone */ }
     };
     sources.push(src);
   }
@@ -378,7 +415,7 @@ function scheduleTeleports(clips: AudioClip[], fromSec: number): void {
     if (!nodes) continue;
     const insts = nodes.fx.instances();
     const trackClips = clips.filter(
-      (c) => c.trackId === t.id && !(liveMidiActive && isMidiClip(c)),
+      (c) => c.trackId === t.id && !c.muted && !(liveMidiActive && isMidiClip(c)),
     );
 
     for (const entry of teleEntries) {
@@ -535,13 +572,16 @@ function scheduleMidiClips(clips: AudioClip[], fromSec: number): void {
   const channelOf = new Map<string, number>();
   let nextCh = 0;
   for (const clip of clips) {
-    if (!isMidiClip(clip) || channelOf.has(clip.trackId)) continue;
+    if (clip.muted || !isMidiClip(clip) || channelOf.has(clip.trackId)) continue;
     if (nextCh > 15) break;
     channelOf.set(clip.trackId, nextCh++);
   }
 
   for (const clip of clips) {
     if (!isMidiClip(clip)) continue;
+    // Clips muted before play schedule no notes; mute is ALSO re-checked at
+    // note-fire time below, so muting a sounding clip lands mid-playback.
+    if (clip.muted) continue;
     const track = trackById.get(clip.trackId);
     if (!track || effectiveVol(track, anySolo) <= 0) continue; // honor mute/solo
     const channel = channelOf.get(clip.trackId);
@@ -557,7 +597,18 @@ function scheduleMidiClips(clips: AudioClip[], fromSec: number): void {
       const offDelay = Math.max(onDelay + 10, (offSec - fromSec) * 1000);
       const midi = n.note;
       const vel = n.velocity;
-      midiTimers.push(window.setTimeout(() => liveNoteOn(channel, program, midi, vel), onDelay));
+      const clipId = clip.id;
+      midiTimers.push(window.setTimeout(() => {
+        // Structural edits (moved/resized/added notes) still need a re-schedule,
+        // but mute is re-read from the editor store at fire time so muting a
+        // sounding MIDI clip lands mid-playback like an audio clip's gate.
+        const live = useEditorStore.getState().clips.find((c) => c.id === clipId);
+        if (live?.muted) return;
+        liveNoteOn(channel, program, midi, vel);
+      }, onDelay));
+      // The note-off always fires: a note-off for a note that was skipped is
+      // harmless, and skipping it would leave a stuck note when the clip is
+      // muted between a note's on and off timers.
       midiTimers.push(window.setTimeout(() => liveNoteOff(channel, midi), offDelay));
     }
   }
@@ -576,6 +627,10 @@ function clearSources(): void {
     try { s.onended = null; s.stop(); s.disconnect(); } catch { /* already stopped */ }
   }
   sources = [];
+  for (const g of clipMuteGains.values()) {
+    try { g.disconnect(); } catch { /* already gone */ }
+  }
+  clipMuteGains = new Map();
   clearMidiTimers();
   stopFxAutomation();
 }
@@ -683,6 +738,7 @@ async function start(fromSec: number): Promise<void> {
   startOffsetSec = begin;
   lastTimePush = 0;
   lastMixSig = mixSignature(ed.tracks);
+  lastClipMuteSig = clipMuteSignature(clips);
   scheduleClips(clips, begin);
   scheduleTeleports(clips, begin);
   scheduleAutomation(begin); // native vol/pan envelopes onto their AudioParams
@@ -718,6 +774,15 @@ async function start(fromSec: number): Promise<void> {
       }
       if (state.masterFxChain !== prev.masterFxChain) {
         applyMasterChainLive(); // live master rack edits (add/remove/reorder/param)
+      }
+      // Clip mute is the one clip property applied live; every other clip edit
+      // is structural and lands on the next (re)schedule.
+      if (state.clips !== prev.clips) {
+        const sig = clipMuteSignature(state.clips);
+        if (sig !== lastClipMuteSig) {
+          lastClipMuteSig = sig;
+          applyClipMutesLive();
+        }
       }
     });
   }

--- a/frontend/src/state/mixStageStore.ts
+++ b/frontend/src/state/mixStageStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+// The MIX Effect Stage selection state. It lives in a module-scope store rather
+// than component state because DAWCenterPanel fully unmounts MixView on every
+// tab switch; local useState would reset the three selectors and the stage
+// would land on the EffectsVizPanel placeholder after a tab round-trip.
+// The state is intentionally NOT persisted: the requirement is SPA-lifetime
+// survival only, and chain entry ids from a previous app session would be
+// meaningless against a freshly built chain.
+// Chain removal (removeEffect / clearChain) is owned by effectChainStore, so
+// selectedChainId can go stale after an entry is removed; MixView tolerates a
+// stale id through its existing `?? chain[0]` fallback when deriving the
+// selected entry, so no cross-store cleanup hook is needed here.
+interface MixStageState {
+  // The chain entry focused in the Effect Stage (a null or stale id falls back
+  // to the first chain entry in MixView's derivation).
+  selectedChainId: string | null;
+  // The explicitly-picked Studio module shown in the stage; it outranks the
+  // selected chain entry's effect-to-module mapping.
+  activeModuleId: string | null;
+  // The Magenta RT2 tool focused in the Effect Stage (Collider / Jam / MRT2).
+  activeMagentaId: string | null;
+  setSelectedChainId: (id: string | null) => void;
+  setActiveModuleId: (id: string | null) => void;
+  setActiveMagentaId: (id: string | null) => void;
+}
+
+export const useMixStageStore = create<MixStageState>()((set) => ({
+  selectedChainId: null,
+  activeModuleId: null,
+  activeMagentaId: null,
+  setSelectedChainId: (id) => set({ selectedChainId: id }),
+  setActiveModuleId: (id) => set({ activeModuleId: id }),
+  setActiveMagentaId: (id) => set({ activeMagentaId: id }),
+}));

--- a/frontend/src/views/AdvancedGenPanel.tsx
+++ b/frontend/src/views/AdvancedGenPanel.tsx
@@ -1034,9 +1034,10 @@ export const AdvancedGenPanel: React.FC<{
             </div>
 
             {/* OUTPUT (Magenta) ↔ FX/SHIFT (SA3) — moved from the chimera card;
-                stretches to the rail bottom so there is no blank space below */}
+                mt-auto anchors it to the rail bottom so it sits level with the
+                left column's sampler faders instead of leaving a gap below */}
             {isMagenta ? (
-              <div className={`${colBox} p-2 flex flex-col gap-1 shrink-0 h-1/2`}>
+              <div className={`${colBox} p-2 flex flex-col gap-1 shrink-0 h-1/2 mt-auto`}>
                 <span className={subTitle}>OUTPUT</span>
                 <div className="flex items-start justify-around gap-1 shrink-0">
                   <RoundToggle label="Cut" icon={Scissors} on={p.cutToDuration} onChange={(v) => sf('cutToDuration', v)} />
@@ -1056,7 +1057,7 @@ export const AdvancedGenPanel: React.FC<{
                 </div>
               </div>
             ) : (
-              <div className={`${colBox} p-2 flex flex-col gap-1 shrink-0 h-1/2`}>
+              <div className={`${colBox} p-2 flex flex-col gap-1 shrink-0 h-1/2 mt-auto`}>
                 <span className={subTitle}>FX</span>
                 <div className="flex items-start justify-around gap-1 shrink-0">
                   <SlideKnob label="Norm thr" value={p.cfgNormThreshold} onChange={(v) => sf('cfgNormThreshold', v)} min={0} max={100} step={0.1} tipKey="cfgNormThreshold" size={46} centerReadout />

--- a/frontend/src/views/MixView.tsx
+++ b/frontend/src/views/MixView.tsx
@@ -34,6 +34,7 @@ import { MAGENTA_TOOLS, magentaToolById, type MagentaTool } from '../lib/magenta
 import { MagentaToolStage } from '../components/audio/MagentaToolStage';
 import { GanPluginStage } from '../components/audio/GanPluginStage';
 import { useGanStore } from '../state/ganStore';
+import { useMixStageStore } from '../state/mixStageStore';
 import { ganApi, type GanPluginSummary } from '../lib/ganClient';
 import { GAN_FILTER } from '../lib/fileFilters';
 import { pickFile } from '../lib/storageClient';
@@ -797,6 +798,36 @@ function buildMixRegistry(p: MixRegArgs): WidgetRegistry {
       ? <MagentaToolStage tool={p.activeMagentaTool} />
     : p.activeModule
       ? <EffectGuiStage module={p.activeModule} sourceFile={p.sourceFile} />
+    : selected?.vst
+      ? (
+        /* A selected VST3 chain entry gets an actionable stage card instead of
+           the generic viz: its REAL UI is the plugin's native editor window,
+           which cannot render inline here. The editor is deliberately NOT
+           reopened automatically on mount: vstEditorStore closes it on tab
+           leave BY DESIGN because a native OS window must not float over other
+           tabs, and an auto-reopen would resurrect that floating window on
+           every return to MIX. One click on the button below reopens it via
+           the exact same handler as the chain row's GUI button, and the
+           dialed-in sound is safe either way because raw_state persists on the
+           chain entry. */
+        <div className="h-full w-full min-h-0 grid place-items-center p-2">
+          <div className="flex flex-col gap-2 rounded-md border border-teal-500/25 bg-black/40 px-4 py-3 min-w-56">
+            <div className="flex items-center gap-1.5">
+              <Plug className="w-3.5 h-3.5 text-teal-300 shrink-0" />
+              <span className="text-[11px] font-bold text-zinc-100 truncate">{selected.vst.plugin_name}</span>
+            </div>
+            {selected.vst.raw_state && <span className="text-[8px] font-mono text-teal-400">settings saved</span>}
+            <button
+              type="button"
+              aria-label="Open plugin GUI"
+              onClick={() => p.onEditVst(selected)}
+              className="btn-ghost text-[9px] py-1 flex items-center justify-center gap-1 text-teal-300 border-teal-500/20 bg-teal-500/5"
+            >
+              <SlidersHorizontal className="w-3 h-3" /> Open plugin GUI
+            </button>
+          </div>
+        </div>
+      )
     : selected && selected.effect === 'spatializer'
       ? <TheOwl params={selected.params} idPrefix={`mix-owl-${selected.id}`} onChange={(np) => p.updateParams(selected.id, np)} />
     : selected
@@ -861,10 +892,17 @@ export const MixView: React.FC = () => {
 
   const [activeCategory, setActiveCategory] = useState('all');
   const [viewMode, setViewMode] = useState<'list' | 'tile'>('tile');
-  const [selectedChainId, setSelectedChainId] = useState<string | null>(null);
-  const [activeModuleId, setActiveModuleId] = useState<string | null>(null);
+  // The three Effect Stage selectors live in mixStageStore (module scope, no
+  // persist) because DAWCenterPanel fully unmounts MixView on tab leave; local
+  // useState would reset them and a tab round-trip would land the stage on the
+  // EffectsVizPanel placeholder instead of the selected effect's real UI.
+  const selectedChainId = useMixStageStore((s) => s.selectedChainId);
+  const setSelectedChainId = useMixStageStore((s) => s.setSelectedChainId);
+  const activeModuleId = useMixStageStore((s) => s.activeModuleId);
+  const setActiveModuleId = useMixStageStore((s) => s.setActiveModuleId);
   // The Magenta RT2 tool focused in the Effect Stage (Collider / Jam / MRT2).
-  const [activeMagentaId, setActiveMagentaId] = useState<string | null>(null);
+  const activeMagentaId = useMixStageStore((s) => s.activeMagentaId);
+  const setActiveMagentaId = useMixStageStore((s) => s.setActiveMagentaId);
   const [srcStats, setSrcStats] = useState<AudioStats | null>(null);
   const [outStats, setOutStats] = useState<AudioStats | null>(null);
   const [dragOverSource, setDragOverSource] = useState(false);
@@ -890,6 +928,42 @@ export const MixView: React.FC = () => {
   // Populate the installed .gan plugin list on first open, then make sure the
   // bundled Ares control surface is packaged so it shows as a Studio tile.
   useEffect(() => { void ganRefresh().then(() => ganEnsureAres()); }, [ganRefresh, ganEnsureAres]);
+
+  // A tab round-trip restores the stage selection from mixStageStore, but the
+  // Ares .gan surface itself may not survive it: EDIT's unmount cleanup closes
+  // a shared Ares session on tab leave. If the restored selected entry is the
+  // 'ares' composite effect, re-open its surface once on mount so the stage
+  // shows the real UI instead of the generic viz. Guard rationale: the
+  // ganStore activeId must be null so a DIFFERENT live .gan plugin the user
+  // left open is never hijacked (ganStore is global and survives tab leaves),
+  // and no explicitly restored module or Magenta stage may exist because those
+  // outrank the chain selection in the stage ladder. selectChain is NOT reused
+  // here because it ganClose()s for non-ares entries, which would kill a
+  // restored gan session. The gan setters are zustand-bound and stable, so
+  // this effect runs once per mount.
+  useEffect(() => {
+    const { selectedChainId: restoredId, activeModuleId: restoredModule, activeMagentaId: restoredMagenta } = useMixStageStore.getState();
+    if (restoredModule || restoredMagenta) return;
+    const chainNow = useEffectChainStore.getState().chain;
+    const entry = chainNow.find((e) => e.id === restoredId) ?? chainNow[0] ?? null;
+    if (!entry || entry.effect !== 'ares') return;
+    if (useGanStore.getState().activeId !== null) return;
+    void (async () => {
+      // Sequence through ensureAres before opening: the sibling mount effect
+      // fires ganRefresh().then(ganEnsureAres) in the same tick, and
+      // package-ares rewrites the installed runtime files in place, so opening
+      // without waiting could iframe half-written files. ensureAres dedups
+      // concurrent calls in ganStore, so both mount paths share one run.
+      await ganEnsureAres();
+      // Re-check the guard after the await: an openPath/openById the user
+      // started while the ensure ran (busy while in flight, activeId once
+      // resolved) must win; the auto re-open must never resolve last and
+      // steal the stage from an explicitly opened plugin.
+      const gs = useGanStore.getState();
+      if (gs.activeId !== null || gs.busy) return;
+      await ganOpenById('ares');
+    })();
+  }, [ganEnsureAres, ganOpenById]);
 
   // ── Ares control surface -> live effect params ─────────────────────────────
   // The Ares .gan XY pad postMessages {type:'updateValue', id, valueX, valueY,
@@ -1041,8 +1115,10 @@ export const MixView: React.FC = () => {
     (activeModuleId ? moduleById[activeModuleId] ?? null : null)
     ?? (mappedModuleId ? moduleById[mappedModuleId] ?? null : null);
 
-  // Picking a module from the library toggles its instrument open/closed.
-  const handlePickModule = (id: string) => { ganClose(); setActiveMagentaId(null); setActiveModuleId((cur) => (cur === id ? null : id)); };
+  // Picking a module from the library toggles its instrument open/closed. The
+  // toggle reads the store directly because the store setter takes a plain
+  // value, not a functional updater.
+  const handlePickModule = (id: string) => { ganClose(); setActiveMagentaId(null); setActiveModuleId(useMixStageStore.getState().activeModuleId === id ? null : id); };
   // Selecting a chain entry hands the stage back to the effect→module mapping.
   const selectChain = (id: string) => {
     setActiveMagentaId(null); setActiveModuleId(null); setSelectedChainId(id);
@@ -1078,7 +1154,7 @@ export const MixView: React.FC = () => {
   const handlePickMagenta = (id: string) => {
     ganClose();
     setActiveModuleId(null);
-    setActiveMagentaId((cur) => (cur === id ? null : id));
+    setActiveMagentaId(useMixStageStore.getState().activeMagentaId === id ? null : id);
   };
   // .gan loader: pick/import sets the active plugin and yields the stage to it.
   const handleOpenGan = async () => {


### PR DESCRIPTION
- 2D genealogy: hover no longer flashes (grace timer implemented, filter transitions removed, edge glow is stroke-based so Chromium never drops the filtered layer); much stronger lineage glow with non-relatives dimmed; LEARN tab warm-mounts with a signature-guarded refresh; layout builds once and the median heuristic no longer scans inside sort comparators
- 3D graph: renders its final look on the first frame (gated on the three.js import), settles off-screen with a single camera fit, pointer math corrected under the UI zoom via a counter-zoom wrapper + measured canvas size, and every node gains an invisible distance-scaled hit sphere (~2.5x) so hovering works from afar; geometry caching + disposal sweeps; hidden tab pauses the render loop entirely
- EDIT clips: per-clip FX and mute buttons plus a BPM/Key readout; mute is live mid-playback (dedicated gain gates; live-synth MIDI checks at note fire), honored by export bounce, freeze, send-to-init, and the frozen-master staleness signature, and persists through .tasmo (old files load unchanged); FX/instrument/time-pitch panels open at the click position via body portals; VST editors open at their reported native dimensions
- MIX: stage selection survives tab switches (mixStageStore); Ares re-opens safely sequenced through a deduped ensure; VST entries get a real stage card with one-click GUI reopen instead of the placeholder, which now only serves effects without a richer UI
- MAKE: right-rail FX/SHIFT card bottom-aligned with the left column
- README: annotated folder-map tree + where-models-go guidance verified against the checkpoint resolver