### PR TITLE
fix(frontend): wire the UNDERFIT center tab into the store and router

### DIFF
--- a/frontend/src/components/layout/DAWCenterPanel.tsx
+++ b/frontend/src/components/layout/DAWCenterPanel.tsx
@@ -37,6 +37,7 @@ const LineageView = lazy(() => import('../library/LineageModal').then((m) => ({ 
 const VJView = lazy(() => import('../../views/VJView').then((m) => ({ default: m.VJView })));
 const DJView = lazy(() => import('../../views/DJView').then((m) => ({ default: m.DJView })));
 const FoundryView = lazy(() => import('../../views/FoundryView').then((m) => ({ default: m.FoundryView })));
+const UnderfitView = lazy(() => import('../../views/UnderfitView').then((m) => ({ default: m.UnderfitView })));
 
 const TabFallback: React.FC = () => (
   <div className="absolute inset-0 grid place-items-center">
@@ -54,7 +55,7 @@ export const DAWCenterPanel: React.FC<{ onSwitchTab?: (tab: string) => void }> =
   // and the LEARN genealogy graph's fetch + layout + pan/zoom.
   const [warmedTabs, setWarmedTabs] = useState<Set<string>>(() => new Set());
   useEffect(() => {
-    if (centerTab === 'dj' || centerTab === 'vj' || centerTab === 'foundry' || centerTab === 'learn') {
+    if (centerTab === 'dj' || centerTab === 'vj' || centerTab === 'foundry' || centerTab === 'underfit' || centerTab === 'learn') {
       setWarmedTabs((prev) => {
         if (prev.has(centerTab)) return prev;
         const next = new Set(prev);
@@ -141,6 +142,14 @@ export const DAWCenterPanel: React.FC<{ onSwitchTab?: (tab: string) => void }> =
               style={{ display: centerTab === 'foundry' ? undefined : 'none' }}
             >
               <Suspense fallback={<TabFallback />}><FoundryView /></Suspense>
+            </div>
+          )}
+          {warmedTabs.has('underfit') && (
+            <div
+              className="absolute inset-0"
+              style={{ display: centerTab === 'underfit' ? undefined : 'none' }}
+            >
+              <Suspense fallback={<TabFallback />}><UnderfitView /></Suspense>
             </div>
           )}
         </div>

--- a/frontend/src/state/appUiStore.ts
+++ b/frontend/src/state/appUiStore.ts
@@ -13,7 +13,7 @@ export function normalizetheDAWView(value: unknown): theDAWView | null {
 /** The center-bar tabs in user-locked order MAKE / EDIT / MIX / DJ / VJ /
  *  TRAIN / LEARN. All workspaces live here; the legacy left-side tabs
  *  (CREATE/PROCESS/TRAIN) are subsumed by these. */
-export const CENTER_TABS = ['make', 'edit', 'session', 'mix', 'dj', 'vj', 'foundry', 'train', 'learn'] as const;
+export const CENTER_TABS = ['make', 'edit', 'session', 'mix', 'dj', 'vj', 'foundry', 'train', 'underfit', 'learn'] as const;
 export type CenterTab = typeof CENTER_TABS[number];
 
 /** Translate legacy navigation targets (used by orb-kit, library row


### PR DESCRIPTION
## Problem
Clicking the UNDERFIT tab does nothing — it doesn't even switch to the tab.

## Cause
Merge #95 added the UNDERFIT tab button (`CenterTabBar`) and `UnderfitView.tsx` but never registered the tab in the center-tab system. Clicking called `setCenterTab('underfit')`, and `normalizeCenterTab` rejected it because `'underfit'` was missing from `CENTER_TABS`, so the store bailed and the tab never switched.

## Fix (frontend only, fully portable)
- `appUiStore.ts`: add `'underfit'` to `CENTER_TABS` (between `train` and `learn`, matching the bar order).
- `DAWCenterPanel.tsx`: lazy-import `UnderfitView` (relative path, same pattern as Foundry/VJ/DJ) and render it with the warmed + visibility-toggle keep-alive pattern so the dashboard iframe survives tab switches.

No absolute paths; frontend build verified clean locally (`vite build`, no errors).