### PR TITLE
fix(frontend): remove duplicate poseControlSource registration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -296,9 +296,8 @@ export default function App() {
     // Imported-project controller auto-attach: drive the imported tracks/effects
     // from the mappings the source DAW project defined (no-ops with no bindings).
     const stopSwayImport = startSwayImportDriver();
-    // Body-pose source (camera, forwarded from the VJ). Publish its channels on
-    // the same bus; the pose values themselves arrive via poseBus regardless of MIDI.
-    registerXrControlSource(poseControlSource);
+    // Body-pose mirror only — the pose source itself is registered
+    // unconditionally in the XR-bus effect above (do not re-register here).
     const stopPoseMirror = startPoseXrMirror();
     // Stream the visualization feed (waveform pack) over the same bridge so a
     // theDAW-XR headset can render theDAW's live audio natively.


### PR DESCRIPTION
poseControlSource was registered twice in frontend/src/App.tsx — once in the unconditional XR-bus effect (correct) and again in the midiEnabled-gated effect (stray, left behind when the merge split that effect). This removes the duplicate in the gated effect; startPoseXrMirror() stays gated. Same class of merge artifact as the duplicate Hammer import fixed in #96. One-line change; no behavior change beyond eliminating the double register/apply on pose targets.