### PR TITLE
v0.1.2: backend log stream in the LOG panel + first-run boot status

### DIFF
--- a/backend/log_ring.py
+++ b/backend/log_ring.py
@@ -1,0 +1,84 @@
+"""In-memory ring buffer of recent backend log records for the LOG panel.
+
+The frontend LOG panel used to show only frontend-emitted events, so VERBOSE
+mode revealed nothing about the backend. This attaches a bounded handler to the
+root logger and exposes the captured records at GET /api/log so the panel can
+stream real backend activity (module loads, sidecar output, warnings, errors,
+tracebacks). Purely in-memory; nothing is persisted, and the per-request access
+log is skipped to keep the panel readable.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from threading import Lock
+
+_MAX = 2000
+_lock = Lock()
+_ring: deque[dict] = deque(maxlen=_MAX)
+_seq = 0
+_handler: logging.Handler | None = None
+
+_LEVEL_MAP = {
+    "DEBUG": "debug",
+    "INFO": "info",
+    "WARNING": "warn",
+    "ERROR": "error",
+    "CRITICAL": "error",
+}
+
+
+class _RingHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        # The access log is one line per HTTP request; too noisy for the panel.
+        if record.name.startswith("uvicorn.access"):
+            return
+        global _seq
+        try:
+            msg = record.getMessage()
+        except Exception:
+            msg = str(record.msg)
+        if record.exc_info:
+            try:
+                fmt = self.formatter or logging.Formatter()
+                msg = f"{msg}\n{fmt.formatException(record.exc_info)}"
+            except Exception:
+                pass
+        with _lock:
+            _seq += 1
+            _ring.append(
+                {
+                    "seq": _seq,
+                    "ts": record.created * 1000.0,
+                    "level": _LEVEL_MAP.get(record.levelname, "info"),
+                    "source": record.name,
+                    "msg": msg,
+                }
+            )
+
+
+def install_log_ring(level: int = logging.INFO) -> None:
+    """Attach the ring handler to the root logger, re-attaching if a logging
+    reconfiguration (e.g. uvicorn startup) dropped it. Idempotent (no duplicate
+    handler). Lowers the root level to ``level`` only if it was higher."""
+    global _handler
+    root = logging.getLogger()
+    if root.level == logging.NOTSET or root.level > level:
+        root.setLevel(level)
+    if _handler is None:
+        _handler = _RingHandler()
+        _handler.setLevel(logging.DEBUG)
+    if _handler not in root.handlers:
+        root.addHandler(_handler)
+
+
+def read_since(since_seq: int = 0, limit: int = 1000) -> dict:
+    """Return records with seq > ``since_seq`` (or the tail when 0), plus the
+    current max seq so the caller can advance its cursor."""
+    with _lock:
+        if since_seq <= 0:
+            entries = list(_ring)[-limit:]
+        else:
+            entries = [e for e in _ring if e["seq"] > since_seq][:limit]
+        return {"seq": _seq, "entries": entries}

--- a/backend/server.py
+++ b/backend/server.py
@@ -815,6 +815,16 @@ def _generate_spectrograms(waveform: torch.Tensor, sr: int) -> dict[str, str]:
 async def _on_startup():
     startup_t0 = time.perf_counter()
 
+    # Attach the in-memory log ring so the LOG panel (VERBOSE mode) can stream
+    # real backend activity. Runs after uvicorn's logging setup and re-attaches
+    # if that dropped the handler. Cheap and torch-free.
+    try:
+        from backend.log_ring import install_log_ring
+
+        install_log_ring()
+    except Exception:
+        logger.debug("log ring install failed", exc_info=True)
+
     # System stats (kept torch-free so server-ready never waits on the ~9.6s
     # torch/stable_audio_3 import; the GPU/torch line is logged by _warm_heavy
     # once the background warm finishes).
@@ -1932,6 +1942,15 @@ async def save_preset(preset: dict):
     # discarded) so callers stay forward-compatible.
     _ = preset
     return {"id": str(uuid.uuid4()), "saved": True}
+
+
+@app.get("/api/log")
+async def get_log(since: int = 0, limit: int = 1000):
+    """Recent backend log records for the LOG panel (VERBOSE mode). Purely
+    in-memory (backend/log_ring.py); the frontend polls with a seq cursor."""
+    from backend.log_ring import read_since
+
+    return read_since(since, limit)
 
 
 app.include_router(assistant_router)

--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-07-05T21:01:03.629Z · Git revision: `65148a15af4d` · Repomix tracked: **no**
+> Generated: 2026-07-05T22:06:25.169Z · Git revision: `7ad08f45e187` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-05T21:01:03.629Z",
-  "repoRevision": "65148a15af4d",
+  "generatedAt": "2026-07-05T22:06:25.169Z",
+  "repoRevision": "7ad08f45e187",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/electron-ui/package.json
+++ b/electron-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thedaw-desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "theDAW desktop shell: an Electron front end that bootstraps and supervises the Python audio backend.",
   "author": "GANTASMO",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import { GantasmoOrb } from './orb-kit/react/GantasmoOrb';
 // the first-paint bundle by lazy-loading it and only mounting it once the user
 // first opens the orb chat (see `assistantMounted` below).
 const AssistantPanel = lazy(() => import('./orb-kit/AssistantPanel'));
-import { logInfo, logWarn } from './state/logStore';
+import { logInfo, logWarn, useLogStore, type LogLevel } from './state/logStore';
 import { handletheDAWAction } from './orb-kit/actionHandlers';
 import { useStatusBarStore } from './state/statusBarStore';
 import { useLibraryStore } from './state/libraryStore';
@@ -101,6 +101,40 @@ export default function App() {
     void poll();
     return () => { cancelled = true; clearTimeout(timer); };
   }, [refreshHealth]);
+
+  // Stream backend log records into the LOG panel so VERBOSE mode shows real
+  // backend activity (module, sidecar, warning, and error logs + tracebacks),
+  // not only frontend events. Cursor-based; starts once the backend is up.
+  useEffect(() => {
+    if (!isBackendReady) return;
+    let cancelled = false;
+    let since = 0;
+    let timer: ReturnType<typeof setTimeout>;
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const res = await fetch(`/api/log?since=${since}`);
+        if (res.ok) {
+          const data = (await res.json()) as {
+            seq: number;
+            entries: Array<{ level: LogLevel; source: string; msg: string }>;
+          };
+          for (const e of data.entries) {
+            useLogStore.getState().append(e.level, e.source, e.msg);
+          }
+          if (typeof data.seq === 'number') since = data.seq;
+        }
+      } catch {
+        // backend momentarily unreachable; keep polling
+      }
+      if (!cancelled) timer = setTimeout(() => void poll(), 2000);
+    };
+    void poll();
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [isBackendReady]);
 
   // Populate the library store the moment the backend port is bound — so the
   // right-side Library / DJ source panels are filled on startup, not only when

--- a/frontend/src/components/layout/LoadingScreen.tsx
+++ b/frontend/src/components/layout/LoadingScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { LiquidChromeTitle } from './LiquidChromeTitle';
+import { useBootStatusStore } from '../../state/bootStatusStore';
 
 interface LoadingScreenProps {
   onSkip: () => void;
@@ -19,6 +20,9 @@ interface LoadingScreenProps {
 export const LoadingScreen: React.FC<LoadingScreenProps> = ({ onSkip, onComplete }) => {
   const [elapsed, setElapsed] = useState(0);
   const [cinematicActive, setCinematicActive] = useState(false);
+  const bootStatus = useBootStatusStore((s) => s.status);
+  const bootLogs = useBootStatusStore((s) => s.logs);
+  const bootError = useBootStatusStore((s) => s.error);
 
   useEffect(() => {
     const t = setInterval(() => setElapsed((e) => e + 1), 1000);
@@ -77,8 +81,31 @@ export const LoadingScreen: React.FC<LoadingScreenProps> = ({ onSkip, onComplete
         style={{ height: 'clamp(34px, 8vh, 110px)', maxWidth: '70vw', animation: 'bootCreditFade 1.3s ease 2s both' }}
       />
 
-      {/* Real escape only after a genuine wait. */}
-      {elapsed >= 40 && (
+      {/* First-run bootstrap status, so a slow or failed setup is visible
+          instead of a silent hang. Low-key under the logo; errors stand out. */}
+      {(bootError || ((bootStatus || bootLogs.length > 0) && elapsed >= 3)) && (
+        <div className="absolute inset-x-0 bottom-9 flex flex-col items-center gap-1 px-6 text-center">
+          {bootError ? (
+            <div className="max-w-xl text-[11px] font-mono leading-relaxed text-red-300/90">
+              Setup error: {bootError}
+            </div>
+          ) : (
+            <>
+              {bootStatus && (
+                <div className="text-[11px] font-mono tracking-wide text-zinc-400">{bootStatus}</div>
+              )}
+              {bootLogs.length > 0 && (
+                <div className="max-w-xl truncate text-[9px] font-mono text-zinc-600">
+                  {bootLogs[bootLogs.length - 1]}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Real escape after a genuine wait, or immediately on a setup error. */}
+      {(elapsed >= 40 || bootError) && (
         <button
           onClick={onSkip}
           className="absolute bottom-2 right-3 text-[9px] font-mono text-zinc-700 hover:text-zinc-400 transition-colors underline"

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,11 +2,48 @@ import {StrictMode} from 'react';
 import {createRoot} from 'react-dom/client';
 import App from './App.tsx';
 import {migrateBrandKeys} from './lib/migrateBrandKeys';
+import {logInfo, logWarn, logError} from './state/logStore';
+import {useBootStatusStore} from './state/bootStatusStore';
 import './index.css';
 
 // Carry any legacy persisted storage over to the current key namespace before
 // any store hydrates, so no local user data is lost.
 migrateBrandKeys();
+
+// Surface uncaught errors + promise rejections in the LOG panel so VERBOSE mode
+// is useful for troubleshooting (previously these never reached the panel).
+window.addEventListener('error', (e) => {
+  const where = e.filename ? ` (${e.filename}:${e.lineno}:${e.colno})` : '';
+  logError('window', `${e.message}${where}`);
+});
+window.addEventListener('unhandledrejection', (e) => {
+  const r = e.reason as {message?: string} | string | undefined;
+  logError('promise', typeof r === 'string' ? r : (r?.message ?? String(r)));
+});
+
+// The packaged Electron main streams first-run bootstrap progress + errors to
+// window.setStatus / window.addLog (electron-ui/main/index.ts). Define them so
+// that output reaches BOTH the loading screen and the LOG panel, instead of
+// vanishing (which made a failed first-run setup look like a silent hang).
+const bootBridge = window as unknown as {
+  setStatus?: (text: string) => void;
+  addLog?: (text: string, cls?: string) => void;
+};
+bootBridge.setStatus = (text) => {
+  useBootStatusStore.getState().setStatus(text);
+  logInfo('bootstrap', text);
+};
+bootBridge.addLog = (text, cls) => {
+  useBootStatusStore.getState().pushLog(text);
+  if (cls === 'error') {
+    useBootStatusStore.getState().setError(text);
+    logError('bootstrap', text);
+  } else if (cls === 'warn') {
+    logWarn('bootstrap', text);
+  } else {
+    logInfo('bootstrap', text);
+  }
+};
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/state/bootStatusStore.ts
+++ b/frontend/src/state/bootStatusStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+
+// First-run bootstrap status surfaced on the loading screen. The packaged
+// Electron main streams `uv sync` / backend-spawn progress and errors to
+// window.setStatus / window.addLog (electron-ui/main/index.ts); those globals
+// (defined in main.tsx) feed this store so a slow or failed first-run setup is
+// VISIBLE instead of looking like a silent hang on the splash.
+
+interface BootStatusState {
+  status: string;
+  logs: string[];
+  error: string | null;
+  setStatus: (s: string) => void;
+  pushLog: (line: string) => void;
+  setError: (e: string) => void;
+}
+
+const MAX_LOGS = 8;
+
+export const useBootStatusStore = create<BootStatusState>()((set) => ({
+  status: '',
+  logs: [],
+  error: null,
+  setStatus: (s) => set({ status: s }),
+  pushLog: (line) =>
+    set((st) => {
+      const logs = [...st.logs, line];
+      if (logs.length > MAX_LOGS) logs.splice(0, logs.length - MAX_LOGS);
+      return { logs };
+    }),
+  setError: (e) => set({ error: e }),
+}));

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stable-audio-3"
-version = "0.1.1"
+version = "0.1.2"
 description = "Stable Audio 3: A state-of-the-art open platform for fast, high-quality generated audio and music"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -5654,7 +5654,7 @@ wheels = [
 
 [[package]]
 name = "stable-audio-3"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aubio", version = "0.4.9", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'arm64' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },


### PR DESCRIPTION
Two fixes plus a version bump.

- LOG: VERBOSE mode now streams real backend activity (module/sidecar/warning/error logs + tracebacks) via a backend log ring at /api/log and a frontend poller; uncaught frontend errors + promise rejections also land in the panel. Previously VERBOSE was identical to SIMPLE and showed no backend info.
- BOOT: the packaged Electron main streams first-run setup progress/errors to window.addLog / window.setStatus, which the app never defined, so a failed first-run setup hung the splash silently. Those are now defined and shown on the loading screen (with an immediate escape on error).

(VJ-under-Pinokio is fixed separately in the theDAW-Pinokio launcher.)