### PR TITLE
docs(foundry): correct provider naming — Better Claude Code by skreamb0t (@StarskreamEXE)

### DIFF
--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/assistant-and-mcp.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/assistant-and-mcp.md
@@ -1,8 +1,9 @@
 # Foundry Assistant — Orb, Providers, and MCP
 
 Reference for Foundry's in-app AI co-designer: the floating **Assistant orb**,
-the multi-provider chat backend, the persistent **Better Claude Code** (BCC)
-session, and the **MCP** bridge that lets the model read and mutate your canvas.
+the multi-provider chat backend, the persistent **Better Claude Code by
+skreamb0t (@StarskreamEXE)** session, and the **MCP** bridge that lets the model
+read and mutate your canvas.
 Plain descriptions of what each piece does and how a message becomes a canvas
 change. For the workspace it drives, see
 [canvas-and-controls.md](canvas-and-controls.md); for the images it can
@@ -72,7 +73,7 @@ sidecar that hosts the rest of Foundry (see
 | Method + path | Purpose |
 |---|---|
 | `GET /api/health` | Liveness probe (`{app, status, time}`). |
-| `GET /api/assistant/providers` | Provider catalog. Claude/BCC is unshifted to the front. |
+| `GET /api/assistant/providers` | Provider catalog. Better Claude Code is unshifted to the front. |
 | `GET /api/assistant/models/:provider` | Model discovery for one provider (live fetch or fallbacks). |
 | `POST /api/assistant/chat` | The one chat endpoint. SSE. Dispatches by `provider`. |
 | `POST /api/assistant/transcribe` | Raw audio (`audio/*`) → faster-whisper → `{ok, text}`. |
@@ -92,12 +93,12 @@ sidecar that hosts the rest of Foundry (see
 
 The assistant is **bring-your-own-key** for cloud providers and needs no key for
 local ones. The catalog is defined in `PROVIDERS` (`server/providers.ts`); the
-Claude Code provider is deliberately **not** in that map and is special-cased in
-the routes.
+Better Claude Code provider is deliberately **not** in that map and is
+special-cased in the routes.
 
 | Provider id | Label | Key required | Local | Notes |
 |---|---|---|---|---|
-| `claude` | BCC (Better Claude Code) | No | Yes | Spawns the local `claude` CLI. Surfaced FIRST in the providers list. |
+| `claude` | Better Claude Code | No | Yes | Spawns the local `claude` CLI. Surfaced FIRST in the providers list. |
 | `gemini` | Google Gemini | Yes | No | OpenAI-compat base; models via Google's `/v1beta/models`. |
 | `openai` | OpenAI | Yes | No | OpenAI-compat. |
 | `anthropic` | Anthropic | Yes | No | Native Anthropic Messages API path. |
@@ -186,7 +187,7 @@ attached for the whole conversation instead of flapping every message.
 | `CLAUDE_TURN_STALL_MS` | 5 min | Inactivity watchdog — re-armed on every stdout frame; only a true stall trips it. |
 
 Each turn is serialized: a message that arrives while a turn is running is
-**queued, not rejected** (BCC parity — mid-turn sends never return 409). The
+**queued, not rejected** (Better Claude Code parity — mid-turn sends never return 409). The
 route parks in the session's FIFO idle-waiter list, keeps the SSE alive with
 pings, and resumes in arrival order when the in-flight turn finishes. Switching
 model or effort on a live conversation respawns the child in place (resume keeps
@@ -358,7 +359,7 @@ former single-file implementation.
 
 Behavior worth knowing:
 
-- **Mid-turn queue (BCC parity).** Typing while a turn streams does not fire a
+- **Mid-turn queue (Better Claude Code parity).** Typing while a turn streams does not fire a
   second colliding request. The message is parked in a FIFO queue (shown in the
   UI) and sent automatically when the current turn ends. **Stop** clears the
   queue and, if the agent is blocked on a question, denies it so the child

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/index.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/index.md
@@ -25,7 +25,7 @@ it stands and links its siblings for context.
 | [custom-code.md](custom-code.md) | The **CustomCode** element: your own HTML/CSS/JS in a sandboxed iframe, its postMessage bridge, parameters, and theDAW bindings. |
 | [textures-and-skins.md](textures-and-skins.md) | The visual asset pipeline — procedural and AI-generated textures, CSS material skins, and image faces, and how they attach and export. |
 | [component-extractor.md](component-extractor.md) | The Component Extractor: turning one reference image into labeled cutout components (and real controls) via vision AI, integrated and standalone. |
-| [assistant-and-mcp.md](assistant-and-mcp.md) | The in-app AI co-designer — the Assistant orb, the multi-provider chat backend, the persistent BCC session, and the MCP canvas bridge. |
+| [assistant-and-mcp.md](assistant-and-mcp.md) | The in-app AI co-designer — the Assistant orb, the multi-provider chat backend, the persistent Better Claude Code session, and the MCP canvas bridge. |
 | [gan-format.md](gan-format.md) | The `.gan` portable web-plugin package: its on-disk shape, Foundry's export/import round-trip, and the theDAW host bridge that wires it up. |
 | [vst3-export.md](vst3-export.md) | The VST3 export path — the browser-side data-bundle exporter and the native iPlug2 **FoundryShell** that loads it at runtime. |
 | [thedaw-integration.md](thedaw-integration.md) | How Foundry lives inside theDAW: the Node sidecar, the center-tab embed, the two control buses, and the exported-`.gan` plugin runtime. |

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/thedaw-docs-integration-proposal.md
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/docs/thedaw-style/thedaw-docs-integration-proposal.md
@@ -56,7 +56,7 @@ code, and relative sibling links. The set's own landing page is
 | [custom-code.md](custom-code.md) | The `CustomCode` element, its sandboxed iframe, postMessage bridge, and parameter model | Guide |
 | [gan-format.md](gan-format.md) | The `.gan` portable web-plugin bundle: on-disk shape, export/import round-trip, host bridge | Guide (reference) |
 | [textures-and-skins.md](textures-and-skins.md) | Procedural and AI textures, CSS material skins, and image faces; how they composite and ride exports | Guide |
-| [assistant-and-mcp.md](assistant-and-mcp.md) | The Assistant orb, the multi-provider chat backend, the persistent BCC session, and the MCP canvas bridge | Guide |
+| [assistant-and-mcp.md](assistant-and-mcp.md) | The Assistant orb, the multi-provider chat backend, the persistent Better Claude Code session, and the MCP canvas bridge | Guide |
 | [thedaw-integration.md](thedaw-integration.md) | The sidecar, the center-tab embed, the two control buses, and the exported-plugin runtime inside theDAW | Guide |
 | [projects-and-data.md](projects-and-data.md) | Where Foundry state lives (IndexedDB, localStorage, on-disk `data/`) and what survives a restart | Guide (reference) |
 | [troubleshooting.md](troubleshooting.md) | Ports, spawn failures, rejected imports, native-shell build errors, and the commands to clear them | Guide (reference) |


### PR DESCRIPTION
docs(foundry): correct provider naming — Better Claude Code by skreamb0t (@StarskreamEXE)

Merge pull request]https://github.com/gantasmo/theDAW/pull/87 

from gantasmo/feat/foundry-tab-and-release-bundling

feat(foundry+release): FOUNDRY tab + bundled Node runtime + Foundry fullstack bundle
- FOUNDRY tab: FoundryView iframes /api/foundry/url; wired into CenterTabBar, DAWCenterPanel (warmed like VJ/DJ), and CENTER_TABS.
- Foundry sidecar runs the compiled server (node dist/server.cjs) in production by default when a built app is present; THEDAW_FOUNDRY_DEV=1 keeps the npm dev server for working on Foundry itself.
- Bundle a Node 22.23.1 runtime (fetch-runtime-tools) plus a Foundry production bundle (fetch-foundry-build: dist/ + pruned node_modules) into electron and Docker, so the tab works with nothing preinstalled.
- Docker: Foundry build stage + copied node binary; pin the node and python bases to @sha256 digests (node matched to 22.23.1) and add an apt security upgrade to the runtime stage.
@[danieljtrujillo](https://github.com/gantasmo/theDAW/commits?author=danieljtrujillo)
danieljtrujillo authored 30 minutes ago
[Merge pull request](https://github.com/gantasmo/theDAW/commit/3c6032a51de09aa3fb226afbcb3367c0a923e3f2) https://github.com/gantasmo/theDAW/pull/88 [from gantasmo/foundry-docs-thedaw-style](https://github.com/gantasmo/theDAW/commit/3c6032a51de09aa3fb226afbcb3367c0a923e3f2) 

docs(foundry): correct provider naming — Better Claude Code by skreamb0t (@StarskreamEXE)