### PR TITLE
docs(foundry): theDAW-styled documentation set for VST Foundry (13 guides)

### DIFF
--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/assistant-and-mcp.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/assistant-and-mcp.md
@@ -1,0 +1,439 @@
+# Foundry Assistant — Orb, Providers, and MCP
+
+Reference for Foundry's in-app AI co-designer: the floating **Assistant orb**,
+the multi-provider chat backend, the persistent **Better Claude Code** (BCC)
+session, and the **MCP** bridge that lets the model read and mutate your canvas.
+Plain descriptions of what each piece does and how a message becomes a canvas
+change. For the workspace it drives, see
+[canvas-and-controls.md](canvas-and-controls.md); for the images it can
+generate, see [textures-and-skins.md](textures-and-skins.md).
+
+The assistant is optional — the rest of Foundry works without ever opening it —
+but when open it has direct control of the layout: it can add, move, style,
+align, group, theme, and delete elements, read hand-drawn annotations, fetch a
+web page, generate textures, and screenshot the live window to check its own
+work visually.
+
+## How the pieces fit together
+
+There are four moving parts, all on one machine:
+
+1. **The orb (browser).** A React overlay that owns the chat UI and the canvas
+   state. It POSTs each turn to the relay and executes tool calls locally.
+2. **The relay server (Node/Express).** Serves the SPA, holds the provider
+   catalog, streams chat over SSE, and bridges MCP tool calls to the browser.
+3. **A provider.** Either a direct cloud/local API (Gemini, OpenAI, …) or the
+   local **Claude Code CLI** spawned as a child process.
+4. **The MCP server (`mcp-server.cjs`).** Only for the Claude path — a stdio
+   JSON-RPC subprocess the CLI talks to, which relays tool calls back into the
+   relay server and out to the browser.
+
+| File | Role |
+|---|---|
+| `server.ts` | Relay entry: builds the Express app, adds Vite/static middleware, binds `127.0.0.1:PORT`, wires graceful shutdown. |
+| `server/config.ts` | `PORT` resolution and the CORS origin allow-list helpers. |
+| `server/routes.ts` | All HTTP routes: chat, transcribe, MCP relay, providers, models, textures, SD, config, state, logs, screen capture. |
+| `server/relay.ts` | `activeSessions` registry + relay timeouts — the MCP-to-browser tool bridge state. |
+| `server/providers.ts` | The `PROVIDERS` catalog plus the OpenAI-compat and Anthropic streamers and their agentic tool loop. |
+| `server/tools.ts` | Tool schemas + system-instruction builder for the direct-API (non-Claude) path. |
+| `server/claude-bridge.ts` | Claude Code CLI spawn, persistent per-conversation sessions, per-session MCP config writer. |
+| `server/net.ts` | SSRF guards (`isPrivateIp` / `assertPublicUrl`) and the `scrapeUrl` reader for `fetchWebPage`. |
+| `mcp-server.cjs` | Stdio JSON-RPC MCP server (~45 tools) the Claude CLI spawns; relays into Express. |
+| `stt/transcribe.py` | Local speech-to-text via faster-whisper (CUDA float16 → CPU int8 fallback). |
+| `src/components/AIAssistantOrb.tsx` | Top-level orb container: composes the chat/tool/speech hooks, settings, history, and the skin. |
+| `src/components/orb/` | The orb's hooks and views (see [The orb UI](#the-orb-ui)). |
+| `src/orb-kit-skin/GantasmoOrb.tsx` | The floating ghost-face orb button (visual skin only; owns its own drag position). |
+
+## The relay server
+
+Everything the assistant needs is served from one Node process, the same
+sidecar that hosts the rest of Foundry (see
+[foundry-overview.md](foundry-overview.md)).
+
+- **Port:** `THEDAW_FOUNDRY_PORT` → `PORT` → `5472` (default), resolved in
+  `server/config.ts`.
+- **Bind:** `127.0.0.1` only (`server.ts`) — never exposed off the machine.
+- **Dev vs prod:** in development Vite runs in **middleware mode on the same
+  port**; HMR is disabled entirely when embedded in theDAW (`DISABLE_HMR=true`)
+  and otherwise runs on `PORT+1`. In production the built `dist/` is served
+  statically with an `index.html` catch-all.
+- **No request/response timeout:** `httpServer.requestTimeout` and `.timeout`
+  are set to `0` so a long agentic turn (many minutes of tool calls) is never
+  aborted mid-stream.
+
+> **CORS is locked to same-origin.** `/api/assistant` and `/api` reject any
+> browser `Origin` that is not this app's own (`server/config.ts`). Requests
+> with **no** `Origin` header — the MCP relay and other server-to-server calls —
+> are allowed, since they are never a cross-site browser attack. Add extra
+> origins with `FOUNDRY_ALLOWED_ORIGINS` (comma-separated) if needed.
+
+### HTTP endpoints
+
+| Method + path | Purpose |
+|---|---|
+| `GET /api/health` | Liveness probe (`{app, status, time}`). |
+| `GET /api/assistant/providers` | Provider catalog. Claude/BCC is unshifted to the front. |
+| `GET /api/assistant/models/:provider` | Model discovery for one provider (live fetch or fallbacks). |
+| `POST /api/assistant/chat` | The one chat endpoint. SSE. Dispatches by `provider`. |
+| `POST /api/assistant/transcribe` | Raw audio (`audio/*`) → faster-whisper → `{ok, text}`. |
+| `POST /api/assistant/session/close` | Dispose a persistent Claude session (orb "new chat" / delete). |
+| `POST /api/assistant/control-response` | Answer a live CLI question/permission (writes to the child's stdin). |
+| `POST /api/assistant/control-request` | UI-initiated CLI control (e.g. `get_context_usage`). |
+| `POST /api/mcp-relay/call` | Called by `mcp-server.cjs`: run a server-side tool, or relay a browser tool over SSE and block for its result. |
+| `POST /api/mcp-relay/result` | Called by the browser: resolve a pending relayed tool call. |
+| `POST /api/screen-capture` | Windows-only OS screenshot of the live theDAW window (PrintWindow). |
+| `GET/POST /api/config` | Load/save app config (`data/config.json`). |
+| `GET/POST /api/state` | Load/save the canvas session (`data/sessions/latest.json`, atomic + `.bak`). |
+| `POST /api/textures/generate`, `/api/textures/upload`, `DELETE /api/textures/:id`, `GET /api/textures/list` | Texture library operations (see [textures-and-skins.md](textures-and-skins.md)). |
+| `GET /api/sd/status`, `POST /api/sd/start`, `/api/sd/stop`, `GET /api/sd/resources` | Local Stable Diffusion process control. |
+| `GET /api/logs` | Recent server log lines (ring buffer + disk tail). |
+
+## Providers and models
+
+The assistant is **bring-your-own-key** for cloud providers and needs no key for
+local ones. The catalog is defined in `PROVIDERS` (`server/providers.ts`); the
+Claude Code provider is deliberately **not** in that map and is special-cased in
+the routes.
+
+| Provider id | Label | Key required | Local | Notes |
+|---|---|---|---|---|
+| `claude` | BCC (Better Claude Code) | No | Yes | Spawns the local `claude` CLI. Surfaced FIRST in the providers list. |
+| `gemini` | Google Gemini | Yes | No | OpenAI-compat base; models via Google's `/v1beta/models`. |
+| `openai` | OpenAI | Yes | No | OpenAI-compat. |
+| `anthropic` | Anthropic | Yes | No | Native Anthropic Messages API path. |
+| `grok` | xAI Grok | Yes | No | OpenAI-compat. |
+| `groq` | Groq | Yes | No | OpenAI-compat (no image input). |
+| `openrouter` | OpenRouter | Yes | No | OpenAI-compat; capabilities parsed per model. |
+| `openrouter-free` | OpenRouter (Free) | No | No | Same catalog filtered to zero-cost models. |
+| `ollama` | Ollama (Local) | No | Yes | `http://localhost:11434`; models via `/api/tags`. |
+| `lmstudio` | LM Studio (Local) | No | Yes | `http://localhost:1234`; OpenAI-compat `/v1/models`. |
+
+> **Do not prune model ids you do not recognize.** `server/providers.ts` and
+> `server/claude-bridge.ts` both carry a hard rule: the live `/models` fetch is
+> the source of truth and the hard-coded fallbacks are safety nets only. Cloud
+> keys reach the latest releases; a model that looks unfamiliar is almost always
+> newer than training data, not invalid.
+
+Cloud keys are entered per-provider in the orb's **Settings → Keys** tab and
+stored in the browser's `localStorage`; they are sent with each chat request.
+If no key is provided, the server falls back to the provider's environment
+variable (`GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+`XAI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`). Model lists are discovered
+at runtime, so the dropdown stays current without an app update.
+
+### The three streaming paths
+
+`POST /api/assistant/chat` is a single SSE endpoint that branches on `provider`:
+
+| Path | Providers | Streamer |
+|---|---|---|
+| Claude CLI | `claude` | `streamClaude` (`server/claude-bridge.ts`) |
+| Anthropic Messages | `anthropic` | `streamAnthropic` (`server/providers.ts`) |
+| OpenAI-compatible | everything else in `PROVIDERS` | `streamOpenAICompat` (`server/providers.ts`) |
+
+The `claude` branch owns its own SSE lifecycle and returns **before** the shared
+setup below. The other two share one path: the route opens the SSE stream,
+registers a relay session in `activeSessions`, and emits a `session_id` frame so
+the browser knows where to POST tool results.
+
+Both direct-API streamers run the **same agentic loop**: call the model, execute
+any tool calls it emits, feed the results back, and repeat until the model
+returns a tool-free answer — capped at `MAX_AGENT_ITERATIONS = 100` (a runaway
+guard, not a functional limit). Server-side tools (texture/SD/`fetchWebPage`/
+`getLogs`) run inside the relay process; every other tool is emitted as a
+`client_tool_call` frame and the loop blocks on the browser's result via the
+relay's pending-promise map. The direct-API tool schemas live in
+`server/tools.ts` (the same canvas tools as MCP, plus `getLogs`); image-input
+and tool-capability errors are detected and the turn retried with those features
+stripped, so a text-only model still answers instead of erroring.
+
+## Better Claude Code (the `claude` provider)
+
+The primary and default provider spawns the local **Claude Code CLI** rather
+than calling an HTTP API. It is invoked and managed by `server/claude-bridge.ts`,
+which mirrors the proven Better Claude Code mechanism (the reference
+implementation now lives under `deprecated/BETTERCLAUDECODE/`).
+
+- **CLI discovery:** `findClaudeCmd()` honors `CLAUDE_CMD` (env override), else
+  looks for `%APPDATA%\npm\claude.cmd` on Windows, else `claude.cmd` / `claude`.
+- **Spawn shape:** on Windows the `.cmd` shim is run via `cmd.exe /c CLAUDE_CMD …`;
+  elsewhere the binary is invoked directly. `NO_COLOR=1` is set.
+- **Base args** (exact set and order):
+
+```
+--model <id> --dangerously-skip-permissions --permission-prompt-tool stdio
+-p --input-format stream-json --output-format stream-json --verbose
+--include-partial-messages [--effort <effort>]
+[--resume <session_id>] [--mcp-config <path> --strict-mcp-config]
+```
+
+> **There is no `--max-turns` flag.** The installed CLI (v2.1.195) does not have
+> one; it runs each agentic turn to completion on its own. Do not reintroduce a
+> turn cap — a complex layout task takes as many tool steps as it needs.
+
+### Persistent per-conversation sessions
+
+Instead of respawning the CLI every message, one long-lived `claude` child is
+kept **per conversation** and reused across turns over stream-json stdio (the
+child's stdin is never closed between turns). This is what keeps the MCP server
+attached for the whole conversation instead of flapping every message.
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `MAX_CLAUDE_SESSIONS` | 8 | Live persistent children; LRU-reaped above this (never a busy one). |
+| `CLAUDE_SESSION_IDLE_MS` | 15 min | Idle session reaped by the background reaper. |
+| `CLAUDE_HEARTBEAT_MS` | 15 s | SSE keepalive comment cadence during a turn. |
+| `CLAUDE_TURN_STALL_MS` | 5 min | Inactivity watchdog — re-armed on every stdout frame; only a true stall trips it. |
+
+Each turn is serialized: a message that arrives while a turn is running is
+**queued, not rejected** (BCC parity — mid-turn sends never return 409). The
+route parks in the session's FIFO idle-waiter list, keeps the SSE alive with
+pings, and resumes in arrival order when the in-flight turn finishes. Switching
+model or effort on a live conversation respawns the child in place (resume keeps
+context). Sessions are torn down on the orb's "new chat"/delete
+(`/api/assistant/session/close`), on idle reap, on child death, and on server
+shutdown; each disposal unlinks the temp MCP config and drops all relay
+registrations.
+
+### Model catalog and effort
+
+Model ids are enumerated in `CLAUDE_MODELS` and passed **exactly** to `--model`
+(the CLI's short aliases like `opus`/`sonnet` are unreliable on this machine).
+`resolveClaudeModel()` maps any stale or family-alias value to the newest full
+id in that family, so the CLI never receives a dead id. `CLAUDE_DEFAULT_MODEL`
+is `claude-opus-4-8`. The catalog includes the current families plus `[1m]`
+1M-context variants the CLI binary accepts.
+
+> Model ids in the catalog change as new releases ship. Read them from
+> `CLAUDE_MODELS` in `server/claude-bridge.ts` (surfaced by
+> `GET /api/assistant/models/claude`) rather than assuming — the list is the
+> source of truth.
+
+`--effort` accepts `low` / `medium` / `high` / `xhigh` / `max` (default `max`).
+The orb exposes the effort dropdown only when the Claude provider is selected.
+
+### Questions and permissions (control requests)
+
+Mid-turn, the CLI can block on stdin asking the user something — an
+`AskUserQuestion` (multiple choice) or a `can_use_tool` permission prompt. The
+bridge forwards these to the live SSE as a `control_request` frame; the orb
+renders a card, and the user's choice is POSTed to
+`/api/assistant/control-response`, which writes a `control_response` back to the
+**same** blocked child. The turn stays open the whole time. The reverse
+direction — the UI asking the CLI something like `get_context_usage` — goes
+through `/api/assistant/control-request`, which powers the orb's real
+context-window meter.
+
+## The MCP tool surface
+
+`mcp-server.cjs` is a stdio JSON-RPC 2.0 MCP server that the Claude CLI spawns as
+a subprocess. For each conversation, `writeClaudeMcpConfig()` writes a temp
+config registering one MCP server named **`vst-foundry`**:
+
+```
+node mcp-server.cjs <PORT> <relayId>
+```
+
+It handles `initialize`, `tools/list` (returns the tool schemas), `ping`, and
+`tools/call`. stdout is reserved for protocol traffic; all diagnostics go to
+stderr, or the JSON-RPC stream corrupts.
+
+The server exposes ~45 tools. They split into two dispatch paths:
+
+- **Server-side tools** (`SERVER_SIDE_TOOLS`) call Express endpoints directly
+  with a 5-minute timeout — no browser needed. These are the texture/SD tools.
+  `fetchWebPage` is also handled server-side, short-circuited inside the
+  `/api/mcp-relay/call` route via SSRF-guarded `scrapeUrl` (`server/net.ts`).
+- **Browser-relayed tools** POST `/api/mcp-relay/call`; the relay pushes a
+  `client_tool_call` frame down the live SSE, the browser runs it against the
+  real canvas, and POSTs the result to `/api/mcp-relay/result`.
+
+> The header comment in `mcp-server.cjs` says "34 canvas/app tools" — that count
+> is stale; the shipped `TOOL_SCHEMAS` array is larger (roughly 45 including the
+> texture/SD family). Trust the array, not the comment.
+
+### Read tools (browser-relayed)
+
+| Tool | Reads |
+|---|---|
+| `getElements` | UI elements (all, or filtered by ids). |
+| `getCanvasState` | Dimensions, zoom, pan, grid, snap, preview, rulers, background. |
+| `getElementTree` | Group nesting + full z-order (paint order); flags CustomCode nodes. |
+| `getRenderedGeometry` | Each element's ACTUAL on-screen rect mapped back to canvas coords (catches drift/rotation/overflow). |
+| `getCustomCode` | One CustomCode element's full source, params, fit mode, runtime diagnostics. |
+| `getAnnotations` | Hand-drawn strokes/shapes/notes + the color legend (placement instructions). |
+| `getAssets` | Imported image/media assets (delegated to `App.tsx`). |
+| `getTextures` | Texture library (delegated to `App.tsx`). |
+| `getCustomModules` | Saved reusable CustomCode modules (delegated to `App.tsx`). |
+| `getBindingCapabilities` | Full binding/modulation map: theDAW + built-in VST targets, per-type rules, current routes. |
+| `captureCanvasScreenshot` | True PNG of the live window (see [Screenshots and vision](#screenshots-and-vision)). |
+
+### Write / canvas tools (browser-relayed)
+
+| Group | Tools |
+|---|---|
+| Element CRUD | `addElements`, `updateElements`, `setCustomCode`, `deleteElements`, `duplicateElements` |
+| Layers | `reorderElement`, `reorderElementTo` |
+| Grouping | `groupElements`, `ungroupElements` |
+| Selection | `setSelection` |
+| Alignment | `alignElements`, `distributeElements` |
+| Canvas | `updateCanvas`, `setCanvasBackground` |
+| History | `undo`, `redo` |
+| App | `setTheme`, `setFontScale`, `addCustomModule` |
+
+`setCustomCode` is the atomic way to edit a CustomCode element — it replaces the
+source (and optionally params) and re-syncs the saved library module so the two
+never drift. See [custom-code.md](custom-code.md).
+
+### Texture / Stable Diffusion tools (server-side)
+
+`generateTexture`, `applyTexture`, `removeTexture`, `deleteTexture`,
+`uploadTexture`, `editTexture`, `upscaleTexture`, `generateTextureVariations`,
+`batchGenerateTextures`, `controlNetGenerate`, `getSDStatus`, `getSDResources`,
+`startSDProcess`, `stopSDProcess`. (`applyTexture`/`removeTexture` are
+browser-relayed because they set element props; the rest hit Express directly.)
+These are covered in [textures-and-skins.md](textures-and-skins.md).
+
+### External
+
+`fetchWebPage` — scrapes a URL server-side and returns its text. Guarded by
+`assertPublicUrl` in `server/net.ts`, which rejects non-http(s) schemes,
+`localhost`, and any host resolving to loopback, private, link-local (including
+the `169.254.169.254` cloud-metadata address), or CGNAT ranges.
+
+### Relay timeouts
+
+| Constant | Where | Value | Role |
+|---|---|---|---|
+| `RELAY_TIMEOUT_MS` | `server/relay.ts`, `mcp-server.cjs` | 120 s | How long a single browser tool round-trip may take. |
+| `RELAY_SERVER_TIMEOUT_MS` | `server/relay.ts` | 115 s | Server-side waiter — fires just BEFORE the client so it never writes to a destroyed socket. |
+| `SERVER_SIDE_TIMEOUT_MS` | `mcp-server.cjs` | 300 s | Direct server-side tool calls (SD generation is slow). |
+
+## How the assistant manipulates the canvas
+
+The browser owns the canvas state, so every mutation ultimately runs in the
+browser. The full round-trip for a Claude-driven canvas tool:
+
+1. The CLI decides to call, say, `addElements`, and sends `tools/call` to
+   `mcp-server.cjs` over stdio.
+2. `mcp-server.cjs` POSTs `/api/mcp-relay/call` with the session id, tool name,
+   and args.
+3. The relay finds the live SSE session, registers a pending promise, and writes
+   a `client_tool_call` frame down the SSE to the browser.
+4. `useChatStream` receives the frame and hands it to `useToolActions`, which
+   executes the tool against the orb's **live** element/canvas refs.
+5. `useToolActions` POSTs `/api/mcp-relay/result`; the relay resolves the pending
+   promise and responds to `mcp-server.cjs`, which returns the result to the CLI.
+
+For the direct-API providers the shape is the same, minus `mcp-server.cjs`: the
+streamer emits `client_tool_call` directly and awaits `/api/mcp-relay/result`.
+
+> **Tools resolve against live state, not a mount-time snapshot.** Tool handlers
+> can run from an SSE closure captured when the orb mounted, so `useToolActions`
+> reads `elementsRef.current` / `canvasStateRef.current` (refreshed every render)
+> instead of the frozen props. This is the fix for the old bug where
+> `getElements` returned `[]` while elements were plainly on the canvas.
+
+A handful of tools (`getAssets`, `getTextures`, `getCustomModules`, and the
+layer/group/selection/align/theme mutations) live in `App.tsx`, not the orb.
+`useToolActions` delegates those via a window `vst-ai-action` event; read tools
+wait for a matching `vst-ai-action-result` event, mutations resolve
+optimistically.
+
+## The orb UI
+
+`AIAssistantOrb.tsx` is the container. It composes three behavior hooks and the
+transcript view, all handed the same live state and refs so behavior matches the
+former single-file implementation.
+
+| File | Role |
+|---|---|
+| `orb/useChatStream.ts` | POSTs `/api/assistant/chat`, reads the SSE loop, updates thinking/text/tool state, drains the mid-turn send queue. |
+| `orb/useToolActions.ts` | Executes `client_tool_call` frames and POSTs results to `/api/mcp-relay/result`. |
+| `orb/useSpeechInput.ts` | Mic capture → `/api/assistant/transcribe` (see [Voice input](#voice-input)). |
+| `orb/providers.ts` | Normalizes backend provider/model records for the dropdowns. |
+| `orb/Transcript.tsx` | Renders the transcript, tool cards, and question/permission prompts. |
+| `orb/constants.ts` | LocalStorage keys, effort options, defaults (`claude` / `claude-opus-4-8`). |
+| `orb/types.ts`, `orb/markdown.ts`, `orb/elements.ts` | Shared types, the inline-markdown link renderer, element normalization/coercion. |
+
+Behavior worth knowing:
+
+- **Mid-turn queue (BCC parity).** Typing while a turn streams does not fire a
+  second colliding request. The message is parked in a FIFO queue (shown in the
+  UI) and sent automatically when the current turn ends. **Stop** clears the
+  queue and, if the agent is blocked on a question, denies it so the child
+  returns to idle.
+- **Per-turn accounting.** The `done` frame carries token usage (including
+  cache), cumulative cost (the orb shows each turn's delta), duration, and error
+  state. The context meter prefers the CLI's real `get_context_usage` reading
+  and falls back to a character-count estimate for other providers.
+- **Sessions.** Chats persist to `localStorage` (heavy base64 images stripped to
+  stay under quota). Each app launch starts a fresh chat; prior chats remain as
+  history. Abandoning or deleting a chat releases its backend Claude session.
+- **The orb button** is `GantasmoOrb` (`src/orb-kit-skin/`) — a draggable
+  ghost-face skin that only renders visuals and remembers its own position; the
+  panel state lives in `AIAssistantOrb`.
+
+## Voice input
+
+The mic button dictates into the chat input (it appends transcribed text; it
+does not auto-send). It appears only when the browser supports `getUserMedia`.
+
+1. `useSpeechInput` records the mic with `MediaRecorder` (prefers `audio/webm`)
+   and, on stop, POSTs the raw audio blob to `/api/assistant/transcribe`.
+2. The route accepts an `express.raw` `audio/*` body (25 MB cap), writes a temp
+   file under `os.tmpdir()/vst-foundry-stt`, and runs `stt/transcribe.py`
+   (120 s timeout), returning `{ ok, text }`.
+3. `transcribe.py` uses faster-whisper — CUDA `float16` first, CPU `int8`
+   fallback — default model `small`. The model auto-downloads and caches on
+   first use. Only the transcript goes to stdout; diagnostics go to stderr.
+
+| Setting | Resolution |
+|---|---|
+| Python interpreter | `THEDAW_PYTHON_CMD` → `PYTHON_CMD` → `py -3.10` (Windows) / `python3` (else). |
+| Whisper model | `small` (arg-overridable in the script). |
+| Device | CUDA `float16`, falling back to CPU `int8`. |
+
+> On Windows the `py -3.10` launcher is used because faster-whisper is installed
+> under Python 3.10 there. If transcription fails, the failure detail is logged
+> and returned as `{ ok:false, error }` — the orb surfaces it inline in the
+> input box rather than silently dropping the recording.
+
+## Screenshots and vision
+
+The assistant can see the canvas two ways:
+
+- **`captureCanvasScreenshot` (MCP tool) / `POST /api/screen-capture`** — a true
+  OS capture of the live theDAW window via a DPI-aware PowerShell
+  `PrintWindow` + `PW_RENDERFULLCONTENT` call. This is Windows-only and captures
+  **real composited pixels including CustomCode** (sandboxed iframes) even when
+  the window is occluded. If it is unavailable, the browser falls back to a
+  synthetic redraw (`canvasMockup`) that cannot show CustomCode.
+- **Attached images.** The camera/upload buttons and clipboard paste attach an
+  image to the next message. For the Claude path the image is written to a temp
+  file and referenced **by path** in the prompt (the CLI rejects inline base64
+  blocks); the direct-API paths send it inline where the model advertises image
+  input, and retry without it if the provider rejects it.
+
+## Operational notes
+
+- **The relay runs on port `5472`**, bound to localhost, started on demand when
+  the Foundry tab opens. theDAW manages its start and stop; see
+  [thedaw-integration.md](thedaw-integration.md).
+- **The Claude path needs the `claude` CLI on PATH** (or `CLAUDE_CMD` set). If a
+  turn errors immediately with a spawn failure, that is the first thing to check.
+- **Local providers must be running.** Ollama (`:11434`) and LM Studio (`:1234`)
+  return a clear "not running" error if their server is down; their tool calls
+  are off unless `THEDAW_ENABLE_LOCAL_OPENAI_TOOLS=1`, because tool support
+  varies by local model.
+- **Temp files** land under `os.tmpdir()`: per-session MCP configs
+  (`vst-mcp-<relayId>.json`), STT recordings (`vst-foundry-stt/`), and pasted
+  images (`vst-foundry-pastes/`). Sessions unlink their own MCP config on
+  teardown; a hard process exit cleans them synchronously.
+- **When something breaks**, `GET /api/logs` returns recent server lines and the
+  Claude bridge logs every turn, spawn, interrupt, and stale-result drain. See
+  [troubleshooting.md](troubleshooting.md).
+
+> **Note:** Foundry source is under active development. This document describes
+> the assistant as it currently ships; if a detail here disagrees with the code,
+> the code is authoritative — read the file named in each section.

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/canvas-and-controls.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/canvas-and-controls.md
@@ -1,0 +1,741 @@
+# Canvas and Controls — The Designer Surface
+
+Reference for the heart of VST Foundry: the infinite design canvas, the control
+elements you drag onto it, and the panels that edit them. This is where a plugin
+face is actually laid out — knobs, sliders, meters, artwork, and their wiring.
+Plain descriptions of what each piece does and where it lives in the source, for
+anyone editing Foundry's front end or trying to understand how a placed control
+turns into a live, routable widget.
+
+For the app around this surface (tabs, AI orb, export flow) see
+[foundry-overview.md](foundry-overview.md). For the image/skin layers referenced
+here in depth, see [textures-and-skins.md](textures-and-skins.md). For CustomCode
+elements, [custom-code.md](custom-code.md). For how a laid-out canvas becomes a
+plugin, [gan-format.md](gan-format.md) and [vst3-export.md](vst3-export.md).
+
+## The element model
+
+Everything on the canvas is a `UIElement` (`src/types.ts`). The set of element
+types is declared once as `ELEMENT_TYPES` — the TypeScript union `ElementType`
+is *derived* from that array, so adding a type there updates every consumer that
+iterates it (the assistant's capability map, the export param builders, etc.).
+
+There are 17 element types:
+
+| Type | Rendered by | Role |
+|---|---|---|
+| `Button` | `controls/ButtonControl` | Momentary / trigger push button |
+| `Knob` | `controls/KnobControl` | Rotary continuous control |
+| `Slider` | `controls/SliderControl` | Linear fader |
+| `Label` | `controls/LabelControl` | Static or live text / LCD readout |
+| `Select` | `controls/SelectControl` | Dropdown option picker |
+| `Toggle` | `controls/ToggleControl` | Two-state switch |
+| `Image` | `Canvas` → `ProcessedImage` | Placed artwork / cutout |
+| `Group` | `Canvas` (recursive) | Container frame for child elements |
+| `Waveform` | `controls/WaveformControl` | Oscilloscope / LFO shape display |
+| `Meter` | `controls/MeterControl` | Level meter (listens to a signal) |
+| `XYPad` | `controls/XYPadControl` | 2-axis pad |
+| `Spatial3D` | `controls/Spatial3DControl` | Radar / spatial pad |
+| `WaveShaper` | `controls/WaveShaperControl` | Distortion transfer-curve control |
+| `Envelope` | `controls/EnvelopeControl` | ADSR editor (self-editing) |
+| `StepSequencer` | `controls/StepSequencerControl` | Grid step sequencer (self-editing) |
+| `Keyboard` | `controls/KeyboardControl` | Piano-key input strip |
+| `CustomCode` | `CustomCodeFrame` | Sandboxed iframe running user JS |
+
+Every element carries geometry (`x`, `y`, `width`, `height`, `rotation`), colours
+(`baseColor`, `activeColor`, `textColor`, `borderColor`, `indicatorColor`), a
+glow block, an optional `effect` animation, an optional `variant` (its look
+template), per-control `styleParams`, an optional `skin`, an optional image
+`faceSrc`, texture fields, and a `binding` (its routing). The whole object is
+serialized as-is, so any field rides autosave, project save, and ZIP export for
+free. Soft state like selection lives outside the element in App state.
+
+> Note: The Foundry front end is under active development. Some control render
+> components and their variant lists are being extended; this document describes
+> what ships in `src/` today. Where a legacy doc in `docs/*.md` disagrees with the
+> code, the code wins.
+
+## The canvas surface
+
+`src/components/Canvas.tsx` is the composition entry for the design surface. It is
+an infinite, pannable, zoomable plane. The heavy lifting is split into
+`src/components/canvas/`:
+
+| File | What it does |
+|---|---|
+| `useCanvasGestures.ts` | Pointer-gesture engine: drag, marquee, pan, resize + the drop-target handlers |
+| `resizeMath.ts` | Pure eight-handle resize geometry (rotation-aware) |
+| `snapMath.ts` | Pure grid + alignment drag-snapping math, unit-tested |
+| `viewportMath.ts` | Pure cursor-anchored wheel-zoom math |
+| `rulers.ts` | Ruler drawing + tick math |
+| `gridOverlay.tsx` | Fixed grid-line background overlay |
+| `ProcessedImage.tsx` | Image-element renderer (background removal, glow, texture) |
+| `AnnotationLayer.tsx` | Freehand / shape / text annotation drawing layer |
+| `AnnotationToolbar.tsx` | Annotate-mode sub-tool + colour palette |
+
+Canvas state lives on `CanvasState` (`src/types.ts`): `width`/`height`,
+`scale`/`panX`/`panY`, `backgroundImage`, `showGrid`, `snapToGrid`, `gridSize`,
+`showRulers`, `requireCtrlToZoom`, `isPreviewMode`, plus the annotation arrays.
+
+The pannable area is a single transformed div; every element renders inside it at
+absolute `left/top` with `transform: rotate(...)`. The on-screen zoom readout, the
+tool switcher, and the "Require Ctrl to Zoom" / "Show Rulers" checkboxes live in a
+floating bottom-centre toolbar drawn by Canvas itself.
+
+### Canvas tools
+
+The bottom toolbar switches `activeTool` (`CanvasTool` = `select | pan |
+annotate`):
+
+| Tool | Shortcut hint | Behaviour |
+|---|---|---|
+| Select | `V` | Click to select, drag to move, marquee on empty canvas, shift-click to multi-select |
+| Pan | `H` / Spacebar | Drag the whole canvas; also triggered by middle-mouse or shift+left anywhere |
+| Annotate | — | Hands left-button gestures to the `AnnotationLayer` (drawings the AI orb can see) |
+
+Zoom is cursor-anchored (`viewportMath.wheelZoomAtPoint`) and requires Ctrl/Cmd by
+default (`requireCtrlToZoom`); without the modifier the wheel pans instead. The
+`+`/`-`/`Reset` buttons clamp scale to `0.1–3`.
+
+### Preview (Demo) mode vs edit mode
+
+`canvasState.isPreviewMode` flips the whole surface between editing the layout and
+interacting with the live controls. In edit mode elements are selectable, show a
+selection ring, hover outline, name badge, resize/rotate chrome, and are
+pointer-inert internally. In preview mode selection chrome disappears, controls
+become interactive (`pointer-events: auto`), and `InteractiveControl` attaches its
+drag listeners so knobs turn and routes fire. Canvas keys each element by `el.id`,
+so a component never remounts across the toggle — `InteractiveControl` explicitly
+wipes any preview-driven live state at the edit boundary.
+
+## Canvas gestures
+
+`useCanvasGestures.ts` owns all pointer state (`canvasRef`, drag/marquee/pan/resize)
+and returns handlers Canvas wires up. It mirrors props/state into refs and keeps a
+single window `mousemove`/`mouseup`/`blur` listener so dragging never churns
+listeners at 60fps.
+
+| Gesture | Trigger | Notes |
+|---|---|---|
+| Move-drag | Mousedown on an element | 3px screen dead-zone before it activates so a click never nudges; snapped delta applied to the whole selection |
+| Marquee | Mousedown on empty canvas | Live intersection test selects overlapping root elements |
+| Pan | Pan tool, middle-mouse, or shift+left | Adds pointer delta to `panX`/`panY` |
+| Resize | Mousedown on one of 8 handles | Single, unlocked selection only; `computeResizeRotated` |
+| Rotate | Drag the rotate handle | `atan2` angle; Shift snaps to 15° steps |
+| Drop | Drag from sidebar / asset panel | Reads `dataTransfer`, snaps to grid, calls `onDrop` |
+
+Locked elements (`isLocked`) are skipped by move and resize. A mouseup that lands
+outside the window is never delivered, so both this engine and the annotation layer
+cancel their in-flight gesture on window `blur` to avoid a stranded drag.
+
+### Resize geometry (`resizeMath.ts`)
+
+`RESIZE_HANDLES` is the eight-handle set — four corners and four edge midpoints —
+each with a unit offset (`ux`/`uy` in `0 / 0.5 / 1`) and a cursor. `computeResize`
+moves the edges the handle name encodes (`n`/`s`/`e`/`w`), snaps only the moving
+edges, floors the box at `MIN_ELEMENT_SIZE` (16), then repositions from the fixed
+anchor. Knob and Spatial3D force a square footprint (`lockSquare`); Shift on a
+corner locks the original aspect ratio. `computeResizeRotated` counter-rotates the
+pointer delta into the element's local frame and resizes about its centre for
+rotated elements (grid snap is skipped there, since snapping a rotated bounding box
+is meaningless).
+
+### Snap geometry (`snapMath.ts`)
+
+`computeDragSnap` rounds the primary (first unlocked) element's top-left to the
+grid, then lets smart alignment override it: for single-element drags it checks the
+dragged box's left/right/centre and top/bottom/centre against every other element's
+edges and centres within `alignThreshold` (`SNAP_THRESHOLD / scale` = a constant
+5-screen-px feel at any zoom) and emits fuchsia guide lines. The snapped *delta* is
+returned and applied to the whole selection, so multi-selections keep their
+relative offsets instead of each element re-rounding onto the grid.
+
+## Annotations
+
+`AnnotationLayer.tsx` is an SVG overlay that only intercepts pointer events while
+the Annotate tool is active. Drawings persist on `canvasState.annotations` and ride
+autosave. Their purpose is dual: a human sketch pad *and* a channel the AI orb can
+read (a colour can map to an element type via the annotation legend). Sub-tools:
+
+| Sub-tool | Draws |
+|---|---|
+| `pen` | Freehand polyline (`stroke`) |
+| `rect` | Rectangle |
+| `ellipse` | Ellipse |
+| `text` | Inline text note (Enter saves, Esc cancels) |
+| `eraser` | Removes stroke points / whole shapes within a 12px radius |
+| `move` | Select, drag, corner-resize, or delete an existing annotation |
+
+The nine-colour palette (`ANNOTATION_PALETTE`) is Apple-system hues. In-progress
+gestures stay local and commit exactly once on pointer-up, so drawing never
+round-trips app state per frame. Erasing a stroke's middle splits it into the
+surviving contiguous runs.
+
+## The control dispatcher
+
+`src/components/InteractiveControl.tsx` is the single dispatcher between an element
+and its visual. It picks the render component by `el.type`, owns all interaction
+state, and wraps every render in decorative layers.
+
+Interaction state it holds: `val` (0–100), `xVal`/`yVal` (XY axes), `isOn`
+(toggle), `isPressed` (button), `isOpen` (select), `liveWaveVal` (a bound
+waveform's live amplitude), and `liveText` (an inbound text route driving a Label).
+
+In preview mode it attaches native pointer listeners to `containerRef.current`:
+
+| Element types | Drag model |
+|---|---|
+| Slider, Knob, Meter, WaveShaper | Vertical drag → `val` 0–100 (Knob sensitivity 0.5; others scale to height) |
+| XYPad, Spatial3D | X/Y drag → `xVal`/`yVal` from the pointer position in the box |
+
+Control render components receive `BaseControlProps` (`el`, `variant`, `isPreview`)
+from `controls/shared.ts`; the interactive ones also receive the `containerRef` the
+dispatcher attaches its listeners to.
+
+### Variant normalization
+
+Before handing a variant to the render component, the dispatcher maps raw
+design-style names to canonical archetypes so the components only branch on a small
+set:
+
+| Raw variant | → Archetype |
+|---|---|
+| Skeuomorphic | Classic |
+| Minimalist | Minimal |
+| Apple-esque Minimalism / Streamline Moderne | Neumorphic |
+| Swiss Style | Brutalist |
+| Space Age Design | 3D |
+| Morphogenetic Design | CellShaded |
+| Neo-minimalism | Checkbox |
+| Soft Minimalism | Outline |
+| Retrofuturism | Mono |
+
+> Note: This normalization feeds the *render* branch only. Per-control adjustable
+> parameters (below) are scoped against the element's *raw* `variant` string, so a
+> param limited to `["Aluminum"]` matches the raw sidebar variant, not the
+> archetype.
+
+### The wrap: glow, face, skin, texture
+
+`wrapElement(content)` composites, from bottom to top:
+
+1. **Base render** of the control (optionally at `opacity: 0` when an image face
+   hides it — keeps layout and pointer wiring intact).
+2. **Glow** — a procedural box-shadow / radial layer driven by `glow`,
+   `glowStyle` (`outer`/`inner`/`center`/`radial`/`solid`/`neon`), `glowAmount`,
+   `glowSpread`, `glowOpacity`, `glowColor`/`glowGradient`. `glowActiveOnly` scales
+   the glow by the live value for Knob/Slider/Meter/XY, or gates it on active state.
+3. **Image face** (universal, `zIndex 1`) — for the eight non-face-aware types.
+4. **Skin overlays** (`zIndex 2`) — decorative CSS material layers from
+   `getSkinLayers`.
+5. **Texture** — a blend-mode-composited background image, offset/scaled/rotated.
+
+### Image-face system
+
+An element can wear a picture via `el.faceSrc`. Six controls are **face-aware** —
+`Knob`, `Button`, `Toggle`, `Slider`, `XYPad`, `Meter` — and paint their own
+value-reactive faces internally (a knob face rotates, a meter face clips bottom-up,
+a button face swaps/brightens on press). The other eight content types
+(`UNIVERSAL_FACE_TYPES`: Select, Label, Waveform, Spatial3D, WaveShaper, Envelope,
+StepSequencer, Keyboard) get a single static face painted by `wrapElement`.
+`faceHideBase` hides the programmatic render underneath via `opacity: 0` only
+(never `display`/`visibility`), so the box, layout, and drag wiring survive. When
+`faceSrc` is unset, every face branch is skipped and the render is byte-identical to
+an unskinned control.
+
+### Routing dispatch and LISTEN
+
+`dispatchRoutes(axis, value, allowDaw)` fans a source control's shaped value to
+every route whose axis matches. `dest: "daw"` routes are preview-gated and pushed
+onto the theDAW control bus; `dest: "element"` routes publish on the ephemeral
+`elementSignalBus`. Legacy single-target bindings are folded in via `routesOf()`
+(see routing below). Buttons only send the leading edge to daw pad targets to avoid
+double-triggering.
+
+The two **display** types listen instead of send. A bound `Meter` drives its `val`
+from the target's live value; a bound `Waveform` drives `liveWaveVal` (amplitude).
+Both seed from the last-known value and re-subscribe when the bound id changes; an
+active drag on the display itself wins over inbound frames.
+
+## Control render components
+
+Each control lives in `src/components/controls/`. Variants are the look presets you
+drag from the sidebar; the render component reads live parameters through
+`styleParam(el, key, fallback)`.
+
+| Control | Shipped variants (from the sidebar palette) | Face-aware | Interactive |
+|---|---|---|---|
+| Knob | Blank, Modernism, Skeuomorphic, Minimalist, Apple-esque, Swiss Style, Morphogenetic, Space Age, Encoder, Aluminum, Vintage, LED Ring, Glass, Jog Wheel | Yes | Yes (drag) |
+| Slider | Blank, Bipole, Modernism, Japandi, Contemp. Luxury, Bauhaus, Channel Fader, LED Slider, Mod Wheel, Pitch Wheel | Yes | Yes (drag) |
+| Button | Blank, Functionalism, Soft Minimalism, Neumorphic, International Style, Drum Pad, LED Push, Chrome | Yes | Yes (press) |
+| Toggle | Blank, Streamline Moderne, Neo-minimalism, Brutalist, Rocker, Lever | Yes | Yes (click) |
+| Meter | Blank, VU Meter, LED Bar, LED Segments | Yes | Listens |
+| XYPad | Blank, Kaoss, Crosshair | Yes | Yes (XY drag) |
+| Label | Blank, Scandinavian, Retrofuturism, LCD | Static face | No |
+| Select | Blank, Mid-century, Swiss Style, Segmented | Static face | Yes (open) |
+| Waveform | Blank, Oscilloscope, Modern, LFO Sine/Triangle/Saw/Square/S&H | Static face | Listens |
+| Spatial3D | Blank, Radar | Static face | Yes (XY drag) |
+| WaveShaper | Blank, Sine Fold, Tanh, Hard Fold, Tube Drive | Static face | Yes (drag) |
+| Envelope | Blank, ADSR | Static face | Self-editing |
+| StepSequencer | Blank, Grid | Static face | Self-editing |
+| Keyboard | Blank, Keys | Static face | No |
+
+`Envelope` and `StepSequencer` are **self-editing**: dragging their handles / cells
+calls `onStyleParams(patch)`, which `InteractiveControl` forwards to
+`onUpdateElements` so the edit persists into `el.styleParams`. `Image` and `Group`
+are drawn by Canvas directly; `CustomCode` renders through the sandboxed
+`CustomCodeFrame` (see [custom-code.md](custom-code.md)).
+
+## Control parameters
+
+`src/components/controls/controlParams.ts` declares the adjustable parameters per
+type in `CONTROL_PARAMS`. One declaration does three jobs: the properties panels
+render an editor per param, the control reads the live value via `styleParam()`,
+and the value persists in `el.styleParams`. A `variants` field limits a param to
+specific variants (omit = all). Every param has a default so a control renders
+identically to its pre-parameterization look when `styleParams` is absent.
+
+`paramsForElement(el)` filters by type + variant (a variant-scoped def wins over an
+unscoped one for the same key). `styleParam(el, key, fallback)` resolves in order:
+stored value → variant-scoped default → caller fallback → unscoped default.
+
+### Knob
+
+| Key | Label | Type | Range / options | Default | Variant scope |
+|---|---|---|---|---|---|
+| `sweepAngle` | Sweep Angle | number | 90–360 | 270 | all |
+| `capSize` | Cap Size % | number | 50–100 | 100 | all |
+| `indicatorLength` | Indicator Length % | number | 20–100 | 60 | all |
+| `indicatorThickness` | Indicator Thickness | number | 1–10 | 3 | all |
+| `tickCount` | Tick Marks | number | 0–24 | 0 | all |
+| `showValueArc` | Value Arc | toggle | — | true | Aluminum |
+| `arcThickness` | Arc Thickness | number | 1–10 | 3 | Aluminum |
+| `bezelWidth` | Bezel Width | number | 0–14 | 4 | Aluminum, Glass |
+| `brushIntensity` | Brush Intensity % | number | 0–100 | 50 | Aluminum |
+| `ledSegments` | LED Segments | number | 6–32 | 15 | LED Ring |
+| `ledUnlitOpacity` | Unlit LED % | number | 0–60 | 15 | LED Ring |
+| `pointerWidth` | Pointer Width % | number | 10–60 | 30 | Vintage |
+| `domeOpacity` | Dome Opacity % | number | 10–100 | 60 | Glass |
+| `glowStrength` | Glow Strength % | number | 0–100 | 50 | Glass, LED Ring |
+| `faceFit` | Face Fit | select | contain / cover / fill | contain | face |
+| `faceOpacity` | Face Opacity % | number | 0–100 | 100 | face |
+| `faceHideBase` | Hide Base Render | toggle | — | true | face |
+| `faceMode` | Face Mode | select | rotate / static | rotate | face |
+| `faceShowIndicator` | Show Indicator | toggle | — | false | face |
+
+### Slider
+
+| Key | Label | Type | Range / options | Default | Variant scope |
+|---|---|---|---|---|---|
+| `trackWidth` | Track Width % | number | 10–100 | 40 | Blank |
+| `capWidth` | Cap Width % | number | 40–100 | 90 | Blank |
+| `capHeight` | Cap Height | number | 8–48 | 20 | Blank |
+| `tickCount` | Tick Marks | number | 0–20 | 0 | all |
+| `showTicks` | Show Tick Scale | toggle | — | true | Channel Fader |
+| `railDepth` | Rail Depth | number | 1–12 | 4 | Channel Fader |
+| `glowStrength` | Glow Strength % | number | 0–100 | 60 | LED Slider |
+| `fillFromCenter` | Fill From Center | toggle | — | true | Bipole |
+| `wheelGrooves` | Wheel Grooves | number | 4–20 | 8 | Mod Wheel, Pitch Wheel |
+| `wellDepth` | Well Depth | number | 1–10 | 4 | Mod Wheel, Pitch Wheel |
+| `faceFit` / `faceOpacity` / `faceHideBase` | (face trio) | — | — | contain / 100 / true | face |
+| `faceRole` | Face Role | select | thumb / track | thumb | face |
+| `faceThumbSize` | Thumb Size % | number | 10–100 | 60 | face |
+
+### Meter
+
+| Key | Label | Type | Range / options | Default | Variant scope |
+|---|---|---|---|---|---|
+| `segmentCount` | Segments | number | 6–32 | 14 | LED Segments |
+| `segmentGap` | Segment Gap | number | 0–6 | 1 | LED Segments |
+| `yellowStart` | Amber Zone Start % | number | 30–90 | 60 | LED Segments |
+| `redStart` | Red Zone Start % | number | 60–98 | 85 | LED Segments |
+| `zoneGreen` / `zoneAmber` / `zoneRed` | Zone colours | color | — | #22c55e / #f59e0b / #ef4444 | LED Segments |
+| `bezelWidth` | Bezel Width | number | 0–10 | 1 | all |
+| `needleThickness` | Needle Thickness | number | 1–8 | 2 | VU Meter |
+| `faceMode` | Face Mode | select | fill / static | fill | face |
+
+### Button
+
+| Key | Label | Type | Range / options | Default | Variant scope |
+|---|---|---|---|---|---|
+| `bezelWidth` | Bezel Width | number | 0–12 | 3 | LED Push, Chrome |
+| `pressDepth` | Press Depth | number | 1–8 | 2 | LED Push, Blank |
+| `labelSize` | Label Size | number | 8–24 | 12 | all |
+| `ledStripHeight` | LED Strip Height | number | 2–12 | 4 | LED Push |
+| `glowStrength` | Glow Strength % | number | 0–100 | 60 | LED Push, Chrome |
+| `facePressed` | Pressed Effect | select | brightness / scale / offset / swap | brightness | face |
+| `facePressedAmount` | Pressed Amount % | number | 0–100 | 30 | face |
+
+Plus the universal face trio (`faceFit` / `faceOpacity` / `faceHideBase`). The
+swap-image URL `facePressedSrc` is written to `styleParams` by code and has no
+editor.
+
+### Toggle
+
+| Key | Label | Type | Range / options | Default | Variant scope |
+|---|---|---|---|---|---|
+| `switchScale` | Switch Size % | number | 50–100 | 100 | all |
+| `leverAngle` | Lever Throw ° | number | 10–50 | 24 | Lever |
+| `showLegends` | I/O Legends | toggle | — | true | Rocker |
+| `housingDepth` | Housing Depth | number | 1–10 | 3 | Rocker, Lever |
+| `glowStrength` | On-Glow Strength % | number | 0–100 | 50 | Rocker, Lever |
+| `faceOn` | On Effect | select | brightness / tint / swap | brightness | face |
+| `faceOnAmount` | On Amount % | number | 0–100 | 30 | face |
+
+Plus the universal face trio; the `faceOnSrc` swap-image URL is code-set with no
+editor.
+
+### XYPad
+
+| Key | Label | Type | Range / options | Default | Variant scope |
+|---|---|---|---|---|---|
+| `gridDivisions` | Grid Divisions | number | 0–12 | 0 (10 for Crosshair) | all / Crosshair |
+| `gridOpacity` | Grid Opacity % | number | 0–40 | 8 | Crosshair |
+| `crosshairOpacity` | Crosshair Opacity % | number | 0–100 | 40 | Crosshair |
+| `dotSize` | Dot Size | number | 6–32 | 12 | all |
+| `trailEcho` | Motion Trail | toggle | — | true | Crosshair |
+| `glowStrength` | Dot Glow % | number | 0–100 | 60 | Kaoss, Crosshair |
+| `faceRole` | Face Role | select | puck / background | puck | face |
+| `facePuckSize` | Puck Size % | number | 5–50 | 20 | face |
+
+Plus the universal face trio.
+
+### Spatial3D
+
+| Key | Label | Type | Range | Default | Variant scope |
+|---|---|---|---|---|---|
+| `gridDivisions` | Grid Divisions | number | 0–12 | 3 | all |
+| `dotSize` | Dot Size | number | 6–32 | 8 | all |
+| `glowStrength` | Dot Glow % | number | 0–100 | 60 | Radar |
+
+### Waveform
+
+| Key | Label | Type | Range | Default | Variant scope |
+|---|---|---|---|---|---|
+| `barCount` | Bars | number | 8–96 | 10 | Modern |
+| `lineThickness` | Line Thickness | number | 1–8 | 2 | all |
+| `amplitude` | Amplitude % | number | 10–100 | 50 (Oscilloscope) / 90 (Modern) / 70 (LFO*, Blank) | per-variant |
+| `mirror` | Mirror | toggle | — | false | Modern |
+| `cycles` | Cycles | number | 1–8 | 2 | LFO Sine/Triangle/Saw/Square/S&H |
+| `phase` | Phase % | number | 0–100 | 0 | LFO Sine/Triangle/Saw/Square/S&H |
+
+### Label
+
+| Key | Label | Type | Range / options | Default | Variant scope |
+|---|---|---|---|---|---|
+| `fontSize` | Font Size | number | 8–64 | 12 (10 Retrofuturism / 16 LCD) | per-variant |
+| `fontWeight` | Weight | select | normal / medium / bold | normal | Blank, Scandinavian Modern, Retrofuturism, Mid-century Modern |
+| `align` | Align | select | left / center / right | left (center for LCD) | all / LCD |
+| `letterSpacing` | Letter Spacing | number | 0–12 | 1.6 (Retrofuturism) / 0 (others) | per-variant |
+| `uppercase` | Uppercase | toggle | — | true Retrofuturism / false others | per-variant |
+| `lcdGlow` | LCD Glow % | number | 0–100 | 40 | LCD |
+
+`Label` also honours an inbound `text` route via `liveText`, overriding `el.label`.
+
+### Select
+
+| Key | Label | Type | Range | Default |
+|---|---|---|---|---|
+| `fontSize` | Font Size | number | 8–24 | 12 |
+| `chevronSize` | Chevron Size | number | 4–16 | 8 |
+
+### WaveShaper
+
+| Key | Label | Type | Range | Default | Variant scope |
+|---|---|---|---|---|---|
+| `symmetry` | Symmetry % | number | 0–100 | 50 | Tube Drive |
+| `gridOpacity` | Grid Opacity % | number | 0–40 | 10 | all |
+| `curveThickness` | Curve Thickness | number | 1–8 | 3 | all |
+| `fillUnderCurve` | Fill Under Curve | toggle | — | true | all |
+
+### Envelope
+
+| Key | Label | Type | Range | Default |
+|---|---|---|---|---|
+| `attack` | Attack | number | 0–100 | 15 |
+| `decay` | Decay | number | 0–100 | 30 |
+| `sustain` | Sustain | number | 0–100 | 70 |
+| `release` | Release | number | 0–100 | 25 |
+| `curveTension` | Curve Tension | number | 0–100 | 30 |
+| `showGrid` | Show Grid | toggle | — | true |
+
+### StepSequencer
+
+| Key | Label | Type | Range | Default |
+|---|---|---|---|---|
+| `rows` | Rows | number | 1–8 | 4 |
+| `steps` | Steps | number | 4–32 | 16 |
+| `cellGap` | Cell Gap | number | 0–6 | 2 |
+| `accentEvery` | Accent Every | number | 2–8 | 4 |
+
+### Keyboard
+
+| Key | Label | Type | Range | Default |
+|---|---|---|---|---|
+| `octaves` | Octaves | number | 1–4 | 2 |
+| `showLabels` | Show Labels | toggle | — | false |
+
+## Skins
+
+`src/lib/skins.ts` defines universal material "skins" — CSS-recipe layers any
+element can wear via `el.skin`, independent of its variant. Each recipe tints
+itself to the host element's base/active colours with `color-mix()`, so the same
+skin reads differently on a purple knob than an amber button. The dispatcher paints
+each overlay as an absolutely-positioned, full-cover, pointer-inert div above the
+control render.
+
+| Skin id | Label | Look |
+|---|---|---|
+| `none` | None | No skin (default) |
+| `aluminum` | Aluminum | Brushed vertical microlines + sheen + inset bevel |
+| `chrome` | Chrome | Horizon gradient, conic sheen, specular streak, dark edge ring |
+| `glass` | Glass | Top highlight ellipse over a white film with an active-tinted inner glow |
+| `bakelite` | Bakelite | Warm dark plastic radial tint, fine speckle, glossy top |
+| `carbon` | Carbon Fiber | Crossed twill weave + diagonal sheen |
+| `matte` | Matte | Desaturating dark film that kills gloss + soft inner shadow |
+| `leather` | Leather | Warm grain radial, pore speckle, dashed inset stitch line |
+| `led-glow` | LED Glow | Inner + outer glow ring in the active colour, no fill |
+
+See [textures-and-skins.md](textures-and-skins.md) for how skins, image faces, and
+generated textures layer together.
+
+## Routing and modulation
+
+An element's `binding` (`ElementBinding`) carries a modulation **stack**:
+`binding.routes` is an array of `ElementRoute`. One control can drive many
+destinations at once — theDAW functions (`dest: "daw"`) and other canvas elements
+(`dest: "element"`). The shaping math and compatibility maps live in
+`src/lib/routing.ts`.
+
+An `ElementRoute` has: `axis` (`value` / `x` / `y`), `dest`, `targetId`, `prop`
+(for element routes), `amount` (−100..100 depth, negative inverts), `curve`, and
+`rangeMin`/`rangeMax` (0–100 output clamp). `applyRoute` normalizes the source to
+0–1, applies depth/invert, then a curve, then the output range:
+
+| Curve | Shape |
+|---|---|
+| `linear` | `v` |
+| `exp` | `v³` — fast late (classic exponential) |
+| `log` | `1 − (1−v)³` — fast early |
+| `scurve` | `v²(3 − 2v)` — smoothstep |
+
+`routesOf(el)` merges explicit routes with legacy single-target fields
+(`targetId` / `xTargetId` / `yTargetId`) migrated on the fly (axis-aware dedup,
+never persisted). The listen `targetId` on Meter/Waveform is excluded — it is not a
+route.
+
+Which axes a type emits (`sourceAxesFor`) and which destination props it accepts
+(`elementDestProps`):
+
+| Type | Emits (source axes) | Accepts as destination (prop → label) |
+|---|---|---|
+| Knob, Slider, WaveShaper | value | value → Value |
+| Toggle | value | on → State |
+| Button | value | — |
+| XYPad, Spatial3D | x, y | valueX → X, valueY → Y |
+| Meter | — (listens) | value → Value |
+| Waveform | — (listens) | value → Amplitude |
+| Label | — | text → Readout |
+
+`isRouteSource(type)` is true when a type emits at least one axis (Knob, Slider,
+WaveShaper, Toggle, Button, XYPad, Spatial3D).
+
+### The routing UI (`BindingPicker`)
+
+`src/components/properties/BindingPicker.tsx` renders one of three surfaces
+depending on the element:
+
+- **RoutingStack** (source controls) — the list of routes, plus an "Add Route"
+  browser. Each route is a compact card: destination + a centre-notched amount
+  slider, expandable to curve, output range, and (for XY sources) the source axis.
+  Legacy single-target bindings show as amber "convert to route" cards. An axis
+  selector appears when the source has more than one axis.
+- **RouteBrowser** — a searchable, grouped picker: live theDAW manifest targets by
+  area (each area gets a deterministic colour dot), then the always-available
+  built-in `vst:` binds (Transport, Plugin, Macros, LFOs, Presets, MIDI, MIDI
+  Notes) — large areas collapse by default — then other canvas elements grouped by
+  compatible property.
+- **ListenPicker** (Meter / Waveform) — a single "Listen to" source select, since
+  display types are driven *by* a target rather than driving one.
+
+`CustomCode` elements bind per numeric parameter through `CustomParamBindingPicker`
+(`el.paramBindings`) rather than the element-level stack. A "theDAW bus"
+status line reports connection; built-in `vst:` binds work even when theDAW is
+offline. The live manifest comes from the bus via `useDawBindings()`. See
+[thedaw-integration.md](thedaw-integration.md) for the bus itself.
+
+## The properties editor
+
+`src/components/CompactElementProperties.tsx` is the active element editor — a
+tabbed, dense panel that App renders inside the draggable context popover (see the
+context menu section below). Tabs are hidden when they do not apply to the selected
+type. It is built from the shared building blocks in
+`src/components/properties/`: the field primitives (`fields/`), the select-option
+arrays (`options.ts`), the numeric plumbing (`useElementField.ts`), the routing UI
+(`BindingPicker`), and the generated Control Parameters editor
+(`ControlParamsSection`).
+
+> Note: A second, full right-panel editor — `PropertiesPanel.tsx` (collapsible
+> Transform / Style / Effects / Routing / Control Parameters / Texture sections, a
+> Properties / Info tab, and a header lock toggle) — has been retired to
+> `deprecated/src/components/PropertiesPanel.tsx` and is imported by nothing in the
+> active app. Several building blocks under `src/components/properties/` still carry
+> doc-comments that mention "both PropertiesPanel and CompactElementProperties";
+> those comments are stale — only `CompactElementProperties` consumes them today.
+
+`CompactElementProperties` tabs (`TabId`):
+
+| Tab | Shows |
+|---|---|
+| `transform` | Position, size, rotation, opacity, lock |
+| `style` | Design variant, corner radius, theme colours, layer blend mode |
+| `fx` | Glow (style/opacity/intensity/spread/colour/gradient) and animation effect |
+| `control` | Export name, label/value/min/max, Select options, Control Parameters |
+| `texture` | Background texture + blend/opacity/size/repeat/scale/rotation/offset |
+| `binding` | The `BindingPicker` routing stack |
+| `image` | Image-only: background removal (tolerance/feathering/target colour) + blend |
+| `raw` | Monaco JSON editor of the whole element |
+
+The `raw` tab is wired through `properties/rawEditor.ts` (`useRawJsonEditor`): a
+debounced diff-commit that flushes on blur/unmount and never writes `id`. Monaco
+also gets hover hints for common property keys. The numeric plumbing lives in
+`useElementField.ts` (`parseNumericInput`, `createFieldChangeHandler`, the
+`UpdateElementsFn` type) and the select-option arrays in `options.ts`
+(full/reduced blend-mode lists, effect list, `normalizeGlowStyle`).
+
+### `ControlParamsSection`
+
+`properties/ControlParamsSection.tsx` renders the generated Control Parameters
+editor used by the `control` tab. It draws:
+
+- a universal **Skin** picker (`element.skin`, on every type except Group);
+- one field per declared param for the element's type/variant (number → range +
+  numeric input, color → colour field, toggle, select) — `face*` params stay hidden
+  until `el.faceSrc` is set;
+- a **Reset parameters** link when any managed key is overridden;
+- a **Control Type** convert dropdown (only when the element carries a picture — a
+  face, or an Image backed by an asset) that dispatches a `vst-convert-type`
+  CustomEvent for the App to handle;
+- **Save to Arsenal** (dispatches `vst-arsenal-save`) for any non-Group control, and
+  **Remove face image** (clears `faceSrc`) once the control wears one.
+
+## The left sidebar
+
+`src/components/Sidebar.tsx` is the component palette, split into two independently
+toggled columns: a **Categories** rail and an **Explorer** column showing the
+selected category's drag tiles. Categories:
+
+| Category | Contents |
+|---|---|
+| Knobs, Sliders, Buttons, Toggles | Native control variants (see the render-component table) |
+| Display | Label, Select variants |
+| Waveforms, Meters, XY Pads, Spatial / 3D | Their variants |
+| Shapers & Sequencers | WaveShaper, Envelope, StepSequencer, Keyboard variants |
+| Custom Code | User-authored CustomCode modules (with a name + code form) |
+| Saved Presets | Element presets saved from the Raw tab (`localStorage` `vst-custom-presets`) |
+| Arsenal | The global saved-control palette (see [textures-and-skins.md](textures-and-skins.md)) |
+
+Each tile is `draggable`; dropping it onto the canvas calls `onDrop` with the type,
+default size, variant, optional `customCode`, and optional `presetData` (spread
+whole onto the new element). Arsenal tiles carry a hover delete-X.
+
+## The header toolbar
+
+`src/components/Header.tsx` is the top strip (collapsible via an edge handlebar in
+`App.tsx`). It carries the workspace actions:
+
+| Control | Action |
+|---|---|
+| Show Rulers / Grid Overlay / Snap to Grid + Size | Canvas guide toggles + grid-size input |
+| Undo / Redo | Full history (Ctrl+Z / Ctrl+Shift+Z) |
+| Upload / Change Background | Loads a background image, auto-fits the scale |
+| Extract Components (scissors) | Opens the component extractor — see [component-extractor.md](component-extractor.md) |
+| Clear (trash) | Removes all elements (shown only when the canvas has elements) |
+| Demo / Edit Mode | Toggles `isPreviewMode` |
+| Project Library (folder) | Opens saved projects — see [projects-and-data.md](projects-and-data.md) |
+| Open .gan (package) | Opens a `.gan` plugin to edit — see [gan-format.md](gan-format.md) |
+| Save / Download JSON | Persist / download the project |
+| Package (archive) | Export the full ZIP — see [vst3-export.md](vst3-export.md) |
+| Export Code | React/TSX or JSON export |
+| Settings (gear) | Theme, canvas size, provider keys, SD paths |
+
+The brand lockup at the left is `brand-title/BrandTitle.tsx`.
+
+## Layers panel
+
+`src/components/LayersPanel.tsx` is the z-order list. It renders the elements
+*reversed* (top layer at the top of the list), supports drag-and-drop reorder plus
+per-row up/down buttons, shows a z-index badge (`z-N`, tagged `(top)` / `(base)`),
+and shows an image thumbnail for Image layers (resolved from the `assets` prop),
+falling back to a two-letter type initial for everything else. Clicking a row
+selects the element (shift/ctrl/meta for multi-select).
+
+## Alignment and distribution
+
+Alignment and distribution ship as inline helpers in `src/App.tsx` —
+`computeAlign(ids, type)` and `computeDistribute(ids, axis)` — driven by the AI
+assistant rather than a manual panel. App's action handler wires them to the orb
+tools `alignElements` (`{ ids, alignment }`) and `distributeElements`
+(`{ ids, axis }`), both registered in `components/orb/useToolActions.ts`.
+
+- **Align, single selection** — snaps the element to the canvas edges or centres:
+  `left`, `centerH`, `right`, `top`, `centerV`, `bottom`.
+- **Align, multi-selection** — aligns elements relative to each other: edges to the
+  selection min/max, centres to the selection average.
+- **Distribute** — `horizontal` or `vertical`; needs more than two movable
+  elements, then evens the gaps between the sorted elements.
+
+Locked elements are skipped in every operation.
+
+> Note: A manual `AlignmentPanel.tsx` used to render these as buttons; it has been
+> retired to `deprecated/src/components/AlignmentPanel.tsx` and is imported by
+> nothing in the active app. The `computeAlign` comment in `App.tsx` still reads
+> "Mirrors AlignmentPanel.handleAlign" from that earlier design — alignment is
+> AI-driven today.
+
+## Context menu
+
+`src/components/ContextMenu.tsx` is a draggable, viewport-clamped fixed popover that
+takes a `ContextMenuAction[]` (label, icon, onClick, shortcut, danger, divider,
+disabled, iconOnly). It renders a vertical action list plus an icon-only toolbar for
+`iconOnly` actions. Canvas triggers it on element right-click (anchored to the
+element's right edge) and on empty-canvas right-click (at the cursor). A grab handle
+lets the user drag it; it hard-clamps to the viewport on open, on drag, on internal
+resize (a `ResizeObserver`), and on window resize, and closes on outside-click or
+Escape. It commonly hosts a `CompactElementProperties` panel as its `children`.
+
+## Event log
+
+`src/components/EventLog.tsx` is a floating console (bottom-right terminal button)
+that merges two streams: the Foundry server's in-memory log (polled from
+`GET /api/logs?lines=400` every 2.5s while the panel is open) and client-side errors
+captured at all times (`window.onerror`, `unhandledrejection`, and a monkey-patched
+`console.error`). Both streams start with an ISO timestamp so a plain sort
+interleaves them chronologically. Lines are classified `error` / `warn` / `info` and
+colour-coded, and the toggle button shows an unseen-error badge for errors that
+arrived while the panel was closed. It surfaces failures the browser F12 console
+cannot see (generation failures, Claude CLI spawn errors, MCP relay, config).
+
+## Asset and texture libraries
+
+Two `CollapsiblePanel` libraries feed the canvas with imagery:
+
+- **`AssetManager.tsx`** — the image library. Upload or AI-generate an image, then
+  drag it onto the canvas as an `Image` element (the drop payload carries
+  `elementType=Image` plus `assetId`/`url`). Includes a 2-up/4-up thumbnail zoom
+  toggle.
+- **`TextureManager.tsx`** — the texture library. Upload (`POST /api/textures/upload`,
+  with a data-URL fallback) or AI-generate, then drag a texture onto a control (the
+  `application/x-vst-texture` payload sets the element's `textureId`).
+
+Both are covered in depth in [textures-and-skins.md](textures-and-skins.md);
+generation itself is in the assistant/SD flow ([assistant-and-mcp.md](assistant-and-mcp.md)).
+
+## Where to go next
+
+- [foundry-overview.md](foundry-overview.md) — the whole app and how these pieces fit together.
+- [custom-code.md](custom-code.md) — the sandboxed CustomCode element and its param bridge.
+- [textures-and-skins.md](textures-and-skins.md) — image faces, skins, textures, the Arsenal.
+- [thedaw-integration.md](thedaw-integration.md) — the control bus and live binding.
+- [gan-format.md](gan-format.md) / [vst3-export.md](vst3-export.md) — turning a canvas into a plugin.
+- [index.md](index.md) — the documentation map.

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/component-extractor.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/component-extractor.md
@@ -1,0 +1,433 @@
+# Component Extractor — From Screenshot to Controls
+
+Reference for Foundry's **Component Extractor**: the workspace that turns one flat
+UI reference image — a plugin faceplate screenshot, a render, a mood board — into
+separate labeled cutout components, and optionally into real interactive controls.
+It segments the picture with vision AI, crops each region, removes its background,
+and drops the result into Foundry's asset, texture, layer, or control sinks. This
+page covers both the integrated extractor built into Foundry and the standalone
+AI-Studio app it was ported from, and how the two relate. Plain descriptions of
+what each piece does.
+
+The extractor exists in two forms:
+
+- The **integrated extractor** inside Foundry (`src/components/extractor/`,
+  `src/lib/extractor/`, `server/extract.ts`) — the version you use day to day.
+- The **standalone app** (`component-extractor/`) — a self-contained
+  Express + Vite AI-Studio project that the integrated version was ported from.
+  It is kept in the tree as the reference implementation and porting guide.
+
+For where extracted cutouts go afterward, see
+[textures-and-skins.md](textures-and-skins.md) and
+[canvas-and-controls.md](canvas-and-controls.md). For where the Gemini key is
+configured, see [assistant-and-mcp.md](assistant-and-mcp.md).
+
+## The two implementations at a glance
+
+Both run the same four-stage pipeline and share the same prompts and JSON
+schemas. They differ in how they talk to Gemini and where the results land.
+
+| | Integrated (Foundry) | Standalone (`component-extractor/`) |
+|---|---|---|
+| Source image | `canvasState.backgroundImage` (no internal file picker) | Its own upload |
+| Server | Foundry's Express server on port **5472** | Own Express + Vite server on port **3000** |
+| Gemini call | Plain REST `fetch` (no SDK), same pattern as `sd.ts` | `@google/genai` SDK (`GoogleGenAI`) |
+| Endpoints | `/api/extract/detect`, `/api/extract/label` | `/api/detect`, `/api/label-crop`, `/api/models` |
+| Element type | `ExtractedElement` | `UIElement` |
+| Manual draws | Queue as `pending` (batched by **Process Pending**) | Auto-processed immediately |
+| Outputs (sinks) | Assets, Textures, Layers, **Controls** | Save / Save All (ZIP) only |
+| `@imgly` load | Dynamic `import()` (keeps ~40 MB WASM off the bundle) | Static import |
+
+> The prompts and response schemas in `server/extract.ts` (`DETECT_SCHEMA`,
+> `LABEL_SCHEMA`, `detectPrompt`, `labelPrompt`) are copied **verbatim** from the
+> standalone `component-extractor/server.ts` — the proven working set. When you
+> change one, change the other to keep them in sync.
+
+> The element interface was renamed from the standalone's `UIElement` to
+> `ExtractedElement` during the port because Foundry already defines its own
+> `UIElement` type (its canvas element). The fields are otherwise identical.
+
+## The extraction pipeline
+
+Both implementations run the same four stages. Steps 1 and 4 are AI calls to
+Gemini through the backend; steps 2 and 3 are pure client-side `<canvas>` work.
+
+1. **Auto-Detection (AI).** The full image is sent to Gemini, which returns
+   normalized `[0..1]` bounding boxes `{ label, type, xmin, ymin, xmax, ymax }`
+   for every UI element it can find.
+2. **Cropping (canvas).** For each box, `extractCrop()` slices the source image
+   with the Canvas API into a PNG data URL.
+3. **Cutout (canvas + AI + WASM).** The crop's background is removed, leaving the
+   isolated control. Cutout is attempted in this order:
+   - **AI polygon mask** — `applyPolygonMask()` clips the crop to the tight
+     foreground polygon Gemini returned during labeling.
+   - **`@imgly/background-removal` fallback** — only when no polygon is
+     available. Runs entirely in-browser on a ~40 MB WASM model downloaded once.
+   - **Trim** — `trimTransparentPixels()` scans the alpha channel (threshold
+     `alpha > 5`), crops to the tightest opaque box, and tightens the element's
+     normalized bounds accordingly.
+4. **Analysis (AI).** Each crop is sent back to Gemini for a `label`,
+   `description`, `type`, `tags`, `group`, `shape`, and the polygon used in
+   step 3.
+
+```
+detect (AI)  →  crop (canvas)  →  cutout: polygon mask → @imgly fallback → trim  →  label (AI)
+```
+
+> The `@imgly/background-removal` model (~40 MB of WASM) downloads on the first
+> cutout and is cached afterward, so the first background-removal pass is slow
+> and later ones are fast. Integrated Foundry imports it dynamically so that
+> weight never lands in the initial bundle.
+
+## Opening the extractor (integrated)
+
+Click **Extract Components** (the Scissors icon) in the Foundry header, next to
+the background-image controls. `App.tsx` wires the button to `setIsExtractorOpen`
+and renders `ExtractorModal` with `sourceImage={canvasState.backgroundImage}`.
+
+The background image is the **sole input** — Foundry already owns background
+upload, so the extractor reuses it instead of adding its own file picker. With no
+background, the workspace shows *"Upload a background image on the canvas
+first."* and there is nothing to detect.
+
+> The workspace **survives close and reopen**: captured elements, cutouts, and
+> settings persist while the modal is closed. State only resets when the
+> background image itself changes, because every element's bounds are relative to
+> that image (`ExtractorModal` watches `sourceImage` via `prevSourceRef`).
+
+## Capturing regions
+
+Three capture methods, mixable freely on one image.
+
+| Method | How | Result |
+|---|---|---|
+| **Auto Detect** | Click **Auto Detect** (Wand icon). | Vision AI returns a bounding box per element; each lands as status `detected`. The source is downscaled to ≤ **2048 px** on the longest side (`drawDownscaledDataUrl`) before base64 — bounds stay normalized so nothing downstream changes. |
+| **Manual rectangle** | Drag a box on the image. | Captures exactly that region as status `pending`. |
+| **Lasso** | Toggle **Lasso** (PenTool icon) or hold **Alt** while dragging, then trace a freeform outline. | Yields a **polygon cutout** (`displayMode: "cutout"`) instead of a plain rectangle; the lasso points are converted to crop-relative coordinates and applied with `applyPolygonMask`. |
+
+The capture surface is `ExtractCanvas`, which draws boxes over the background
+image, renders existing elements as overlays, and reports normalized coordinates
+back to the modal via `onDrawBox`. A drag under 5 px in either dimension is
+ignored.
+
+> Integrated Foundry deliberately does **not** auto-process a manually drawn box.
+> It queues as `pending` so you can capture several regions and process them in
+> one batch — the original standalone app ran the full AI pipeline on every box
+> the instant you drew it, hammering the API. The standalone still behaves that
+> way (`processElement(newElement)` fires inside its `handleManualDraw`).
+
+### Sensitivity
+
+The **Sensitivity** slider (0–100 %, stored `0..1`, step `0.05`) tunes both AI
+stages by injecting text into the prompts — it changes no client math.
+
+| Sensitivity | Detection (`detectPrompt`) | Cutout tightness (`labelPrompt`) |
+|---|---|---|
+| High (> 0.7) | "Be extremely aggressive and detect even the smallest or faintest elements." | Polygon hugs the object very closely, cutting aggressively. |
+| Middle | "Use a balanced threshold for detection." | Polygon hugs the object closely. |
+| Low (< 0.3) | "Be conservative and only detect the most obvious, distinct, large elements." | Polygon is slightly loose so nothing gets clipped. |
+
+Set sensitivity **before** running Auto Detect or Process Pending — it feeds the
+prompt on each call.
+
+## Processing captured regions
+
+Captured regions sit in the tray marked *"Waiting to process…"*. Click
+**Process Pending** to run the pipeline on every waiting region sequentially
+(`pending` and `detected` states). Each element walks the status ladder:
+
+```
+pending / detected  →  processing  →  labeled
+```
+
+`processElement()` performs: label + AI polygon cutout → `@imgly` fallback (only
+if no polygon cutout) → `trimTransparentPixels`, then writes back the label,
+type, tags, group, shape, tightened bounds, and `displayMode: "cutout"`.
+
+### Per-card Redo
+
+Each labeled card has its own sensitivity slider and a **Redo** button. Redo
+re-runs the whole pipeline on that one element at the card's sensitivity (which
+defaults to the global toolbar value). It re-crops the source at the element's
+**current** bounds, clears the old cutout/mask/polygon, resets it to `pending`,
+and processes it fresh — useful when the first pass produced a bad cutout or a
+wrong label.
+
+## The tray and display modes
+
+Every capture is a card in the **Captured Assets** tray (`ExtractTray`, rendered
+newest-first). Each card carries three display modes; the active one decides
+which image every sink and export uses.
+
+| Mode | Image | Notes |
+|---|---|---|
+| **Rect** | `cropDataUrl` | The raw rectangular crop. Always available. |
+| **Auto** | `cutoutDataUrl` | The AI/`@imgly` background-removed cutout. Disabled until a cutout exists. |
+| **Mask** | `maskDataUrl` | A hand-painted mask (see below). Selecting it opens the mask editor. |
+
+Precedence when a sink resolves an element's image is **mask > cutout > crop**.
+
+Card controls: an editable **label** field, the detected **group** and **tags**,
+a **Control type** select (for Make-Control, below), the Redo slider, a
+per-card **Delete**, and the four per-card sinks (Design / Tex / Control / Save).
+
+## Mask editor
+
+Selecting **Mask** opens `MaskEditor`, a brush canvas overlaid at `z-60`. It
+paints a separate white mask canvas and composites it onto the image with
+`destination-in` (keep pixels where the mask is opaque).
+
+| Tool | Compositing | Effect |
+|---|---|---|
+| **Add** | `source-over`, white | Reveals pixels (paints the mask opaque). |
+| **Remove** | `destination-out` | Erases pixels (paints the mask transparent). |
+
+The **Brush Size** slider runs 1–100 px. **Save Mask** exports the composited
+result as a PNG data URL and stores it as the element's `maskDataUrl` with
+`displayMode: "mask"`.
+
+## Design sinks
+
+The extractor gets assets out in seven ways. "Labeled" actions apply to every
+card in the `labeled` state; per-card actions apply to one card and use its
+current display mode.
+
+| Action | Where | Result |
+|---|---|---|
+| **Save** | Per card | Downloads that asset as a PNG using its current display mode. |
+| **Save All** | Tray header | Downloads `assets.zip` (JSZip) — one PNG per asset plus `metadata.json`. Duplicate labels get an index suffix so nothing overwrites. |
+| **Add All as Assets** | Tray header | Adds every labeled cutout to the Foundry **Asset library** (`onAddAssets`). |
+| **Add All as Textures** | Tray header | Uploads each cutout and adds it to the **Texture Library** (`onAddTextures`). |
+| **Place All as Layers** | Tray header | Adds the assets **and** places them on the canvas as Image layers at their original coordinates. |
+| **Place All as Controls** | Tray header | Promotes each labeled cutout to a native interactive control wearing the cutout as its face. |
+| **→ Design** / **Tex** / **Control** | Per card | The single-card forms of Place as Layer, Add as Texture, and Make Control. |
+
+`metadata.json` (inside `assets.zip`) is an array of `{ id, label, type, group,
+tags, bounds:{ xmin, ymin, xmax, ymax } }`.
+
+### Placing layers
+
+`PlacedLayer` bounds are normalized. `App.handleExtractorPlaceLayers` scales them
+onto the canvas with `boundsToCanvasRect(bounds, canvasState)`. Because the
+background sets `canvasState.width`/`height` to its own natural dimensions on
+upload, a placed layer lands exactly where the component sat in the original
+image. `boundsToCanvasRect` clamps degenerate boxes to a 1 px minimum.
+
+### The texture sink
+
+`handleAddAsTextures` calls the shared `uploadCutout` helper for each element:
+it converts any blob URL (an `@imgly` cutout) to a data URL, then
+`POST`s `/api/textures/upload` to obtain a durable `/textures/<id>` URL on disk
+that outlives blob-URL revocation. When the upload fails it falls back to the
+inline data URL. The durable id is recovered from the returned URL so the texture
+keeps the same on-disk identity its DELETE route matches against.
+
+### Make Control (image-faced controls)
+
+`handleMakeControls` promotes a cutout into a **real interactive control** that
+wears the image as its `faceSrc`. Each card's **Control type** select chooses the
+target `ElementType`; the modal uploads the cutout through the same
+`uploadCutout` helper for a durable face URL, then places a `PlacedLayer` carrying
+`controlType` + `faceUrl`.
+
+`App.handleExtractorPlaceLayers` then branches: a `controlType` other than
+`Image` spawns a native control (`faceSrc = faceUrl ?? asset.url`, `value: 50`)
+rather than an `assetId`-backed Image layer.
+
+> The default control type comes from `defaultControlType`, which looks the
+> detected type up in `ELEMENT_TYPE_ALIASES` and defaults to **`Image`** — not
+> `Knob` — when there is no alias match. `normalizeElementType` alone falls back
+> to `Knob`, which would misfile a logo or graphic as a knob; a graphic with no
+> control meaning stays an `Image`. Any of Foundry's 17 `ELEMENT_TYPES` can be
+> chosen per card.
+
+Once placed, a Make-Control element is a normal Foundry control: it can be bound,
+restyled, and saved to the Arsenal from its properties panel. See
+[canvas-and-controls.md](canvas-and-controls.md).
+
+## Provider, key, and model
+
+The integrated extractor uses **Gemini** for both detection and labeling and
+shares Foundry's existing provider configuration — there is no separate setup.
+
+- **API key** — read from `localStorage` under `LS_PROVIDER_KEYS`
+  (`"vst-foundry-provider-api-keys"`), the same store the AI Assistant orb uses.
+  If no in-app key is present, the server falls back to its `GEMINI_API_KEY`
+  environment variable. There is no key field in the extractor.
+- **Model** — the toolbar **Model** dropdown is fetched live from
+  `/api/assistant/models/gemini`; the default is taken from the `gemini` entry of
+  `/api/assistant/providers`. Nothing is hardcoded — whatever Gemini models your
+  key exposes are what you can pick.
+
+> The server requires an explicit model: `validateExtractBody` returns
+> `400 "model required"` when the request body has none. The standalone
+> `server.ts` instead defaults its request-body `model` to a Gemini id when one
+> is omitted.
+
+## Backend endpoints
+
+### Integrated (Foundry server, port 5472)
+
+`server/extract.ts`, registered via `registerExtractRoutes(app)` **after** the
+CORS middleware so it inherits the origin lock. Plain REST against
+`https://generativelanguage.googleapis.com/v1beta`, 120 s abort timeout.
+
+| Method / path | Purpose | Body | Errors |
+|---|---|---|---|
+| `POST /api/extract/detect` | Detect every element → normalized bboxes | `image, mimeType, sensitivity, apiKey, model` | `400` bad input / no key, `403` foreign Origin, `502` Gemini failure |
+| `POST /api/extract/label` | Label + polygon trace for one crop | same | same |
+
+Validation (`validateExtractBody`): `image` and `mimeType` required; `mimeType`
+must match `image/(png|jpe?g|webp)`; `model` required; a Gemini key must resolve
+(request body first, env fallback); `sensitivity` clamped to `0..1`.
+
+> The `/api/extract` routes only exist after a **Foundry server restart**
+> following install. The frontend workspace loads immediately, but detect/label
+> calls **404 until the server is relaunched**. This is the one known
+> install-time caveat; see [troubleshooting.md](troubleshooting.md).
+
+### Standalone (`component-extractor/server.ts`, port 3000)
+
+Uses the `@google/genai` SDK. Serves the Vite dev middleware in development and
+the built `dist/` in production. JSON body limit 50 MB.
+
+| Method / path | Purpose |
+|---|---|
+| `POST /api/detect` | Detect bboxes for a full image |
+| `POST /api/label-crop` | Label + polygon trace for one crop |
+| `POST /api/models` | List available Gemini models via the SDK pager |
+
+## Response schemas
+
+Shared by both implementations (`DETECT_SCHEMA` / `LABEL_SCHEMA` in
+`server/extract.ts`, `Type.*` equivalents in `server.ts`).
+
+**Detect** — an array of:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `label` | string | Descriptive name (e.g. "Reverb Knob") |
+| `type` | string | Element type (knob, button, panel, display, …) |
+| `xmin, ymin, xmax, ymax` | number | Normalized `0.0–1.0` bounding box |
+
+**Label** — one object:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `label` | string | Short label |
+| `description` | string | What the element does |
+| `type` | string | Control type |
+| `tags` | string[] | Descriptive tags (e.g. `knob`, `metal`, `red`) |
+| `group` | string | Suggested logical group (e.g. "Delay Controls") |
+| `shape` | string | General foreground shape (circle, rectangle, …) |
+| `polygon` | `[x,y][]` | Tight foreground outline in normalized coordinates, used for the cutout |
+
+## Data shapes (frontend)
+
+`ExtractedElement` (`src/lib/extractor/types.ts`) — one captured region:
+
+| Field | Purpose |
+|---|---|
+| `id, label, type, description, tags, group, shape` | Identity + AI metadata |
+| `xmin, ymin, xmax, ymax` | Normalized bounds (tightened by trim) |
+| `polygon` | AI foreground outline |
+| `cropDataUrl` | Raw rectangular crop |
+| `cutoutDataUrl` | Background-removed cutout |
+| `maskDataUrl` | Hand-painted mask |
+| `displayMode` | `"rect" \| "cutout" \| "mask"` |
+| `status` | `"pending" \| "detected" \| "processing" \| "labeled"` |
+
+`PlacedLayer` (`ExtractorModal.tsx`) — a cutout mapped back onto the source for
+placement: `{ asset, bounds{xmin,ymin,xmax,ymax}, label, type?, controlType?,
+faceUrl? }`. `controlType` and `faceUrl` are set only by Make Control.
+
+## Blob-URL ownership
+
+The `@imgly` fallback creates blob URLs (`URL.createObjectURL`). The integrated
+modal fixes a leak the original had by tracking every owned blob URL in
+`blobUrlsRef`:
+
+- Revoked on element delete, on background-image reset, and on unmount.
+- **Ownership is handed to the design** when a cutout is placed as an asset or
+  control — the URL is removed from `blobUrlsRef` so the modal's cleanup sweep
+  never revokes a URL the canvas still renders.
+- An intermediate `@imgly` blob URL orphaned by a subsequent trim is revoked
+  immediately.
+
+## File map
+
+### Integrated (inside Foundry)
+
+| File | Role |
+|---|---|
+| `src/components/extractor/ExtractorModal.tsx` | Orchestrator modal: pipeline, blob-URL ownership, the four sinks |
+| `src/components/extractor/ExtractCanvas.tsx` | Draw / lasso capture surface over the background image |
+| `src/components/extractor/ExtractTray.tsx` | Captured-asset tray: per-card refine + Asset/Texture/Control/Layer buttons |
+| `src/components/extractor/MaskEditor.tsx` | Brush mask editor (Add/Remove, `destination-in`) |
+| `src/lib/extractor/types.ts` | `ExtractedElement` interface |
+| `src/lib/extractor/utils.ts` | `extractCrop`, `trimTransparentPixels`, `applyPolygonMask`, `generateId` |
+| `src/lib/extractor/mapping.ts` | `boundsToCanvasRect` — normalized bounds → canvas pixel rect |
+| `src/lib/extractor/mapping.test.ts` | Vitest for scaling/clamping |
+| `server/extract.ts` | `/api/extract/detect` + `/api/extract/label` (Gemini REST) |
+| `src/server.extract.test.ts` | Validation + origin-lock tests for the backend routes |
+| `src/App.tsx` | Wires the modal + sinks (`handleExtractorAddAssets`, `handleExtractorPlaceLayers`, textures) |
+
+### Standalone (`component-extractor/`)
+
+| File | Role |
+|---|---|
+| `server.ts` | Express + Vite server: `/api/detect`, `/api/label-crop`, `/api/models` (SDK) |
+| `src/App.tsx` | Root orchestrating upload, detect, process, tray, mask editor |
+| `src/types.ts` | `UIElement` interface (source of the ported `ExtractedElement`) |
+| `src/lib/utils.ts` | `extractCrop`, `trimTransparentPixels`, `applyPolygonMask` helpers |
+| `src/components/CanvasArea.tsx` | Draw / lasso capture surface |
+| `src/components/AssetTray.tsx` | Captured-asset tray |
+| `src/components/MaskEditor.tsx` | Brush mask editor |
+| `INTEGRATION_GUIDE.md` | Guide for porting the technique into an existing app |
+| `package.json` | Deps: `@google/genai`, `@imgly/background-removal`, `jszip`, `file-saver`, `lucide-react` |
+
+## The standalone app
+
+`component-extractor/` is a complete AI-Studio project you can run on its own. It
+is the origin of the integrated version and doubles as living documentation of
+the technique (`INTEGRATION_GUIDE.md`).
+
+```bash
+cd component-extractor
+npm install
+npm run dev        # tsx server.ts → http://localhost:3000
+```
+
+It differs from the integrated version in the ways listed in
+[The two implementations at a glance](#the-two-implementations-at-a-glance): its
+own upload, the `@google/genai` SDK, a `/api/models` list endpoint,
+immediate processing of manual draws, and Save / Save-All (ZIP) as its only
+outputs — it has no concept of Foundry's asset, texture, layer, or control sinks.
+
+`INTEGRATION_GUIDE.md` documents the four-stage technique and the exact
+`extractCrop` / `removeBackground` / schema code used when porting it into a
+full-stack React + Express app, which is how the integrated extractor was built.
+
+## Operational notes
+
+- **Restart after install.** The `/api/extract/detect` and `/api/extract/label`
+  routes go live only after a Foundry server relaunch; they 404 until then.
+- **Empty state.** With no canvas background image, the workspace shows a prompt
+  to upload one — the background is the extractor's only input.
+- **First cutout is slow.** The `@imgly` background-removal WASM (~40 MB)
+  downloads once on first use and is cached afterward.
+- **Model dropdown empty?** The list is fetched live from
+  `/api/assistant/models/gemini`; confirm the Gemini key set in the AI Assistant
+  orb is valid. See [assistant-and-mcp.md](assistant-and-mcp.md).
+- **Detection or processing fails.** A missing or invalid Gemini key returns
+  `400` with a message about the key; a Gemini-side error returns `502`. Set the
+  key in the orb settings or `GEMINI_API_KEY` on the server. See
+  [troubleshooting.md](troubleshooting.md).
+
+## See also
+
+- [foundry-overview.md](foundry-overview.md) — where the extractor fits in Foundry.
+- [canvas-and-controls.md](canvas-and-controls.md) — the controls a cutout can become and how faces render.
+- [textures-and-skins.md](textures-and-skins.md) — using extracted cutouts as textures and skins.
+- [assistant-and-mcp.md](assistant-and-mcp.md) — where the Gemini provider key is configured.
+- [troubleshooting.md](troubleshooting.md) — install-time and provider-key issues.

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/custom-code.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/custom-code.md
@@ -1,0 +1,412 @@
+# Custom Code — First-Class Code Components
+
+Reference for Foundry's **CustomCode** element: a canvas element whose contents
+are your own HTML/CSS/JS, rendered in a sandboxed iframe with a live two-way
+bridge to the rest of the design. Unlike the built-in controls (Knob, Slider,
+Meter, …) a CustomCode element has no fixed shape — it is whatever your code
+draws — yet it still participates in the same parameter, skin, texture, and
+theDAW control-bus systems every native control uses. This doc covers what runs
+inside the frame, the postMessage protocol that connects it to the host, how its
+parameters are declared and kept sane, how per-parameter theDAW bindings work in
+both directions, and what the unit tests pin down. It is written for someone
+authoring custom elements or working on the subsystem itself.
+
+For how native controls render and route, see
+[canvas-and-controls.md](canvas-and-controls.md); for how CustomCode params turn
+into exported plugin parameters, see [vst3-export.md](vst3-export.md) and
+[gan-format.md](gan-format.md); for the theDAW side of the control bus, see
+[thedaw-integration.md](thedaw-integration.md).
+
+## The pieces
+
+Three core source files own the subsystem. Everything else (the assistant, the
+Bind tab, export) composes them.
+
+| File | Role |
+|---|---|
+| `src/components/CustomCodeFrame.tsx` | React host: builds the sandboxed iframe document, pushes live values/styles in, receives register/param-changed/size/error/ready out, and wires per-param theDAW bindings. |
+| `src/lib/customCodeBridge.ts` | The postMessage protocol constants, the in-iframe bootstrap source string, the document assembler, `--el-*`/`--app-*` style-token mapping, and the runtime-diagnostics store. |
+| `src/lib/customParams.ts` | `sanitizeCustomParams` / `mergeCustomParams`: validate untrusted param schemas and reconcile a re-registered schema against existing user values. |
+
+Authoring is not a single dedicated panel on this branch. A CustomCode element's
+HTML and parameter schema are written by the AI assistant's `getCustomCode` /
+`setCustomCode` tools (`src/components/orb/useToolActions.ts`) and can be
+hand-edited through the properties **Raw** tab — a Monaco JSON editor over the
+whole element in `src/components/CompactElementProperties.tsx`. Per-parameter
+theDAW bindings are surfaced by the **Bind** tab
+(`src/components/properties/BindingPicker.tsx`). See **Editing a CustomCode
+element** below.
+
+> Note: an earlier dedicated properties panel (`CustomCodePanel.tsx`, mounted by
+> `PropertiesPanel.tsx`) owned code editing, per-param editing, the fit-mode
+> select, the runtime-error banner, and a Save-to-Library button. Both files now
+> live only under `deprecated/src/components/` and are mounted nowhere in the
+> live app; a couple of stale `see CustomCodePanel` comments still linger in
+> `src/types.ts` and `src/lib/customCodeBridge.ts`. Treat any reference to
+> `CustomCodePanel` as historical.
+
+The bridge protocol lives in one place on purpose: the exact same
+`BRIDGE_BOOTSTRAP_SOURCE` and message names are used by the live app
+(`CustomCodeFrame`) **and** by the standalone VST3 export renderer
+(`src/lib/vst3ExportUi.ts`), so a custom element behaves identically in the
+designer and in a shipped plugin.
+
+> A CustomCode element is a normal `UIElement` with `type: "CustomCode"`. Its
+> code lives in `el.customCode`, its parameter schema in `el.params`, its
+> per-param theDAW bindings in `el.paramBindings`, and its fit mode in
+> `el.customCodeFit`. All of those ride the ordinary autosave / project-save /
+> zip-export path because the whole element is serialized as-is.
+
+## The frame model
+
+`CustomCodeFrame` renders an `<iframe sandbox="allow-scripts">` whose `srcDoc` is
+a self-contained document assembled by `buildBridgeDoc()`. The sandbox grants
+scripts only — no `allow-same-origin`, no `allow-forms`, no top-navigation — so
+the code runs in an opaque origin and cannot reach the host DOM, cookies, or
+storage. All communication is by `postMessage`.
+
+Key behaviors:
+
+- **The document is rebuilt only when the code or theme changes.** Parameter
+  values and style tokens are delivered over `postMessage`, never by rebuilding
+  the `srcDoc` — so dragging a control or applying a skin updates the element
+  without reloading or flickering it. The `srcDoc` memo depends only on
+  `el.customCode` and the theme-var string (read once at mount).
+- **One inbound message listener per element,** bound by `el.id`. It reads the
+  current element and callbacks through refs so it never re-binds on unrelated
+  re-renders, and it ignores any message whose `e.source` is not this iframe's
+  `contentWindow`.
+- **State is re-pushed on `foundry:ready`** (and again in the iframe's `onLoad`)
+  to beat any race where the host's first `setParams`/`setStyle` lands before
+  the bootstrap installed its listener.
+- **In design mode a transparent overlay** (`zIndex: 3`) sits over the iframe so
+  the element can be dragged/resized/rotated; in preview mode the overlay is
+  removed so the iframe is interactive. The wrapper is `pointer-events-auto`
+  only in preview.
+- **Material shell.** The host paints the same background / glow / skin
+  (`getSkinLayers`) / texture layers around the iframe that `InteractiveControl`
+  paints for native controls, so skins and textures apply to custom content
+  regardless of whether the code cooperates. See
+  [textures-and-skins.md](textures-and-skins.md).
+
+## The bridge protocol
+
+`BRIDGE_MESSAGES` in `customCodeBridge.ts` defines every message. All wire types
+are namespaced `foundry:` and the string literals are shared by both halves of
+the bridge and by the exported bundle.
+
+| Constant | Wire `type` | Direction | Payload | Purpose |
+|---|---|---|---|---|
+| `setParams` | `foundry:setParams` | host → iframe | `{ params: { key: value } }` | Push live parameter values. Merged into `window.PARAMS`. |
+| `setStyle` | `foundry:setStyle` | host → iframe | `{ vars: { "--el-*"/"--foundry-*": string } }` | Push skin/material CSS vars and size vars onto `:root`. |
+| `registerParams` | `foundry:registerParams` | iframe → host | `{ params: [...] }` | Code advertises its own parameter schema. |
+| `paramChanged` | `foundry:paramChanged` | iframe → host | `{ key, value }` | A control inside the iframe moved. |
+| `contentSize` | `foundry:contentSize` | iframe → host | `{ w, h }` | Natural content size, drives the `scale` fit. |
+| `error` | `foundry:error` | iframe → host | `{ message, stack? }` | A runtime error caught in the sandbox. |
+| `ready` | `foundry:ready` | iframe → host | — | Bootstrap handshake; host re-pushes state. |
+
+Each message has a matching TypeScript interface in `customCodeBridge.ts`
+(`SetParamsMessage`, `RegisterParamsMessage`, etc.) grouped into the
+`HostToFrameMessage` and `FrameToHostMessage` unions.
+
+## What your code sees inside the frame
+
+`BRIDGE_BOOTSTRAP_SOURCE` runs before your markup (it is injected as a `<script>`
+in `<head>`, after the `window.PARAMS` seed). It is written in ES5 so it runs in
+any sandbox and is byte-identical between the live app and the export. It gives
+your code these globals:
+
+| Global | Provided by | What it does |
+|---|---|---|
+| `window.PARAMS` | bridge (seeded from `el.params`, then merged on each `setParams`) | The flat `{ key: value }` map of current parameter values. Read a value as `window.PARAMS.myKey`. |
+| `window.onFoundryParams` | you assign it | If it is a function, the bridge calls it with the full `window.PARAMS` object every time new values arrive — react to live edits here. |
+| `window.foundryRegisterParams(schema)` | bridge | Advertise your own parameter schema to the host (posts `registerParams`). Marks the frame as user-registered so DOM auto-discovery is skipped. |
+| `window.foundrySetParam(key, value)` | bridge | Report that a control changed. Updates `window.PARAMS[key]` and posts `paramChanged` so the host element state, undo history, and any theDAW binding stay in sync. |
+
+Example custom element:
+
+```html
+<input id="gain" type="range" min="0" max="100" value="50" />
+<div id="readout">50</div>
+<script>
+  var slider = document.getElementById("gain");
+  var readout = document.getElementById("readout");
+  function render() {
+    readout.textContent = window.PARAMS.gain;
+  }
+  // React to host-pushed values (bindings, assistant/raw-JSON edits).
+  window.onFoundryParams = function () {
+    slider.value = window.PARAMS.gain;
+    render();
+  };
+  // Report user drags back to the host.
+  slider.addEventListener("input", function () {
+    window.foundrySetParam("gain", Number(slider.value));
+    render();
+  });
+</script>
+```
+
+> If your code never calls `foundryRegisterParams`, the bootstrap runs a
+> one-macrotask-delayed DOM scan (`discover`) for standard form controls —
+> `input[type=range|number|color|checkbox]` and `select` — and registers each as
+> a param, deriving the key from `id` / `name` / `aria-label` / associated
+> `<label>` text (falling back to `param1`, `param2`, …) and wiring each
+> control's `input` event to `foundrySetParam`. Registering explicitly disables
+> this scan.
+
+The bootstrap also reports **content size** from the union of body children
+rects plus `scrollWidth`/`scrollHeight` (re-fired via a `ResizeObserver`), and
+forwards `window.onerror` / `unhandledrejection` to the host as `foundry:error`.
+
+## Parameters: the CustomParam schema
+
+A parameter is a `CustomParam` (declared in `src/types.ts`). The host pushes the
+current values into the iframe as `window.PARAMS`; the assistant and the Raw JSON
+editor edit the schema itself.
+
+| Field | Type | Applies to | Notes |
+|---|---|---|---|
+| `id?` | `string` | all | Optional stable per-param React list key. Preserved across a sanitize/merge when present; the Bind-tab picker falls back to `key` when it is absent. |
+| `key` | `string` | all | Read in code as `window.PARAMS[key]`. Sanitized to `[a-zA-Z0-9_$]`. |
+| `label` | `string` | all | Display name in the UI (e.g. the Bind-tab picker); falls back to `key`. |
+| `type` | `"number" \| "color" \| "select" \| "toggle" \| "text"` | all | Determines the editor and the value coercion. |
+| `value` | `number \| string \| boolean` | all | Current value, coerced to `type`. |
+| `default?` | `number \| string \| boolean` | all | Optional default (used by VST3 export). |
+| `min` / `max` / `step` | `number` | `number` | Range and increment for the slider/number editor. |
+| `options?` | `string[]` | `select` | Choices; value must be one of them. |
+
+Params reach an element from four places: authored by the assistant when it
+writes the element (`setCustomCode`), self-registered by the running code via
+`foundryRegisterParams`, restored from a saved project / library module, or
+hand-edited in the Raw JSON editor.
+
+### Sanitizing untrusted schemas
+
+`sanitizeCustomParams(raw)` is the gate for any schema from an untrusted source —
+an iframe self-registering via `foundryRegisterParams`, params passed to the
+assistant's `setCustomCode`, hand-edited JSON, or older data. It guarantees the
+shape the UI and bridge depend on so a malformed entry can never crash a render
+or feed a bad value into the iframe.
+
+| Rule | Behavior |
+|---|---|
+| Non-array input | Returns `[]`. |
+| Missing/empty `key`, or key after stripping `[^a-zA-Z0-9_$]` is empty | Entry dropped. |
+| Duplicate `key` | First occurrence wins; later ones dropped. |
+| Unknown `type` | Coerced to `"text"`. |
+| `number` value | Coerced via `Number(...)`; non-finite → `0`; clamped to `min`/`max` (skipped when `min > max`). |
+| `toggle` value | Booleans pass through; strings parsed explicitly so `"false"`/`"0"` are `false`; others via `!!`. |
+| `color` value | Non-string → `"#ffffff"`. |
+| `select` value | `options` filtered to strings; value not in `options` falls back to the first option (or `""`). |
+| `text`/other value | Coerced to string (`null`/`undefined` → `""`). |
+| `id` | Preserved only if it is a string. |
+
+### Merging a re-registered schema
+
+`mergeCustomParams(existing, registered)` reconciles a freshly registered schema
+against the element's existing params so a code regen or an iframe re-register
+never wipes values the user set. The registered schema defines structure and
+order; user values survive.
+
+| Aspect | Source of truth |
+|---|---|
+| Order, `type`, `label`, `min`, `max`, `step`, `options` | The registered schema. |
+| `value` for a key present in both | The **existing** value, re-coerced/clamped to the registered type and range. |
+| `value` for a new key | The registered value. |
+| Keys absent from the registered schema | Pruned. |
+| `id` for a key present in both | The existing id is preserved (stable React keys). |
+
+Everything runs back through `sanitizeCustomParams`, so the result is always
+valid. In `App.tsx`, `handleRegisterParams` applies this through
+`setElementsWithoutHistory` (the undo-bypassing setter) and bails before touching
+state when the merge produces no change — a re-register on every iframe reload
+must not spam undo/redo.
+
+## Editing a CustomCode element
+
+There is no dedicated CustomCode properties panel on this branch (the former
+`CustomCodePanel` is deprecated — see **The pieces** above). Editing is surfaced
+three ways:
+
+- **The AI assistant (primary).** The orb's `getCustomCode` / `setCustomCode`
+  tools (`src/components/orb/useToolActions.ts`) are the main authoring path.
+  `getCustomCode(id)` returns the element's full, never-truncated
+  `{ customCode, params, customCodeFit, diagnostics }`, so the model edits the
+  real current source and can see whether its last edit threw.
+  `setCustomCode(id, { customCode, params? })` writes `el.customCode` and, when
+  `params` is supplied, runs it through `sanitizeCustomParams`.
+- **Raw JSON editor.** The properties **Raw** tab
+  (`CompactElementProperties.tsx`) is a Monaco (`@monaco-editor/react`) JSON
+  editor over the whole element, so `customCode`, `params`, `customCodeFit`, and
+  `paramBindings` can all be hand-edited there. It is generic (every element type
+  has it), not CustomCode-specific.
+- **Bind tab.** The per-numeric-param theDAW binding picker — see **theDAW
+  control-bus wiring** below.
+
+**Library modules.** Adding a CustomCode element or calling `setCustomCode`
+persists `{ name, customCode, params }` as a reusable `CustomModule` in the
+sidebar palette via `onRegisterModule`, so a saved module tracks edits instead of
+drifting.
+
+## Fit modes
+
+`el.customCodeFit` controls how the sandboxed content fills the element box. It
+is honored by `CustomCodeFrame` and the export renderer; on this branch it is set
+through the Raw JSON editor or the assistant (there is no dedicated fit control).
+
+| Value | Behavior |
+|---|---|
+| `scale` (default) | Render at the iframe's natural content size, then CSS-transform-scale it to the element box. Before the first `contentSize` arrives, it falls back to filling the box so the element is never invisible. |
+| `stretch` | The iframe fills the box; responsive code reads `--foundry-width` / `--foundry-height` (pushed as style vars). |
+| `none` | Legacy 1:1 iframe filling the box, no scaling. |
+
+## Skins, materials, and theme in the frame
+
+`elementStyleTokens(el)` maps the element's visual fields onto `--el-*` CSS
+variables that are declared on the iframe's `:root` and pushed live on every
+change via `setStyle`. Only defined fields are emitted.
+
+| CSS var | Source field |
+|---|---|
+| `--el-base-color` | `el.baseColor` |
+| `--el-active-color` | `el.activeColor` |
+| `--el-border-color` | `el.borderColor` |
+| `--el-text-color` | `el.textColor` |
+| `--el-opacity` | `el.opacity / 100` |
+| `--el-skin` | `el.skin` |
+
+The `--foundry-width` / `--foundry-height` size vars (used by the `stretch` fit)
+are **not** part of `elementStyleTokens`. `sizeVars()` / `styleVarsFor()` in
+`CustomCodeFrame.tsx` derive them from `el.width` / `el.height` and merge them
+into the same `setStyle` push.
+
+The app's theme tokens (`--app-base`, `--app-surface`, `--app-main`,
+`--app-accent`, …) are also injected once so embedded markup can reference the
+same palette as the rest of the app. The document's default `body` styles wire
+`color` to `--el-text-color` (falling back to `--app-main`) and `accent-color`
+to `--el-active-color` (falling back to `--app-accent`), so auto-discovered form
+controls inherit the theme without any cooperation from your code.
+
+## theDAW control-bus wiring
+
+A native control has one value and routes it through an element-level routing
+stack. CustomCode has **no single value**, so it binds theDAW targets **per
+numeric parameter** instead. The capability helpers live in `dawControlBus.ts`.
+
+| Helper | Result for CustomCode | Meaning |
+|---|---|---|
+| `bindableKindsFor("CustomCode")` | `null` | Not part of the element-level routing/write UI. |
+| `listenKindsFor("CustomCode")` | `null` | Not an element-level listener. |
+| `customCodeBindableParams(el)` | the element's `type: "number"` params, in order (`[]` for any non-CustomCode element) | The per-param bindable/listenable set. |
+| `customCodeParamKinds()` | `["knob", "fader"]` | The continuous, writable theDAW kinds a numeric param may bind to. |
+
+Each binding is a `CustomParamBinding` (`{ key, targetId }`) stored in
+`el.paramBindings`. The properties **Bind** tab (`BindingPicker` →
+`CustomParamBindingPicker`) shows one theDAW-target dropdown per numeric param,
+and the tab is offered only when `customCodeBindableParams(el).length > 0`. A
+single binding is **bidirectional**: one numeric param serves both directions.
+
+**LISTEN (theDAW → iframe).** For each `paramBinding`, `CustomCodeFrame` starts
+the bus (`startDawControlBus`) and the local `vst:` runtime
+(`startVstBindRuntime`, for LFO/macro/transport binds), seeds from
+`getDawValue(targetId)`, and subscribes with `subscribeDawValue`. Each incoming
+target value `raw` is mapped to a percentage with
+`scaleFromTarget(raw, getDawTarget(targetId))` and then onto the param's own
+range: `min + (pct / 100) * (max - min)`, pushed into the iframe as a
+`setParams` for that one key.
+
+**WRITE (iframe → theDAW).** When the iframe posts `paramChanged` with a numeric
+value and a matching `paramBinding` exists, the host computes the percentage from
+the param's range — `pct = (value - min) / (max - min) * 100` — and calls
+`setDawTarget(targetId, scaleToTarget(pct, getDawTarget(targetId)))`.
+
+`setDawTarget` dispatches to the local `vst:` write handler first (for built-in
+LFOs / macros / transport) and then forwards the same `control-set` frame on the
+bus. The bus itself is a WebSocket controller peer that connects to theDAW's XR
+relay at `ws(s)://<hostname>:8600/api/xr/control/ws`, mirroring theDAW's
+`frontend/src/state/xrControlClient.ts` wire contract. See
+[thedaw-integration.md](thedaw-integration.md) for the manifest/listen-value
+architecture and the built-in `vst:` bind catalog.
+
+> The Foundry sidecar serves this app on port **5472**; theDAW's backend (which
+> owns the XR relay and the bindable-target manifest) runs on **8600**. If no
+> theDAW host is present the bus simply keeps trying to reconnect every 2000ms —
+> unbound custom code and preview `vst:` binds still work.
+
+## Export parity
+
+CustomCode is a first-class citizen of both export formats.
+
+- **VST3 data bundle** (`src/lib/vst3Export.ts`). CustomCode is handled *before*
+  the `SKIP_TYPES` gate: each **numeric** param becomes a host-automatable
+  continuous VST3 param with id `<element-slug>-<param-slug>` (matching the id
+  the exported UI computes), a `min`/`max` from the param (with `max === min`
+  bumped to `min + 1`), and a MIDI CC from the shared pool. A `paramBinding`'s
+  target id is emitted as an informational `binding.dawTargetId` (any bound
+  theDAW target, not only `vst:` ids). The standalone renderer (`vst3ExportUi.ts`) reproduces
+  the bidirectional per-param bind exactly as the in-app frame does. See
+  [vst3-export.md](vst3-export.md).
+- **`.gan` package** (`src/lib/ganExport.ts`). The `.gan` `index.html` swaps the
+  native bridge script for an inline GAN bridge; the full editable project
+  (including `customModules`) is embedded for a lossless round-trip. See
+  [gan-format.md](gan-format.md).
+
+## Diagnostics
+
+Runtime errors from the sandbox are captured centrally in `customCodeBridge.ts`.
+
+- `customCodeDiagnostics` is a `Map<elementId, CustomCodeDiagnostic[]>`, capped
+  at 20 entries per element (`MAX_DIAGNOSTICS_PER_ELEMENT`, oldest dropped) so a
+  spinning error loop cannot grow it without bound.
+- `pushCustomCodeDiagnostic(elementId, diag)` is called by `CustomCodeFrame` on
+  every `foundry:error`; a `CustomCodeDiagnostic` is `{ message, stack?, ts }`
+  where `ts` is a `Date.now()` stamp.
+- `clearCustomCodeDiagnostics(elementId)` empties one element's list.
+- The map is **not reactive** — the assistant's `getCustomCode` tool reads it on
+  demand (the former `CustomCodePanel` polled it on a 1s interval, but that panel
+  is deprecated). See [assistant-and-mcp.md](assistant-and-mcp.md).
+
+## Security notes
+
+> **The sandbox is `allow-scripts` only.** No `allow-same-origin`, so the frame
+> is an opaque origin that cannot touch the host DOM, storage, or cookies. Treat
+> all iframe → host messages as untrusted: the host validates `e.source`,
+> ignores non-object data, and runs every registered schema through
+> `sanitizeCustomParams`.
+
+> **Injection hardening.** `buildBridgeDoc` embeds the initial params as JSON
+> escaped by `escapeScriptJson`, which turns `<` into `\u003c` and escapes the
+> U+2028/U+2029 line separators (illegal in JS string literals) — so a param
+> value containing `</script>` can never break out of the seed `<script>` or
+> inject markup. The same escaping is mirrored in `vst3Export`'s
+> `serializeForJs`.
+
+## What the tests lock in
+
+Two Vitest suites pin the subsystem's contract.
+
+`src/lib/customParams.test.ts` (and the shared-bridge checks in it):
+
+| Test area | Guarantee |
+|---|---|
+| `sanitizeCustomParams` | Non-array → `[]`; illegal key chars stripped and keyless entries dropped; duplicate keys deduped (first wins); number values coerced and clamped to `min`/`max`; `toggle` values parsed explicitly — the strings `"false"`/`"true"` map to the right boolean and the number `1` coerces truthy; `select` options filtered to strings and value falls back to the first option. |
+| `mergeCustomParams` | Existing value survives a re-register; keys absent from the registered schema are pruned; new keys arrive with registered values in registered order; the registered type is adopted and the old value re-coerced; the preserved value is clamped into the new range; the existing stable `id` is kept; handles `undefined` existing and empty registered. |
+| `escapeScriptJson` | `<` → `\u003c`; U+2028 → `\u2028`; U+2029 → `\u2029`. |
+| `buildBridgeDoc` | Contains the seeded `window.PARAMS`, the bootstrap source, the `foundry:paramChanged` literal, and the injected theme/style CSS. A param value carrying `</script>` yields exactly two real closing `</script>` tags (the injected one is escaped). |
+| `BRIDGE_BOOTSTRAP_SOURCE` | Is syntactically valid JS (`new Function(...)` does not throw). |
+| `elementStyleTokens` | Maps set fields (`--el-base-color`, `--el-opacity` = `opacity/100`) and omits undefined ones. |
+
+`src/lib/dawControlBus.customcode.test.ts`:
+
+| Test area | Guarantee |
+|---|---|
+| `customCodeBindableParams` | Returns only the numeric params of a CustomCode element, in order; `[]` when there are no numeric params, no params at all, or the element is not CustomCode (even if it carries params). |
+| `customCodeParamKinds` | Exactly `["knob", "fader"]`. |
+| Kind-map regression | `bindableKindsFor("CustomCode")` and `listenKindsFor("CustomCode")` stay `null`; the native maps (`Knob`, `Toggle`, `Meter`) are unchanged — the per-param path must not disturb the element-level routing/listen UI. |
+
+> Note: Foundry source is under active development by concurrent contributors.
+> The behaviors above were read directly from the source files named throughout
+> this doc; if a panel layout or picker looks different from what you see, trust
+> the code and the tests over this description, and cross-check against
+> [troubleshooting.md](troubleshooting.md).

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/foundry-overview.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/foundry-overview.md
@@ -1,0 +1,352 @@
+# VST Foundry — Overview and Architecture
+
+This is the entry-point reference for VST Foundry: what it is end to end, how the
+pieces fit together, and where to read more. Foundry is a visual builder for
+audio-plugin and web-audio interfaces — you lay out knobs, sliders, meters, and
+artwork on a canvas, style and wire them, optionally let an AI co-designer drive
+the canvas, then export a runnable plugin. This page maps the whole system: the
+designer app, the `.gan` bundle format, the VST3 export path through the iPlug2
+FoundryShell, the assistant, and how Foundry embeds inside theDAW. Every section
+links to a sibling doc for depth. Plain descriptions of what each piece does.
+
+## What Foundry is
+
+Foundry is a single-page React app with a small Node/Express backend. It is a
+*designer*, not a DAW: it produces plugin UIs and their parameter manifests, but
+it hosts no audio graph of its own. A design is a flat list of absolutely
+positioned UI elements over a canvas, plus assets (images), textures, saved
+custom modules, and canvas state. From that design Foundry can emit several
+export targets — React/TSX source, raw JSON, a self-contained ZIP, a `.gan`
+web-plugin package, or a VST3 data bundle that a prebuilt native shell loads.
+
+Foundry runs in two ways, from the same codebase:
+
+| Mode | How it starts | Port | Who uses it |
+|---|---|---|---|
+| Standalone | `launch.bat` → `npm run dev` (tsx runs `server.ts`) | `5472` | Opening Foundry on its own in a browser |
+| Embedded sidecar | theDAW spawns `npm run dev` as a subprocess and iframes it | `5472` | The **Foundry** center tab inside theDAW |
+
+Both serve the same Express app; the health probe `GET /api/health` returns
+`{"app":"vst-foundry","status":"ok",...}`, which is how theDAW confirms the
+sidecar is really Foundry and not some other process squatting on the port. The
+default port is `5472` (`server/config.ts`, overridable via `THEDAW_FOUNDRY_PORT`
+or `PORT`).
+
+> The legacy `README.md` says port `3000`. The code default is `5472`
+> (`server/config.ts`). Where docs and code disagree, the code is authoritative.
+
+## Architecture at a glance
+
+```
+                          ┌──────────────────────────────────────────────┐
+                          │                Foundry (React SPA)            │
+                          │                                               │
+   Categories palette ───▶│  Canvas ──▶ InteractiveControl (dispatcher)   │
+   drag element           │    │           renders 1 of 14 control comps  │
+                          │    │           + glow / face / skin / texture  │
+   Properties / Compact ──▶│  UIElement[]  (single design state)          │
+   editors                │    │                                          │
+   AI Assistant orb ──────▶│    │  ◀── tools mutate the same UIElement[]   │
+                          │    ▼                                          │
+                          │  src/lib exporters                            │
+                          │   ├─ vst3Export.ts   → VST3 data bundle        │
+                          │   ├─ ganExport.ts    → .gan package            │
+                          │   └─ (React/TSX, JSON, ZIP)                    │
+                          └───────┬───────────────────────┬───────────────┘
+                                  │                       │
+                    ┌─────────────▼──────────┐   ┌────────▼────────────────┐
+                    │  .gan  (ZIP "GANv1")   │   │ VST3 data bundle         │
+                    │  manifest.json         │   │ manifest.json + ui/      │
+                    │  index.html + params.js│   │  loaded from Resources/  │
+                    │  source/foundry-project│   └────────┬────────────────┘
+                    └──────┬─────────────────┘            │
+                           │                     ┌────────▼────────────────┐
+                    ┌──────▼──────────────┐      │ FoundryShell.vst3        │
+                    │ theDAW MIX / GANduit │      │ prebuilt iPlug2 WebView  │
+                    │ iframes the runtime  │      │ plugin (native, C++)     │
+                    └─────────────────────┘      └──────────────────────────┘
+
+        theDAW backend                     theDAW frontend
+        ┌───────────────────────┐          ┌──────────────────────────┐
+        │ foundry/sidecar.py     │  spawn   │ FoundryView.tsx          │
+        │  npm run dev (:5472)   │◀────────▶│  iframes /api/foundry/url │
+        │ plugin/*  (.gan import)│          │ GanPluginStage / Ares    │
+        └───────────────────────┘          └──────────────────────────┘
+```
+
+The single design state (`UIElement[]` plus canvas state, assets, textures, and
+custom modules) is the hub. The palette, the property editors, the canvas
+gestures, and the AI assistant all mutate that same array; every exporter reads
+it. Because the design serializes whole, autosave, project save, and every
+export path pick up new fields for free.
+
+## The designer app
+
+Foundry's window is a left sidebar (element palette + explorer), the canvas in
+the middle, and a right panel (layers + properties), with a header toolbar on
+top. See [canvas-and-controls.md](canvas-and-controls.md) for the full tour of
+the canvas gestures, the control catalog, styling, routing, and the property
+editors. The essentials:
+
+- **Canvas** (`src/components/Canvas.tsx`) — an infinite, pannable, zoomable
+  surface. It renders one `InteractiveControl` per element and owns selection,
+  multi-select, drag, resize, rotate, snapping, rulers, grid, and the
+  right-click context menu. Gesture math lives in pure, unit-tested helpers
+  (`canvas/resizeMath.ts`, `canvas/snapMath.ts`) driven by
+  `canvas/useCanvasGestures.ts`.
+- **InteractiveControl** (`src/components/InteractiveControl.tsx`) — the central
+  dispatcher. It picks the right render component by `el.type`, owns all
+  interaction state (value, x/y, on, pressed, open, live wave value, live text),
+  wraps every render in `wrapElement()` to paint glow, image-face, skin, and
+  texture layers, and fans a control's normalized 0–100 value out to its routes.
+- **Control components** (`src/components/controls/`) — 14 render components
+  (Knob, Slider, Toggle, Button, Select, Label, Waveform, Meter, XYPad,
+  Spatial3D, WaveShaper, Envelope, StepSequencer, Keyboard). Image and Group are
+  handled by the canvas; CustomCode renders through a sandboxed iframe
+  (`CustomCodeFrame.tsx`). Per-type adjustable parameters are declared in
+  `controls/controlParams.ts`.
+- **Panels** — `LayersPanel.tsx` (z-order), `PropertiesPanel.tsx` (full,
+  collapsible) and `CompactElementProperties.tsx` (tabbed) editors,
+  `AlignmentPanel.tsx`, `AssetManager.tsx` (images), `TextureManager.tsx`
+  (skins/textures), and `EventLog.tsx` (a floating console over the server log
+  plus captured client errors).
+
+### Element types
+
+`src/types.ts` `ELEMENT_TYPES` is the single source of truth; the `ElementType`
+union is derived from it, so every iterator stays in sync. There are 17 types.
+
+| Type | Kind | Exports a host param? |
+|---|---|---|
+| Knob | Rotary control | Yes — 1 continuous |
+| Slider | Fader | Yes — 1 continuous |
+| Meter | Level display (listen-driven) | Yes — 1 continuous |
+| WaveShaper | Distortion-curve control | Yes — 1 continuous |
+| Toggle | Switch | Yes — 1 boolean |
+| Button | Push button | Yes — 1 trigger |
+| Select | Dropdown | Yes — 1 enum |
+| XYPad | 2-axis pad | Yes — 2 params (`-x`, `-y`) |
+| Spatial3D | Radar / spatial pad | Yes — 2 params (`-x`, `-y`) |
+| Envelope | ADSR editor | Yes — 4 params (attack/decay/sustain/release) |
+| Label | Text / LCD readout | No |
+| Image | Bitmap / artwork | No |
+| Group | Container of elements | No |
+| Waveform | Oscilloscope / LFO display | No |
+| StepSequencer | Grid step pattern | No |
+| Keyboard | Piano-key input strip | No |
+| CustomCode | Sandboxed user JS | No element param; each numeric CustomParam becomes one continuous param |
+
+The seven "No" types (Label, Image, Group, Waveform, StepSequencer, Keyboard,
+and CustomCode itself) are the `SKIP_TYPES` in `vst3Export.ts` — they have no
+single host-automatable scalar. CustomCode is special-cased before the skip
+gate: each numeric CustomParam it declares becomes a continuous parameter.
+
+## The AI assistant
+
+A floating AI Assistant orb (`src/components/AIAssistantOrb.tsx`) sits over the
+canvas. It is a co-designer with direct control of the layout — it can add,
+move, style, align, theme, and delete elements, read the canvas, take
+screenshots to inspect alignment visually, fetch a reference web page, and author
+CustomCode elements. It is bring-your-own-key: providers and models are picked in
+Settings, discovered per provider at runtime, so model lists stay current without
+app updates. Foundry also ships a stdio MCP server (`mcp-server.cjs`) that
+exposes the same tool surface to external MCP clients. See
+[assistant-and-mcp.md](assistant-and-mcp.md) for providers, tools, effort/mode
+selectors, and the CustomCode workflow.
+
+> Legacy docs pin a specific Claude default model id. Model names drift; read the
+> current default from the running app / provider list rather than trusting a
+> doc. See [assistant-and-mcp.md](assistant-and-mcp.md).
+
+## Export targets
+
+When a design is ready, Foundry can emit any of the following. The two
+plugin-grade targets — `.gan` and the VST3 bundle — share one parameter list, so
+parameter ids never drift between a manifest and its UI.
+
+| Target | Built by | What it is | Depth doc |
+|---|---|---|---|
+| React/TSX | `ExportModal.tsx` | Canvas as React components | [canvas-and-controls.md](canvas-and-controls.md) |
+| JSON | `ExportModal.tsx` | Raw project state | [projects-and-data.md](projects-and-data.md) |
+| ZIP package | `ExportModal.tsx` | `project.json` + assets + README | [projects-and-data.md](projects-and-data.md) |
+| `.gan` | `src/lib/ganExport.ts` | theDAW web-plugin package | [gan-format.md](gan-format.md) |
+| VST3 data bundle | `src/lib/vst3Export.ts` | Data half of a native VST3 | [vst3-export.md](vst3-export.md) |
+
+### The `.gan` bundle
+
+A `.gan` is theDAW's portable web-plugin package — a ZIP with the trailing
+archive comment `GANv1`. Foundry writes four entries:
+
+| Entry | Purpose |
+|---|---|
+| `manifest.json` | Plugin identity, `controls[]` (values the UI emits), `params[]` (host-drivable 0..1 inputs), canvas size |
+| `index.html` | The standalone renderer with the inline `.gan` postMessage bridge injected (no sidecar bridge file needed) |
+| `params.js` | The serialized design (`window.FOUNDRY_DESIGN`) the renderer reads |
+| `source/foundry-project.json` | The full editable project (elements, canvas, assets, textures, custom modules) for lossless re-editing; theDAW/GANduit ignore it |
+
+The manifest is fixed to `format:"gan"`, `format_version:1`, `kind:"controller"`
+(effect/instrument are not supported by the web runtime), `author`/`company`
+`GANTASMO`, `source:"vst-foundry"`. `controls[]` and `params[]` are both derived
+from the same VST3 param list (`buildVst3Manifest`), so a control id in the
+manifest matches exactly what the UI posts upward via
+`{type:'updateValue', id, value}`. Because the manifest is the authoritative
+check, some tools may strip the ZIP comment without breaking recognition. Full
+schema, the round-trip re-editing path, and the bridge contract are in
+[gan-format.md](gan-format.md).
+
+### The VST3 data bundle and FoundryShell
+
+A Foundry VST3 export is a *data bundle*, not a compiled binary. `vst3Export.ts`
+produces `manifest.json`, `ui/index.html`, `ui/params.js`, and `README.txt`
+(zipped via JSZip). The binary half is **FoundryShell**, a prebuilt native iPlug2
+plugin under `vst3-shell/FoundryShell-src/` that loads the data bundle from its
+VST3 `Contents/Resources/` directory at runtime.
+
+| FoundryShell identity | Value (`config.h`) |
+|---|---|
+| Plugin name | `FoundryShell` |
+| Manufacturer | `theDAW` |
+| Unique id / mfr id | `'Fdsh'` / `'StDw'` |
+| Version | `1.0.0` |
+| Type | `0` (effect), VST3 subcategory `Fx` |
+| Channel I/O | `2-2` (stereo in/out) |
+| MIDI | in **and** out enabled; MPE off |
+| Editor | WebView UI, `600x600` @ 60 fps, host-resizable |
+
+The shell is a WebView plugin (WebView2 on Windows, WKWebView on macOS), not
+IGraphics. At construction it resolves its Resources dir and calls
+`LoadManifest`, initializing up to 128 iPlug2 params by kind
+(continuous/boolean/trigger/enum); if the manifest is missing it falls back to a
+single Gain param so the plugin always constructs. DSP is stereo passthrough plus
+smoothed gain/pan, diffing param values to emit MIDI CC and executing bound
+actions. Parameter binding, the CC pool (`20-31`, then `102-119`, then `64-119`;
+the 128 cap is on parameter count, not CC numbers), the WebView bridge, and the
+MSBuild build are covered in [vst3-export.md](vst3-export.md).
+
+> The native shell build is mid-change. The checked-in
+> `FoundryShell-src/projects/FoundryShell-vst3.vcxproj` references files not
+> present in the tree (`config/FoundryShell-win.props`, `resources/resource.h`,
+> `resources/main.rc`, `projects/packages.config`) and uses iPlug2-example-relative
+> include paths, so a clean checkout cannot build the shell without the gitignored
+> `iPlug2/` SDK clone and those missing files. Treat the prebuilt `FoundryShell.vst3`
+> as the shipping artifact; see [vst3-export.md](vst3-export.md) for the current
+> build state.
+
+## How Foundry embeds in theDAW
+
+theDAW hosts Foundry two independent ways, both documented in depth in
+[thedaw-integration.md](thedaw-integration.md):
+
+1. **The designer, as a live sidecar.** `backend/modules/foundry/sidecar.py`
+   spawns `npm run dev` (cwd is this project) as a subprocess on port `5472`,
+   passing `DISABLE_HMR=true` so Vite's HMR WebSocket does not spam the console.
+   It installs `node_modules` first if missing, logs to
+   `data/logs/foundry-sidecar.log`, and detects readiness via `/api/health`. The
+   endpoints `GET /api/foundry/url|status` and `POST /api/foundry/start|stop`
+   drive it; the frontend `FoundryView.tsx` fetches `/api/foundry/url` (retrying)
+   and iframes the returned URL as a center-panel tab.
+2. **Exported plugins, as runnable `.gan`s.** `backend/modules/plugin/` imports,
+   packages, and serves `.gan` plugins (`/api/plugin/*`). Installed plugins live
+   under `data/plugins/*.gan`, are extracted to `data/plugins/_runtime/<id>/`,
+   and are iframed into the MIX stage (`GanPluginStage.tsx`). The bundled **Owl**
+   and **Ares** surfaces are built this way; `aresBridge.ts` auto-wires an Ares
+   `.gan`'s controls onto FX-chain params.
+
+## Directory map
+
+Root of `C:/Users/skream/projects/StableDAW/VST-Foundry-UI/VST-UI-FOUNDRY`:
+
+| Path | What it holds |
+|---|---|
+| `server.ts` | Standalone entry: the fullstack dev server (Vite + Express) started by `npm run dev` |
+| `server/` | Express backend modules (see below) |
+| `src/` | The React SPA (see below) |
+| `vst3-shell/` | Native iPlug2 FoundryShell sources + SDK clone (see below) |
+| `component-extractor/` | Standalone vision-AI component extractor app (own Vite/Express) |
+| `mcp-server.cjs` | stdio MCP server exposing the assistant's tools to external clients |
+| `launch.bat` | Standalone launcher: verifies Node, installs deps, runs `npm run dev` |
+| `package.json` | Deps + scripts (`dev`, `build`, `start`, `lint`, `test`) |
+| `docs/` | Documentation (legacy guides + this `thedaw-style/` set) |
+| `data/` | Gitignored local state: config, sessions, textures, generated, logs |
+| `deprecated/` | Archived files (never deleted, moved here) |
+| `dist/` | Build output |
+| `scripts/` | Tooling (`verify-providers.mjs` — LLM provider health check) |
+| `stt/`, `research/` | Speech-to-text assets, research notes |
+| `DOCUMENTATION.md`, `README.md` | Legacy architecture reference + project overview (mining material; code wins on conflict) |
+
+`src/` (the SPA):
+
+| Path | What it holds |
+|---|---|
+| `App.tsx`, `main.tsx` | App shell and React entry |
+| `types.ts` | Single source of truth: `ELEMENT_TYPES`, `UIElement`, routes/bindings, `Asset`/`Texture`/`Annotation`/`CanvasState` |
+| `components/` | Canvas, panels, modals, and top-level UI |
+| `components/controls/` | The 14 control render components + `controlParams.ts`, `shared.ts` |
+| `components/properties/` | `BindingPicker`, `ControlParamsSection`, shared `fields/`, `options.ts`, `useElementField.ts`, `rawEditor.ts` |
+| `components/canvas/` | Gesture engine + pure `resizeMath.ts` / `snapMath.ts` + `AnnotationLayer.tsx` |
+| `components/extractor/`, `orb/`, `texture-gen/`, `brand-title/` | Component-extractor UI, assistant orb, texture-gen modal, brand lockup |
+| `lib/` | Core logic: `gan*.ts`, `vst3Export*.ts`, `vstBinds*.ts`, `routing.ts`, `skins.ts`, `proceduralTextures.ts`, `dawControlBus.ts`, `elementSignalBus.ts`, `arsenal.ts`, `customParams.ts`, `customCodeBridge.ts` |
+| `hooks/` | `useAutosave`, `useHistory`, `useDawBindings`, `useKeyboardShortcuts`, `useProjectPersistence`, `useClipboard` |
+
+`server/` (the Express backend):
+
+| File | Role |
+|---|---|
+| `config.ts` | `PORT` (default `5472`) + CORS helpers |
+| `routes.ts` | Route registration incl. `GET /api/health` (`{app:"vst-foundry"}`), state, config, logs, textures |
+| `persistence.ts`, `paths.ts` | Session/config load-save and the `data/` layout |
+| `claude-bridge.ts`, `providers.ts`, `relay.ts`, `tools.ts` | Assistant provider streaming, MCP relay, tool surface |
+| `extract.ts` | Component-extractor endpoints |
+| `sd.ts` | Stable Diffusion process management for texture generation |
+| `net.ts`, `proc.ts`, `logging.ts` | URL scrape (SSRF-guarded), subprocess helpers, in-memory log ring |
+
+`vst3-shell/`:
+
+| Path | What it holds |
+|---|---|
+| `FoundryShell-src/config.h` | iPlug2 `PLUG_*` identity macros |
+| `FoundryShell-src/FoundryShell.h/.cpp` | Plugin class + WebView host + passthrough DSP + MIDI |
+| `FoundryShell-src/projects/` | MSBuild `.vcxproj` (v143, VST3 dynamic library) |
+| `FoundryShell-src/resources/web/ui/` | Default fallback WebView UI (`index.html` + `foundry-bridge.js`) |
+| `iPlug2/` | Full iPlug2 SDK clone (gitignored — never committed) |
+| `nuget.exe` | Restores the WebView2 + WIL NuGet packages before the build |
+
+## Stack and ports reference
+
+| Piece | Value |
+|---|---|
+| Frontend | React 19, Vite 6, Monaco editor, Tailwind 4, `jszip` + `file-saver` |
+| Backend | Express 5, run via `tsx` in dev |
+| Tests | Vitest (`npm test` → `vitest run`) |
+| Standalone / sidecar port | `5472` (`THEDAW_FOUNDRY_PORT` or `PORT` overrides) |
+| Vite HMR WebSocket | `PORT + 1`; disabled when `DISABLE_HMR=true` (sidecar) |
+| Health probe | `GET /api/health` → `{"app":"vst-foundry","status":"ok"}` |
+| theDAW sidecar log | `data/logs/foundry-sidecar.log` |
+
+```bash
+# Standalone (from the project root)
+launch.bat            # verify Node, install deps, then `npm run dev`
+npm run dev           # tsx server.ts — Vite + Express on http://localhost:5472
+npm run build         # vite build + esbuild the server to dist/server.cjs
+npm test              # vitest run
+```
+
+## Where to go next
+
+- [canvas-and-controls.md](canvas-and-controls.md) — the canvas, the 14 control
+  types, styling, routing, and the property editors.
+- [custom-code.md](custom-code.md) — the sandboxed CustomCode element and its
+  postMessage bridge.
+- [component-extractor.md](component-extractor.md) — vision-AI extraction of
+  controls from a background image.
+- [gan-format.md](gan-format.md) — the `.gan` package schema and round-trip.
+- [vst3-export.md](vst3-export.md) — the VST3 data bundle and FoundryShell.
+- [textures-and-skins.md](textures-and-skins.md) — the texture library, skins,
+  and blend modes.
+- [assistant-and-mcp.md](assistant-and-mcp.md) — the AI orb, providers, and MCP.
+- [thedaw-integration.md](thedaw-integration.md) — the sidecar and the `.gan`
+  plugin path inside theDAW.
+- [projects-and-data.md](projects-and-data.md) — persistence, autosave, and the
+  `data/` layout.
+- [troubleshooting.md](troubleshooting.md) — common failures and fixes.
+- [index.md](index.md) — the documentation index.

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/gan-format.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/gan-format.md
@@ -1,0 +1,384 @@
+# The .gan Format — Portable Plugin Bundles
+
+Reference for the `.gan` file — theDAW's portable web-plugin package (a
+"pseudo-VST"). A `.gan` is a self-contained ZIP holding a manifest, an HTML entry
+point, and its assets. Foundry writes one from a finished design; theDAW installs
+it, extracts it, and iframes it into the MIX stage where its controls drive the
+audio graph over `postMessage`. This doc covers the on-disk shape of a `.gan`,
+how Foundry exports and re-imports one, the host bridge that wires it up, and the
+round-trip guarantees. How theDAW installs, extracts, serves, and runs an
+installed `.gan` — the `/api/plugin/*` surface and its runtime — is owned by
+[thedaw-integration.md](thedaw-integration.md); this doc cross-links there rather
+than restating it. It is for anyone touching the export/import path or the
+on-disk package format.
+
+For the sibling native-plugin format, see [vst3-export.md](vst3-export.md) — the
+`.gan` reuses that module's parameter model and standalone renderer. For how a
+`.gan`'s controls are auto-wired onto FX-chain params inside theDAW, see
+[thedaw-integration.md](thedaw-integration.md).
+
+## What a .gan is
+
+A `.gan` is a normal ZIP archive with a trailing archive comment of `GANv1`. Two
+independent implementations read and write it: the Foundry web app (TypeScript,
+under `src/lib/`) and the theDAW backend (Python, under
+`backend/modules/plugin/`). Both agree on the manifest schema so a file written
+by one loads in the other without translation.
+
+| Property | Value |
+|---|---|
+| Container | ZIP (DEFLATE compression) |
+| Archive comment | `GANv1` (`GAN_COMMENT`) |
+| Format version | `1` (`format_version` / `CURRENT_FORMAT_VERSION`) |
+| Required entry | `manifest.json` |
+| Entry point | `index.html` (from `manifest.entry_html`) |
+| Kind | `controller` — emits control values, does not process audio |
+
+> The archive comment is a hint, not the source of truth. Some tools strip ZIP
+> comments, so both readers treat **a valid `manifest.json`** as the authoritative
+> "is this a `.gan`" check. The Foundry importer records whether the comment was
+> present (`hadGanComment`) but never fails on its absence.
+
+### Entries in a Foundry-written .gan
+
+`buildGanPackage` in `src/lib/ganExport.ts` writes exactly four entries:
+
+| Entry | Contents | Read by |
+|---|---|---|
+| `manifest.json` | The `GanManifest` (pretty-printed JSON) | Foundry, theDAW, GANduit |
+| `index.html` | Standalone UI shell with the inline `.gan` bridge injected | The host iframe |
+| `params.js` | `window.FOUNDRY_DESIGN = {…}` — the serialized design the UI renders | `index.html` |
+| `source/foundry-project.json` | The **full editable project** for lossless re-editing | Foundry only |
+
+> `source/foundry-project.json` is inert to theDAW and GANduit — they only read
+> `manifest.json`, `index.html`, and any assets those reference. It exists purely
+> so Foundry can reopen the `.gan` and keep editing (see *Round-trip* below).
+
+## The manifest (manifest.json)
+
+The manifest is a flat declaration of what the plugin is, the parameters a host
+can drive, and the control outputs it emits. The TypeScript type
+(`GanManifest` in `src/lib/ganManifest.ts`) and the Pydantic model
+(`GanManifest` in `backend/modules/plugin/gan_manifest.py`) are kept in lockstep.
+
+| Field | Type | Foundry export value | Notes |
+|---|---|---|---|
+| `format` | string | `"gan"` | Constant. |
+| `format_version` | int | `1` | Bumped only on a breaking schema change. |
+| `thedaw_version` | string | `"0.1.0"` | Provenance stamp. |
+| `id` | string | `ganIdFor(name, elements)` | Stable per design — see *Plugin ids*. |
+| `name` | string | Trimmed plugin name, or `"Foundry Plugin"` | |
+| `description` | string | `"Exported from VST Foundry."` | |
+| `version` | string | `"1.0.0"` | |
+| `kind` | string | `"controller"` | `effect`/`instrument` are not supported by the web runtime. |
+| `entry_html` | string | `"index.html"` | The asset the runtime iframes. |
+| `icon` | string \| null | `null` | |
+| `author` / `company` | string | `"GANTASMO"` | |
+| `created_at` / `modified_at` | ISO string | Timestamps (overridable in tests) | The Python `save` re-stamps these on write. |
+| `canvas` | `{ width, height }` | From `canvasState` | Drives the runtime's contain-fit aspect ratio. |
+| `audio_io` | `{ input, output }` | Both `{ channels: 2, enabled: false }` | A controller has no audio path. |
+| `params` | `GanParam[]` | Host-drivable **inputs** | See *Controls vs params*. |
+| `controls` | `GanControl[]` | Plugin **outputs** | See *Controls vs params*. |
+| `source` | string \| null | `"vst-foundry"` | Provenance of the design. |
+
+### Plugin ids
+
+`ganIdFor(name, elements)` in `ganManifest.ts` derives a stable id without any
+async crypto: `slugify(name)` (or `"plugin"`) plus a short `djb2` hash of the
+name and the JSON-serialized element list, rendered as 8 hex characters. The same
+design always yields the same id; changing the layout changes the id.
+
+> The theDAW backend uses a different id scheme when it *builds* a `.gan` from a
+> raw Foundry export (`owl_import.py`): `slug(name) + first 8 hex of the
+> SHA-256 of the raw project.json`, or a caller-supplied `plugin_id` such as
+> `the-owl` / `ares`. Ids are only guaranteed stable within one producer, not
+> across the two.
+
+## Controls vs params
+
+Both lists are derived from the **same** VST3 parameter list that
+`buildVst3Manifest` (`src/lib/vst3Export.ts`) computes for the standalone UI, so
+the ids in the manifest are byte-identical to the ids the exported UI posts. See
+[vst3-export.md](vst3-export.md) for the full param-derivation rules (element
+types, XY/Envelope fan-out, the CC pool, the 128-param cap).
+
+| List | Direction | Meaning | Shape per entry |
+|---|---|---|---|
+| `controls[]` | Plugin → host (**out**) | Values the UI emits via `{type:'updateValue', id, value}` | `{ id, name, kind }` where `kind` is `value` \| `xy` \| `xyz` \| `trigger` |
+| `params[]` | Host → plugin (**in**) | Normalized `0..1` values the host can drive back into the UI | `{ id, name, type, min:0, max:1, default:0, unit:'' }` where `type` is `float` \| `bool` |
+
+The Foundry mapping is one control and one param per emitted VST3 param id:
+
+- A VST3 param of kind `trigger` → control `kind: "trigger"`, param `type: "bool"`.
+- A VST3 param of kind `boolean` → control `kind: "value"`, param `type: "bool"`.
+- Everything else (continuous / enum / XY axes) → control `kind: "value"`, param
+  `type: "float"`.
+
+Because XY and Spatial3D controls are already split into separate `<id>-x` /
+`<id>-y` VST3 params upstream, each axis appears as its own `value` control here
+rather than as a single `xy` control. (The `xy` / `xyz` control kinds still exist
+in the schema and are produced by theDAW's backend importer — see below.)
+
+## Exporting a .gan from Foundry
+
+`exportGan(elements, canvasState, assets, textures, customModules, pluginName)`
+in `src/lib/ganExport.ts` builds the package and triggers a browser download. It
+mirrors the VST3 bundle's `jszip` + `file-saver` pattern.
+
+```
+exportGan(...)
+  └─ buildGanPackage(...)            // pure, no I/O — unit-testable
+       ├─ buildGanManifest(...)      // ganManifest.ts
+       ├─ buildVst3Ui(...)           // vst3Export.ts → params.js (window.FOUNDRY_DESIGN)
+       ├─ buildGanIndexHtml()        // shared shell + inline .gan bridge
+       └─ source/foundry-project.json
+  └─ JSZip → generateAsync({ comment: "GANv1", compression: "DEFLATE" })
+  └─ saveAs(blob, "<slug>.gan")
+```
+
+The download file name is `slugify(name).gan`, falling back to
+`foundry-plugin.gan` when the slug is empty or the reserved value `param`.
+
+### The index.html bridge swap
+
+The `.gan` reuses the exact same standalone renderer as the VST3 data bundle
+(`buildIndexHtml` in `src/lib/vst3ExportUi.ts`). The renderer only talks to its
+host through two globals — it *calls* `window.foundryHost.setParam(id, v)` and
+*defines* `window.foundryApplyParam(id, v)`. In a native VST3 that host is a
+sidecar file, `foundry-bridge.js`. `buildGanIndexHtml` swaps that `<script>` tag
+for the inline `GAN_BRIDGE_JS`, so the exported page defines its own
+`window.foundryHost` and needs no sidecar file.
+
+```
+// native shell HTML:   <script src="foundry-bridge.js"></script>
+// .gan HTML:           <script> …inline GAN_BRIDGE_JS… </script>
+```
+
+> If the shared template ever stops emitting the `foundry-bridge.js` tag, the
+> builder defensively injects the inline bridge *before* `params.js` instead, so
+> the UI can never silently load without a `foundryHost` and emit nothing.
+
+## The host bridge (ganBridge.ts)
+
+`GAN_BRIDGE_JS` in `src/lib/ganBridge.ts` is the tiny script embedded verbatim in
+the `.gan`'s `index.html`. It adapts the renderer's two globals to theDAW /
+GANduit's `postMessage` contract, matching what `owl_import.py`'s composed
+surfaces already speak.
+
+| Direction | Trigger | Action |
+|---|---|---|
+| UI → host | Renderer calls `window.foundryHost.setParam(id, 0..1)` | Posts `{type:'updateValue', id, value}` to `window.parent` |
+| Host → UI | Parent posts `updateValue` / `applyParam` / `param` with an `id` | Calls `window.foundryApplyParam(String(id), Number(value))` |
+| Host → UI | Parent posts `{type:'level'}` | Broadcasts the frame **down** to every child iframe (meter feed); the native renderer ignores it |
+| Child → host | A child iframe posts `updateValue` / `x` / `y` / `trigger` | Relays the frame **up** to the host, mirroring `owl_import.py`'s relay |
+
+> Maintenance constraint: `GAN_BRIDGE_JS` is inlined inside an HTML `<script>`
+> string literal, so it must contain **no backticks and no `${` sequences**. Keep
+> it plain ES5 concatenation.
+
+## The embedded editable source (round-trip)
+
+`source/foundry-project.json` holds a `GanProjectSource`:
+
+| Field | Contents |
+|---|---|
+| `version` | `1` |
+| `elements` | Every `UIElement`, unmodified |
+| `canvasState` | Full canvas state (size, background, pan/zoom, rulers) |
+| `assets` | Media assets |
+| `textures` | Generated textures |
+| `customModules` | Saved CustomCode modules |
+
+This is a superset of what `params.js` (`window.FOUNDRY_DESIGN`) carries —
+`FOUNDRY_DESIGN` omits `customModules` because the runtime does not need them.
+Keeping the full project embedded is what makes re-opening a `.gan` lossless.
+
+> The [Arsenal](#the-arsenal) is deliberately **not** part of the embedded source.
+> It is global, cross-project state and never travels inside a `.gan`.
+
+## Importing a .gan back into Foundry
+
+`parseGan(data)` in `src/lib/ganImport.ts` reads `.gan` bytes into an editable
+project. It returns `{ manifest, project, sourceKind, hadGanComment }` and throws
+**only** when the file is not a readable `.gan` (the ZIP won't open, or
+`manifest.json` is missing / not valid JSON).
+
+| `sourceKind` | When | Fidelity |
+|---|---|---|
+| `embedded` | `source/foundry-project.json` is present and parses | Lossless — the exact original elements, canvas, textures, and modules |
+| `reconstructed` | No embedded source (or it is corrupt) | Best-effort — one native control per manifest control, on a grid |
+
+### Reconstruction from a source-less .gan
+
+A `.gan` made outside Foundry — by theDAW's backend importer, by hand, or by a
+third party — has no embedded source. `reconstructFromManifest` lays out one
+element per `manifest.controls[]` entry on a grid (the original coordinates are
+not recoverable from the manifest):
+
+- Column count = `max(1, floor(canvas.width / 160))`; positions step by 160px
+  across and 140px down, starting at `(24, 24)`, each element `96×96`.
+- Control `kind` maps to element type: `trigger` → `Button`, `xy` / `xyz` →
+  `XYPad`, everything else → `Knob`.
+- Values default to `value: 0`, `min: 0`, `max: 1`.
+
+The result is never empty and is clearly flagged as `reconstructed` so the UI can
+warn that the layout is approximate.
+
+## The Arsenal
+
+The Arsenal (`src/lib/arsenal.ts`) is a cross-project, cross-reload palette of
+saved controls. It is documented here to draw a hard line: **it is not part of any
+`.gan`, `SavedProject`, or zip export.** It lives under a single `idb-keyval` key,
+`vst-arsenal`, so a control you save once is available in every project and after
+every reload.
+
+| Function | Behavior | Returns |
+|---|---|---|
+| `loadArsenal()` | Reads the list; `[]` on empty, malformed, or read error (never throws) | `ArsenalEntry[]` |
+| `addToArsenal(entry)` | Overwrites the entry sharing the same `name`, else appends | Updated list |
+| `removeFromArsenal(id)` | Drops the entry with that `id` (no-op if gone) | Updated list |
+
+An `ArsenalEntry` carries `id` (uuid), `name`, `type`, `defaultWidth`,
+`defaultHeight`, an optional `previewUrl`, `createdAt`, and `presetData` — the
+**instance-agnostic** `UIElement` fields (no `id` / `x` / `y`) so an entry drops
+onto any canvas through the existing preset-drag path unchanged.
+
+> Same-name overwrite matches `handleAddCustomModule`: saving under a name you
+> already used replaces that slot in place instead of piling up duplicates; a
+> fresh name appends. Every mutator returns the updated list so callers can push
+> it straight into React state without a second read.
+
+## Round-trip guarantees and tests
+
+`src/lib/ganRoundTrip.test.ts` (Vitest) pins the contract:
+
+| Test | Guarantee |
+|---|---|
+| `buildGanManifest` | A single Knob yields a `controller` manifest with `source: "vst-foundry"`, one `value` control, and one `float` param; canvas matches. |
+| `buildGanPackage` | The package has exactly `index.html`, `manifest.json`, `params.js`, `source/foundry-project.json`; `index.html` uses the **inline** bridge (no `foundry-bridge.js`), contains `window.foundryHost` and `type: "updateValue"`; `params.js` defines `window.FOUNDRY_DESIGN`. |
+| `parseGan` (embedded) | A round-tripped `.gan` restores the exact `elements` and `canvasState`, reports `sourceKind: "embedded"`, `hadGanComment: true`, and the stable id. |
+| `parseGan` (no manifest) | A ZIP with no `manifest.json` rejects with an error mentioning `manifest.json`. |
+| `parseGan` (source-less) | A manifest-only `.gan` reconstructs one element per control, `sourceKind: "reconstructed"`, first element a `Knob` keeping the control id. |
+
+Run the suite from the Foundry app root:
+
+```bash
+cd VST-Foundry-UI/VST-UI-FOUNDRY
+npm run test -- ganRoundTrip
+```
+
+## How theDAW builds a .gan from a raw export
+
+theDAW can also manufacture a `.gan` from a *raw* Foundry export (a flat
+`project.json` plus a `background.png`) without the embedded source. This is the
+`import_vst_foundry(...)` path in `backend/modules/plugin/owl_import.py`, used
+for the two bundled surfaces **The Owl** and **Ares**. It returns
+`(GanManifest, assets)` for `GanFile.save`, producing a `kind: "controller"`,
+`source: "vst-foundry"` manifest whose `id` is the caller's `plugin_id` or
+`slug(name) + sha256(raw)[:8]` (see *[Plugin ids](#plugin-ids)*). This is the
+`reconstructed`-fidelity producer in
+*[Two ways a .gan is born](#two-ways-a-gan-is-born)* below.
+
+The importer's theDAW-side details — how each export element is rendered
+(`CustomCode` → an `el_<id>.html` iframe, native `Knob` → a draggable rotary,
+`Image` / unknown types → placeholders), the four-step canvas-size resolution
+(background PNG IHDR size → explicit `canvasWidth` / `canvasHeight` → element
+extents → the `1672 × 941` default), and the composed `index.html`'s up/down
+`postMessage` relay — are documented once in
+[thedaw-integration.md](thedaw-integration.md#importing-a-foundry-export) so the
+two docs cannot drift as the importer changes.
+
+> Note: `backend/modules/plugin/owl_import.py` and `router.py` are under active
+> edit at the time of writing. The cross-linked behavior reflects the current
+> on-disk source; expect churn in the importer's element handling.
+
+## The .gan package on the theDAW side
+
+`backend/modules/plugin/gan_file.py` reads and writes `.gan` files as ZIPs with
+the `GANv1` comment.
+
+| Method | Purpose |
+|---|---|
+| `GanFile.save(manifest, assets, path)` | Writes `manifest.json` + assets; re-stamps `created_at` / `modified_at`, sets `format_version`. Warns above a 200 MB soft cap. |
+| `GanFile.info(path)` | Reads **only** the manifest. Rejects a `format_version` newer than theDAW supports. |
+| `GanFile.load(path)` | Returns `(manifest, assets)` — all entries except `manifest.json`. |
+| `GanFile.extract(path, out_dir)` | Unpacks assets for static serving, with zip-slip path guards, and writes the manifest alongside. |
+
+## The plugin API and runtime
+
+Once a `.gan` exists on disk, `backend/modules/plugin/router.py` installs,
+extracts, and serves it under the `/api/plugin` prefix (`sidebar: false`).
+Installed plugins live at `data/plugins/*.gan`; each is extracted into
+`data/plugins/_runtime/<id>/` for iframing.
+
+The endpoint surface (`/api/plugin/*`) and the runtime staleness mechanism —
+`_ensure_runtime` comparing a `.gan_mtime` stamp (in nanoseconds) against the
+source `.gan` and re-extracting when they differ, and `serve_runtime` sending
+`Cache-Control: no-cache` on `.html` so an already-open iframe never renders a
+stale copy — are owned by
+[thedaw-integration.md](thedaw-integration.md#the-plugin-runtime-running-an-exported-gan-inside-thedaw)
+so the two docs cannot drift. gan-format.md stops at the on-disk package; the
+moment it is served is theDAW's side of the boundary. The one on-disk
+consequence worth restating is in *[Gotchas](#gotchas)* below: re-packaging must
+bump the `.gan` mtime, which is why every backend path routes through
+`_extract_runtime`.
+
+## How theDAW serves and displays a .gan
+
+The frontend consumes the plugin API through a thin client and a Zustand store,
+then iframes the served runtime.
+
+| Piece | Role |
+|---|---|
+| `frontend/src/lib/ganClient.ts` | `ganApi.list` / `open` / `openById` / `importOwl` / `packageOwl` / `packageAres` / `reveal` over `/api/plugin/*`. |
+| `frontend/src/state/ganStore.ts` | Installed library + the one plugin currently open (`activeId` / `activeUrl` / `activeName`). |
+| `frontend/src/components/audio/GanPluginStage.tsx` | Iframes `/api/plugin/<id>/runtime/index.html` in the MIX Effect Stage; **Expand** pops a near-fullscreen overlay keeping the same `src` (no reload, state persists). |
+
+The runtime's `index.html` letterboxes its canvas to fit (aspect ratio
+preserved), so an oversized plugin shrinks rather than overflows. Control
+`postMessage` frames bubble up to the app, where they can be routed onto FX-chain
+parameters. The auto-wire that maps Ares's control ids onto a composite FX entry,
+and the live master-level meter feed, are covered in
+[thedaw-integration.md](thedaw-integration.md).
+
+## Two ways a .gan is born
+
+| | Foundry web export (`ganExport.ts`) | theDAW backend build (`owl_import.py`) |
+|---|---|---|
+| Input | A live Foundry design (elements + canvas + assets) | A raw `project.json` + `background.png` |
+| Renderer | Shared standalone renderer (`vst3ExportUi.ts`) driving `params.js` | Composed percentage-layout `index.html` with per-element iframes |
+| Host bridge | Inline `GAN_BRIDGE_JS` injected into `index.html` | Inline relay script in the composed `index.html` |
+| Embedded source | Yes — `source/foundry-project.json` (lossless re-edit) | No |
+| Re-import fidelity | `embedded` (exact) | `reconstructed` (grid approximation) |
+| Plugin id | `slug(name)` + `djb2` design hash | `plugin_id` or `slug(name)` + `sha256(raw)[:8]` |
+| Manifest `kind` / `source` | `controller` / `vst-foundry` | `controller` / `vst-foundry` |
+
+## Gotchas
+
+- **Ids never drift within a producer, but do across producers.** A Foundry-web
+  `.gan` and a backend-built `.gan` of the "same" design will not share an id.
+  Reconstructed imports keep whatever ids the manifest carried.
+- **`kind` is always `controller`.** The web runtime does not process audio;
+  `effect` / `instrument` are reserved in the schema but unsupported.
+- **A stripped ZIP comment is fine.** Validity is decided by `manifest.json`, not
+  by `GANv1`.
+- **The Arsenal never ships in a `.gan`.** If a saved control seems "missing" from
+  an exported plugin, that is by design — the Arsenal is global browser state.
+- **Re-packaging must bump the `.gan` mtime.** Runtime freshness keys off it; a
+  path that materialises a runtime without stamping `.gan_mtime` would serve stale
+  assets forever, which is why every backend path routes through
+  `_extract_runtime`.
+
+## See also
+
+- [vst3-export.md](vst3-export.md) — the parameter model, CC pool, and standalone
+  renderer the `.gan` reuses.
+- [custom-code.md](custom-code.md) — how CustomCode elements behave inside the
+  bundle and its iframes.
+- [thedaw-integration.md](thedaw-integration.md) — the sidecar, the Ares
+  auto-wire, and the MIX stage.
+- [projects-and-data.md](projects-and-data.md) — where Foundry projects and
+  assets live on disk.
+- [foundry-overview.md](foundry-overview.md) — the builder that produces these
+  designs.
+- [troubleshooting.md](troubleshooting.md) — when a plugin fails to load or serve.

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/index.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/index.md
@@ -1,0 +1,52 @@
+# VST Foundry Documentation
+
+VST Foundry is a browser-based, drag-and-drop builder for audio-plugin and
+web-audio interfaces. You lay knobs, sliders, meters, and artwork out on a live
+canvas, style and wire them, optionally let a multi-provider AI co-designer drive
+the canvas for you, generate textures and media in-app, then export a runnable
+plugin — React/TSX source, raw JSON, a self-contained ZIP, a portable `.gan`
+web-plugin, or a VST3 data bundle that a prebuilt native shell loads. Foundry is
+a *designer*, not a DAW: it produces plugin UIs and their parameter manifests and
+hosts no audio graph of its own. It runs on its own in a browser and, from the
+same codebase, as a vendored sidecar embedded as the **Foundry** center tab
+inside [theDAW](https://github.com/gantasmo/theDAW).
+
+This is the theDAW-styled doc set for VST Foundry. Start at
+[foundry-overview.md](foundry-overview.md), which maps the whole system end to
+end; every page below then goes deep on one piece. Each doc describes the code as
+it stands and links its siblings for context.
+
+## Docs
+
+| Doc | Covers |
+|---|---|
+| [foundry-overview.md](foundry-overview.md) | The entry point: what Foundry is end to end, how the designer app, `.gan` format, VST3 path, assistant, and theDAW embed fit together. |
+| [canvas-and-controls.md](canvas-and-controls.md) | The designer surface — the infinite canvas, the 17 element types, and the panels that place, style, and wire each control. |
+| [custom-code.md](custom-code.md) | The **CustomCode** element: your own HTML/CSS/JS in a sandboxed iframe, its postMessage bridge, parameters, and theDAW bindings. |
+| [textures-and-skins.md](textures-and-skins.md) | The visual asset pipeline — procedural and AI-generated textures, CSS material skins, and image faces, and how they attach and export. |
+| [component-extractor.md](component-extractor.md) | The Component Extractor: turning one reference image into labeled cutout components (and real controls) via vision AI, integrated and standalone. |
+| [assistant-and-mcp.md](assistant-and-mcp.md) | The in-app AI co-designer — the Assistant orb, the multi-provider chat backend, the persistent BCC session, and the MCP canvas bridge. |
+| [gan-format.md](gan-format.md) | The `.gan` portable web-plugin package: its on-disk shape, Foundry's export/import round-trip, and the theDAW host bridge that wires it up. |
+| [vst3-export.md](vst3-export.md) | The VST3 export path — the browser-side data-bundle exporter and the native iPlug2 **FoundryShell** that loads it at runtime. |
+| [thedaw-integration.md](thedaw-integration.md) | How Foundry lives inside theDAW: the Node sidecar, the center-tab embed, the two control buses, and the exported-`.gan` plugin runtime. |
+| [projects-and-data.md](projects-and-data.md) | The persistence model — where the canvas lives across IndexedDB, localStorage, and the sidecar `data/` folder, and what survives a restart. |
+| [troubleshooting.md](troubleshooting.md) | When Foundry will not start: ports, sidecar spawns, rejected imports, native-shell build failures, the exact errors, and how to clear them. |
+| [index.md](index.md) | This page — the map of the doc set. |
+| [thedaw-docs-integration-proposal.md](thedaw-docs-integration-proposal.md) | Proposal for folding this doc set into theDAW's own wiki/docs. |
+
+> Note: `thedaw-docs-integration-proposal.md` is present but is a *proposal*, not
+> a shipped plan — it describes how this doc set could fold into theDAW's own
+> wiki/docs and awaits a decision. Treat it as a design note, not current state.
+
+## Where else things live
+
+The pre-restyle legacy docs still sit one level up in
+[`../`](../) (for example [`../getting-started.md`](../getting-started.md),
+[`../ai-assistant.md`](../ai-assistant.md), and the legacy
+[`../index.md`](../index.md)). Design and implementation plans and their reports
+live in [`../plans/`](../plans/) and [`../reports/`](../reports/). Where the
+legacy docs and this set disagree, treat this set and the code as authoritative.
+
+---
+
+<p align="center"><a href="foundry-overview.md">Next: Foundry Overview &gt;</a></p>

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/projects-and-data.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/projects-and-data.md
@@ -1,0 +1,352 @@
+# Projects and Local Data — Persistence Model
+
+Reference for how VST Foundry saves your work: where the current canvas lives,
+how named projects are stored, what the on-disk `data/` folder holds, which
+browser keys hold what, and exactly what survives a restart. This is the map for
+anyone debugging "why did my layout come back / not come back," or deciding what
+to back up. Plain descriptions of what each piece does. For opening/editing
+`.gan` plugin bundles specifically, see [gan-format.md](gan-format.md); for the
+VST3 data bundle, see [vst3-export.md](vst3-export.md).
+
+Foundry stores state in three places at once: **browser IndexedDB** (via
+`idb-keyval`), **browser localStorage**, and the **sidecar's on-disk `data/`
+folder**. The working canvas is written to all of the durable stores on every
+change, so a project outlives a tab close, a browser restart, or a sidecar
+restart. Nothing here is a cloud service — everything is local to the machine.
+
+## Where state lives at a glance
+
+| What | Store | Key / path | Survives |
+|---|---|---|---|
+| Current working canvas (autosave) | IndexedDB + disk | `ui-modeler-autosave` and `data/sessions/latest.json` | Tab close, browser restart, sidecar restart |
+| Named saved projects (Project Library) | IndexedDB | `ui-modeler-projects` | Same browser profile only |
+| Arsenal (saved controls palette) | IndexedDB | `vst-arsenal` | Same browser profile; global across projects |
+| Uploaded / generated texture files | Disk | `data/textures/` | Any restart; shared across projects |
+| SD + app config | Disk | `data/config.json` | Any restart |
+| Server log | Disk | `data/logs/app.log` | Any restart |
+| AI provider / model / keys / effort | localStorage | `vst-foundry-*` | Same browser profile |
+| Assistant chat history | localStorage | `vst-foundry-assistant-sessions` | Same browser profile |
+| Sidebar component presets | localStorage | `vst-custom-presets` | Same browser profile |
+| Element-to-element modulation signals | in-memory only | — | Nothing (runtime only) |
+
+> The working canvas is the only thing written to *both* the browser and the
+> disk. Everything else lives in exactly one place. That dual write is what lets
+> the same project reappear even after clearing browser storage — the sidecar
+> reloads it from `data/sessions/latest.json`.
+
+## The on-disk `data/` tree
+
+The sidecar defines its data tree in `server/paths.ts` and creates the folders
+once, at import time, before anything reads or writes them. The root is always
+`data/` **relative to the sidecar's working directory** (`process.cwd()`):
+
+```
+data/
+  config.json          # SD paths, ports, image-gen prefs (AppCfg)
+  config.json.bak       # last-known-good copy, written before each save
+  sessions/
+    latest.json         # server-side autosave of the full project state
+    latest.json.bak     # last-known-good copy, written before each save
+  textures/             # uploaded + AI-generated image files, served at /textures/<file>
+  logs/
+    app.log             # sidecar log
+    app.log.1           # single rollover once app.log passes its size cap
+```
+
+| Path | Written by | Holds |
+|---|---|---|
+| `data/config.json` | `server/persistence.ts` (`saveAppCfg`) via `POST /api/config` | `{ sd: { preferred, a1111, comfyui, modelLibraryDir, outputDir } }` |
+| `data/sessions/latest.json` | `server/routes.ts` (`POST /api/state`) | `{ elements, canvasState, assets, textures, customModules }` |
+| `data/textures/` | `POST /api/textures/upload` and AI image generation (`server/sd.ts`) | `<uuid>.png` / `.jpg` / `.gif` / `.webp` image files |
+| `data/logs/app.log` | `server/logging.ts` (`appendLog`) | Timestamped sidecar log lines |
+
+> The whole `data/` tree is local and disposable. Deleting it resets Foundry to
+> a blank canvas and default SD config; the code recreates the folders on next
+> launch. It is safe to back up by copying the `data/` folder wholesale.
+
+> Drift note: the legacy `docs/local-data.md` describes a separate
+> `data/generated/` folder for AI images. In the current code, generated images
+> are written into `data/textures/` alongside uploads (`server/sd.ts` writes to
+> `TEXTURES_DIR`); there is no `generated/` directory.
+
+### Config path in detail
+
+`data/config.json` holds only Stable Diffusion / image-generation settings — it
+is **not** where projects live. Its shape (`AppCfg` in `server/persistence.ts`):
+
+| Field | Meaning |
+|---|---|
+| `sd.preferred` | `"a1111"` or `"comfyui"` — which local SD backend to use |
+| `sd.a1111` / `sd.comfyui` | `{ execPath, port, autoStart, extraArgs, pythonPath }` per backend |
+| `sd.modelLibraryDir` | Folder scanned for ComfyUI checkpoints |
+| `sd.outputDir` | Optional image output override |
+
+Ports default to `7860` (A1111) and `8188` (ComfyUI). See
+[textures-and-skins.md](textures-and-skins.md) for the image pipeline.
+
+## Browser storage: IndexedDB keys (`idb-keyval`)
+
+Foundry uses the `idb-keyval` library for structured, larger-than-localStorage
+data (projects can carry base64 background images and inline texture data URLs).
+
+| Key | Written by | Holds |
+|---|---|---|
+| `ui-modeler-autosave` | `src/hooks/useAutosave.ts` | The live working canvas: `{ elements, canvasState, assets, textures, customModules }` |
+| `ui-modeler-projects` | `src/hooks/useProjectPersistence.ts` | Array of `SavedProject` — the named Project Library |
+| `vst-arsenal` | `src/lib/arsenal.ts` | Global saved-control palette; cross-project, never part of a project or export |
+
+> The Arsenal (`vst-arsenal`) is deliberately *outside* the project model. A
+> control you "Save to Arsenal" is available in every project and is never
+> written into `ui-modeler-projects`, `latest.json`, or any export bundle. See
+> [canvas-and-controls.md](canvas-and-controls.md) for how the Arsenal is used.
+
+> None of the IndexedDB keys keep a `.bak` copy. Only the disk files
+> (`config.json`, `latest.json`) are versioned. If IndexedDB is cleared, the
+> working canvas is still recoverable from `data/sessions/latest.json`, but the
+> named Project Library and the Arsenal are not — they exist only in the browser.
+
+## Browser storage: localStorage keys
+
+localStorage holds small preference strings and the assistant's own state. Keys
+are defined in `src/components/orb/constants.ts` and a few component files.
+
+| Key | Set in | Holds |
+|---|---|---|
+| `vst-foundry-provider` | `orb/constants.ts` | Selected AI provider id (default `claude`) |
+| `vst-foundry-model` | `orb/constants.ts` | Selected model id (default `claude-opus-4-8`) |
+| `vst-foundry-provider-api-keys` | `orb/constants.ts` | JSON map of `provider -> API key` |
+| `vst-foundry-custom-api-key` | `orb/constants.ts` | Legacy single Gemini key; migrated into the keyed map on read |
+| `vst-foundry-effort` | `orb/constants.ts` | Assistant effort level (default `max`) |
+| `vst-foundry-assistant-sessions` | `AIAssistantOrb.tsx` | Chat session history (base64 images stripped to fit the ~5 MB quota) |
+| `vst-custom-presets` | `Sidebar.tsx`, `CompactElementProperties.tsx` | Sidebar component presets |
+| `vst-custom-code` | (legacy) `useProjectPersistence.ts` | Old sidebar-local CustomCode modules; **read once and migrated**, never written |
+| (host-supplied) | `orb-kit-skin/GantasmoOrb.tsx` | Orb screen position, under a `persistenceKey` the host passes in |
+
+> API keys live in browser localStorage, not on disk. They never leave the
+> machine, but they are also not part of any project or export — moving a
+> project to another browser/machine means re-entering keys. See
+> [assistant-and-mcp.md](assistant-and-mcp.md).
+
+> `vst-custom-code` is a one-way migration. On startup the persistence hook reads
+> any legacy CustomCode modules from it, folds them into the unified
+> `customModules` store, and from then on those modules ride along with the
+> project (autosave / `latest.json` / `.gan`). It is never written back.
+
+## Load order on startup
+
+`useProjectPersistence` runs one mount-time load. It reads sources in priority
+order and the first that has real content wins:
+
+1. **Named projects** — read `ui-modeler-projects` from IndexedDB into the
+   Project Library list (this is always loaded; it is separate from the canvas).
+2. **Server state** — `GET /api/state` (returns `data/sessions/latest.json`). If
+   the response has `elements` or `canvasState`, it is applied and the local
+   autosave is skipped entirely. Server state takes priority over IndexedDB.
+3. **Local autosave** — only if the server had nothing: read
+   `ui-modeler-autosave` from IndexedDB and apply it.
+4. **Legacy module migration** — `vst-custom-code` is read as a fallback source
+   of `customModules` whenever the loaded state carries none of its own.
+
+> Empty-response guard: an empty `{}` from the server does **not** wipe the
+> canvas. The load only accepts server state when `serverState.elements ||
+> serverState.canvasState` is present, so a fresh/empty sidecar cannot clobber a
+> canvas that IndexedDB still holds.
+
+All load paths call `clearHistory(newElements)` (not `setElements`), so undo
+history starts clean after a load. The named-project load (`executeLoadProject`)
+and the `.gan` import (`handleImportGanFile`) additionally call
+`clearElementSignals()` so stale element-to-element modulation from the previous
+document cannot bleed in. The mount-time startup load (server / autosave) does
+not clear element signals — harmless there, since there is no prior document at
+first mount.
+
+## Autosave
+
+The working canvas is persisted by `src/hooks/useAutosave.ts`. On any change to
+`elements`, `canvasState`, `assets`, `textures`, or `customModules` it debounces
+**400 ms**, then writes to **both** stores:
+
+- `set("ui-modeler-autosave", state)` in IndexedDB.
+- `POST /api/state` with the same payload (fire-and-forget; failures are silent
+  so an unavailable sidecar never blocks editing).
+
+The autosave is gated on `hasLoadedAutosave.current`. Until the mount-time load
+finishes, autosave is a no-op, so the empty initial React state can never
+overwrite a real saved project.
+
+> Drift note: the legacy `docs/project-management.md` states autosave runs "every
+> 5s." The current hook debounces 400 ms per change, not on a fixed interval.
+
+The server-side write (`POST /api/state`) validates the body is a non-array
+object, backs up the previous `latest.json` to `latest.json.bak`, then writes
+atomically via a `latest.json.tmp` + rename.
+
+## The Project Library
+
+The Project Library (the **Project Library** toolbar button) is a named-snapshot
+store separate from autosave. The modal is `src/components/ProjectLibraryModal.tsx`;
+all logic is in `src/hooks/useProjectPersistence.ts`.
+
+A saved project (`SavedProject`) has this shape:
+
+| Field | Notes |
+|---|---|
+| `id` | Random base36 id |
+| `name` | User-entered label |
+| `createdAt` | `Date.now()` epoch ms |
+| `elements` | Full element array |
+| `canvasState` | Canvas size / background / view |
+| `assets` | Image assets (inline) |
+| `textures?` | Texture library (optional) |
+
+| Action | Handler | Effect |
+|---|---|---|
+| Save | `handleSaveProject(name)` | Prepends a new `SavedProject` and rewrites `ui-modeler-projects` |
+| Load | `handleLoadProject` → `executeLoadProject` | Confirms if the canvas is non-empty, then swaps in the project |
+| Delete | `handleDeleteProject` → `executeDeleteProject` | Confirms, filters the id out, rewrites `ui-modeler-projects` |
+
+> `SavedProject` does **not** include `customModules`. Named-project save/load
+> carries `elements`, `canvasState`, `assets`, and `textures` only —
+> CustomCode modules are preserved by autosave and `.gan` export, but not by the
+> Project Library. Loading a named project also does not reset `customModules`,
+> so whatever modules were already registered stay registered.
+
+Loading a project clears element signals, calls `clearHistory` (fresh undo
+stack), applies canvas/assets/textures, and clears the selection. If the current
+canvas already has elements, the load is held behind a confirmation
+(`loadProjectTarget`) so you cannot silently discard unsaved work.
+
+## Exporting and importing
+
+Foundry can write the current design to disk in several formats. The table below
+covers what each produces; the two plugin formats have their own deep-dive docs.
+
+| Output | Handler / module | Contents |
+|---|---|---|
+| Download JSON | `handleDownloadProject` | `project.json` = `{ version: 1, elements, canvasState, assets, textures }` |
+| Export Package (ZIP) | `handleExportPackage` | `project.json` + `background.png` + `elements/<name>_<i>.json` per element + `README.md` |
+| `.gan` plugin bundle | `src/lib/ganExport.ts` (`exportGan`) | See below and [gan-format.md](gan-format.md) |
+| VST3 data bundle | `src/lib/vst3Export.ts` | See [vst3-export.md](vst3-export.md) |
+
+The Export Package ZIP is a human-readable snapshot, not a plugin. Its
+`project.json` is the same shape as the plain JSON download; textures are carried
+inline inside `project.json` (there is no separate textures folder), and
+`customModules` are not included.
+
+### `.gan` bundles vs. project JSON
+
+A `.gan` is a ZIP with a trailing archive comment `"GANv1"` (`GAN_COMMENT`). It
+is the one export format that round-trips **losslessly** back into Foundry,
+because it embeds the entire editable project. Entries written by
+`buildGanPackage`:
+
+| Entry | Purpose |
+|---|---|
+| `manifest.json` | GAN controller manifest (params / controls) — what theDAW/GANduit read |
+| `index.html` | Runtime shell with the inline GAN bridge |
+| `params.js` | `window.FOUNDRY_DESIGN` + the vanilla renderer |
+| `source/foundry-project.json` | Full editable project: `{ version: 1, elements, canvasState, assets, textures, customModules }` |
+
+The `source/foundry-project.json` entry is what makes a Foundry-authored `.gan`
+re-editable — it is the only export that preserves `customModules`. theDAW and
+GANduit ignore it at runtime.
+
+Import paths wired in `useProjectPersistence`:
+
+- **`.gan` import** — `handleImportGanFile(file)` → `parseGan`. If the bundle has
+  `source/foundry-project.json`, the full project (including `customModules`) is
+  restored (`sourceKind: "embedded"`). A foreign `.gan` with no embedded source
+  is reconstructed best-effort from its manifest (`sourceKind: "reconstructed"`),
+  logged to the console. Both paths clear element signals and reset undo history.
+
+> The persistence hook only wires a file picker for `.gan`. The Export Package
+> `README.md` says you can "import `project.json` back into VST Foundry," but the
+> Project Library loads from IndexedDB, not from a JSON file — re-importing a raw
+> `project.json` is not a path exposed by `useProjectPersistence`. To keep a
+> re-editable file on disk, prefer `.gan`.
+
+## Legacy binding migration on load
+
+`src/lib/routing.ts` matters to persistence because of how it treats old saved
+projects. Elements once carried single-target binding fields (`targetId`,
+`xTargetId`, `yTargetId`); the current model uses a `binding.routes` stack.
+`routesOf(el)` merges any legacy single-target fields into the effective route
+stack **on the fly, never persisting them** — saving an element keeps exactly
+what the user set. A project saved under the old shape still routes correctly
+without a migration pass rewriting its stored data. See
+[canvas-and-controls.md](canvas-and-controls.md) for the routing model itself.
+
+## What survives a restart
+
+| Item | Tab close | Browser restart | Cleared browser storage | Sidecar restart |
+|---|---|---|---|---|
+| Working canvas | Yes | Yes | Yes (reloaded from `latest.json`) | Yes |
+| Named projects | Yes | Yes | No (IndexedDB only) | Yes |
+| Arsenal | Yes | Yes | No (IndexedDB only) | Yes |
+| Texture files | Yes | Yes | Yes (on disk) | Yes |
+| AI keys / prefs / chat history | Yes | Yes | No (localStorage) | Yes |
+| Element modulation signals | No | No | No | No |
+
+> The working canvas is the most durable thing in Foundry because it is written
+> to both the browser and disk. The Project Library and Arsenal are the least
+> durable across environments — they live only in one browser profile's
+> IndexedDB, with no disk mirror and no `.bak`.
+
+## Backup behavior
+
+Only the two on-disk JSON files are versioned, and both use the same safe-write
+pattern: copy the current file to `<file>.bak`, write a `.tmp`, then rename over
+the original.
+
+| File | On save | On load if primary is corrupt |
+|---|---|---|
+| `data/config.json` | Copied to `config.json.bak` | Falls back to `.bak`, then to defaults |
+| `data/sessions/latest.json` | Copied to `latest.json.bak` | Falls back to `.bak`, then returns `null` |
+| `data/logs/app.log` | Single rollover to `app.log.1` past the size cap | — |
+
+IndexedDB keys (`ui-modeler-projects`, `ui-modeler-autosave`, `vst-arsenal`) are
+single-slot with no backup copy. To snapshot the durable state of an install,
+copy the whole `data/` folder; to snapshot the browser-only state (named
+projects, Arsenal, keys), export/back up the browser profile.
+
+## `metadata.json` is not project data
+
+The tree has one `metadata.json`, under `component-extractor/`. It is an **AI
+Studio remix app descriptor** for the bundled Component Extractor tool, not
+Foundry persistence:
+
+```json
+{
+  "name": "Component Extractor",
+  "description": "A manual and AI-assisted asset-slicing tool for UI components. Drag boxes to capture assets, or use Gemini to auto-detect and label UI elements like knobs, buttons, and panels.",
+  "requestFramePermissions": [],
+  "majorCapabilities": ["MAJOR_CAPABILITY_SERVER_SIDE_GEMINI_API"]
+}
+```
+
+It describes the container app to the AI Studio host and never holds any saved
+canvas, project, or user data. There is no `metadata.json` at the Foundry
+project root. Deleting a project or clearing `data/` does not touch it.
+
+> Note: `component-extractor/` is a newly added, in-flight area of the tree.
+> Its descriptor is stable, but the surrounding tool is under active
+> development — treat details beyond this file as subject to change.
+
+## Operational notes
+
+- The sidecar serves on **port 5472** by default (`THEDAW_FOUNDRY_PORT` or `PORT`
+  override it in `server/config.ts`). The legacy `README.md` mentions port 3000;
+  the current default is 5472. See [thedaw-integration.md](thedaw-integration.md).
+- `data/` is resolved from the sidecar's `process.cwd()`. Launching the sidecar
+  from a different directory points it at a different (empty) `data/` tree — the
+  server-side autosave and textures will appear "lost" until it is launched from
+  the original working directory again.
+- If a load looks stale, the server copy wins: check `data/sessions/latest.json`
+  first, since it overrides the browser autosave on startup.
+- Texture files are shared across all projects (they live on disk, keyed by uuid,
+  and are referenced by url), so deleting a texture affects every project that
+  points at it. See [textures-and-skins.md](textures-and-skins.md).
+- For recovery when the canvas will not load or a `.gan` will not open, see
+  [troubleshooting.md](troubleshooting.md).
+
+See also: [foundry-overview.md](foundry-overview.md), [index.md](index.md).

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/textures-and-skins.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/textures-and-skins.md
@@ -1,0 +1,366 @@
+# Textures and Skins — Visual Asset Pipeline
+
+Reference for how Foundry gives controls a material look: procedural and
+AI-generated **textures**, CSS material **skins**, and image **faces**. It
+covers where the pixels come from (a built-in procedural pack, uploads, and
+Stable Diffusion / DALL-E / Gemini generation), where they are stored (in the
+browser project state and on the sidecar's `data/textures/` folder), how they
+are attached to a control, group, or image, how they composite on top of the
+base render, and how they ride along when a project is saved, exported as a
+`.gan`, or exported as a VST3 bundle. It is for anyone touching the texture/skin
+UI, the generation endpoints, or the export path. Plain descriptions of what each
+piece does.
+
+For the control render layer these visuals sit on top of, see
+[canvas-and-controls.md](canvas-and-controls.md). For how the finished design
+(including textures) is packaged, see [gan-format.md](gan-format.md) and
+[vst3-export.md](vst3-export.md).
+
+## The three visual layers
+
+Foundry has three independent ways to change how a control looks. They stack, so
+one control can carry all three at once. Each is opt-in and each is stored on the
+element, so it rides every save path for free.
+
+| Layer | Element field(s) | What it is | Where the pixels live |
+|---|---|---|---|
+| **Texture** | `textureId` (+ `texture*` transform fields) | A raster image tiled/scaled over the whole control box, blended with a mix-blend-mode | A `Texture` in the project's `textures[]` (built-in, uploaded, or AI-generated) |
+| **Skin** | `skin` | A pure-CSS material recipe (aluminum, chrome, glass…) that tints itself to the element's colors | Code — `src/lib/skins.ts`, no image bytes |
+| **Face** | `faceSrc` (+ `face*` style params) | An image "cutout" that replaces or overlays the programmatic render of a single control | A URL (data URL or `/textures/<id>`) stored directly on the element |
+
+> Skin and texture are element-agnostic — any control (and, for textures, a Group
+> or Image) can wear them. Faces are control-specific: six controls paint their
+> own value-reactive faces internally, the other eight get a static face. See
+> [Image faces](#image-faces) below.
+
+## Two libraries: assets vs textures
+
+The left sidebar has two image libraries. They look similar but serve different
+roles and store their pixels differently.
+
+| | Asset Library (`AssetManager.tsx`) | Texture Library (`TextureManager.tsx`) |
+|---|---|---|
+| Holds | `Asset[]` — images meant to become **Image elements** on the canvas | `Texture[]` — images meant to **skin controls** as background textures |
+| Drag target | Empty canvas → creates an `Image` element | Onto a control/group → sets its `textureId` |
+| Drag payload | `elementType=Image`, `assetId`, `assetUrl`, `defaultWidth/Height` | `application/x-vst-texture` = `{ id }` |
+| Upload path | Client-side only: `FileReader` → data URL kept inline in state | `POST /api/textures/upload` → server file, with data-URL fallback |
+| AI gen target | `TextureGenerateModal` with `target="asset"` | `TextureGenerateModal` with `target="texture"` |
+| Thumbnails | 4-up compact by default; header zoom toggles 2-up | Same |
+
+Both are `CollapsiblePanel`s with **Upload** and **Gen** buttons and a
+zoom-toggle in the header. Selecting a tile reveals a delete (`X`) button;
+hovering an asset tile also shows a **Use** button that drops it on the canvas.
+
+> Asset images are embedded as data URLs directly in project state — they are
+> never written to `data/textures/`. Uploaded textures are the opposite: they are
+> written to disk and referenced by a short `/textures/<file>` URL. This matters
+> for export inlining (see [How textures travel](#how-textures-skins-and-faces-travel)).
+
+## Built-in procedural texture pack
+
+`src/lib/proceduralTextures.ts` ships an eight-texture pack that costs zero bytes
+on disk. Each texture is drawn to an offscreen 512×512 canvas at runtime and
+exported as a PNG data URL. Generation is fully deterministic — a seeded
+`mulberry32` PRNG (never `Math.random`) with a fixed seed per texture — so every
+build produces byte-identical pixels and stable ids, which keeps the
+autosave/dedupe path from ever seeing them "change".
+
+| Id | Name | Seed | How it is drawn |
+|---|---|---|---|
+| `builtin-brushed-steel` | Brushed Steel | 1001 | Vertical metal gradient + ~9000 faint full-width horizontal strokes + a diagonal sheen band |
+| `builtin-carbon-weave` | Carbon Weave | 1002 | 16px twill cells with alternating fiber-bundle gradients and thin weave separations |
+| `builtin-leather-grain` | Leather Grain | 1003 | fBm mottle + value-noise grain per pixel, then wrapped dark pores and warm highlights |
+| `builtin-wood-grain` | Wood Grain | 1004 | Warped vertical strands (22 ring periods) modulated by fine fibre noise |
+| `builtin-plastic-noise` | Plastic Noise | 1005 | Baked vertical sheen + broad mottle + very fine grain |
+| `builtin-concrete` | Concrete | 1006 | 5-octave fBm base with wrapped dark pits and light flecks |
+| `builtin-perforated-metal` | Perforated Metal | 1007 | Dark plate + 32px punched dot grid, each hole a radial gradient with highlight/shadow arcs |
+| `builtin-scanlines` | Scanlines | 1008 | CRT lines on a 4px period with per-line jitter and faint vertical phosphor triads |
+
+All eight are authored to tile seamlessly at 512px: patterns use a period that
+divides 512, and value-noise is sampled from a wrapped lattice
+(`makeTileableNoise` / `makeFbm`). `wrappedCircle()` re-draws speckle dots that
+fall near a tile edge on the opposite side so holes and pores stay seamless.
+
+Each built-in `Texture` carries `isGenerated: true` and `provider: "builtin"`.
+`generateBuiltinTextures()` returns an empty array outside a browser (no
+`document`), so callers can invoke it unconditionally.
+
+> The pack is merged into the library once, after the mount-time project load
+> settles (`App.tsx`, gated on `hasLoadedAutosave`). Built-ins not already present
+> by their stable id are **prepended** so they head the list; the id-dedupe returns
+> the previous array unchanged once they are present, so autosave never spins a
+> dirty cycle when a later load echoes them back.
+
+## Generating textures and artwork with AI
+
+`TextureGenerateModal.tsx` is the generation UI, shared by both libraries (the
+`target` prop switches between adding results to `textures[]` or `assets[]`). Its
+form and result rendering are split into `src/components/texture-gen/`.
+
+| Provider tab | `provider` sent | Backend | Notes |
+|---|---|---|---|
+| Stable Diffusion → Automatic1111 | `a1111` | `generateViaA1111` | Local; talks to A1111 on port `7860` by default |
+| Stable Diffusion → ComfyUI | `comfyui` | `generateViaComfyUI` | Local; talks to ComfyUI on port `8188` by default |
+| DALL-E | `openai` / `dalle` | `generateViaDallE` | Cloud (OpenAI); optional per-request API key override |
+| Gemini | `gemini` | `generateViaGemini` | Cloud (Google); optional per-request API key override |
+
+The SD tab additionally exposes a start/stop control and a live status pill
+(polled every `STATUS_POLL_MS = 5000` ms via `GET /api/sd/status`), plus an
+Advanced section for model/checkpoint, VAE, and a LoRA stack (each LoRA a
+`{ name, weight }` pair, weight 0.1–1.5). Cloud tabs expose size, count, and — for
+DALL-E — quality (`standard`/`hd`) and style (`vivid`/`natural`). `CLOUD_SIZES`
+offers `512×512` through `1792×1024`.
+
+### texture-gen module roles
+
+| File | Role |
+|---|---|
+| `TextureGenerateModal.tsx` | Owns all state, config/status/resources fetching, generation + queue orchestration |
+| `texture-gen/GenerateForm.tsx` | Presentational prompt + parameter inputs (SD toggle, basic params, advanced/LoRA) |
+| `texture-gen/ResultsGrid.tsx` | 4-up grid of the immediate `Generate` results |
+| `texture-gen/QueuePanel.tsx` | Queue list with per-item status, thumbnails, and remove controls |
+| `texture-gen/buildParams.ts` | Pure builder that assembles the `TextureGenParams` request body |
+| `texture-gen/constants.ts` | `CLOUD_SIZES`, shared Tailwind class strings, `STATUS_POLL_MS` |
+| `texture-gen/types.ts` | `GeneratedTexture`, `QueueItem`, `SDResources`, `ProviderTab`, `SdType` |
+| `texture-gen/NumberField.tsx` | Small numeric input used across the form |
+
+Two run modes share one endpoint (`POST /api/textures/generate`):
+
+- **Generate** — fires one request immediately and shows the results grid.
+- **+ Queue** — appends a `QueueItem`; an effect auto-processes the next
+  `pending` item whenever the modal is idle. A synchronous `queueProcessingRef`
+  guard prevents a double-start in the same tick, and an `AbortController` cancels
+  the in-flight fetch when the modal closes.
+
+> The modal validates before it calls the SD backend: an SD tab must be
+> configured (a path set in Settings) **and** running, or generation is blocked
+> with an inline error. Cloud tabs skip that gate.
+
+## Uploading textures
+
+`TextureManager` reads each dropped file as a data URL, then `POST`s it to the
+sidecar:
+
+```
+POST /api/textures/upload
+{ "dataUrl": "data:image/png;base64,…", "name": "brass.png" }
+→ { "id": "<uuid>", "name": "brass.png", "url": "/textures/<uuid>.png" }
+```
+
+The server validates the MIME type (`png`, `jpg`/`jpeg`, `gif`, `webp`), writes
+`<uuid>.<ext>` into `TEXTURES_DIR`, and returns the short URL. If the request
+fails for any reason, the client falls back to keeping the raw **data URL** in
+state so the texture is still usable — it just is not persisted as a file.
+
+Asset uploads (`AssetManager`) never hit the server: the file is read to a data
+URL and kept inline, and an `Image` element carries the natural `width`/`height`
+sampled from an in-memory `Image` load.
+
+## Server storage and endpoints
+
+The sidecar's on-disk tree is defined in `server/paths.ts`; texture routes live
+in `server/routes.ts` and SD process/generation logic in `server/sd.ts`.
+
+| Path | Role |
+|---|---|
+| `data/textures/` | `TEXTURES_DIR` — uploaded and AI-generated image files, served statically at `/textures/` |
+| `data/generated/` | Scratch output from image tools (edit/upscale/variations/etc.) |
+| `data/sessions/latest.json` | Autosaved project state (`SESSION_PATH`, with `.bak` recovery) |
+| `data/config.json` | App/SD config (`CONFIG_PATH`) |
+| `data/logs/` | Sidecar log files |
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/textures/*` | GET | Static file serving of `TEXTURES_DIR` |
+| `/api/textures/upload` | POST | Save a base64 data URL as a texture file |
+| `/api/textures/:id` | DELETE | Delete a texture file by uuid (id validated as a 36-char uuid) |
+| `/api/textures/list` | GET | List texture files on disk |
+| `/api/textures/generate` | POST | Generate images via the selected provider, saved as texture files |
+| `/api/config` | GET / POST | Read / merge-and-save app + SD config |
+| `/api/sd/status` | GET | Whether an SD process is running, its type/port/start time |
+| `/api/sd/start` / `/api/sd/stop` | POST | Start / stop the configured SD process |
+| `/api/sd/resources` | GET | Models, VAEs, LoRAs, samplers for a given SD type |
+
+Generated images are written by `saveImagesToFiles()` (`server/sd.ts`): each image
+becomes `<uuid>.png` in `TEXTURES_DIR`, returned as
+`{ id, name: "Gen N (provider)", url: "/textures/<file>", prompt, provider, createdAt, isGenerated: true }`.
+
+## Applying a texture to a control
+
+A texture is attached by setting the element's `textureId`. There are three ways
+in:
+
+| Path | Mechanism |
+|---|---|
+| Drag from Texture Library | `TextureManager` sets `application/x-vst-texture`; `Canvas` `onDrop` calls `onUpdateElements([id], { textureId })` |
+| Properties panel | The **Texture** tab in `CompactElementProperties` / `PropertiesPanel` picks a tile and sets `textureId` |
+| AI assistant | The orb's `applyTexture` tool (`useToolActions.ts`) patches `textureId` + optional transform fields; `removeTexture` clears them all |
+
+At render time, `Canvas` resolves the id to a URL —
+`textures.find(a => a.id === el.textureId)?.url` — and passes it as `textureUrl`
+to `InteractiveControl` (native controls), `CustomCodeFrame` (CustomCode), or
+`ProcessedImage` (Image elements). Groups paint the texture overlay directly in
+`Canvas`.
+
+The overlay is a full-cover, `pointerEvents: none` div whose inner div reads the
+element's texture transform fields:
+
+| Field | Default | UI range | Maps to |
+|---|---|---|---|
+| `textureBlendMode` | `normal` | 12-mode set below | wrapper `mixBlendMode` |
+| `textureOpacity` | `100` | 0–100% | inner `opacity` (÷100) |
+| `textureSize` | `cover` | Cover / Contain / Auto / Stretch (`100% 100%`) | `backgroundSize` |
+| `textureRepeat` | `no-repeat` | No Repeat / Repeat / Repeat X / Repeat Y | `backgroundRepeat` |
+| `textureScale` | `100` | 10–400% | `transform: scale()` (÷100) |
+| `textureRotation` | `0` | 0–360° | `transform: rotate()` |
+| `textureOffsetX` / `textureOffsetY` | `0` | free px | `backgroundPosition` offset from centre |
+
+Texture blend modes are a reduced set (`TEXTURE_BLEND_MODE_OPTIONS` in
+`properties/options.ts`): `normal`, `multiply`, `screen`, `overlay`, `darken`,
+`lighten`, `color-dodge`, `color-burn`, `hard-light`, `soft-light`, `difference`,
+`exclusion`. (An Image element's own *layer* blend uses the full 16-mode
+`BLEND_MODE_OPTIONS`, which adds hue/saturation/color/luminosity.)
+
+## Material skins
+
+`src/lib/skins.ts` provides universal material "skins" — CSS-only recipes any
+element can wear independent of its variant. `getSkinLayers(id, { base, active })`
+resolves a skin id plus the host element's colors into concrete layers:
+
+- `containerStyle` — an optional style merged onto the element container.
+- `overlayStyles[]` — zero or more full-cover overlay layers the dispatcher
+  renders as absolutely-positioned, `pointerEvents: none` divs with
+  `borderRadius: inherit`.
+
+Every recipe tints itself to the host via CSS `color-mix()`, so the same skin
+reads differently on a purple knob than on an amber button.
+
+| Skin id | Label | Recipe (summary) |
+|---|---|---|
+| `none` | None | No layers (also returned for unknown ids) |
+| `aluminum` | Aluminum | Base-tinted metal gradient + microline overlay + sheen + inset bevel |
+| `chrome` | Chrome | Horizon gradient + conic sheen + specular streak + dark edge ring |
+| `glass` | Glass | Top highlight ellipse over a low-opacity white film + active-tinted inner glow |
+| `bakelite` | Bakelite | Warm radial brown tint + fine speckle + glossy top light |
+| `carbon` | Carbon Fiber | Two crossed repeating-gradients (twill) over a dark tint + diagonal sheen |
+| `matte` | Matte | Desaturating dark multiply film + soft inner shadow |
+| `leather` | Leather | Warm radial tint + radial-speckle pores + dashed inset stitch outline |
+| `led-glow` | LED Glow | Inner + outer glow ring in the element's active color, no fill |
+
+The skin is chosen in the properties panel via `ControlParamsSection.tsx`, which
+renders a universal **Skin** picker on every element type **except Group**. The
+chosen id is stored on `element.skin` (cleared to `undefined` for "none"). The
+`"none"` entry must stay first in the `SKINS` list — settings UIs use it as the
+default option.
+
+> Colors for the tint come from `el.baseColor` / `el.activeColor`, falling back to
+> per-archetype defaults from `getDefaultColors()` in
+> [`colorUtils`](#color-and-image-helpers).
+
+## Image faces
+
+A **face** (`faceSrc`) is an image rendered as a control's visual, opt-in per
+element. Two mechanisms exist:
+
+- **Face-aware controls** (Knob, Button, Toggle, Slider, XYPad, Meter) paint
+  their own value-reactive faces internally.
+- **Universal-face controls** (Select, Label, Waveform, Spatial3D, WaveShaper,
+  Envelope, StepSequencer, Keyboard — `UNIVERSAL_FACE_TYPES`) get a **static**
+  face painted by `InteractiveControl.wrapElement()` when `faceSrc` is set.
+
+For universal faces, three style params tune the composite (with explicit
+fallbacks because they are not declared in `CONTROL_PARAMS` for these types):
+
+| Param | Default | Effect |
+|---|---|---|
+| `faceFit` | `contain` | `backgroundSize`; `fill` maps to `100% 100%` |
+| `faceOpacity` | `100` | Face layer opacity (÷100) |
+| `faceHideBase` | `true` | Hides the base render **via `opacity: 0` only** — the box, layout, and pointer wiring stay live underneath |
+
+> `faceHideBase` never uses `visibility`/`display: none`. Interactive display
+> types (Spatial3D, WaveShaper) keep their drag listeners on `containerRef` while
+> the face composites on top. When `faceSrc` is unset, every face branch is
+> skipped and the wrapper output is byte-identical to a plain render — the
+> load-bearing default-rendering contract.
+
+## Layer stacking order
+
+`InteractiveControl.wrapElement()` composites the layers in this DOM order (later
+= visually on top):
+
+1. **Container** — `baseStyle` + `cornerRadiusStyle` + the skin's `containerStyle`.
+2. **Glow** (`glowDiv`) — the procedural glow engine.
+3. **Base render** — the actual control component, wrapped in an `opacity: 0` div
+   when a universal face is shown with `faceHideBase`.
+4. **Face** (`zIndex: 1`) — full-cover `faceSrc` background, `pointerEvents: none`,
+   `borderRadius: inherit`.
+5. **Skin overlays** (`zIndex: 2`) — each `overlayStyles` entry.
+6. **Texture** — full-cover overlay with `mixBlendMode = textureBlendMode`, last
+   in the DOM so it sits above the skin.
+
+## How textures, skins, and faces travel
+
+All three visuals are plain fields on `UIElement` (or, for textures, entries in
+`textures[]`), so they serialize whole with the project on every save path —
+autosave, project save, `.gan`, and VST3 bundle.
+
+| Destination | What carries the visuals | Texture pixel handling |
+|---|---|---|
+| Autosave / project state | `elements[]`, `textures[]`, `assets[]` in `data/sessions/latest.json` | Uploaded/generated textures stay as `/textures/<file>` refs; built-ins are data URLs |
+| `.gan` bundle | `source/foundry-project.json` embeds `{ version, elements, canvasState, assets, textures, customModules }`; `params.js` sets `window.FOUNDRY_DESIGN` | See caveat below |
+| VST3 data bundle | `ui/params.js` sets `window.FOUNDRY_DESIGN = { elements, canvasState, assets, textures }` | See caveat below |
+
+> **Inlining caveat.** `buildVst3Ui()` (used by both the VST3 bundle and the
+> `.gan`) passes texture/asset `url` fields through untouched. Fields that begin
+> with `data:` are already inline and self-contained. Fields that begin with
+> `/textures/` point at server-side files and are **not** inlined by this step — a
+> later build stage must replace them with `data:` URLs for the bundle to be fully
+> offline. The exported README repeats this warning. No network fetches happen at
+> export time.
+
+## Color and image helpers
+
+| File | Function | Purpose |
+|---|---|---|
+| `src/lib/colorUtils.ts` | `getArchetype(variant)` | Maps a design-style variant name (e.g. `Skeuomorphic`, `Swiss Style`) to a canonical archetype (`Classic`, `Brutalist`, `Neumorphic`, `3D`, `Minimal`, `CellShaded`, `Modern`) |
+| `src/lib/colorUtils.ts` | `getDefaultColors(variant)` | Per-archetype default `base`/`active`/`text`/`border` colors used when an element leaves them unset (feeds skin tinting) |
+| `src/lib/imageUtils.ts` | `removeImageBackground(url, tolerance, targetColorHex?, feathering?)` | Chroma-key background removal for **Image assets** — clears pixels within `tolerance` color distance of a target (default: the top-left pixel), with optional alpha feathering; returns a PNG data URL |
+
+`removeImageBackground` backs the Image element's `imageModifiers` (removeBg,
+tolerance, feathering, targetColor) — it is an asset-processing helper, not part
+of the control texture/skin path.
+
+## A note on `orb-kit-skin`
+
+`src/orb-kit-skin/` (the `GantasmoOrb` component plus `gantasmo-orb.css` and
+`orb-chat.css`) is the visual theme for the **AI Assistant orb's chat UI**, loaded
+by `AIAssistantOrb.tsx`. Despite the word "skin," it is unrelated to the control
+material skins in `skins.ts` — it styles the assistant surface, not canvas
+elements. See [foundry-overview.md](foundry-overview.md) for the assistant orb.
+
+## Related sources feeding the libraries
+
+- The **component extractor** can lift regions of a reference image and add them
+  straight to the Texture Library (`ExtractorModal.onAddTextures`). See
+  [component-extractor.md](component-extractor.md).
+
+> Note: the component extractor is a newly added feature and is under active
+> development at the time of writing; its texture-library sink exists and is wired
+> into `App.tsx`, but expect its UI to keep changing.
+
+## Operational notes
+
+- **Built-ins are free and stable.** They regenerate identically every load and
+  dedupe by id, so they never bloat autosave or drift.
+- **Uploaded textures are files; assets are inline.** Deleting a texture removes
+  its `data/textures/` file via `DELETE /api/textures/:id`; deleting an asset just
+  drops it from state.
+- **A missing texture file degrades quietly.** If a `/textures/<id>` file is gone,
+  the resolved URL is empty and the control renders without the overlay — no
+  crash. Result thumbnails hide themselves on image load error.
+- **SD must be configured and running** before an SD-tab generation will fire;
+  the modal blocks and shows why. Cloud tabs need a server-configured key or a
+  per-request override.
+- **Before exporting a fully offline bundle,** confirm no texture/asset URL still
+  begins with `/textures/` — those must be inlined as `data:` URLs (see the
+  inlining caveat above).

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/thedaw-docs-integration-proposal.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/thedaw-docs-integration-proposal.md
@@ -1,0 +1,270 @@
+# theDAW Docs Integration — Proposal for the Foundry Doc Set
+
+A proposal for folding this Foundry documentation set into theDAW's own
+documentation: where each file should live (`docs/guides/`, `docs/workflows/`, or
+the GitHub wiki), which files to register in the RAG index, what to add to the
+wiki sidebar and Home page, and how the existing `docs/guides/foundry.md` should
+relate to the set without duplicating it. It is written for whoever owns theDAW's
+docs and RAG index and has to approve and carry out the move. Plain descriptions
+of what each step is and what it touches.
+
+> This file is a proposal only. It makes **no edits to theDAW**. Nothing under
+> theDAW's `docs/`, `backend/rag.py`, or the wiki is changed by this document —
+> every mapping, `DOC_PATHS` entry, and wiki edit below is a *suggestion* to be
+> reviewed and applied by hand. Per theDAW's `CLAUDE.md`, all doc and RAG changes
+> are approval-based; this document is the approval request, not the change.
+
+## Scope and constraints
+
+The Foundry doc set lives in the vendored Foundry repository under
+`docs/thedaw-style/`. theDAW's docs live in a separate repository root
+(`docs/guides/`, `docs/workflows/`, `docs/wiki/theDAW/`) and are indexed for the
+in-app assistant by `backend/rag.py`. This proposal spans that boundary: the
+source files stay where they are; copies (or moves) into theDAW's tree are what
+gets approved.
+
+| Constraint | Detail |
+|---|---|
+| Approval-based | No doc, `DOC_PATHS`, or wiki edit is applied without sign-off. |
+| No source edits | This proposal touches no Foundry source and no theDAW source. |
+| Preserve cross-links | The set is densely cross-linked with bare relative sibling links (for example `[vst3-export.md](vst3-export.md)`); the destination layout must keep those links valid. |
+| Current-state only | Several Foundry files are being edited concurrently. This proposal, and the docs it references, describe the code as it stands; in-flight areas are flagged. |
+
+> Note: at the time of writing, `backend/modules/foundry/sidecar.py`,
+> `backend/modules/plugin/router.py`, `backend/modules/plugin/owl_import.py`,
+> `frontend/src/components/audio/EffectGuiStage.tsx`,
+> `frontend/src/components/audio/TheOwl.tsx`, `frontend/vite.orb.config.ts`, and
+> the FoundryShell `config.h` are modified in the working tree, and
+> `component-extractor/` and `AspectStage.tsx` are untracked. The set documents
+> these areas as they currently exist. Re-verify the affected sections
+> (`thedaw-integration.md`, `component-extractor.md`, `vst3-export.md`) against
+> the code before publishing.
+
+## The doc set
+
+Twelve reference documents plus this proposal (thirteen files). Each content doc
+is already written in theDAW's documentation style: an H1 title with a plain
+subtitle, an intro paragraph, `##` sections, Markdown tables, `>` notes, fenced
+code, and relative sibling links. The set's own landing page is
+[index.md](index.md); its entry point is [foundry-overview.md](foundry-overview.md).
+
+| File | Covers | Reads as |
+|---|---|---|
+| [index.md](index.md) | Landing page and table of contents for the set | Orientation |
+| [foundry-overview.md](foundry-overview.md) | What Foundry is end to end, its architecture at a glance, and links to every sibling | Guide (entry) |
+| [canvas-and-controls.md](canvas-and-controls.md) | The design canvas, the 17 element types, and the panels that place, style, and wire them | Guide |
+| [custom-code.md](custom-code.md) | The `CustomCode` element, its sandboxed iframe, postMessage bridge, and parameter model | Guide |
+| [gan-format.md](gan-format.md) | The `.gan` portable web-plugin bundle: on-disk shape, export/import round-trip, host bridge | Guide (reference) |
+| [textures-and-skins.md](textures-and-skins.md) | Procedural and AI textures, CSS material skins, and image faces; how they composite and ride exports | Guide |
+| [assistant-and-mcp.md](assistant-and-mcp.md) | The Assistant orb, the multi-provider chat backend, the persistent BCC session, and the MCP canvas bridge | Guide |
+| [thedaw-integration.md](thedaw-integration.md) | The sidecar, the center-tab embed, the two control buses, and the exported-plugin runtime inside theDAW | Guide |
+| [projects-and-data.md](projects-and-data.md) | Where Foundry state lives (IndexedDB, localStorage, on-disk `data/`) and what survives a restart | Guide (reference) |
+| [troubleshooting.md](troubleshooting.md) | Ports, spawn failures, rejected imports, native-shell build errors, and the commands to clear them | Guide (reference) |
+| [component-extractor.md](component-extractor.md) | Turning one reference image into labeled cutout components and real controls via vision AI | Workflow |
+| [vst3-export.md](vst3-export.md) | Exporting a canvas to a VST3 data bundle and the native iPlug2 FoundryShell that loads it | Workflow |
+| [thedaw-docs-integration-proposal.md](thedaw-docs-integration-proposal.md) | This file | Proposal |
+
+> Note: `thedaw-docs-integration-proposal.md` (this file) is **not** shipped into
+> theDAW. It stays in the Foundry repo as the integration record. It is excluded
+> from every destination and `DOC_PATHS` entry below.
+
+## 1. Destination mapping
+
+theDAW splits its docs three ways: `docs/guides/` holds "what each piece does"
+references (this is where `foundry.md` and `underfit.md` already live and are
+RAG-indexed), `docs/workflows/` holds step-by-step task walkthroughs (`lora.md`,
+`inference.md`, `autoencoder.md`, `underfit-lora-training.md`), and
+`docs/wiki/theDAW/` holds short orientation pages that link out to the depth.
+
+The set is a cohesive, densely cross-linked unit. Every doc links its siblings by
+bare relative filename (for example `canvas-and-controls.md` links
+`[vst3-export.md](vst3-export.md)`). To keep those links valid with **zero body
+edits**, the whole set should land in a single directory under identical
+filenames. The recommended home is a new `docs/guides/foundry/` subfolder.
+
+### Recommended: unified under `docs/guides/foundry/`
+
+Keeps all sibling links intact, groups the set beside the existing
+`docs/guides/foundry.md`, and ships in the packaged desktop build (which bundles
+`docs/**/*.md`). Filenames are preserved 1:1 from `docs/thedaw-style/`.
+
+| Source (`docs/thedaw-style/`) | Destination | Reads as |
+|---|---|---|
+| `index.md` | `docs/guides/foundry/index.md` | Orientation |
+| `foundry-overview.md` | `docs/guides/foundry/foundry-overview.md` | Guide (entry) |
+| `canvas-and-controls.md` | `docs/guides/foundry/canvas-and-controls.md` | Guide |
+| `custom-code.md` | `docs/guides/foundry/custom-code.md` | Guide |
+| `gan-format.md` | `docs/guides/foundry/gan-format.md` | Guide |
+| `textures-and-skins.md` | `docs/guides/foundry/textures-and-skins.md` | Guide |
+| `assistant-and-mcp.md` | `docs/guides/foundry/assistant-and-mcp.md` | Guide |
+| `thedaw-integration.md` | `docs/guides/foundry/thedaw-integration.md` | Guide |
+| `projects-and-data.md` | `docs/guides/foundry/projects-and-data.md` | Guide |
+| `troubleshooting.md` | `docs/guides/foundry/troubleshooting.md` | Guide |
+| `component-extractor.md` | `docs/guides/foundry/component-extractor.md` | Workflow |
+| `vst3-export.md` | `docs/guides/foundry/vst3-export.md` | Workflow |
+
+Under this layout the guide-vs-workflow distinction is honored by cross-linking
+and by the wiki, not by physical fragmentation: `component-extractor.md` and
+`vst3-export.md` still read as task walkthroughs and are surfaced as such from the
+wiki Foundry page and from `docs/guides/foundry.md`, but they stay beside the
+references they link to.
+
+### Alternative: physical split into `docs/workflows/`
+
+If theDAW's convention requires the two walkthrough-flavored docs to live under
+`docs/workflows/`, move them there and leave the ten references (plus `index.md`)
+in `docs/guides/foundry/`.
+
+| Source | Destination |
+|---|---|
+| `component-extractor.md` | `docs/workflows/foundry-component-extractor.md` |
+| `vst3-export.md` | `docs/workflows/foundry-vst3-export.md` |
+
+> This split **breaks relative links** and requires body edits, so it is not the
+> default. Moving these two out of the set changes the relative path between them
+> and their siblings. Every `[vst3-export.md](vst3-export.md)` and
+> `[component-extractor.md](component-extractor.md)` link (in `index.md`,
+> `foundry-overview.md`, `canvas-and-controls.md`, `custom-code.md`,
+> `gan-format.md`, `textures-and-skins.md`, and in the two files themselves) would
+> need rewriting to `../workflows/foundry-vst3-export.md`, and the two moved
+> files' own sibling links would need `../guides/foundry/` prefixes. Those edits
+> are approval-gated like everything else here. Prefer the unified layout unless
+> there is a strong reason not to.
+
+## 2. Proposed `DOC_PATHS` entries for RAG
+
+`backend/rag.py` indexes an explicit list, `DOC_PATHS`, chunked by `##` headers
+(`MAX_CHUNK_CHARS = 800`). The RAG serves the **in-app assistant**, which answers
+end-user questions, so the goal is user-relevant coverage, not indexing every
+source-internal reference. The set's files are large (18–39 KB each) and several
+document source-file internals that an end user would never ask about; indexing
+all twelve would add a large number of chunks and can dilute retrieval.
+
+The recommendation is two tiers. Register the user-facing conceptual docs; leave
+the deep source-internal references as repo/wiki docs only (still shipped, still
+linked, just not embedded).
+
+> These entries assume the **unified `docs/guides/foundry/` layout** from §1 has
+> been approved and the files copied. If the alternative split is used instead,
+> change the two workflow paths to `docs / "workflows" / "foundry-*.md"`.
+
+```python
+# --- PROPOSED (approval-based) — add to DOC_PATHS in backend/rag.py ---
+# VST Foundry guide set (docs/guides/foundry/). The concise user entry,
+# docs/guides/foundry.md, is already indexed above and links into this set.
+# Tier 1 — user-facing, recommended for RAG:
+PROJECT_ROOT / "docs" / "guides" / "foundry" / "foundry-overview.md",
+PROJECT_ROOT / "docs" / "guides" / "foundry" / "canvas-and-controls.md",
+PROJECT_ROOT / "docs" / "guides" / "foundry" / "textures-and-skins.md",
+PROJECT_ROOT / "docs" / "guides" / "foundry" / "assistant-and-mcp.md",
+PROJECT_ROOT / "docs" / "guides" / "foundry" / "component-extractor.md",
+PROJECT_ROOT / "docs" / "guides" / "foundry" / "vst3-export.md",
+PROJECT_ROOT / "docs" / "guides" / "foundry" / "gan-format.md",
+PROJECT_ROOT / "docs" / "guides" / "foundry" / "projects-and-data.md",
+PROJECT_ROOT / "docs" / "guides" / "foundry" / "troubleshooting.md",
+# Tier 2 — source-internal references. OPTIONAL for RAG; index only if the
+# assistant is expected to answer developer-level questions. Otherwise leave
+# them as repo/wiki docs (they still ship and are still linked):
+# PROJECT_ROOT / "docs" / "guides" / "foundry" / "custom-code.md",
+# PROJECT_ROOT / "docs" / "guides" / "foundry" / "thedaw-integration.md",
+# --- END PROPOSED ---
+```
+
+> `index.md` is deliberately not indexed: it is a table of contents, so its chunks
+> would be low-signal for retrieval. `thedaw-docs-integration-proposal.md` is
+> never indexed — it does not ship into theDAW.
+
+> After any approved change to `DOC_PATHS`, the index re-hashes and rebuilds on
+> next assistant use (`_compute_docs_hash` includes each path's mtime), so no
+> manual re-index step is needed. Confirm there are no `[RAG] Skipping missing doc`
+> warnings on startup, which would mean a path in the list does not resolve.
+
+## 3. Wiki sidebar and Home additions
+
+The set is too deep to paste into the wiki, whose pages are short orientation
+stubs that link out to the depth (see `Modules-and-Sidecars.md`). The proposal is
+one **new orientation page**, `docs/wiki/theDAW/Foundry.md`, written fresh in the
+wiki's own style (a few paragraphs plus a table linking into the guide set) — not
+a copy of any set file. `foundry-overview.md` is the source to summarize. Drafting
+that page is its own approval item (§5).
+
+### `docs/wiki/theDAW/_Sidebar.md`
+
+Add a `Foundry` entry to the `### theDAW` list, after `Modules and Sidecars`:
+
+```markdown
+- [Modules and Sidecars](Modules-and-Sidecars)
+- [Foundry](Foundry)
+- [Troubleshooting](Troubleshooting)
+```
+
+### `docs/wiki/theDAW/Home.md`
+
+Add one row to the `## Pages` table, after the `Modules and Sidecars` row:
+
+```markdown
+| [Foundry](Foundry) | The plugin-UI builder: canvas, controls, textures, export, and how it embeds. |
+```
+
+> The new `Foundry.md` wiki page should link into the guide set by GitHub blob URL
+> (the pattern the wiki already uses for the User Guide and README), for example
+> `https://github.com/gantasmo/theDAW/blob/main/docs/guides/foundry/foundry-overview.md`,
+> since wiki pages and `docs/` live in different trees and cannot use relative
+> links to each other.
+
+## 4. Relationship to the existing `docs/guides/foundry.md`
+
+`docs/guides/foundry.md` already exists as the **concise, user-facing** Foundry
+guide, and it is already in `DOC_PATHS`. It should stay exactly that: a short
+"what the tab is and how to use it" overview. This set is the **deep reference**
+underneath it. The two must not duplicate each other.
+
+| Doc | Role | Audience |
+|---|---|---|
+| `docs/guides/foundry.md` (existing) | Concise tab overview: opening Foundry, the workspace, the AI orb, texture generation, exporting, operational notes | End users |
+| `docs/guides/foundry/` (this set) | Subsystem-level reference: element model, `.gan`/VST3 internals, extractor pipeline, control buses, persistence, failure modes | Power users and developers |
+
+Proposed relationship, to be applied on approval (an edit to `foundry.md`, so
+approval-based):
+
+- Add a short "Further reference" pointer near the top or bottom of `foundry.md`
+  linking into the set — `[foundry/foundry-overview.md](foundry/foundry-overview.md)`
+  as the entry point, plus the two walkthroughs (`component-extractor.md`,
+  `vst3-export.md`) by name.
+- Where `foundry.md` already summarizes a topic the set covers in depth (the
+  workspace, the AI orb, exporting, operational notes), keep the summary and add a
+  "see …" link to the matching set doc instead of expanding it in place.
+- The set's own docs already link *back* to concepts by sibling filename; they do
+  not need a link to `foundry.md`, but `foundry-overview.md` may gain one pointing
+  up to the concise guide as the "start here" page.
+
+> Do not merge the two. `foundry.md` is what a first-time user reads; the set is
+> what someone editing Foundry or debugging an export reads. Keeping them separate
+> keeps the RAG's user-facing answers concise while the depth stays one link away.
+
+## 5. Approval checklist
+
+Each item is an independent, approval-gated action. None is applied by this
+document. Recommended order top to bottom.
+
+- [ ] Approve the destination layout: unified `docs/guides/foundry/` (§1
+      recommended) **or** the physical `docs/workflows/` split (§1 alternative,
+      accepting the link-rewrite cost).
+- [ ] Copy the twelve content files into the approved destination, preserving
+      filenames. Exclude `thedaw-docs-integration-proposal.md`.
+- [ ] If the alternative split is chosen, rewrite the affected relative sibling
+      links in the moved and referencing files (§1).
+- [ ] Add the approved `DOC_PATHS` entries to `backend/rag.py` (§2). Decide Tier 2
+      (`custom-code.md`, `thedaw-integration.md`) in or out.
+- [ ] Start theDAW and confirm no `[RAG] Skipping missing doc` warnings for the
+      new paths; spot-check an assistant question against the new content.
+- [ ] Draft the new `docs/wiki/theDAW/Foundry.md` orientation page (fresh, wiki
+      style, blob-URL links into the set).
+- [ ] Apply the `_Sidebar.md` and `Home.md` additions (§3).
+- [ ] Edit `docs/guides/foundry.md` to add the "Further reference" links into the
+      set and swap in-place depth for "see …" links (§4). Do not duplicate.
+- [ ] Re-verify the in-flight sections (`thedaw-integration.md`,
+      `component-extractor.md`, `vst3-export.md`) against the current source before
+      publishing, since those files are being edited concurrently.
+- [ ] Per theDAW's `CLAUDE.md`, keep this proposal as the record of what was
+      approved and applied.

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/thedaw-integration.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/thedaw-integration.md
@@ -1,0 +1,483 @@
+# theDAW Integration — Sidecar, Tab, and Plugin Runtime
+
+Reference for how VST Foundry lives inside theDAW. Foundry is a vendored
+standalone app: theDAW runs it as a Node sidecar, embeds it as a center tab,
+and — separately — runs the interfaces you export from it as portable `.gan`
+web-plugins in the MIX effect stage. This doc covers both halves and the seams
+between them: the sidecar process, the tab embed, the two control buses that
+reach out of the Foundry iframe, and the plugin runtime that plays an exported
+`.gan` back inside theDAW. It is for anyone wiring, debugging, or extending that
+boundary. For the builder itself see [foundry-overview.md](foundry-overview.md);
+for the package format see [gan-format.md](gan-format.md); for the AI orb and MCP
+surface see [assistant-and-mcp.md](assistant-and-mcp.md).
+
+> Concurrent developers are editing several of the files named here. The
+> behavior below reflects the code as it stands; where an area is visibly in
+> flight it carries a `Note:`.
+
+## The two integration paths
+
+Foundry touches theDAW through two independent pipelines. Keeping them straight
+avoids a lot of confusion, because both are loosely called "control wiring."
+
+| Path | When | Transport | Reaches theDAW how |
+|---|---|---|---|
+| **Design-time (the tab)** | While you build a UI in the Foundry tab | Foundry SPA in an iframe on port `5472` | Foundry's own `dawControlBus` opens a WebSocket straight to theDAW's backend `:8600`; live canvas controls drive theDAW targets |
+| **Runtime (the plugin)** | After you export a `.gan` and open it in MIX | `.gan` runtime HTML in an iframe under `/api/plugin/<id>/runtime/` | The plugin posts `updateValue` messages up to the host page; `aresBridge` (or a native surface) routes them onto FX params |
+
+The first path is Foundry-source code running inside the sidecar iframe. The
+second is a static bundle Foundry produced, served by theDAW's Python backend
+and wired up by theDAW's React frontend. They never share a channel.
+
+## The Foundry sidecar
+
+theDAW spawns Foundry as a Node dev-server subprocess and manages its whole
+lifecycle. The logic lives in `backend/modules/foundry/sidecar.py`.
+
+### Spawn and readiness
+
+`ensure_running()` is the entry point. It:
+
+1. Returns immediately if a Foundry server is already answering on the port.
+2. Refuses the port if something that is **not** Foundry is listening there.
+3. Runs `npm install` first when `node_modules` is missing (the one-time wait on
+   a fresh clone).
+4. Spawns the dev server and waits up to `PORT_READY_TIMEOUT_SEC` (90s) for it to
+   answer, polling every 0.5s.
+
+```
+cmd  = npm run dev
+cwd  = <repo>/VST-Foundry-UI/VST-UI-FOUNDRY
+```
+
+The working directory is anchored at `parents[3]` of `sidecar.py`
+(`foundry → modules → backend → repo`), so it resolves regardless of the process
+CWD. `npm run dev` runs `tsx server.ts` — an Express app with Vite in middleware
+mode on the **same** port, not a separate Vite server.
+
+### Configuration
+
+`resolve_config()` reads two environment variables and locates `npm`.
+
+| Setting | Source | Default |
+|---|---|---|
+| Port | `THEDAW_FOUNDRY_PORT` env | `5472` (`DEFAULT_PORT`) |
+| Project path | `THEDAW_FOUNDRY_PROJECT` env | `<repo>/VST-Foundry-UI/VST-UI-FOUNDRY` |
+| npm binary | `shutil.which("npm.cmd")` → `which("npm")` | `"npm"` |
+| Ready timeout | constant | `90.0s` |
+
+The spawn injects two env vars into the child:
+
+| Env var | Value | Effect |
+|---|---|---|
+| `THEDAW_FOUNDRY_PORT` | resolved port | Foundry binds `127.0.0.1:<port>` |
+| `DISABLE_HMR` | `"true"` | Turns off Vite HMR + file watching in the embedded server |
+
+`DISABLE_HMR=true` matters: nobody live-edits Foundry's source when it runs as an
+embedded sidecar, so HMR is pure overhead. With it off, `server.ts` passes
+`hmr: false` to Vite, which stops Vite from opening the HMR WebSocket whose
+unreachable retries otherwise flood the browser console with
+`ERR_CONNECTION_REFUSED`. Standalone (no `DISABLE_HMR`), HMR runs on `PORT + 1`
+(`5473`) so multiple Foundry instances never collide on Vite's fixed default
+(`24678`).
+
+### Health detection
+
+The sidecar decides whether Foundry is up by hitting its health endpoint, not by
+a bare port check:
+
+```
+GET http://127.0.0.1:<port>/api/health
+→ body contains  "app":"vst-foundry"
+```
+
+`/api/health` and `/api/shutdown` are served by the **Foundry** Express app
+(`server/routes.ts`), not by theDAW's backend. `_is_foundry_server()` reads the
+first 512 bytes, strips spaces, and looks for the `"app":"vst-foundry"` marker.
+A port that is listening but does not return that marker is treated as a foreign
+process, and `ensure_running()` raises rather than iframing something unknown.
+
+### Logging
+
+All child stdout/stderr is captured to a logfile (never `DEVNULL`), so a spawn
+that dies leaves a trail:
+
+```
+<repo>/data/logs/foundry-sidecar.log
+```
+
+`ensure_running()` appends the log tail to the `RuntimeError` it raises on
+`npm install` failure, a premature exit, or a port-open timeout — that tail is
+what the `/api/foundry/url` 503 detail (and the tab's error card) surfaces.
+
+### Shutdown and teardown
+
+`stop()` tries the gentlest teardown first and escalates:
+
+1. `POST /api/shutdown` to the Foundry app, then wait for it to stop answering.
+2. `Popen.terminate()`, then `.kill()` on timeout.
+3. On Windows only: `netstat -ano` to find the PID still `LISTENING` on the port,
+   then `SIGTERM` it.
+
+Teardown is wired to run automatically two ways: `atexit.register(_atexit_stop)`
+at import time, and the router's `@router.on_event("shutdown")` FastAPI hook. So
+the Node server is not orphaned when the backend exits.
+
+> A fresh `theDAW.bat` launch clears any stale process on the port via the
+> netstat/PID path, so a previous crash that left Foundry listening does not
+> block the next start.
+
+### Endpoints (`/api/foundry`)
+
+Registered by `backend/modules/foundry/router.py`; `module.json` sets
+`sidebar: false`, `backend: true`, `api_prefix: /api/foundry`.
+
+| Method + path | Purpose | On failure |
+|---|---|---|
+| `GET /api/foundry/url` | Ensure the sidecar is running; return `{ url }` | `503` with the sidecar's error detail (incl. log tail) |
+| `GET /api/foundry/status` | Probe without starting: project path, port, listening, process_alive, url, issues, `ok` | Always `200` |
+| `POST /api/foundry/start` | Force `ensure_running()`; return `{ ok, url }` | `503` |
+| `POST /api/foundry/stop` | Stop the sidecar; return `{ ok, stopped }` | `503` if still listening |
+
+`GET /status` never starts the process. It reports `ok = not issues and
+listening`, where `issues` includes a missing project path, a missing
+`package.json`, or `npm` not on PATH.
+
+## The Foundry tab
+
+`frontend/src/views/FoundryView.tsx` is the React view that embeds the sidecar.
+It is code-split and mounted by `DAWCenterPanel.tsx` — a lazy import, a center
+tab, never a sidebar item.
+
+### Load flow
+
+On mount, `FoundryView` calls `GET /api/foundry/url`. Because the first launch
+may be doing an `npm install`, it retries on failure:
+
+| Behavior | Value |
+|---|---|
+| Retry limit | 20 attempts |
+| Retry interval | 2000ms (2s) |
+| On success | iframe `src = http://localhost:<port>` |
+| On exhaustion | error card showing the backend detail |
+
+The iframe uses `allow="clipboard-write; fullscreen; autoplay"`. A header strip
+above it has a **Reload** button (resets the retry counter and re-fetches) and an
+**open-externally** link that opens the same URL in a browser tab.
+
+### Warmed mounting
+
+`DAWCenterPanel` keeps a `warmedTabs` set. Once `foundry` (or `dj`, `vj`,
+`underfit`) has been visited, its view stays mounted and only its CSS visibility
+toggles with the active tab. So switching away and back does not tear down the
+iframe or re-run the sidecar handshake — the Foundry SPA and its in-progress
+work survive tab switches. Each tab renders inside its own `Suspense` boundary,
+so a not-yet-loaded sibling never blanks it.
+
+> "VST Foundry did not start" on the error card means all 20 retries failed.
+> `GET /api/foundry/status` reports the project path, port, and issues; the
+> root cause detail is in `data/logs/foundry-sidecar.log`. See
+> [troubleshooting.md](troubleshooting.md).
+
+## Crossing the iframe: the two buses
+
+Two bus modules in Foundry's `src/lib/` govern control flow. Only one of them
+crosses the iframe boundary out to theDAW.
+
+### dawControlBus — reaches theDAW (design-time)
+
+`src/lib/dawControlBus.ts` connects, from inside the Foundry iframe, straight to
+theDAW's XR control relay as a **controller** peer:
+
+```
+ws(s)://<hostname>:8600/api/xr/control/ws
+```
+
+This is a direct WebSocket to theDAW's backend — no iframe `postMessage` origin
+bridge is involved. theDAW's browser tab (the one hosting the Foundry iframe) is
+the **host** peer: it owns the manifest of bindable targets and applies inbound
+`control-set` frames by routing them to whatever registered source owns each id.
+The relay is transport-only and fans every frame to all peers. The wire contract
+mirrors theDAW's `frontend/src/state/xrControlClient.ts`.
+
+| Direction | Frame | Meaning |
+|---|---|---|
+| controller → host | `{type:"request-controls"}` | Ask the host to (re)publish its manifest |
+| controller → host | `{type:"control-set", id, value}` | Drive a target (number, or boolean for toggles) |
+| host → controller | `{type:"manifest", version, entries:[DawTarget...]}` | The bindable-target list |
+| host → controller | `{type:"control-changed", id, value}` | A target's live value (up to 60fps) |
+
+Design decisions worth knowing:
+
+- **Two stores, on purpose.** A React snapshot (`connected` / `targets` /
+  `version`) drives the binding UI; a separate out-of-band `liveValues` Map plus
+  per-id `valueListeners` carry the 60fps LISTEN stream, so a fast-moving id
+  re-renders only its own subscribers. Reconnect is every 2000ms.
+- **`vst:` binds dispatch locally first.** `setDawTarget()` sends a `vst:` id to
+  the local `vstWriteHandler` (LFOs, macros, local transport in `vstBindRuntime`)
+  and *then* forwards the same `control-set` frame on the bus. Live theDAW ids
+  are bus-only. `scaleToTarget` / `scaleFromTarget` map Foundry's 0–100 range to
+  and from each target's declared `min..max`; booleans collapse to `0`/`100`.
+- **Readonly sources.** Input-only theDAW sources (sway/pose) carry `readonly`
+  and are excluded from the write picker but welcomed by the LISTEN path — they
+  are the star signals for live meters and scopes.
+
+### elementSignalBus — stays inside Foundry
+
+`src/lib/elementSignalBus.ts` is a runtime-only pub/sub for element→element
+modulation (a moving control drives a ganged knob, a Label readout, a Meter
+level). It is keyed `"<elementId>:<prop>"`, its values are **ephemeral** (it
+never touches the element store, autosave, or undo — like a real VST, moving a
+mod-routed knob does not rewrite the patch), and `clearElementSignals()` is
+called on project load so stale modulation cannot bleed between documents.
+
+> Note: `elementSignalBus` does **not** cross the iframe. It is Foundry-internal.
+> Of the two buses, only `dawControlBus` reaches theDAW. If you are chasing why a
+> Foundry control does or does not move a theDAW parameter, `dawControlBus` and
+> the XR relay on `:8600` are the only path.
+
+## The plugin runtime: running an exported `.gan` inside theDAW
+
+The second half of the integration has nothing to do with the sidecar. When you
+export a design, it becomes a `.gan` package that theDAW's Python backend serves
+as a self-contained web plugin. The code lives in `backend/modules/plugin/`;
+`module.json` registers it at `api_prefix: /api/plugin`, `sidebar: false`.
+
+### What a `.gan` is
+
+A `.gan` is a ZIP (`GanFile` in `gan_file.py`) carrying a `manifest.json` plus
+the plugin's web assets (`index.html` + images). It is marked two ways so a tool
+that strips ZIP comments can still be identified:
+
+| Marker | Value |
+|---|---|
+| ZIP archive comment | `GANv1` |
+| `manifest.format` | `gan` |
+| `manifest.format_version` | `1` (loading rejects anything higher) |
+
+The manifest (`gan_manifest.py`) is a flat declaration. For an imported Foundry
+export it is `kind = "controller"` (emits control values, processes no audio;
+`effect`/`instrument` are not yet supported by the web runtime),
+`entry_html = "index.html"`, `author`/`company = "GANTASMO"`, and
+`source = "vst-foundry"`. It carries two lists:
+
+| Field | Meaning |
+|---|---|
+| `controls[]` | Outputs the plugin **emits** (`updateValue` posts); `kind` is `value` / `xy` / `xyz` / `trigger` |
+| `params[]` | Host-drivable normalized `0..1` **inputs** |
+
+### Importing a Foundry export
+
+`owl_import.import_vst_foundry()` composes a Foundry export — a `project.json`
+(flat list of absolutely-positioned elements) plus a sibling `background.png` —
+into a single responsive `index.html`. Each element is laid out by **percentage**
+over the background so it scales with the stage while staying pinned to the art.
+
+| Export element type | Rendered as | Emitted control |
+|---|---|---|
+| `CustomCode` | Its own `el_<id>.html` iframe (the code is a full-window document) | `kind = "xy"` if the code contains `valueX`, else `value` |
+| `Knob` (native) | A minimal draggable rotary posting its `0..1` value to the host | `value` |
+| `Image` | Borderless non-interactive placeholder (art is already baked into `background.png`) | none |
+| unknown type | Labelled dashed placeholder (never silently dropped) | none |
+
+Canvas size is resolved in this order, first hit wins:
+
+1. The `background.png` real pixel size (parsed from the PNG IHDR header).
+2. Explicit `canvasWidth`/`canvasHeight` (or `width`/`height`) fields.
+3. The element extents (max `x+width`, max `y+height`).
+4. The documented default `1672 × 941`.
+
+The imported plugin id is `slug(name)-<sha256(project.json)[:8]>` — stable for a
+given export.
+
+> Foundry's own exporter (`src/lib/ganManifest.ts`) derives ids differently (a
+> `djb2` short-hash) and embeds a lossless editable copy of the project. The
+> backend `owl_import` path is the lighter "compose the art into a controller"
+> importer used for the bundled surfaces. See [gan-format.md](gan-format.md) for
+> the full-fidelity round-trip export.
+
+### Endpoints (`/api/plugin`)
+
+| Method + path | Purpose |
+|---|---|
+| `POST /api/plugin/import-owl` | Import a Foundry export (`project.json` or its folder) into a stored `.gan`; returns manifest + entry URL |
+| `GET /api/plugin/list` | List installed plugins (manifest summary each) |
+| `GET /api/plugin/info?path=` | Read the manifest of a `.gan` at an arbitrary path (no install) |
+| `POST /api/plugin/open` | Open an installed plugin by `id`, or install + open a `.gan` at a `path` |
+| `POST /api/plugin/package-owl` | (Re)build the bundled "The Owl" `.gan` from in-repo assets |
+| `POST /api/plugin/package-ares` | (Re)build the bundled "Ares" `.gan` from its in-repo Foundry export |
+| `POST /api/plugin/reveal` | Reveal a file in the OS file manager (Explorer/Finder), selecting it |
+| `DELETE /api/plugin/{id}` | Remove an installed plugin and its extracted runtime |
+| `GET /api/plugin/{id}/runtime/{asset}` | Serve one extracted plugin asset to the iframe |
+
+The frontend HTTP client is `frontend/src/lib/ganClient.ts` (`ganApi`); the
+installed-library + open-plugin state is a Zustand store,
+`frontend/src/state/ganStore.ts`.
+
+### Runtime extraction and staleness
+
+Installed `.gan` files live in `data/plugins/*.gan`. Each is extracted to a
+runtime directory on first serve:
+
+```
+data/plugins/_runtime/<id>/
+data/plugins/_runtime/<id>/.gan_mtime   ← the source .gan's mtime, in ns
+```
+
+`_ensure_runtime()` re-extracts whenever the stored `.gan` is newer than the
+`.gan_mtime` stamp, so a re-packaged plugin (for instance one carrying a
+contain-fit layout fix) is never served from a stale runtime. Every path that
+materializes a runtime goes through `_extract_runtime()` so the stamp is always
+written — a direct `GanFile.extract` elsewhere would look "fresh" forever.
+
+`serve_runtime()`:
+
+- Path-guards every request against traversal outside the runtime dir.
+- Serves `.html` with `Cache-Control: no-cache` (the composed `index.html` is
+  regenerated on layout changes, so an open iframe never renders a stale,
+  stretched copy from disk cache); large static assets like `background.png`
+  still cache normally.
+
+## The runtime relay: postMessage across nested iframes
+
+A composed `.gan` `index.html` is itself a host for one child iframe per
+`CustomCode` element. The relay `<script>` it injects bridges three DOM levels —
+theDAW host page → the `.gan` `index.html` → each `el_<id>.html` child:
+
+| Message | Direction | Handling |
+|---|---|---|
+| `{type:"updateValue", id, ...}` | child → `.gan` → host | Relayed **up** to `window.parent` (theDAW) so the host can route the control |
+| `{type:"level", value}` | host → `.gan` → children | Forwarded **down** to every element iframe (drives meter feedback) |
+
+So a plugin's controls bubble out to theDAW, and theDAW's live audio level
+reaches every control inside the plugin, without either side knowing about the
+nesting in between.
+
+## Auto-wire: Ares control surface → live FX params
+
+The runtime counterpart of the design-time XR bus is `aresBridge`
+(`frontend/src/lib/aresBridge.ts`). It routes the bundled **Ares** `.gan`'s
+`updateValue` messages onto a single `ares` composite entry in whichever FX chain
+is live (MIX's effect chain, or an EDIT track/master chain).
+
+- Each mapped Ares control id sets one param of the `ares` entry
+  (`ARES_CTRL_PARAM` — the five knobs, the wet/dry slider, Freeze, the filter-type
+  selector, and five blade toggles).
+- The XY Kaoss pad is special-cased: its X / Y / Z drive three macro axes
+  `ARES_PAD_AXES = [filterCutoff, wetDry, grainsDensity]`.
+- Patches are **rAF-coalesced** (merged per frame) so 60fps pad input never
+  thrashes the store, and the live racks push params without a rebuild so it
+  stays click-free.
+- Exactly **one** bridge is active app-wide: registering a new one detaches the
+  previous owner, so the same message is never applied twice.
+
+`MixView` registers the bridge for the life of the MIX view. `findEntry` resolves
+the `ares` entry from `useEffectChainStore`; the XY-pad control id is resolved
+from the installed plugin's controls (the control named `ares_xy_kaoss_pad`) with
+fallback `ARES_XY_PAD_FALLBACK_ID` (`pf5ixrn`). EDIT's WaveformEditor Ares popup
+takes over ownership while it is open (its later registration displaces MIX's),
+then MIX resumes on close.
+
+While Ares is open, MIX also pushes the live master output level **into** the
+`.gan` so its meter reflects real signal: it reads the player analyser, computes
+an RMS level, and posts `{type:"level", value}` to the runtime iframe
+(`#gan-stage-frame`), which the relay fans down to the plugin's controls.
+
+## The plugin stages (frontend surfaces)
+
+theDAW mounts a plugin in the MIX effect-stage footprint (the same slot Studio
+Modules use) through one of four React surfaces. All share one hard rule:
+fixed-aspect artwork is **contain-fit**, never stretched.
+
+| Component | Renders | Fit strategy |
+|---|---|---|
+| `AspectStage.tsx` | The canonical fixed-aspect wrapper for native React surfaces | Container-query units: box `= min(100cqw, 100cqh·W/H)` × `min(100cqh, 100cqw·H/W)`, centered, letterboxed |
+| `TheOwl.tsx` | The spatializer surface (native React, **not** a `.gan`) | Uses `AspectStage` over the `1672×941` Owl art |
+| `GanPluginStage.tsx` | A loaded `.gan` runtime in an iframe (`#gan-stage-frame`) | The runtime `index.html` letterboxes itself with viewport units |
+| `EffectGuiStage.tsx` | A Studio Module GUI iframe from `/edit-modules/<file>` | Measures the module's native frame, injects a contain-fit stylesheet |
+
+### Why contain-fit, and the recurring bug
+
+`AspectStage.tsx` exists to kill one specific bug: sizing an art box as
+`aspect-ratio: W/H` **plus** `width:100%; height:100%` (or `background-size:100%
+100%` on a full-size box). The explicit 100%×100% overrides the aspect ratio and
+skews the artwork to the stage's shape. The fix is one formula applied in one
+place — the container-query box above. Children position by percentage of that
+box, which is exactly the artwork rectangle, so overlaid controls always land on
+their art regardless of stage shape.
+
+The `.gan` runtime does the equivalent with **viewport** units (correct there,
+because the iframe body *is* the stage); `AspectStage` is the nested-DOM
+counterpart for native React surfaces, where viewport units would wrongly track
+the whole window.
+
+### TheOwl specifics
+
+`TheOwl` iframes the two original Owl canvas surfaces — `/owl/kaoss.html` and
+`/owl/room.html` — so the real particle trails, glowing indicator, crosshairs,
+and source rings come from the source art. It listens for their `updateValue`
+messages and bridges them onto the spatializer params:
+
+| Panel message id | Payload | Maps to |
+|---|---|---|
+| `oivsvlg` (Kaoss) | `valueX` / `valueY` | azimuth / elevation |
+| `owl-room` (spatial room) | `rad` / `z` | distance / depth |
+
+Right-clicking the Owl surface packages and reveals the sidecar `.gan` via
+`ganApi.packageOwl()` + `ganApi.reveal()`, the VST-bundle-style share action.
+
+### EffectGuiStage specifics
+
+`EffectGuiStage` feeds audio to the module over `postMessage`. The module loads
+audio **without** starting playback, so mounting the stage never autoplays.
+
+| Message | Direction | Purpose |
+|---|---|---|
+| `thedaw-audio` `{buffer, name}` | host → module | Hand the module the current source to decode/preview |
+| `thedaw-transport` `{action:"play"\|"pause"}` | host → module | Drive playback from the stage's toggle |
+| `thedaw-transport-state` `{playing}` | module → host | The module echoes real playback state (incl. its own buttons) so the toggle stays truthful |
+
+## Bundled surfaces
+
+Two surfaces ship built from in-repo assets rather than user imports.
+
+| Surface | Plugin id | Built by | Asset sources |
+|---|---|---|---|
+| The Owl | `the-owl` | `POST /api/plugin/package-owl` | `backend/modules/plugin/assets/the-owl/project.json` + `frontend/public/owl/the-owl.png`; excludes the preset carousel |
+| Ares | `ares` | `POST /api/plugin/package-ares` | `backend/modules/plugin/assets/ares/project.json` (its `background.png` sits beside it) |
+
+`package-owl` / `package-ares` are idempotent — they rebuild the `.gan` and
+re-extract a fresh runtime — so edits to the bundled `project.json` ship even to a
+machine that already has an older copy installed. `ganStore.ensureAres()`
+(re)packages Ares on MIX open so it always shows as a Studio tile.
+
+## Ports and services
+
+| Service | Port | Bind | Notes |
+|---|---|---|---|
+| theDAW backend (FastAPI) | `8600` | — | Serves `/api/foundry/*`, `/api/plugin/*`, and the XR control WS |
+| theDAW SPA (Vite) | `5173` | — | The host page that iframes Foundry |
+| Foundry sidecar (Express + Vite) | `5472` | `127.0.0.1` | `THEDAW_FOUNDRY_PORT`; Express + Vite share one port |
+| Foundry HMR (standalone only) | `5473` | — | `PORT + 1`; disabled entirely when embedded (`DISABLE_HMR=true`) |
+| Vite fixed HMR default (avoided) | `24678` | — | Never used embedded; the reason `DISABLE_HMR` exists |
+
+## Operational notes
+
+- **First launch installs dependencies.** A missing `node_modules` triggers
+  `npm install` before the dev server serves — the one-time wait on a fresh
+  clone. Node.js (already a theDAW prerequisite) must be on PATH.
+- **The sidecar owns the process.** theDAW starts it on demand and stops it
+  cleanly on backend exit (`atexit` + FastAPI shutdown hook). Do not launch a
+  second `npm run dev` on `5472` by hand; the sidecar treats a foreign listener
+  on its port as an error and refuses to iframe it.
+- **Diagnostics are in one file.** Every sidecar spawn writes to
+  `data/logs/foundry-sidecar.log`; its tail is echoed into the `/api/foundry/url`
+  503 detail and the tab's error card.
+- **Design-time vs runtime wiring are separate.** A control that should move a
+  theDAW parameter *while designing* goes over `dawControlBus` (WS `:8600`); a
+  control in an *exported* `.gan` goes over `postMessage` through `aresBridge`.
+  A break in one is not a break in the other.
+- **Re-package to ship layout fixes.** Because runtimes are stamped with the
+  `.gan` mtime and HTML is served `no-cache`, rebuilding a bundled surface (or
+  re-importing an export) is enough to push a layout change to an already-open
+  stage — no manual cache clearing.

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/troubleshooting.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/troubleshooting.md
@@ -1,0 +1,273 @@
+# Troubleshooting — Ports, Spawns, and Common Failures
+
+Reference for when Foundry will not start, a port is stuck, an import is rejected,
+or the native VST3 shell will not build. It covers the two ways Foundry runs
+(embedded as a theDAW sidecar, and standalone from `launch.bat`), the ports each
+uses, the exact error messages the code emits and what each one means, where the
+logs land, and the copy-paste commands to clear a jammed port. Plain descriptions
+of what each failure is and how to resolve it. For how the sidecar is wired into
+theDAW see [thedaw-integration.md](thedaw-integration.md); for the `.gan`
+container see [gan-format.md](gan-format.md); for the native shell see
+[vst3-export.md](vst3-export.md).
+
+## Ports at a glance
+
+Foundry serves everything — UI, API, SSE relay — from a single port. Vite runs in
+middleware mode on that same port, so there is no separate frontend port.
+
+| Port | Owner | Where set | Notes |
+|---|---|---|---|
+| `5472` | Foundry relay + dev server | `server/config.ts` (`THEDAW_FOUNDRY_PORT` \|\| `PORT` \|\| `5472`) | Bound to `127.0.0.1` only. The one port Foundry actually listens on. |
+| `5473` (`PORT+1`) | Vite HMR WebSocket, standalone only | `server.ts` (`hmr: { port: PORT + 1 }`) | Only opened when HMR is on. Disabled entirely when embedded. |
+| `24678` | Vite's default HMR port | Vite default | Foundry overrides it to `PORT+1` so multiple instances never collide on it. |
+| `8600` | theDAW backend (FastAPI) | theDAW | Not Foundry, but `theDAW.bat` clears it on launch. |
+| `5173` | theDAW frontend (Vite) | theDAW | Not Foundry, but `theDAW.bat` clears it on launch. |
+| `5187` | theDAW auxiliary service | theDAW | Not Foundry, but `theDAW.bat` clears it on launch. |
+
+> The relay binds `127.0.0.1`, never `0.0.0.0`. Foundry is a local-only tool; you
+> cannot reach it from another machine, and that is intentional. A CORS
+> allow-list (`server/config.ts`) further rejects any browser `Origin` other than
+> `http://localhost:5472` / `http://127.0.0.1:5472`. Extra origins can be added
+> via `FOUNDRY_ALLOWED_ORIGINS` (comma-separated).
+
+## Relay / dev-server port conflicts
+
+The default port is `5472`. Override it with `THEDAW_FOUNDRY_PORT` (both the
+sidecar and the server read the same variable), or with `PORT` when run
+standalone.
+
+The symptom depends on who hits the busy port first:
+
+| Symptom | Origin | Meaning |
+|---|---|---|
+| Console: `Port 5472 is already in use. Stop the existing process and try again.` then exit | `server.ts` `EADDRINUSE` handler | The Foundry server itself could not bind. Another process (often a previous Foundry that did not shut down) holds the port. |
+| `Port 5472 is already in use, but it is not VST Foundry.` (503 from `/api/foundry/url`) | `sidecar.ensure_running()` | The port is listening, but `GET /api/health` did not return `"app":"vst-foundry"`. Some other service grabbed `5472`. |
+
+The sidecar distinguishes "our server is already up" from "someone else is on the
+port" by probing `http://127.0.0.1:5472/api/health` and checking the body for
+`"app":"vst-foundry"`. If that string is present it reuses the running instance;
+if the port is merely listening it refuses to spawn and raises the second error
+above.
+
+To find and clear whatever holds the port on Windows:
+
+```bat
+netstat -ano | findstr ":5472 " | findstr "LISTENING"
+taskkill /F /PID <pid-from-the-last-column>
+```
+
+Then reopen the Foundry tab (or re-run `launch.bat`). To move Foundry off `5472`
+entirely instead of clearing the port:
+
+```bat
+set THEDAW_FOUNDRY_PORT=5480
+```
+
+## Stale :5472 listeners — theDAW.bat clears them
+
+A Foundry sidecar that was force-killed (crash, closed console, killed parent) can
+leave a Node process still bound to `5472`. On the next theDAW launch this would
+surface as the "already in use, but it is not VST Foundry" error above — except
+`theDAW.bat` pre-clears it. Before starting anything, the launcher kills stale
+`LISTENING` processes on all of theDAW's ports, `5472` included:
+
+```bat
+for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":5472 " ^| findstr "LISTENING"') do taskkill /F /PID %%a
+```
+
+So a fresh `.\theDAW.bat` is the sanctioned fix for a stuck port — it clears
+`5173`, `8600`, `5187`, and `5472`, waits one second, then boots. In normal
+operation you should not need to run `taskkill` by hand; theDAW also stops the
+sidecar cleanly on backend exit (`POST /api/shutdown`, then terminate/kill, then a
+Windows `netstat` PID sweep as a last resort), plus an `atexit` hook and the
+FastAPI `shutdown` event.
+
+## Sidecar spawn failures
+
+When you open the Foundry tab, `FoundryView.tsx` calls `GET /api/foundry/url`,
+which runs `sidecar.ensure_running()`. That function reuses a live server if one
+answers, otherwise it runs `npm install` (only if `node_modules` is missing) and
+spawns `npm run dev`, then polls `/api/health` for up to **90 seconds**
+(`PORT_READY_TIMEOUT_SEC`) at a 0.5 s interval. Every failure raises a
+`RuntimeError` that the route returns as a `503` with the message as `detail`, and
+the tab shows "VST Foundry did not start" with that text.
+
+| Message (from `sidecar.py`) | Cause | Fix |
+|---|---|---|
+| `VST Foundry project not found at <path>. Set THEDAW_FOUNDRY_PROJECT to override.` | The project directory does not exist at the resolved path. | Confirm `VST-Foundry-UI/VST-UI-FOUNDRY` exists next to theDAW, or set `THEDAW_FOUNDRY_PROJECT` to its absolute path. |
+| `VST Foundry sidecar: npm not found (<err>). Install Node.js.` | `npm` is not on `PATH`. | Install Node.js; reopen the console so `PATH` refreshes. |
+| `npm install failed in <path> (rc=<n>). Run it manually to see the full error output, then retry.` | The one-time dependency install failed (network, permissions, broken optional dep). | Run `npm install` in the project folder by hand and read the real error; see [npm install issues](#npm-install-issues). |
+| `Failed to launch VST Foundry sidecar: <err>. Is npm on PATH?` | The `npm run dev` spawn itself failed to start. | Verify `npm` runs from a plain shell in the project folder. |
+| `VST Foundry sidecar exited before becoming ready (rc=<n>). Check package.json scripts.` | The dev process started but died before opening the port (bad script, TypeScript error, missing dep). | Read `foundry-sidecar.log` (the message appends its tail); fix the underlying crash. |
+| `VST Foundry sidecar didn't open port 5472 within 90s.` | The process is alive but never became reachable within the timeout. | Check the log tail included in the message; a slow first install or a hung build is the usual cause. |
+
+The `RuntimeError` messages for the exit / timeout cases append the tail of
+`foundry-sidecar.log` (see [Where the logs land](#where-the-logs-land)), so the
+real stack trace travels with the error into the tab.
+
+`GET /api/foundry/status` returns a structured probe you can read without opening
+the tab — it reports the resolved `project_path`, the `port`, whether Foundry is
+`listening`, whether the child `process_alive`, the `url`, and an `issues` list
+(missing project dir, missing `package.json`, `npm` not on `PATH`).
+
+> The tab does its own retry loop: `FoundryView.tsx` re-requests `/api/foundry/url`
+> up to **20 times, every 2 s** (about 40 s of front-end patience) before it shows
+> the error card. The Reload button resets that counter and starts over, which is
+> the first thing to try after fixing a cause above.
+
+## Dev-server restarts and HMR
+
+The `dev` script is `tsx server.ts` — plain `tsx`, not `tsx --watch`. Editing
+server source therefore does **not** hot-restart the Express process; you stop and
+relaunch it (Reload the tab, or Ctrl+C and re-run `launch.bat`). Front-end module
+edits are handled by Vite running in middleware mode inside the same server.
+
+| Mode | HMR | Behavior |
+|---|---|---|
+| Embedded in theDAW | Off (`DISABLE_HMR=true`) | The sidecar passes `DISABLE_HMR=true`, so Vite opens no HMR WebSocket. This removes the unreachable HMR socket whose retries otherwise flood the browser console with `ERR_CONNECTION_REFUSED`. Reload the tab to pick up changes. |
+| Standalone (`launch.bat`) | On, port `PORT+1` (`5473`) | Vite serves HMR on a per-instance port so multiple standalone Foundry instances never collide on Vite's fixed default (`24678`). Client edits refresh live; server edits still need a restart. |
+
+> If the browser console fills with `ERR_CONNECTION_REFUSED` toward a WebSocket,
+> you are almost certainly running embedded with HMR expected on. That is normal
+> only when `DISABLE_HMR` was not set — inside theDAW it always is. There is no
+> file-watch auto-restart of the Node process in this repo; do not wait for one.
+
+## npm install issues
+
+Dependencies install lazily the first time Foundry runs, from three entry points:
+
+- `theDAW.bat` runs `npm install` in `VST-Foundry-UI/VST-UI-FOUNDRY` if its
+  `node_modules` is missing, before launching the stack.
+- The sidecar (`ensure_running`) runs `npm install` if `node_modules` is missing,
+  capturing all output to `foundry-sidecar.log`.
+- `launch.bat` (standalone) runs `npm install` if `node_modules` is missing.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `[WARN] Native binaries broken (known npm optional-dep bug)` in `launch.bat` | npm installed an optional native dep silently broken. `launch.bat` probes it with `node -e "require('./node_modules/@tailwindcss/oxide/index.js')"`. | `launch.bat` auto-heals: it deletes `node_modules` + `package-lock.json` and reinstalls. |
+| Tailwind / CSS build errors mentioning `@tailwindcss/oxide` or `lightningcss` | The platform-specific optional dep (`@tailwindcss/oxide-win32-x64-msvc`, `lightningcss-win32-x64-msvc`) did not install. | Delete `node_modules` and `package-lock.json`, then `npm install` again (a clean reinstall, same as the auto-heal). |
+| `npm install failed ... (rc=<n>)` from the sidecar | Install failed under theDAW; the error is swallowed into the log. | Run `npm install` manually in the project folder to see the full error, fix it, then reopen the tab. |
+
+Manual clean reinstall (matches what `launch.bat` does on the native-binary
+warning):
+
+```bat
+cd VST-Foundry-UI\VST-UI-FOUNDRY
+rmdir /s /q node_modules
+del /f /q package-lock.json
+npm install
+```
+
+> Node.js must be on `PATH` for every path above. `launch.bat` and the sidecar
+> both hard-fail with an install/spawn error if `npm` is not found. Node is
+> already a theDAW prerequisite, so inside theDAW this is only an issue on a
+> broken `PATH`.
+
+## .gan import failures
+
+Importing a Foundry export into theDAW goes through `POST /api/plugin/import-owl`
+(`owl_import.import_vst_foundry`), which reads a `project.json` (plus a
+`background.png` beside it) and composes a controller-kind `.gan`. Rejections
+return `400`/`404` with the message shown.
+
+| Message | Origin | Meaning / fix |
+|---|---|---|
+| `project.json not found at: <path>` | `router.import_owl` | The path (or `<path>/project.json` for a folder) does not resolve to a file. Point at the export's `project.json` or its containing folder. |
+| `project.json not found: <path>` | `import_vst_foundry` | Same, raised deeper as `FileNotFoundError`. Confirm the export exists. |
+| `Import failed: Invalid VST Foundry export: 'elements' is not a list` | `import_vst_foundry` (`ValueError`) | The export JSON has no valid `elements` array — it is not a Foundry `project.json`, or it is truncated/corrupt. Re-export from Foundry. |
+| `Invalid .gan: missing manifest.json` | `GanFile.info` (`ValueError`) | The `.gan` (a ZIP) has no `manifest.json`. The file is corrupt or not a `.gan`. |
+| `This .gan uses format v<N>, but theDAW supports up to v1. Please update theDAW.` | `GanFile.info` (`ValueError`) | The `.gan` was written by a newer format version. Update theDAW. |
+| `Plugin not found: <id>` | `_ensure_runtime` / `open` | No installed `.gan` with that id in `data/plugins`. Import it first, or open by `path`. |
+| `Asset not found` (404 from `/runtime/...`) | `serve_runtime` | The requested runtime asset does not exist or was blocked by the path-traversal guard. Re-open the plugin to re-extract its runtime. |
+
+Import behavior worth knowing when a `.gan` looks wrong rather than erroring:
+
+- **Canvas size** is taken from the `background.png` IHDR pixel size first, then
+  explicit `canvasWidth`/`canvasHeight` (or `width`/`height`), then the element
+  extents, then a default of `1672 x 941`. A misplaced layout usually means the
+  background PNG was missing at import time, so the fallback size was used.
+- **Element types**: `CustomCode` becomes its own `el_<id>.html` iframe; a native
+  `Knob` becomes a draggable rotary; `Image` and unknown types render as
+  non-interactive placeholders (the importer logs each one rather than dropping
+  it). A control that "does nothing" is often an `Image`/unknown placeholder.
+- **Stale runtime**: an installed `.gan` is extracted to
+  `data/plugins/_runtime/<id>/` and stamped with the source `.gan`'s mtime. If a
+  re-packaged plugin still renders the old layout, the stamp guards against that —
+  re-opening re-extracts when the `.gan` is newer. `.html` is served
+  `Cache-Control: no-cache` so an open iframe never keeps a stale copy.
+
+See [gan-format.md](gan-format.md) for the container layout and
+[custom-code.md](custom-code.md) for how `CustomCode` elements are wrapped.
+
+## VST3 shell build prerequisites
+
+The native `FoundryShell.vst3` is a separate artifact from the web app — a
+WebView-hosted iPlug2 plugin built by MSBuild from
+`vst3-shell/FoundryShell-src/projects/FoundryShell-vst3.vcxproj`. The web export
+(`src/lib/vst3Export.ts`) only produces the DATA half (`manifest.json` + `ui/`)
+that drops into an already-built shell; it compiles no binary. See
+[vst3-export.md](vst3-export.md) for how the two halves fit together.
+
+| Requirement | Detail |
+|---|---|
+| Toolset | MSBuild with `PlatformToolset v143` (Visual Studio 2022 / Build Tools 2022, C++ desktop workload). |
+| Configs / platforms | `Debug`, `Release`, `Tracer` × `x64`, `ARM64EC`. Output: `build-win\vst3\<Platform>\<Configuration>\`, `TargetExt .vst3`. |
+| NuGet: WebView2 | `Microsoft.Web.WebView2` **1.0.2903.40** (`WebView2LoaderPreference` is `Static`). |
+| NuGet: WIL | `Microsoft.Windows.ImplementationLibrary` **1.0.240803.1**. |
+| NuGet restorer | `vst3-shell/nuget.exe` restores the two packages above from `packages.config`. |
+| iPlug2 SDK | Full clone at `vst3-shell/iPlug2/` (gitignored — never committed). |
+| VST3 SDK | Steinberg VST3 SDK under `Dependencies/IPlug/VST3_SDK/` (gitignored). |
+
+If the NuGet packages are not restored, the build stops early with the
+`EnsureNuGetPackageBuildImports` error: *"This project references NuGet package(s)
+that are missing on this computer. Use NuGet Package Restore to download them ...
+The missing file is `..\packages\...`"*. Restore before building:
+
+```bat
+cd VST-Foundry-UI\VST-UI-FOUNDRY\vst3-shell
+nuget.exe restore FoundryShell-src\projects\packages.config -PackagesDirectory FoundryShell-src\projects\packages
+```
+
+After a successful compile, the `CopyFoundryWebUI` post-build target copies
+`resources/web/ui/**` into the built bundle's `Contents/Resources/ui/` (and into
+the installed `VST3_X64_PATH` copy when present), so the shell runs standalone
+with its default UI before any Foundry export is dropped in.
+
+> **Note — build scaffolding is in flight.** The checked-in `FoundryShell-src`
+> tree is missing files the `.vcxproj` imports: `config/FoundryShell-win.props`
+> (which supplies `VST3_DEFS`, `VST3_INC_PATHS`, `WDL_PATH`, `BUILD_DIR`,
+> `BINARY_NAME`, `VST3_X64_PATH`), `resources/resource.h`, `resources/main.rc`,
+> `projects/packages.config`, and `projects/packages/`. The include paths are also
+> iPlug2-example-relative (`..\..\..\IPlug`,
+> `..\..\..\Dependencies\IPlug\VST3_SDK`), so the project is templated to live at
+> `iPlug2/Examples/FoundryShell/projects/` inside the SDK clone. A clean checkout
+> cannot build the shell as-is; it needs the iPlug2 + VST3 SDKs re-fetched and the
+> project placed inside the SDK's `Examples` tree. Concurrent work is touching this
+> area — treat the current `vst3-shell` layout as mid-change.
+
+## Where the logs land
+
+| Log | Path | Written by | Contents |
+|---|---|---|---|
+| Sidecar spawn log | `data/logs/foundry-sidecar.log` (theDAW repo root) | `sidecar.py` (`_open_log`) | All `npm install` and `npm run dev` stdout/stderr from the theDAW-spawned Foundry. First place to look when the tab says Foundry did not start. |
+| Foundry app log | `data/logs/app.log` (under `VST-Foundry-UI/VST-UI-FOUNDRY/`) | `server/logging.ts` (`appendLog`) | Foundry's own runtime log. Rolls once to `app.log.1` past 5 MB; last 500 lines also kept in memory. |
+| `.gan` library | `data/plugins/*.gan` and `data/plugins/_runtime/<id>/` (theDAW repo root) | `plugin/router.py` | Installed plugins and their extracted runtimes; inspect when an import "succeeds" but renders wrong. |
+| theDAW console | `[backend]` / `[frontend]` / `[tunnel]` prefixed lines | `backend._devstack` | The live launch console; the sidecar's own crash text is echoed here via the `503` detail too. |
+
+> Two `data/` trees exist and are easy to confuse. The **sidecar** log lives under
+> **theDAW's** repo-root `data/logs/` (because theDAW spawns it), while Foundry's
+> **own** `app.log` lives under **Foundry's** `data/logs/` (its `process.cwd()`).
+> When embedded, both are present; read `foundry-sidecar.log` for start-up
+> failures and `app.log` for runtime behavior once Foundry is up. See
+> [projects-and-data.md](projects-and-data.md) for the full data layout.
+
+## Quick diagnostics
+
+| Question | Command / action |
+|---|---|
+| Is Foundry actually up? | `curl http://127.0.0.1:5472/api/health` — body contains `"app":"vst-foundry"` when it is. |
+| What does theDAW think the sidecar state is? | `curl http://127.0.0.1:8600/api/foundry/status` — resolved path, port, `listening`, `process_alive`, `issues`. |
+| Who holds 5472? | `netstat -ano \| findstr ":5472 " \| findstr "LISTENING"` then `taskkill /F /PID <pid>`. |
+| Clear all stale theDAW ports and reboot | Re-run `.\theDAW.bat` (clears `5173`, `8600`, `5187`, `5472`). |
+| Why did start-up fail? | Read the tail of `data/logs/foundry-sidecar.log`, or the `503` detail on the tab. |
+| Force a clean dep reinstall | `rmdir /s /q node_modules && del /f /q package-lock.json && npm install` in the project folder. |

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/vst3-export.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/vst3-export.md
@@ -1,0 +1,488 @@
+# VST3 Export — From Canvas to Plugin Binary
+
+Reference for Foundry's **VST3 export** path: how a canvas of knobs, sliders and
+meters becomes a loadable VST3 plugin. Foundry does not compile a binary. It
+emits a small **data bundle** (a manifest plus a self-contained web UI) that a
+prebuilt native **shell** — an iPlug2 WebView plugin called *FoundryShell* —
+reads at load time. This doc covers both halves: the browser-side exporter
+(`vst3Export.ts`, `vst3ExportUi.ts`, the `vst:` bind system, the Export modal)
+and the native side (`FoundryShell.cpp/.h`, `config.h`, the JS bridge, the
+MSBuild project), plus what the export tests hold in place. Plain descriptions of
+what each piece does.
+
+For the rest of Foundry see [foundry-overview.md](foundry-overview.md); for
+theDAW's own native plugin filetype see [gan-format.md](gan-format.md); for the
+controls that become parameters see
+[canvas-and-controls.md](canvas-and-controls.md).
+
+## The two halves of a Foundry VST3
+
+A Foundry-exported plugin is always two separate artifacts that meet on disk:
+
+| Half | Produced by | Contains | Compiled? |
+|---|---|---|---|
+| **Data bundle** | `src/lib/vst3Export.ts` (browser) | `manifest.json`, `ui/index.html`, `ui/params.js`, `README.txt` | No |
+| **Native shell** | `vst3-shell/` MSBuild project | `FoundryShell.vst3` (a WebView2-hosting DLL) | Yes, once |
+
+The bundle is regenerated every time you tweak a design. The shell is built once
+and reused for every plugin — it is generic. At load time the shell resolves its
+own `Contents/Resources/` directory, reads `manifest.json` to declare its
+parameters, and points its WebView at `ui/index.html`. Rename the shell folder,
+drop a bundle inside it, and you have a plugin.
+
+> The bundle carries no binary. `exportVst3Bundle` in `vst3Export.ts` explicitly
+> "packages the data half of the plugin" — the prebuilt `FoundryShell.vst3` is a
+> separate download. See *Installing an export* below.
+
+## Opening the exporter
+
+Export lives in `src/components/ExportModal.tsx`, a three-tab modal:
+
+| Tab | Output | Entry point |
+|---|---|---|
+| **React Code** | A `UIModule.tsx` component string (copy to clipboard) | `generateCode()` (inline) |
+| **VST3 Bundle** | The `.zip` data bundle described here | `exportVst3Bundle(...)` |
+| **.gan Plugin** | theDAW's native `.gan` filetype (see [gan-format.md](gan-format.md)) | `exportGan(...)` |
+
+The VST3 tab has one option — a **Plugin name** text field — and a live summary
+line: *"N parameters from M controls."* Both the summary and the export call
+`buildVst3Manifest(...)`, so the count you see is exactly the count that ships
+(the modal memoizes the manifest to keep them from drifting). An empty name
+falls back to `Foundry Plugin`. The **Export .zip** button calls
+`exportVst3Bundle` and surfaces any failure as an inline error rather than a
+silent console log.
+
+## What becomes a parameter
+
+`buildVst3Manifest(elements, canvasState, pluginName)` walks the design in
+**element order** and emits host-visible parameters. Each element type maps to a
+fixed set of parameters:
+
+| Element type | Params emitted | Kind | Range / notes |
+|---|---|---|---|
+| Knob, Slider, Meter | 1 | `continuous` | `min`/`max` from the element (default `0`/`100`); default = `value` or midpoint |
+| WaveShaper | 1 (`<id>`) | `continuous` | named `<name> Drive`, `0..100` |
+| Toggle | 1 | `boolean` | default `false` |
+| Button | 1 | `trigger` | momentary |
+| Select | 1 | `enum` | `options[]`; **always `cc = -1`** |
+| XYPad, Spatial3D | 2 (`<id>-x`, `<id>-y`) | `continuous` | each `0..100`, default `50` |
+| Envelope | 4 (`-attack`/`-decay`/`-sustain`/`-release`) | `continuous` | `0..100`; defaults read from `styleParams` (15/30/70/25) |
+| CustomCode | 1 per **numeric** param | `continuous` | id `<element-slug>-<param-slug>`; handled specially (below) |
+
+Types that carry no single host-automatable scalar are skipped entirely:
+
+| Skipped type | Why |
+|---|---|
+| Label, Image, Group | Not a control |
+| Waveform | Display-only (can still be a *listen* target — see binds) |
+| StepSequencer | Multi-cell pattern, no single scalar |
+| Keyboard | Note input, no single scalar |
+| CustomCode (the element itself) | Only its numeric params export, not the element |
+
+### CustomCode parameters
+
+CustomCode is a member of the skip set, but it is handled **before** the skip
+gate: each param of `type: "number"` becomes its own continuous host parameter,
+id `<element-slug>-<param-slug>`, named `<element name> <label|key>`. A
+zero-width range (`min === max`) is repaired to `min..min+1`. The default is the
+param's explicit `default`, else its `value`, else the range midpoint. A
+CustomCode element with no numeric params yields nothing — unchanged from
+before it was special-cased. See [custom-code.md](custom-code.md) for the param
+schema and the sandbox bridge.
+
+> The manifest is capped at **128 parameters** (`MAX_PARAMS`). Controls past the
+> cap are dropped with a `console.warn`. The cap matches the shell's fixed
+> `kMaxParams = 128` slot pool, so a design can never declare more params than
+> the shell can hold.
+
+## MIDI CC assignment
+
+Every continuous/boolean/trigger parameter is handed a MIDI CC number from a
+fixed pool, in order. The pool is deliberately shaped to avoid CC ranges that
+would misbehave as automation:
+
+| Pool order | CC numbers | Avoided | Reason |
+|---|---|---|---|
+| 1st | 20–31 | 0–19 | Mod wheel, bank select MSB, data entry, etc. |
+| 2nd | 102–119 | 32–63 | CC LSB / bank-select pair range |
+| 3rd | 64–119 (dedup) | 120–127 | Channel Mode messages (All Notes Off, Reset…) — would silence the channel |
+
+No two parameters ever share a CC (the pool is de-duplicated). When the pool is
+exhausted, remaining params get `cc = -1` (no CC mapping) and a warning is
+logged. **Enum (`Select`) params are always `cc = -1`** — the shell does not emit
+CC for discrete selections, so pulling from the pool would waste a slot and
+starve continuous controls.
+
+## Parameter ids and the slug contract
+
+Every parameter id comes from one slug function, `foundrySlugify`, held as the
+string constant `SLUGIFY_FN_SOURCE` in `vst3Export.ts`:
+
+```js
+function foundrySlugify(input) {
+  var s = String(input == null ? "" : input).toLowerCase();
+  s = s.replace(/[^a-z0-9]+/g, "-").replace(/^-+/, "").replace(/-+$/, "");
+  return s || "param";
+}
+```
+
+That exact source is `new Function()`-compiled in TypeScript to slug the
+manifest ids, **and** injected verbatim into the exported `ui/index.html` so the
+renderer slugs the same ids. The manifest ids and the UI's ids are therefore
+byte-identical — the WebView can look a parameter up by string id and always
+match the manifest. Never re-implement the slug on either side; the single
+source is the whole point.
+
+## The bundle on disk
+
+`exportVst3Bundle` assembles a JSZip and triggers a browser download named
+`<slug>-vst3-bundle.zip`:
+
+| Entry | Built by | Purpose |
+|---|---|---|
+| `manifest.json` | `buildVst3Manifest` (pretty-printed) | Plugin identity + `params[]` + `bindings[]` |
+| `ui/index.html` | `buildVst3Ui` → `buildIndexHtml` | Static, self-contained interactive UI (identical every export) |
+| `ui/params.js` | `buildVst3Ui` | `window.FOUNDRY_DESIGN = {elements, canvasState, assets, textures}` |
+| `README.txt` | `buildReadme` | Install instructions + param/bind counts |
+
+`manifest.json` shape:
+
+```json
+{
+  "formatVersion": 1,
+  "plugin": { "name": "My Plugin", "width": 800, "height": 600 },
+  "params":   [ /* Vst3Param */ ],
+  "bindings": [ /* Vst3BindingEntry */ ]
+}
+```
+
+`plugin.width`/`height` come from `canvasState` and tell the shell what editor
+size to request.
+
+> `ui/params.js` inlines any asset/texture whose `url` is already a `data:` URL,
+> but leaves server-side `/textures/...` URLs untouched — a later build step must
+> replace those with `data:` URLs for the bundle to be fully offline. No network
+> fetch happens during export. See [textures-and-skins.md](textures-and-skins.md).
+
+## The standalone UI
+
+`vst3ExportUi.ts` emits the **static** `ui/index.html`. It is the same HTML for
+every export; all design-specific data lives in `params.js`. The renderer is
+plain vanilla ES5-ish JS (no React, no build step) and makes no network
+requests. `buildIndexHtml` assembles exactly three `<script>` blocks, in order:
+
+```html
+<script src="foundry-bridge.js"></script>   <!-- native bridge, shipped by the shell -->
+<script src="params.js"></script>           <!-- window.FOUNDRY_DESIGN -->
+<script> /* the injected renderer */ </script>
+```
+
+The renderer talks to the plugin over the bridge:
+
+- `window.foundryHost.setParam(paramId, 0..1)` — UI pushes a value to the plugin.
+- `window.foundryApplyParam(paramId, 0..1)` — plugin pushes host automation /
+  preset recall down to the UI.
+
+It also embeds a **copy of the preview bind runtime** (see below), so LFOs,
+macros, random S&H and a local transport animate bound displays even with no
+host. When the native shell pushes a real value via
+`window.__foundrySetBindValue(id, v)`, that id's shell value **suppresses the
+local simulation for 1 second** — real data always outranks the simulation. The
+renderer also runs a UI-clocked pull loop, sending `kMsgTagGetBindValues`
+(`msgTag: 1`) to the shell about 20×/s to fetch transport and metering.
+
+> In a plain browser (bundle preview, or a `.zip` opened outside the shell),
+> `foundry-bridge.js` 404s and `window.IPlugSendMsg` is undefined. The
+> renderer's guards make that harmless: the UI runs **view-only**, driven only by
+> its local bind runtime. This is expected, not an error.
+
+## Control-to-param binding — the `vst:` catalog
+
+A control can do more than expose a parameter — it can be **bound** to a
+built-in "VST target": send a MIDI CC, fire a note, drive output gain, mirror the
+host transport onto a meter, and so on. These targets live in `vstBinds.ts` as a
+catalog of `DawTarget`-shaped entries, all namespaced `vst:`.
+
+The catalog is deliberately **wider than any single runtime**. A given `vst:`
+target may be honored in the in-app preview, forwarded to theDAW, and/or acted
+on by the exported shell — or simply carried and ignored where nobody implements
+it (never an error). The areas:
+
+| Area | Example ids | Count | Notes |
+|---|---|---|---|
+| MIDI Control Change | `vst:midi.cc.0` … `vst:midi.cc.127` | 128 | Named per General MIDI where known |
+| MIDI Performance | `vst:midi.pitchbend`, `.aftertouch`, `.program`, `.panic` | 4 | |
+| MIDI Notes | `vst:midi.note.0` … `.127` | 128 | Momentary pads; velocity = shaped value at press |
+| Transport | `vst:transport.play/stop/record/loop/metronome/rtz/tap/tempo` | 8 | Write requests |
+| Transport (listen) | `vst:transport.playing/beat/bar/playhead` (+ `tempo`) | 4 | `readonly` signals |
+| Plugin | `vst:plugin.bypass/drywet/gain.in/gain.out/pan` | 5 | Only `gain.out` + `pan` act in the shell today |
+| Macros | `vst:macro.1` … `.8` | 8 | Virtual knobs; write from any control, listen from any display |
+| LFOs | `vst:lfo.1..4` + each `.rate/.depth/.shape` | 16 | Shapes: sine/triangle/saw/square/s&h |
+| Modulation | `vst:mod.random`, `.random.rate`, `.envfollow` | 3 | Envelope follower fed by the shell's input RMS |
+| Presets | `vst:preset.next/prev/save/init/random/ab/copyab` | 7 | No shell action yet; carried + daw-forwarded |
+| Metering | `vst:meter.in.l/in.r/out.l/out.r/out.peak/clip/gr` | 7 | Listen sources |
+| Metering (spectrum) | `vst:meter.band.1` … `.8` | 8 | No publisher yet; read 0 until one lands |
+
+`isVstBindId(id)` tests the `vst:` prefix; `vstWriteBinds()` returns the writable
+entries (the route browser's built-in section) and `vstListenBinds()` the
+`listen: true` entries (the ListenPicker's built-in section). `readonly` entries
+are excluded from the write picker.
+
+### Route vs listen entries in the manifest
+
+`buildVst3Bindings` collects every `vst:` bind in the design into
+`manifest.bindings[]`. Each entry (`Vst3BindingEntry`) is one of two modes:
+
+| Mode | Meaning | Ships when |
+|---|---|---|
+| `route` | A control param drives the target: shape `amount → curve → range`, then perform the action | Only if the source param survived the 128-param cap |
+| `listen` | A display element animates from the target's live value | Always (a Waveform exports no param yet still animates) |
+
+Route bindings are drawn from the element's **route stack** (`routesOf(el)` in
+`src/lib/routing.ts`), including all `vst:` routes, not just the first — one knob
+can drive CC 74 **and** a macro **and** an LFO rate. For XYPad/Spatial3D the axis maps onto the `-x`/`-y` param id. CustomCode
+per-param binds ship as unshaped routes (the param *is* the value). Meter and
+Waveform `binding.targetId`s ship as `listen` entries; the Meter carries its
+param id, the Waveform does not.
+
+### Route shaping math
+
+The shaping applied to a route value is identical in three places — the
+in-app preview (`routing.applyRoute`), the exported UI runtime, and the native
+shell (`ShapeBind` in `FoundryShell.cpp`):
+
+| Stage | Operation |
+|---|---|
+| Amount (`-100..100`) | `amt >= 0 ? src*amt : (1-src)*-amt` — negative inverts |
+| Curve | `linear` \| `exp` (`v³`) \| `log` (`1-(1-v)³`) \| `scurve` (smoothstep `v²(3-2v)`) |
+| Range | clamp into `rangeMin..rangeMax` (0..100) |
+
+Keeping the three implementations in lockstep is why the same `amount/curve/
+rangeMin/rangeMax` fields ride in every binding entry.
+
+### The preview bind runtime
+
+`vstBindRuntime.ts` owns the live state behind every `preview: true` catalog
+entry so designs animate with no theDAW and no audio:
+
+| State | Behavior |
+|---|---|
+| Macros 1–8 | Virtual knobs: a write is held and re-published to listeners |
+| LFO 1–4 | Free-running oscillators; `rate`/`depth`/`shape` writable; `s&h` re-samples on phase wrap |
+| Random S&H | Clocked sample-and-hold noise (`vst:mod.random`) |
+| Local transport | play/stop/record/loop/metronome/tap; publishes playing, beat phase, bar phase (4/4), playhead |
+
+It registers `handleVstBindWrite` via `setVstWriteHandler` at module load, and
+`tickVstBindRuntime(dt)` (driven by a `requestAnimationFrame` loop) advances the
+oscillators and publishes **only** ids that currently have listeners
+(`hasDawValueListeners`). `dt` is clamped to `0.25s` so a backgrounded tab never
+jumps state. The exported UI carries a near-identical copy of this runtime so
+the plugin behaves the same offline. MIDI / preset / plugin-master ids have no
+preview-local state — the bus forward and the shell own those.
+
+## The native shell — iPlug2 FoundryShell
+
+`FoundryShell` is a generic iPlug2 **WebView** plugin
+(`IPlugWebViewEditorDelegate`, not IGraphics) that hosts an HTML/JS UI in a
+native WebView2 (Windows) / WKWebView (macOS). Identity and capabilities are
+fixed in `config.h`:
+
+| Macro | Value | Meaning |
+|---|---|---|
+| `PLUG_NAME` | `FoundryShell` | Plugin name |
+| `PLUG_MFR` | `theDAW` | Manufacturer |
+| `PLUG_VERSION_STR` | `1.0.0` | Version |
+| `PLUG_UNIQUE_ID` | `'Fdsh'` | Plugin unique id |
+| `PLUG_MFR_ID` | `'StDw'` | Manufacturer id |
+| `PLUG_TYPE` | `0` | Effect |
+| `VST3_SUBCATEGORY` | `Fx` | VST3 category |
+| `PLUG_CHANNEL_IO` | `2-2` | Stereo in / stereo out |
+| `PLUG_LATENCY` | `0` | No reported latency |
+| `PLUG_DOES_MIDI_IN` / `_OUT` | `1` / `1` | MIDI in and out |
+| `PLUG_DOES_MPE` | `0` | MPE off |
+| `PLUG_HAS_UI` | `1` | Has an editor |
+| `PLUG_WIDTH` × `PLUG_HEIGHT` | `600` × `600` | Default editor size |
+| `PLUG_FPS` | `60` | Editor refresh |
+| `PLUG_HOST_RESIZE` | `1` | Host may resize the editor |
+
+`config.h` also declares AUv2 entry points and AAX type ids, so the same source
+targets VST3, AU and AAX.
+
+### Construction and manifest load
+
+At construction (`FoundryShell.cpp`) the shell:
+
+1. Resolves its bundle `Contents/Resources/` dir via `BundleResourcePath`
+   (`gHINSTANCE` on Windows VST3).
+2. Calls `LoadManifest`, which parses `manifest.json` with `nlohmann::json`
+   using **type-tolerant** field readers (a Toggle's `"default": false` must not
+   throw when read as a number), initializes up to `kMaxParams = 128` iPlug2
+   params by kind, and reads `plugin.width`/`height` to `SetEditorSize`.
+3. Parses `bindings` (via `LoadBindings`) **after** params, so `paramId → index`
+   resolution sees the full list.
+
+Kind maps to an iPlug2 init call:
+
+| Manifest kind | iPlug2 init | Notes |
+|---|---|---|
+| `continuous` | `InitDouble(min, max)` | Range guarded (`max > min`); default clamped and finite-checked |
+| `boolean` | `InitBool(default)` | |
+| `trigger` | `InitBool(false)` | |
+| `enum` | `InitEnum(default, nOptions)` | Per-option display text set from `options[]` |
+
+> If `manifest.json` is missing or corrupt, the constructor **falls back to a
+> single Gain parameter emitting CC 7** so the plugin always constructs and
+> loads. Unused slots (`n`..127) become hidden, non-automatable dummies. The
+> manifest load is wrapped so no manifest content can ever abort construction.
+
+### The native <-> web bridge
+
+`resources/web/ui/foundry-bridge.js` is the JS half of the bridge, shipped
+inside the bundle beside `index.html`. It builds the Foundry contract on top of
+iPlug2's injected `IPlugSendMsg`:
+
+| Direction | Call | Wire |
+|---|---|---|
+| UI → plugin | `foundryHost.setParam(id, 0..1)` | `SAMFUI` `msgTag 0` (`kMsgTagSetParam`), payload `base64({id, v})` |
+| UI → plugin | pull loop | `SAMFUI` `msgTag 1` (`kMsgTagGetBindValues`), no payload |
+| plugin → UI | param map | `window.__foundrySetParamMap(entries)` (index/id/elementId/kind/cc) |
+| plugin → UI | automation / recall | `SPVFD(index, v)` → `foundryApplyParam(id, v)` |
+| plugin → UI | listen values | `window.__foundrySetBindValue(id, v0to100 \| bool)` |
+
+On `OnMessage`, `kMsgTagSetParam` maps the string `paramId` to its index and
+calls `SendParameterValueFromUI` (wrapped in `Begin/EndInformHostOfParamChange`).
+`OnUIOpen` pushes the param map first, then the current value of every param, so
+the JS handler can translate incoming automation before any arrives.
+
+### DSP and MIDI (`ProcessBlock`)
+
+`ProcessBlock` is a **pure stereo passthrough** (handling in/out aliasing and
+channel-count mismatch), plus:
+
+- **Smoothed output gain / pan** — only when a `gain.out` or `pan` bind exists.
+  Balance law (unity at center) so binding a centered pan control never changes
+  level; per-sample smoothing avoids zipper noise.
+- **CC emission** — every continuous/boolean/trigger param is diffed each block;
+  a changed value emits a MIDI CC on channel 1. Diffing on the audio thread is
+  realtime-safe and catches both UI edits and host automation. Enum params are
+  skipped.
+- **Built-in binds** — for each route bind whose param changed, `ShapeBind`
+  shapes the normalized value and performs the action.
+- **Listen telemetry** — when anything is bound as `listen`, transport is read
+  from the host's `ITimeInfo` and post-fader I/O RMS + peak + a block-rate
+  envelope follower are computed and stored in `std::atomic`s for the UI pull.
+
+Bind actions the shell implements natively (`ParseBindTarget` →
+`EFoundryBindAction`); anything else parses to `None` and is carried but ignored:
+
+| `vst:` id | Action | Behavior |
+|---|---|---|
+| `vst:midi.cc.N` | MidiCC | CC N on channel 1, quantized 0..127 |
+| `vst:midi.note.N` | MidiNote | Gate at shaped ≥ 0.5; velocity = shaped value at rising edge |
+| `vst:midi.pitchbend` | MidiPitchBend | 14-bit, bipolar around center |
+| `vst:midi.aftertouch` | MidiAftertouch | Channel pressure 0..127 |
+| `vst:midi.program` | MidiProgram | Program change 0..127 |
+| `vst:midi.panic` | MidiPanic | Rising edge → CC 120 (All Sound Off) + All Notes Off |
+| `vst:plugin.gain.out` | GainOut | Master output gain, −60..+12 dB, smoothed |
+| `vst:plugin.pan` | Pan | Master balance, unity at center |
+
+Listen ids the shell publishes back (`PushBindValuesToUI`, on the UI thread in
+answer to the pull): `vst:transport.tempo/beat/bar/playhead/playing`,
+`vst:meter.in.l/in.r/out.l/out.r/out.peak/clip`, and `vst:mod.envfollow`. Meter
+values use a `sqrt(RMS) × 100` scale. LFO / macro ids are skipped (the UI's local
+runtime owns them); spectrum and gain-reduction ids are skipped (no publisher
+yet). `OnReset` forces CC re-emission and releases all gates.
+
+## Installing an export into the shell
+
+From the bundle's `README.txt`, the manual install:
+
+```text
+1. Obtain the prebuilt native shell "FoundryShell.vst3".
+2. Copy the CONTENTS of the bundle (manifest.json and the ui/ folder) into:
+       FoundryShell.vst3/Contents/Resources/
+3. Rename the "FoundryShell.vst3" folder to your plugin name, e.g. MyPlugin.vst3
+4. Install the .vst3 folder in your system VST3 directory and rescan in your DAW.
+```
+
+The bundle's `ui/index.html` expects the shell's `foundry-bridge.js` to sit
+beside it in `Resources/ui/` — the shell ships that file, and the bundle drops
+`index.html` + `params.js` in next to it.
+
+## Building the native shell
+
+The shell is built by MSBuild on
+`vst3-shell/FoundryShell-src/projects/FoundryShell-vst3.vcxproj`:
+
+| Property | Value |
+|---|---|
+| PlatformToolset | `v143` |
+| ConfigurationType | `DynamicLibrary`, `TargetExt` `.vst3` |
+| Configurations | `Debug`, `Release`, `Tracer` |
+| Platforms | `x64`, `ARM64EC` |
+| Output | `$(SolutionDir)build-win/vst3/<Platform>/<Configuration>/` |
+| WebView2 loader | `WebView2LoaderPreference = Static` |
+
+It compiles `FoundryShell.cpp` alongside the Steinberg VST3 SDK sources, the
+iPlug2 IPlug/VST3 core, the WebView delegate (`IPlugWebView_win.cpp`,
+`IPlugWebViewEditorDelegate.cpp`), and `WDL/win32_utf8.c`. Two NuGet packages
+must be restored first, or `EnsureNuGetPackageBuildImports` errors out:
+
+| Package | Version |
+|---|---|
+| `Microsoft.Web.WebView2` | `1.0.2903.40` |
+| `Microsoft.Windows.ImplementationLibrary` (WIL) | `1.0.240803.1` |
+
+`vst3-shell/nuget.exe` (a ~8.5 MB PE32 .NET console tool) is the restorer. After
+the build, the `CopyFoundryWebUI` post-build target copies
+`resources/web/ui/**` into the built `.vst3`'s `Contents/Resources/ui/` (and
+into the installed `VST3_X64_PATH` copy), so the shell runs standalone with its
+default UI before any Foundry export is dropped in.
+
+> The `vst3-shell/iPlug2/` folder is a full iPlug2 SDK clone and is **gitignored**
+> ("iPlug2 clone is huge — never commit it"), as is the VST3 SDK under
+> `Dependencies/`. A clean checkout cannot build the shell until those are
+> re-fetched.
+
+> The `.vcxproj` uses iPlug2-example-relative include paths (e.g.
+> `..\..\..\IPlug`, `..\..\..\Dependencies\IPlug\VST3_SDK`), so it is templated
+> to live under `iPlug2/Examples/FoundryShell/projects/` inside the SDK clone. It
+> also references build inputs that are **not** in the checked-in
+> `FoundryShell-src` tree: `config/FoundryShell-win.props` (which supplies
+> `VST3_DEFS`, `BUILD_DIR`, `BINARY_NAME`, `VST3_X64_PATH`, …), `resources/
+> resource.h`, `resources/main.rc`, `projects/packages.config`, and
+> `projects/packages/`. These come from the iPlug2 example scaffold and must be
+> present at build time.
+
+> Note: the shell sources are under active development (`config.h` is currently
+> modified in the working tree). Treat the identity macros and DSP details above
+> as the current on-disk state, which may be mid-change.
+
+## What the export tests lock in
+
+Two Vitest suites protect the exporter contract:
+
+| Test file | Locks in |
+|---|---|
+| `vst3ExportBindings.test.ts` | One shaped `route` entry per `vst:` route on a param element; XY axes map onto `-x`/`-y` ids; `listen` entries for bound Meter (with param) and Waveform (no param); CustomCode per-param `vst:` binds as unshaped routes; empty `bindings` for an unbound design (field always present); legacy single-target migration via `routesOf` |
+| `vst3ExportCustomCode.test.ts` | One continuous param per numeric CustomParam with slugged namespaced ids; non-numeric params ignored; empty CustomCode emits nothing; zero-width range guarded to `min+1`; native params ride alongside without CC collisions; informational `binding` from `paramBindings`; the 128-param cap; and that the exported `index.html` embeds the real shared CustomCode bridge (`BRIDGE_BOOTSTRAP_SOURCE`) and has exactly three `</script>` closings |
+
+Run them with the project's Vitest runner:
+
+```bash
+npm test -- vst3Export
+```
+
+These lock the two invariants the whole path depends on: parameter ids are
+stable and slug-derived, and the `bindings` array faithfully mirrors the design's
+`vst:` routes and listens so the native shell can act on them.
+
+## Related docs
+
+- [foundry-overview.md](foundry-overview.md) — the app around this path
+- [canvas-and-controls.md](canvas-and-controls.md) — the controls that become params
+- [custom-code.md](custom-code.md) — CustomCode params and the sandbox bridge
+- [gan-format.md](gan-format.md) — theDAW's native `.gan` plugin filetype
+- [textures-and-skins.md](textures-and-skins.md) — asset/texture inlining in the bundle
+- [thedaw-integration.md](thedaw-integration.md) — the XR control bus and `vst:` forwarding
+- [troubleshooting.md](troubleshooting.md) — when a plugin will not load or a bind does nothing


### PR DESCRIPTION
## What
Complete theDAW-styled documentation set for VST Foundry: 13 new files under `VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/` — 11 subsystem guides (overview, canvas/controls, component extractor, custom code, .gan format, VST3 export, textures/skins, assistant/MCP, theDAW integration, projects/data, troubleshooting) plus `index.md` and `thedaw-docs-integration-proposal.md`.

## How it was built and audited
- 38-agent documentation swarm over the Foundry codebase.
- Every guide passed an accuracy audit (8+ concrete claims verified against source), a style audit against `docs/guides/underfit.md`, and a coverage check; two guides were auto-fixed and re-audited.
- A completeness critic swept the whole set for gaps/contradictions; final whole-set audit passed with zero critical findings (12+ spot-checked claims, zero discrepancies).

## Notes
- Legacy pre-restyle docs in `VST-UI-FOUNDRY/docs/*.md` are untouched.
- The integration proposal is **proposal-only** — nothing in theDAW's `docs/` or `backend/rag.py` is modified; RAG/doc changes remain approval-based.
- Some subsystems (gan libs, native shell build) were mid-development while writing; the docs note those areas as in flight.
