### PR TITLE
feat(foundry+release): FOUNDRY tab + bundled Node runtime + Foundry fullstack bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,4 +289,7 @@ electron-ui/resources/tools/
 # Staged VJ production build (gantasmo/VJ-9000 dist), regenerated at package
 # time by scripts/fetch-vj-build.mjs.
 electron-ui/resources/vj-dist/
+# Staged VST Foundry production bundle (dist/ + prod node_modules), regenerated
+# at package time by scripts/fetch-foundry-build.mjs.
+electron-ui/resources/foundry-app/
 logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 ########################################################################
 # Stage 1: frontend build.
 ########################################################################
-FROM node:22-slim AS ui
+FROM node:22.23.1-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4 AS ui
 
 WORKDIR /build/frontend
 
@@ -37,7 +37,7 @@ RUN npm run build
 # command), so the backend can mount the compiled dist at /vj-app and serve it
 # with no Node.js at runtime. Override the source with VJ_REPO / VJ_REF.
 ########################################################################
-FROM node:22-slim AS vj
+FROM node:22.23.1-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4 AS vj
 WORKDIR /build/vj
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git \
@@ -51,9 +51,28 @@ RUN --mount=type=cache,target=/root/.npm \
     && npm run build
 
 ########################################################################
+# Stage 1c: VST Foundry fullstack build.
+#
+# Foundry is an in-repo Node/Express app. Build it from the context, then prune
+# to production deps so the runtime stage ships only what `node dist/server.cjs`
+# needs. Package files are copied first so source edits don't bust the npm cache.
+########################################################################
+FROM node:22.23.1-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4 AS foundry
+WORKDIR /build/foundry
+COPY VST-Foundry-UI/VST-UI-FOUNDRY/package.json VST-Foundry-UI/VST-UI-FOUNDRY/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+COPY VST-Foundry-UI/VST-UI-FOUNDRY/ ./
+RUN npm run build && npm prune --omit=dev
+
+########################################################################
 # Stage 2: Python runtime.
 ########################################################################
-FROM python:3.10-slim-bookworm AS runtime
+FROM python:3.10-slim-bookworm@sha256:89cef4d55961e885def21b86e34e102e65b7eab8cd281e806a66ff1709c9a455 AS runtime
+
+# Node.js runtime for the VST Foundry sidecar (it runs `node dist/server.cjs`).
+# The single binary is copied from the official node image; libstdc++6 is the
+# one shared lib the slim python base lacks that node links against.
+COPY --from=node:22.23.1-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4 /usr/local/bin/node /usr/local/bin/node
 
 # The uv binary is copied from the official distroless image. The tag is
 # pinned; bump it deliberately, never float on :latest.
@@ -64,12 +83,17 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.26 /uv /uvx /bin/
 # compiles at install time. git supports optional VCS installs such as the
 # py-aup3 Audacity parser. libglib2.0-0 satisfies opencv-python-headless on
 # slim images.
+# apt-get upgrade patches fixable Debian CVEs in the digest-pinned base at
+# build time (the base is immutable via @sha256, but its repos still serve
+# current security updates). Kept in the same layer as install + cleanup.
 RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends \
         ffmpeg \
         build-essential \
         git \
         libglib2.0-0 \
+        libstdc++6 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -112,6 +136,14 @@ COPY --from=ui /build/frontend/dist ./frontend/dist
 # resolves (_REPO_ROOT/"vj-dist") and mounts at /vj-app. This removes the VJ
 # tab's Node.js requirement, so it works in the container like anywhere else.
 COPY --from=vj /build/vj/dist ./vj-dist
+
+# The VST Foundry production bundle lands where the foundry sidecar resolves it
+# (_REPO_ROOT/"VST-Foundry-UI"/"VST-UI-FOUNDRY"). It runs `node dist/server.cjs`
+# with the node binary copied above — a fullstack Node app, so it ships dist/ +
+# production node_modules + package.json.
+COPY --from=foundry /build/foundry/dist ./VST-Foundry-UI/VST-UI-FOUNDRY/dist
+COPY --from=foundry /build/foundry/node_modules ./VST-Foundry-UI/VST-UI-FOUNDRY/node_modules
+COPY --from=foundry /build/foundry/package.json ./VST-Foundry-UI/VST-UI-FOUNDRY/package.json
 
 # The RAG embedder (all-MiniLM-L6-v2) is baked into the image at a path that
 # is INSIDE the image and is never shadowed by a volume mount. backend/rag.py

