### PR TITLE
fix(release): expand VJ temp 8.3 short name with realpathSync.native

### DIFF
--- a/electron-ui/scripts/fetch-vj-build.mjs
+++ b/electron-ui/scripts/fetch-vj-build.mjs
@@ -56,14 +56,15 @@ function resolveSource() {
   for (const c of candidates) {
     if (existsSync(join(c, 'package.json'))) return { path: c, cloned: false }
   }
-  // Nothing local — clone the public repo into a temp dir. realpathSync
+  // Nothing local — clone the public repo into a temp dir. realpathSync.native
   // expands any Windows 8.3 short name in the temp path (e.g. RUNNER~1 ->
-  // runneradmin on CI): vite's build-html plugin computes the emitted
-  // index.html name via path.relative(root, htmlRealPath), and if root is the
-  // short name while the html resolves to the long name, that relative path
-  // escapes the root ("../../..") and rollup rejects it. Canonicalizing the
-  // base up front keeps root and the html real path on the same spelling.
-  const dest = join(realpathSync(tmpdir()), `vj-9000-${VJ_REF}`)
+  // runneradmin on the CI runner): vite's build-html plugin computes the
+  // emitted index.html name via path.relative(root, htmlRealPath), and if root
+  // is the short name while the html resolves to the long name, that relative
+  // path escapes the root ("../../..") and rollup rejects it. The .native
+  // variant is required: plain realpathSync resolves symlinks and ".." but
+  // does NOT expand 8.3 short names, so it would leave RUNNER~1 in place.
+  const dest = join(realpathSync.native(tmpdir()), `vj-9000-${VJ_REF}`)
   rmSync(dest, { recursive: true, force: true })
   console.log(`[fetch-vj] cloning ${VJ_REPO}@${VJ_REF} -> ${dest}`)
   run(gitCmd, ['clone', '--depth', '1', '--branch', VJ_REF, VJ_REPO, dest])


### PR DESCRIPTION
Follow-up to #93. The Windows exe job still failed the VJ build after #93 because the previous fix used plain `realpathSync`, which does not expand Windows 8.3 short names. The CI clone target stayed `C:\Users\RUNNER~1\...` and vite's build-html plugin still errored:
```
received "../../../../../../runneradmin/AppData/Local/Temp/vj-9000-feat/vj-redesign-vfx/index.html"
```
(root kept the short name `RUNNER~1` while the html resolved to the long name `runneradmin`).

`realpathSync.native` hits the OS path canonicalizer, which expands the short name. Verified on Windows:
```
realpathSync('C:\PROGRA~1')        -> C:\PROGRA~1        (short name preserved)
realpathSync.native('C:\PROGRA~1') -> C:\Program Files   (short name expanded)
```
With this, the clone `dest` carries no short component at all, so vite's root matches the html real path regardless of how vite resolves the html id. The next CI log will show the clone target as `...runneradmin...` instead of `...RUNNER~1...`.

Docker (#93) is confirmed fixed: a full local `docker build` completed (exit 0) and the CI docker-ghcr + macos jobs passed.