### PR TITLE
fix(frontend): remove duplicate Hammer import in CenterTabBar

### DIFF
--- a/frontend/src/components/layout/CenterTabBar.tsx
+++ b/frontend/src/components/layout/CenterTabBar.tsx
@@ -10,7 +10,6 @@ import {
   Hammer,
   FlaskConical,
   Rows3,
-  Hammer,
 } from 'lucide-react';
 import { type CenterTab } from '../../state/appUiStore';
 


### PR DESCRIPTION
Merge #95 (pr/foundry-features) combined two branches that each added a Hammer import to CenterTabBar's lucide-react block, leaving it declared twice. Babel/vite reject it with 'Identifier Hammer has already been declared', which breaks electron-vite dev and the frontend build on main. Remove the duplicate; Hammer stays imported once (used by the Foundry tab).