--- a/backend/modules/foundry/sidecar.py
+++ b/backend/modules/foundry/sidecar.py
@@ -1,4 +1,17 @@
-"""Manage the VST Foundry fullstack dev server as a theDAW sidecar."""
+"""Manage the VST Foundry fullstack server as a theDAW sidecar.
+
+VST Foundry is an in-repo Node/Express app (VST-Foundry-UI/VST-UI-FOUNDRY) with
+its own frontend + backend, so it runs as its own server on a dedicated port
+and the theDAW UI embeds it by iframe (see frontend FoundryView).
+
+DEFAULT (production): when a compiled build is present (``dist/server.cjs`` +
+``node_modules``), run it directly with node — no npm, no dev server, no install
+step. The packaged release ships the built app plus a bundled node runtime, so
+this path needs nothing preinstalled. ``THEDAW_NODE`` overrides the node binary.
+
+DEV (``THEDAW_FOUNDRY_DEV=1``, or when no build exists): npm-install on first run
+then ``npm run dev`` (Vite+Express, HMR off) for working ON Foundry itself.
+"""
 
 from __future__ import annotations
 
@@ -85,6 +98,29 @@ def resolve_config() -> FoundryConfig:
 
     npm_path = shutil.which("npm.cmd") or shutil.which("npm") or "npm"
     return FoundryConfig(project_path=project_path, port=port, npm_path=npm_path)
+
+
+def _resolve_node() -> Optional[str]:
+    """The node binary to run the compiled Foundry server with. Honors
+    THEDAW_NODE, else finds one on PATH (the packaged app prepends its bundled
+    tools dir to PATH, so a shipped node is picked up automatically)."""
+    explicit = os.getenv("THEDAW_NODE")
+    if explicit:
+        return explicit
+    return shutil.which("node") or shutil.which("node.exe")
+
+
+def _production_server(cfg: FoundryConfig) -> Optional[Path]:
+    """The compiled fullstack server (``dist/server.cjs``, produced by
+    ``npm run build``) if it exists AND its runtime deps are present. esbuild
+    bundles server.ts with ``--packages=external``, so ``node_modules`` must
+    ship alongside dist/. Returns None when no runnable production build is
+    available (then the sidecar falls back to the npm dev server)."""
+    server = cfg.project_path / "dist" / "server.cjs"
+    node_modules = cfg.project_path / "node_modules"
+    if server.is_file() and node_modules.is_dir():
+        return server
+    return None
 
 
 def _port_is_listening(port: int, host: str = "127.0.0.1") -> bool:
@@ -206,41 +242,53 @@ def ensure_running(*, wait_for_ready: bool = True) -> str:
                     "Set THEDAW_FOUNDRY_PROJECT to override."
                 )
 
-            node_modules = cfg.project_path / "node_modules"
-            if not node_modules.is_dir():
-                log.info("foundry.sidecar: node_modules missing — running npm install")
-                try:
-                    with _open_log() as log_fh:
-                        rc = subprocess.call(
-                            [cfg.npm_path, "install"],
-                            cwd=str(cfg.project_path),
-                            stdout=log_fh,
-                            stderr=log_fh,
-                            shell=False,
-                        )
-                except FileNotFoundError as e:
-                    raise RuntimeError(
-                        f"VST Foundry sidecar: npm not found ({e}). Install Node.js."
-                    ) from e
-                if rc != 0:
-                    raise RuntimeError(
-                        f"npm install failed in {cfg.project_path} (rc={rc}). "
-                        "Run it manually to see the full error output, then retry."
-                        f"\n--- foundry-sidecar.log (tail) ---\n{_log_tail()}"
-                    )
+            env = os.environ.copy()
+            env["THEDAW_FOUNDRY_PORT"] = str(cfg.port)
 
