### PR TITLE
fix(release): unblock Windows VJ build and Linux Docker pyk4a install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,9 +109,17 @@ ENV PYTHONUNBUFFERED=1 \
 # group holds only pytest and ruff, so --no-dev is a verified reduction, not
 # a guess. theDAW.bat runs "uv sync --group dev" on developer machines only
 # to add those tools.
+#
+# pyk4a-bundle (the Azure Kinect point-cloud backend for the akvj module) is
+# skipped in the container: its only Linux wheel is manylinux_2_38 (glibc
+# >= 2.38) and this digest-pinned bookworm base ships glibc 2.36, so uv cannot
+# install it here. The container has no Kinect device anyway, and the akvj
+# sidecar imports pyk4a lazily (inside functions / via a subprocess probe), so
+# the backend boots fine without it. The dependency stays in pyproject/uv.lock
+# with its win32-or-linux-x86_64 marker so bare-metal Linux installs keep it.
 COPY pyproject.toml uv.lock .python-version ./
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-install-project
+    uv sync --frozen --no-dev --no-install-project --no-install-package pyk4a-bundle
 
 # README.md is required because pyproject.toml declares it as the project
 # readme and the project install builds metadata from it.
@@ -126,9 +134,10 @@ COPY docs/ ./docs/
 COPY frontend/public/USER_GUIDE.md ./frontend/public/USER_GUIDE.md
 
 # The second sync installs the project itself against the already-cached
-# dependency set.
+# dependency set. pyk4a-bundle is skipped for the same reason as the first sync
+# (glibc 2.38 wheel vs the base's glibc 2.36; no Kinect device in the container).
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev --no-install-package pyk4a-bundle
 
 # The built SPA lands where backend/server.py expects it
 # (PROJECT_ROOT/frontend/dist) for the theDAW_SERVE_UI mount.

--- a/electron-ui/scripts/fetch-vj-build.mjs
+++ b/electron-ui/scripts/fetch-vj-build.mjs
@@ -17,7 +17,7 @@
 // Run:  node scripts/fetch-vj-build.mjs
 
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, existsSync, rmSync, cpSync } from 'node:fs'
+import { mkdirSync, existsSync, rmSync, cpSync, realpathSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
@@ -56,8 +56,14 @@ function resolveSource() {
   for (const c of candidates) {
     if (existsSync(join(c, 'package.json'))) return { path: c, cloned: false }
   }
-  // Nothing local — clone the public repo into a temp dir.
-  const dest = join(tmpdir(), `vj-9000-${VJ_REF}`)
+  // Nothing local — clone the public repo into a temp dir. realpathSync
+  // expands any Windows 8.3 short name in the temp path (e.g. RUNNER~1 ->
+  // runneradmin on CI): vite's build-html plugin computes the emitted
+  // index.html name via path.relative(root, htmlRealPath), and if root is the
+  // short name while the html resolves to the long name, that relative path
+  // escapes the root ("../../..") and rollup rejects it. Canonicalizing the
+  // base up front keeps root and the html real path on the same spelling.
+  const dest = join(realpathSync(tmpdir()), `vj-9000-${VJ_REF}`)
   rmSync(dest, { recursive: true, force: true })
   console.log(`[fetch-vj] cloning ${VJ_REPO}@${VJ_REF} -> ${dest}`)
   run(gitCmd, ['clone', '--depth', '1', '--branch', VJ_REF, VJ_REPO, dest])


### PR DESCRIPTION
Second round of v0.1.0 release fixes, both verified against the failing CI logs of run 28647402825.

## Windows exe (`windows-exe` job)
The VJ build failed:
```
[vite:build-html] The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received "../../../../../../runneradmin/AppData/Local/Temp/vj-9000-feat/vj-redesign-vfx/index.html".
```
`fetch-vj-build.mjs` clones VJ into `tmpdir()`, which on the runner is the Windows 8.3 short name (`RUNNER~1`). vite's build-html plugin names the emitted `index.html` via `path.relative(root, htmlRealPath)`; root was the short name while the html resolved to the long name (`runneradmin`), so the relative path escaped root and rollup rejected it. Fix: `realpathSync(tmpdir())` canonicalizes the base so both share one spelling.

## Docker (`docker-ghcr` job)
```
error: Distribution `pyk4a-bundle==1.5.0.1` can't be installed because it doesn't have a source distribution or wheel for the current platform
```
`pyk4a-bundle`'s only Linux wheel is `manylinux_2_38` (glibc >= 2.38); the digest-pinned `python:3.10-slim-bookworm` base is glibc 2.36. Fix: `--no-install-package pyk4a-bundle` on both `uv sync` steps. The container has no Kinect device and the akvj sidecar imports pyk4a lazily, so the backend boots fine. The dependency stays in pyproject/uv.lock (win32 or linux-x86_64 marker) so bare-metal Linux installs keep it.

`pyk4a-bundle` is the only Linux-incompatible dependency; `flash-attn` is already win32-gated.