-            cmd = [cfg.npm_path, "run", "dev"]
+            prod_server = _production_server(cfg)
+            node_bin = _resolve_node()
+            if os.getenv("THEDAW_FOUNDRY_DEV") != "1" and prod_server and node_bin:
+                # PRODUCTION (default when a built app is present): run the
+                # compiled fullstack server directly with node — no npm, no dev
+                # server, no install step. The packaged release ships dist/ +
+                # node_modules + a node runtime, so this needs nothing installed.
+                env["NODE_ENV"] = "production"
+                cmd = [node_bin, str(prod_server)]
+            else:
+                # DEV / source checkout (or THEDAW_FOUNDRY_DEV=1): install deps
+                # on first run, then run the Vite+Express dev server. HMR off —
+                # nobody live-edits Foundry's source through the embed, and the
+                # unreachable HMR socket (24678) otherwise floods the console.
+                node_modules = cfg.project_path / "node_modules"
+                if not node_modules.is_dir():
+                    log.info(
+                        "foundry.sidecar: node_modules missing — running npm install"
+                    )
+                    try:
+                        with _open_log() as log_fh:
+                            rc = subprocess.call(
+                                [cfg.npm_path, "install"],
+                                cwd=str(cfg.project_path),
+                                stdout=log_fh,
+                                stderr=log_fh,
+                                shell=False,
+                            )
+                    except FileNotFoundError as e:
+                        raise RuntimeError(
+                            f"VST Foundry sidecar: npm not found ({e}). Install Node.js."
+                        ) from e
+                    if rc != 0:
+                        raise RuntimeError(
+                            f"npm install failed in {cfg.project_path} (rc={rc}). "
+                            "Run it manually to see the full error output, then retry."
+                            f"\n--- foundry-sidecar.log (tail) ---\n{_log_tail()}"
+                        )
+                env["DISABLE_HMR"] = "true"
+                cmd = [cfg.npm_path, "run", "dev"]
+
             log.info(
                 "foundry.sidecar: spawning %s (cwd=%s)", " ".join(cmd), cfg.project_path
             )
-            env = os.environ.copy()
-            env["THEDAW_FOUNDRY_PORT"] = str(cfg.port)
-            # Embedded sidecar: no one live-edits Foundry's source here, so turn
-            # off Vite HMR + file watching. This removes the unreachable HMR
-            # WebSocket (port 24678) whose retries otherwise flood the browser
-            # console with ERR_CONNECTION_REFUSED. (Foundry's vite.config honors
-            # DISABLE_HMR; theDAW's own frontend runs HMR-off by default too.)
-            env["DISABLE_HMR"] = "true"
             try:
                 creationflags = 0
                 if sys.platform == "win32":

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-07-03T01:55:38.017Z · Git revision: `95633fa280a6` · Repomix tracked: **no**
+> Generated: 2026-07-03T03:03:57.887Z · Git revision: `9d19680df02d` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-03T01:55:38.017Z",
-  "repoRevision": "95633fa280a6",
+  "generatedAt": "2026-07-03T03:03:57.887Z",
+  "repoRevision": "9d19680df02d",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-02T09:40:26.733Z",
+  "generatedAt": "2026-07-03T03:06:18.714Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/electron-ui/electron-builder.yml
+++ b/electron-ui/electron-builder.yml
@@ -83,6 +83,15 @@ extraResources:
     to: python/vj-dist
     filter:
       - "**/*"
+  # VST Foundry production bundle (dist/ + production node_modules + package.json),
+  # staged by scripts/fetch-foundry-build.mjs (npm run fetch:foundry). Lands where the
+  # foundry sidecar resolves it (_REPO_ROOT/"VST-Foundry-UI"/"VST-UI-FOUNDRY") and runs
+  # `node dist/server.cjs` with the bundled node (resources/tools/node). Foundry is a
+  # fullstack Node app, so unlike VJ it ships its whole runtime. Gitignored + regenerated.
+  - from: resources/foundry-app
+    to: python/VST-Foundry-UI/VST-UI-FOUNDRY
+    filter:
+      - "**/*"
   # uv + ffmpeg + ffprobe, downloaded by scripts/fetch-runtime-tools.mjs before
   # the build. Prepended to the spawned backend's PATH at runtime. The contents
   # are HOST-PLATFORM-SPECIFIC (Windows: uv.exe/ffmpeg.exe/ffprobe.exe, macOS:

--- a/electron-ui/package.json
+++ b/electron-ui/package.json
@@ -11,11 +11,12 @@
     "preview": "electron-vite preview",
     "fetch:tools": "node scripts/fetch-runtime-tools.mjs",
     "fetch:vj": "node scripts/fetch-vj-build.mjs",
+    "fetch:foundry": "node scripts/fetch-foundry-build.mjs",
     "package": "electron-vite build && electron-builder",
-    "dist:win": "npm run fetch:tools && npm run fetch:vj && electron-vite build && electron-builder --win",
-    "dist:mac": "npm run fetch:tools && npm run fetch:vj && electron-vite build && electron-builder --mac",
-    "dist:win:ci": "npm run fetch:tools && npm run fetch:vj && electron-vite build && electron-builder --win --publish never",
-    "dist:mac:ci": "npm run fetch:tools && npm run fetch:vj && electron-vite build && electron-builder --mac --publish never"
+    "dist:win": "npm run fetch:tools && npm run fetch:vj && npm run fetch:foundry && electron-vite build && electron-builder --win",
+    "dist:mac": "npm run fetch:tools && npm run fetch:vj && npm run fetch:foundry && electron-vite build && electron-builder --mac",
+    "dist:win:ci": "npm run fetch:tools && npm run fetch:vj && npm run fetch:foundry && electron-vite build && electron-builder --win --publish never",
+    "dist:mac:ci": "npm run fetch:tools && npm run fetch:vj && npm run fetch:foundry && electron-vite build && electron-builder --mac --publish never"
   },
   "dependencies": {},
   "devDependencies": {

--- a/electron-ui/scripts/fetch-foundry-build.mjs
+++ b/electron-ui/scripts/fetch-foundry-build.mjs
@@ -1,0 +1,70 @@
+// Build the in-repo VST Foundry app (VST-Foundry-UI/VST-UI-FOUNDRY) and stage a
+// PRODUCTION bundle that electron-builder ships into the installer under
+// python/VST-Foundry-UI/VST-UI-FOUNDRY (see electron-builder.yml -> extraResources).
+// At runtime the foundry sidecar runs `node dist/server.cjs` with the bundled
+// node (see fetch-runtime-tools.mjs) — no npm, no dev server, no install step.
+//
+// The staged bundle is the minimal runtime: the compiled frontend + server
+// (dist/), production-only node_modules (esbuild builds server.cjs with
+// --packages=external, so express et al. must ship), and package.json.
+//
+// Run:  node scripts/fetch-foundry-build.mjs
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, existsSync, rmSync, cpSync, copyFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..', '..') // stable-audio-3
+const srcDir = resolve(repoRoot, 'VST-Foundry-UI', 'VST-UI-FOUNDRY')
+const stageDir = resolve(__dirname, '..', 'resources', 'foundry-app')
+
+function run(cmd, args, cwd) {
+  // Windows npm resolves to npm.cmd; Node 20+ won't execFile a .cmd directly,
+  // so route through cmd.exe (not shell:true, which is deprecated for arrays).
+  if (process.platform === 'win32') {
+    execFileSync('cmd.exe', ['/d', '/s', '/c', cmd, ...args], { cwd, stdio: 'inherit' })
+  } else {
+    execFileSync(cmd, args, { cwd, stdio: 'inherit' })
+  }
+}
+
+function main() {
+  if (!existsSync(join(srcDir, 'package.json'))) {
+    throw new Error(`[fetch-foundry] VST Foundry source not found at ${srcDir}`)
+  }
+  console.log(`[fetch-foundry] building VST Foundry from ${srcDir}`)
+
+  if (!existsSync(join(srcDir, 'node_modules'))) {
+    const hasLock = existsSync(join(srcDir, 'package-lock.json'))
+    run('npm', [hasLock ? 'ci' : 'install'], srcDir)
+  }
+  run('npm', ['run', 'build'], srcDir)
+
+  if (!existsSync(join(srcDir, 'dist', 'server.cjs'))) {
+    throw new Error('[fetch-foundry] build did not produce dist/server.cjs')
+  }
+
+  // Assemble the staging dir: dist/ + package.json (+ lockfile), then install
+  // production-only deps INTO it so the shipped node_modules stays lean.
+  rmSync(stageDir, { recursive: true, force: true })
+  mkdirSync(stageDir, { recursive: true })
+  cpSync(join(srcDir, 'dist'), join(stageDir, 'dist'), { recursive: true })
+  copyFileSync(join(srcDir, 'package.json'), join(stageDir, 'package.json'))
+  if (existsSync(join(srcDir, 'package-lock.json'))) {
+    copyFileSync(join(srcDir, 'package-lock.json'), join(stageDir, 'package-lock.json'))
+  }
+  // Ship .env.example so the packaged app documents the optional AI keys.
+  if (existsSync(join(srcDir, '.env.example'))) {
+    copyFileSync(join(srcDir, '.env.example'), join(stageDir, '.env.example'))
+  }
+
+  console.log('[fetch-foundry] installing production dependencies into the bundle')
+  const hasLock = existsSync(join(stageDir, 'package-lock.json'))
+  run('npm', [hasLock ? 'ci' : 'install', '--omit=dev', '--no-audit', '--no-fund'], stageDir)
+
+  console.log(`[fetch-foundry] staged VST Foundry production bundle at ${stageDir}`)
+}
+
+main()

--- a/electron-ui/scripts/fetch-runtime-tools.mjs
+++ b/electron-ui/scripts/fetch-runtime-tools.mjs
@@ -54,6 +54,21 @@ function uvUrl() {
   return `${base}/uv-${triple}.tar.gz`
 }
 
+// Pinned Node.js runtime — used to run the bundled VST Foundry fullstack
+// server (node dist/server.cjs). SYNC RULE: bump deliberately after checking
+// https://nodejs.org/dist/ for the latest v22 LTS; never float 'latest'.
+// 22.23.1 was the latest v22 LTS when this pin was written (2026-07).
+const NODE_VERSION = '22.23.1'
+
+function nodeUrl() {
+  const base = `https://nodejs.org/dist/v${NODE_VERSION}`
+  if (process.platform === 'win32') {
+    return `${base}/node-v${NODE_VERSION}-win-x64.zip`
+  }
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64'
+  return `${base}/node-v${NODE_VERSION}-darwin-${arch}.tar.gz`
+}
+
 // Windows FFmpeg comes from gyan.dev exactly as before (matching
 // install/setup.ps1). macOS FFmpeg + ffprobe come from Martin Riedl's static
 // build server (https://ffmpeg.martin-riedl.de), pinned to the immutable
@@ -162,6 +177,26 @@ async function fetchUv() {
   rmSync(work, { recursive: true, force: true })
 }
 
+async function fetchNode() {
+  const binName = process.platform === 'win32' ? 'node.exe' : 'node'
+  const dest = join(toolsDir, binName)
+  if (present(dest)) {
+    log(`${binName} already present, skipping`)
+    return
+  }
+  const work = join(tmpdir(), 'thedaw-fetch-node')
+  rmSync(work, { recursive: true, force: true })
+  mkdirSync(work, { recursive: true })
+  const url = nodeUrl()
+  const archive = join(work, process.platform === 'win32' ? 'node.zip' : 'node.tar.gz')
+  await download(url, archive)
+  extract(archive, work)
+  const found = findFile(work, binName)
+  if (!found) throw new Error(`${binName} not found in the downloaded archive`)
+  install(found, dest)
+  rmSync(work, { recursive: true, force: true })
+}
+
 async function fetchFfmpegWin() {
   const ffmpeg = join(toolsDir, 'ffmpeg.exe')
   const ffprobe = join(toolsDir, 'ffprobe.exe')
@@ -217,6 +252,7 @@ async function main() {
   }
   mkdirSync(toolsDir, { recursive: true })
   await fetchUv()
+  await fetchNode()
   if (process.platform === 'win32') {
     await fetchFfmpegWin()
   } else {

--- a/frontend/src/components/layout/CenterTabBar.tsx
+++ b/frontend/src/components/layout/CenterTabBar.tsx
@@ -8,6 +8,7 @@ import {
   Tv2,
   Disc,
   Rows3,
+  Hammer,
 } from 'lucide-react';
 import { type CenterTab } from '../../state/appUiStore';
 
@@ -105,6 +106,18 @@ const TABS: Array<{
       bg: 'bg-fuchsia-500/15',
       text: 'text-fuchsia-100',
       iconText: 'text-fuchsia-300',
+    },
+  },
+  {
+    id: 'foundry',
+    label: 'Foundry',
+    desc: 'Design and export custom VST / plugin interfaces on an infinite canvas',
+    icon: Hammer,
+    accent: {
+      border: 'border-amber-500/50',
+      bg: 'bg-amber-500/15',
+      text: 'text-amber-100',
+      iconText: 'text-amber-300',
     },
   },
   {

--- a/frontend/src/components/layout/DAWCenterPanel.tsx
+++ b/frontend/src/components/layout/DAWCenterPanel.tsx
@@ -36,6 +36,7 @@ const TrainView = lazy(() => import('../../views/TrainView').then((m) => ({ defa
 const LineageView = lazy(() => import('../library/LineageModal').then((m) => ({ default: m.LineageView })));
 const VJView = lazy(() => import('../../views/VJView').then((m) => ({ default: m.VJView })));
 const DJView = lazy(() => import('../../views/DJView').then((m) => ({ default: m.DJView })));
+const FoundryView = lazy(() => import('../../views/FoundryView').then((m) => ({ default: m.FoundryView })));
 
 const TabFallback: React.FC = () => (
   <div className="absolute inset-0 grid place-items-center">
@@ -53,7 +54,7 @@ export const DAWCenterPanel: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   // and the LEARN genealogy graph's fetch + layout + pan/zoom.
   const [warmedTabs, setWarmedTabs] = useState<Set<string>>(() => new Set());
   useEffect(() => {
-    if (centerTab === 'dj' || centerTab === 'vj' || centerTab === 'learn') {
+    if (centerTab === 'dj' || centerTab === 'vj' || centerTab === 'foundry' || centerTab === 'learn') {
       setWarmedTabs((prev) => {
         if (prev.has(centerTab)) return prev;
         const next = new Set(prev);
@@ -132,6 +133,14 @@ export const DAWCenterPanel: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               style={{ display: centerTab === 'vj' ? undefined : 'none' }}
             >
               <Suspense fallback={<TabFallback />}><VJView /></Suspense>
+            </div>
+          )}
+          {warmedTabs.has('foundry') && (
+            <div
+              className="absolute inset-0"
+              style={{ display: centerTab === 'foundry' ? undefined : 'none' }}
+            >
+              <Suspense fallback={<TabFallback />}><FoundryView /></Suspense>
             </div>
           )}
         </div>

--- a/frontend/src/state/appUiStore.ts
+++ b/frontend/src/state/appUiStore.ts
@@ -13,7 +13,7 @@ export function normalizetheDAWView(value: unknown): theDAWView | null {
 /** The center-bar tabs in user-locked order MAKE / EDIT / MIX / DJ / VJ /
  *  TRAIN / LEARN. All workspaces live here; the legacy left-side tabs
  *  (CREATE/PROCESS/TRAIN) are subsumed by these. */
-export const CENTER_TABS = ['make', 'edit', 'session', 'mix', 'dj', 'vj', 'train', 'learn'] as const;
+export const CENTER_TABS = ['make', 'edit', 'session', 'mix', 'dj', 'vj', 'foundry', 'train', 'learn'] as const;
 export type CenterTab = typeof CENTER_TABS[number];
 
 /** Translate legacy navigation targets (used by orb-kit, library row

--- a/frontend/src/views/FoundryView.tsx
+++ b/frontend/src/views/FoundryView.tsx
@@ -1,0 +1,133 @@
+/**
+ * FOUNDRY tab — embeds the VST Foundry app (a visual VST/plugin UI builder)
+ * in an iframe. Foundry is a fullstack Node app that serves ITSELF on its own
+ * port, so unlike VJ there is no static mount or control bridge: we just fetch
+ * its live URL from `/api/foundry/url` (which spawns the sidecar on first call)
+ * and point the iframe at it. First launch can take a while — the Node server
+ * installs deps and boots — so we retry the fetch and show a clear state.
+ *
+ * "Pop out" opens the same URL in a standalone window for a full-screen design
+ * surface. When Foundry isn't available (no Node.js / no project), the backend
+ * returns a 503 whose message we surface verbatim.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ExternalLink, Hammer, RotateCw } from 'lucide-react';
+
+const MAX_LOAD_RETRIES = 40; // ~80s at 2s spacing — first boot builds the app
+
+export const FoundryView: React.FC = () => {
+  const [url, setUrl] = useState<string | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [detail, setDetail] = useState<string>('');
+  const retriesRef = useRef(0);
+  const timerRef = useRef<number | null>(null);
+
+  const loadUrl = useCallback(async () => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setStatus('loading');
+    try {
+      const r = await fetch('/api/foundry/url');
+      if (!r.ok) {
+        // Surface the backend's diagnostic (e.g. "install Node.js") verbatim.
+        let msg = `backend returned ${r.status}`;
+        try {
+          const j = (await r.json()) as { detail?: string };
+          if (j.detail) msg = j.detail;
+        } catch { /* non-JSON body */ }
+        throw new Error(msg);
+      }
+      const j = (await r.json()) as { url: string };
+      setUrl(j.url);
+      retriesRef.current = 0;
+      setStatus('ready');
+      setDetail('');
+    } catch (e) {
+      if (retriesRef.current < MAX_LOAD_RETRIES) {
+        retriesRef.current += 1;
+        setStatus('loading');
+        setDetail('starting the VST Foundry server (first launch can take a minute)…');
+        timerRef.current = window.setTimeout(() => void loadUrl(), 2000);
+      } else {
+        setStatus('error');
+        setDetail(e instanceof Error ? e.message : String(e));
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadUrl();
+    return () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    };
+  }, [loadUrl]);
+
+  const retry = () => {
+    retriesRef.current = 0;
+    void loadUrl();
+  };
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-[#0a080f]">
+      <div className="flex items-center gap-2 px-3 h-8 border-b border-white/5 shrink-0">
+        <Hammer className="w-3.5 h-3.5 text-amber-300" />
+        <span className="text-[10px] font-mono uppercase tracking-widest text-amber-200/80">
+          VST Foundry
+        </span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={retry}
+          aria-label="Reload VST Foundry"
+          title="Reload VST Foundry"
+          className="btn-ghost inline-flex items-center gap-1 text-[10px]"
+        >
+          <RotateCw className="w-3 h-3" />
+        </button>
+        <button
+          type="button"
+          onClick={() => url && window.open(url, '_blank', 'noopener,noreferrer')}
+          disabled={!url}
+          aria-label="Open VST Foundry in a new window"
+          title="Open in a new window"
+          className="btn-ghost inline-flex items-center gap-1 text-[10px] disabled:opacity-40"
+        >
+          <ExternalLink className="w-3 h-3" />
+        </button>
+      </div>
+
+      <div className="flex-1 min-h-0 relative">
+        {status === 'ready' && url ? (
+          <iframe
+            src={url}
+            title="VST Foundry"
+            className="absolute inset-0 w-full h-full border-0 bg-white"
+            allow="clipboard-read; clipboard-write"
+          />
+        ) : (
+          <div className="absolute inset-0 grid place-items-center px-6 text-center">
+            {status === 'loading' ? (
+              <span className="text-[11px] font-mono uppercase tracking-widest text-zinc-500 animate-pulse">
+                {detail || 'loading VST Foundry…'}
+              </span>
+            ) : (
+              <div className="max-w-md space-y-3">
+                <p className="text-xs text-red-300/90 font-mono">VST Foundry unavailable</p>
+                <p className="text-[11px] text-zinc-400 whitespace-pre-wrap break-words">{detail}</p>
+                <button
+                  type="button"
+                  onClick={retry}
+                  className="btn-ghost inline-flex items-center gap-1 text-[11px]"
+                >
+                  <RotateCw className="w-3 h-3" /> Retry
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
- FOUNDRY tab: FoundryView iframes /api/foundry/url; wired into CenterTabBar, DAWCenterPanel (warmed like VJ/DJ), and CENTER_TABS.
- Foundry sidecar runs the compiled server (node dist/server.cjs) in production by default when a built app is present; THEDAW_FOUNDRY_DEV=1 keeps the npm dev server for working on Foundry itself.
- Bundle a Node 22.23.1 runtime (fetch-runtime-tools) plus a Foundry production bundle (fetch-foundry-build: dist/ + pruned node_modules) into electron and Docker, so the tab works with nothing preinstalled.
- Docker: Foundry build stage + copied node binary; pin the node and python bases to @sha256 digests (node matched to 22.23.1) and add an apt security upgrade to the runtime stage.