### PR TITLE
feat(edit): color-theme picker for the EDIT layout backgrounds + borders

### DIFF
--- a/docs/reports/feature-doc-coverage-report.md
+++ b/docs/reports/feature-doc-coverage-report.md
@@ -1,7 +1,7 @@
 # Feature Documentation Coverage Report
 
 > [!NOTE]
-> Generated: 2026-07-06T04:58:42.587Z · Git revision: `ff2f949ec473` · Repomix tracked: **no**
+> Generated: 2026-07-06T05:21:07.367Z · Git revision: `2224067f8c58` · Repomix tracked: **no**
 
 ## Audit Dashboard
 

--- a/docs/reports/feature-doc-coverage.json
+++ b/docs/reports/feature-doc-coverage.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-06T04:58:42.587Z",
-  "repoRevision": "ff2f949ec473",
+  "generatedAt": "2026-07-06T05:21:07.367Z",
+  "repoRevision": "2224067f8c58",
   "repomixContext": {
     "path": "repomix-output.md",
     "present": true,

--- a/frontend/src/components/audio/EditThemePicker.tsx
+++ b/frontend/src/components/audio/EditThemePicker.tsx
@@ -1,0 +1,227 @@
+/**
+ * EDIT-layout theme picker — a small toolbar control that opens a popover of
+ * color-theme swatches (Dark / Metal / Light / Pastel / Gradient) plus a
+ * "custom image" option. Writes to editThemeStore; WaveformEditor applies the
+ * resulting CSS variables to its root. The popover is portaled to <body> so it
+ * is not itself re-colored by the active theme.
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Palette, Check, ImagePlus, X } from 'lucide-react';
+import { useEditThemeStore } from '../../state/editThemeStore';
+import {
+  EDIT_THEMES,
+  CUSTOM_IMAGE_ID,
+  resolveEditThemeVars,
+  type EditTheme,
+} from '../../lib/editThemes';
+
+const GROUP_ORDER = ['Dark', 'Metal', 'Light', 'Pastel', 'Gradient'];
+
+function swatchStyle(theme: EditTheme): React.CSSProperties {
+  const { vars } = resolveEditThemeVars(theme.id, null);
+  return {
+    background: vars['--et-root-bg'],
+    borderColor: `rgb(${vars['--et-line']} / 0.5)`,
+  };
+}
+
+function swatchInnerStyle(theme: EditTheme): React.CSSProperties {
+  const { vars } = resolveEditThemeVars(theme.id, null);
+  return { background: vars['--et-panel'], borderColor: `rgb(${vars['--et-line']} / 0.35)` };
+}
+
+export function EditThemePicker(): React.ReactElement {
+  const themeId = useEditThemeStore((s) => s.themeId);
+  const customImage = useEditThemeStore((s) => s.customImage);
+  const setTheme = useEditThemeStore((s) => s.setTheme);
+  const setCustomImage = useEditThemeStore((s) => s.setCustomImage);
+
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const grouped = useMemo(() => {
+    const by: Record<string, EditTheme[]> = {};
+    for (const t of EDIT_THEMES) (by[t.group] ||= []).push(t);
+    return GROUP_ORDER.filter((g) => by[g]?.length).map((g) => ({ group: g, themes: by[g] }));
+  }, []);
+
+  const place = useCallback(() => {
+    const r = btnRef.current?.getBoundingClientRect();
+    if (!r) return;
+    const width = 288;
+    const left = Math.max(8, Math.min(r.left, window.innerWidth - width - 8));
+    setPos({ top: r.bottom + 6, left });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    place();
+    const onDown = (e: MouseEvent) => {
+      if (popRef.current?.contains(e.target as Node)) return;
+      if (btnRef.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    const onScroll = () => place();
+    window.addEventListener('mousedown', onDown);
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('resize', place);
+    window.addEventListener('scroll', onScroll, true);
+    return () => {
+      window.removeEventListener('mousedown', onDown);
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('resize', place);
+      window.removeEventListener('scroll', onScroll, true);
+    };
+  }, [open, place]);
+
+  const onPickImage = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      e.target.value = '';
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === 'string') setCustomImage(reader.result);
+      };
+      reader.readAsDataURL(file);
+      setOpen(false);
+    },
+    [setCustomImage],
+  );
+
+  const activeIsImage = themeId === CUSTOM_IMAGE_ID && !!customImage;
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Editor color theme"
+        title="Editor color theme: recolor the EDIT layout backgrounds and borders"
+        className={`flex items-center gap-1.5 p-1 px-2 rounded border transition-colors text-[9px] font-mono uppercase tracking-wider
+          ${open ? 'bg-purple-600/20 border-purple-500/40 text-purple-300' : 'border-white/5 text-zinc-500 hover:text-white hover:bg-white/5'}`}
+      >
+        <Palette className="w-3 h-3" /> THEME
+      </button>
+
+      {/* Accessible, visually-hidden file input for the custom-image option. */}
+      <label htmlFor="edit-theme-image-input" className="sr-only">
+        Editor background image
+      </label>
+      <input
+        ref={fileRef}
+        id="edit-theme-image-input"
+        name="edit-theme-image"
+        type="file"
+        accept="image/*"
+        onChange={onPickImage}
+        className="hidden"
+        aria-label="Choose editor background image"
+      />
+
+      {open && pos
+        ? createPortal(
+            <div
+              ref={popRef}
+              role="menu"
+              aria-label="Editor color themes"
+              style={{ top: pos.top, left: pos.left, width: 288 }}
+              className="fixed z-[200] rounded-lg border border-white/10 bg-[#0f0d16] shadow-2xl p-2.5 max-h-[70vh] overflow-y-auto"
+            >
+              {grouped.map(({ group, themes }) => (
+                <div key={group} className="mb-2 last:mb-0">
+                  <div className="text-[8px] font-mono uppercase tracking-widest text-zinc-500 px-0.5 mb-1">
+                    {group}
+                  </div>
+                  <div className="grid grid-cols-2 gap-1.5">
+                    {themes.map((t) => {
+                      const active = themeId === t.id;
+                      return (
+                        <button
+                          key={t.id}
+                          role="menuitemradio"
+                          aria-checked={active}
+                          onClick={() => {
+                            setTheme(t.id);
+                            setOpen(false);
+                          }}
+                          title={t.label}
+                          className={`flex items-center gap-2 rounded border p-1.5 text-left transition-colors
+                            ${active ? 'border-purple-500/60 bg-purple-500/10' : 'border-white/10 hover:border-white/25 hover:bg-white/5'}`}
+                        >
+                          <span
+                            className="relative w-7 h-7 rounded border shrink-0 overflow-hidden"
+                            style={swatchStyle(t)}
+                          >
+                            <span
+                              className="absolute left-1 right-1 bottom-1 h-2 rounded-[2px] border"
+                              style={swatchInnerStyle(t)}
+                            />
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="block text-[10px] text-zinc-200 truncate leading-tight">
+                              {t.label}
+                            </span>
+                          </span>
+                          {active ? <Check className="w-3 h-3 text-purple-300 shrink-0" /> : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+
+              {/* Custom image */}
+              <div className="mt-2 pt-2 border-t border-white/10">
+                <div className="text-[8px] font-mono uppercase tracking-widest text-zinc-500 px-0.5 mb-1">
+                  Image
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <button
+                    role="menuitemradio"
+                    aria-checked={activeIsImage}
+                    onClick={() => fileRef.current?.click()}
+                    className={`flex flex-1 items-center gap-2 rounded border p-1.5 transition-colors
+                      ${activeIsImage ? 'border-purple-500/60 bg-purple-500/10' : 'border-white/10 hover:border-white/25 hover:bg-white/5'}`}
+                  >
+                    <span
+                      className="w-7 h-7 rounded border border-white/20 shrink-0 bg-cover bg-center"
+                      style={
+                        customImage
+                          ? { backgroundImage: `url("${customImage}")` }
+                          : { background: 'linear-gradient(135deg,#39304f,#1a1526)' }
+                      }
+                    />
+                    <span className="flex items-center gap-1.5 text-[10px] text-zinc-200">
+                      <ImagePlus className="w-3 h-3 text-zinc-400" />
+                      {customImage ? 'Change image…' : 'Choose image…'}
+                    </span>
+                  </button>
+                  {customImage ? (
+                    <button
+                      onClick={() => setCustomImage(null)}
+                      aria-label="Remove background image"
+                      title="Remove background image"
+                      className="p-1.5 rounded border border-white/10 text-zinc-400 hover:text-white hover:bg-white/5 transition-colors"
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -46,6 +46,9 @@ import { publishSelectedTracks } from '../../state/editorSelectionBridge';
 import * as liveMixer from '../../state/liveMixer';
 import { useDjAnalysisStore } from '../../state/djAnalysisStore';
 import { ContextMenu, useContextMenu, type ContextMenuItem } from '../ui/ContextMenu';
+import { EditThemePicker } from './EditThemePicker';
+import { useEditThemeStore } from '../../state/editThemeStore';
+import { resolveEditThemeVars } from '../../lib/editThemes';
 
 const TRACK_HEADER_PX = 180;
 const TRACK_HEIGHT = 104;
@@ -2363,8 +2366,20 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
     }
   }, []);
 
+  const editThemeId = useEditThemeStore((s) => s.themeId);
+  const editThemeImage = useEditThemeStore((s) => s.customImage);
+  const editTheme = useMemo(
+    () => resolveEditThemeVars(editThemeId, editThemeImage),
+    [editThemeId, editThemeImage],
+  );
+
   return (
-    <div className="hardware-card h-full flex flex-col bg-black/40 overflow-hidden" ref={containerRef}>
+    <div
+      className="edit-theme-scope hardware-card h-full flex flex-col overflow-hidden"
+      data-et-light={editTheme.light ? '1' : undefined}
+      style={editTheme.vars as React.CSSProperties}
+      ref={containerRef}
+    >
       {/* Editor Toolbar */}
       <div className="flex items-center justify-between p-2 border-b border-white/5 bg-black/20 shrink-0">
         <div className="flex items-center gap-3">
@@ -2548,6 +2563,8 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
           >
             <Wand2 className="w-3 h-3" /> METAMORPH
           </button>
+
+          <EditThemePicker />
         </div>
 
         <div className="flex items-center gap-3">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -206,3 +206,64 @@ select optgroup {
 .genealogy-svg g.gen-lit-hot[data-node-id] > rect:first-of-type { stroke-width: 4; }
 .genealogy-svg g.gen-lit[data-edge-from] { opacity: 1; }
 .genealogy-svg g.gen-lit[data-edge-from] path { stroke-width: 4.5; }
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * EDIT-LAYOUT THEMING.
+ * The WaveformEditor root carries `.edit-theme-scope` and inline `--et-*`
+ * variables (see lib/editThemes.ts + state/editThemeStore.ts). These UNLAYERED
+ * rules remap the layout's neutral chrome — every black-opacity surface,
+ * white-opacity fill, and white/hex border — onto those variables. Unlayered
+ * beats Tailwind's utilities layer, so no per-element class edits are needed;
+ * the default "Midnight" variables reproduce the original palette exactly, so
+ * an un-themed editor is pixel-identical. Semantic accents (purple/red/amber/…)
+ * are intentionally NOT remapped.
+ * ─────────────────────────────────────────────────────────────────────────── */
+.edit-theme-scope { background: var(--et-root-bg); }
+
+/* Black-opacity surface fills → themed shade (one base preserves the hierarchy). */
+.edit-theme-scope .bg-black\/20 { background-color: rgb(var(--et-shade) / 0.20); }
+.edit-theme-scope .bg-black\/30 { background-color: rgb(var(--et-shade) / 0.30); }
+.edit-theme-scope .bg-black\/40 { background-color: rgb(var(--et-shade) / 0.40); }
+.edit-theme-scope .bg-black\/50 { background-color: rgb(var(--et-shade) / 0.50); }
+.edit-theme-scope .bg-black\/60 { background-color: rgb(var(--et-shade) / 0.60); }
+.edit-theme-scope .bg-black\/80 { background-color: rgb(var(--et-shade) / 0.80); }
+.edit-theme-scope .bg-black\/90 { background-color: rgb(var(--et-shade) / 0.90); }
+.edit-theme-scope .bg-black\/95 { background-color: rgb(var(--et-shade) / 0.95); }
+
+/* Solid hex surfaces. */
+.edit-theme-scope .bg-\[\#07050a\] { background-color: var(--et-canvas); }
+.edit-theme-scope .bg-\[\#0c0a12\] { background-color: var(--et-panel); }
+.edit-theme-scope .bg-\[\#0a080f\] { background-color: var(--et-popup); }
+
+/* White-opacity subtle fills → themed tint. */
+.edit-theme-scope .bg-white\/2 { background-color: rgb(var(--et-tint) / 0.02); }
+.edit-theme-scope .bg-white\/5 { background-color: rgb(var(--et-tint) / 0.05); }
+.edit-theme-scope .bg-white\/10 { background-color: rgb(var(--et-tint) / 0.10); }
+.edit-theme-scope .bg-white\/20 { background-color: rgb(var(--et-tint) / 0.20); }
+.edit-theme-scope .bg-white\/30 { background-color: rgb(var(--et-tint) / 0.30); }
+.edit-theme-scope .bg-white\/40 { background-color: rgb(var(--et-tint) / 0.40); }
+.edit-theme-scope .bg-white\/60 { background-color: rgb(var(--et-tint) / 0.60); }
+.edit-theme-scope .bg-white\/70 { background-color: rgb(var(--et-tint) / 0.70); }
+
+/* Borders. */
+.edit-theme-scope .border-white\/5 { border-color: rgb(var(--et-line) / 0.05); }
+.edit-theme-scope .border-white\/8 { border-color: rgb(var(--et-line) / 0.08); }
+.edit-theme-scope .border-white\/10 { border-color: rgb(var(--et-line) / 0.10); }
+.edit-theme-scope .border-white\/15 { border-color: rgb(var(--et-line) / 0.15); }
+.edit-theme-scope .border-white\/25 { border-color: rgb(var(--et-line) / 0.25); }
+.edit-theme-scope .border-white\/40 { border-color: rgb(var(--et-line) / 0.40); }
+.edit-theme-scope .border-\[\#1a1528\] { border-color: var(--et-line-hex); }
+
+/* Light themes: keep the dim label/value text legible over light surfaces.
+ * Solid semantic text (text-white on colored buttons, text-purple, etc.) is
+ * left alone; only the neutral inherited + dim-utility text is darkened. */
+.edit-theme-scope[data-et-light="1"] { color: rgb(var(--et-ink)); }
+.edit-theme-scope[data-et-light="1"] .text-white\/40 { color: rgb(var(--et-ink) / 0.60); }
+.edit-theme-scope[data-et-light="1"] .text-white\/50 { color: rgb(var(--et-ink) / 0.66); }
+.edit-theme-scope[data-et-light="1"] .text-white\/60 { color: rgb(var(--et-ink) / 0.72); }
+.edit-theme-scope[data-et-light="1"] .text-white\/70 { color: rgb(var(--et-ink) / 0.80); }
+.edit-theme-scope[data-et-light="1"] .text-white\/80 { color: rgb(var(--et-ink) / 0.88); }
+.edit-theme-scope[data-et-light="1"] .text-zinc-300,
+.edit-theme-scope[data-et-light="1"] .text-zinc-400,
+.edit-theme-scope[data-et-light="1"] .text-zinc-500,
+.edit-theme-scope[data-et-light="1"] .text-zinc-600 { color: rgb(var(--et-ink) / 0.70); }

--- a/frontend/src/lib/editThemes.ts
+++ b/frontend/src/lib/editThemes.ts
@@ -1,0 +1,341 @@
+/**
+ * EDIT-layout color themes.
+ *
+ * The WaveformEditor root carries the `edit-theme-scope` class. A block of
+ * unlayered CSS in index.css remaps the layout's neutral chrome — every
+ * `bg-black/*` surface, `bg-white/*` fill, and `border-white/*` / hex border —
+ * onto the CSS custom properties defined here. Because the default "Midnight"
+ * theme's variables reproduce the original hardcoded palette exactly, an
+ * un-themed editor is pixel-identical; every other theme just swaps the
+ * variable values. Only backgrounds + borders (+ text legibility on light
+ * themes) are affected — semantic accents (purple/red/amber/…) are untouched.
+ *
+ * Variable roles:
+ *   --et-root-bg : the editor canvas backdrop (solid, gradient, or image)
+ *   --et-shade   : rgb triple that all `bg-black/α` surfaces resolve to
+ *   --et-canvas  : the scrolling timeline background (`#07050a`)
+ *   --et-panel   : the track-header column (`#0c0a12`)
+ *   --et-popup   : floating panels (`#0a080f`)
+ *   --et-line    : rgb triple for `border-white/α` dividers
+ *   --et-line-hex: the track-header hex border (`#1a1528`)
+ *   --et-tint    : rgb triple for `bg-white/α` subtle fills
+ *   --et-ink     : rgb triple for text on light themes
+ */
+
+export interface EditTheme {
+  id: string;
+  label: string;
+  group: string;
+  light?: boolean;
+  /** Overrides merged over DEFAULT_ET_VARS. */
+  vars: Record<string, string>;
+}
+
+/** Midnight / default — these values reproduce the original EDIT palette. */
+export const DEFAULT_ET_VARS: Record<string, string> = {
+  '--et-root-bg': 'rgba(0,0,0,0.4)',
+  '--et-shade': '0 0 0',
+  '--et-canvas': '#07050a',
+  '--et-panel': '#0c0a12',
+  '--et-popup': '#0a080f',
+  '--et-line': '255 255 255',
+  '--et-line-hex': '#1a1528',
+  '--et-tint': '255 255 255',
+  '--et-ink': '245 243 255',
+};
+
+export const EDIT_THEMES: EditTheme[] = [
+  // ── Dark ──────────────────────────────────────────────────────────────
+  { id: 'midnight', label: 'Midnight', group: 'Dark', vars: {} },
+  {
+    id: 'obsidian',
+    label: 'Obsidian',
+    group: 'Dark',
+    vars: {
+      '--et-root-bg': 'radial-gradient(circle at 50% -10%, #14141c 0%, #050507 62%)',
+      '--et-shade': '0 0 0',
+      '--et-canvas': '#050507',
+      '--et-panel': '#0a0a0d',
+      '--et-popup': '#050506',
+      '--et-line': '236 239 246',
+      '--et-line-hex': '#191922',
+      '--et-tint': '236 239 246',
+    },
+  },
+  {
+    id: 'graphite',
+    label: 'Graphite',
+    group: 'Dark',
+    vars: {
+      '--et-root-bg': '#111216',
+      '--et-shade': '18 20 26',
+      '--et-canvas': '#15161a',
+      '--et-panel': '#1d1f24',
+      '--et-popup': '#131418',
+      '--et-line': '212 218 230',
+      '--et-line-hex': '#2a2d34',
+      '--et-tint': '236 240 250',
+    },
+  },
+  // ── Silver / Metal ────────────────────────────────────────────────────
+  {
+    id: 'silver-black',
+    label: 'Silver & Black',
+    group: 'Metal',
+    vars: {
+      '--et-root-bg': 'linear-gradient(180deg,#101114 0%,#0a0a0c 100%)',
+      '--et-shade': '120 128 145',
+      '--et-canvas': '#0a0a0c',
+      '--et-panel': '#17181c',
+      '--et-popup': '#0a0a0c',
+      '--et-line': '196 204 218',
+      '--et-line-hex': '#333a44',
+      '--et-tint': '200 208 222',
+    },
+  },
+  {
+    id: 'brushed-steel',
+    label: 'Brushed Steel',
+    group: 'Metal',
+    vars: {
+      '--et-root-bg': 'linear-gradient(135deg,#2b2e34 0%,#16181c 45%,#2b2e34 100%)',
+      '--et-shade': '70 76 88',
+      '--et-canvas': 'rgba(14,15,18,0.72)',
+      '--et-panel': 'rgba(30,33,39,0.9)',
+      '--et-popup': 'rgba(16,17,20,0.94)',
+      '--et-line': '205 212 224',
+      '--et-line-hex': '#3a3f49',
+      '--et-tint': '210 216 228',
+    },
+  },
+  {
+    id: 'titanium',
+    label: 'Titanium',
+    group: 'Metal',
+    vars: {
+      '--et-root-bg': '#111316',
+      '--et-shade': '90 98 110',
+      '--et-canvas': '#16181b',
+      '--et-panel': '#202329',
+      '--et-popup': '#15171a',
+      '--et-line': '188 198 210',
+      '--et-line-hex': '#313640',
+      '--et-tint': '198 206 218',
+    },
+  },
+  // ── Light / Off-white ─────────────────────────────────────────────────
+  {
+    id: 'porcelain',
+    label: 'Porcelain',
+    group: 'Light',
+    light: true,
+    vars: {
+      '--et-root-bg': '#e8e6e1',
+      '--et-shade': '176 172 164',
+      '--et-canvas': '#eceae7',
+      '--et-panel': '#e2e0da',
+      '--et-popup': '#f2f1ed',
+      '--et-line': '40 38 44',
+      '--et-line-hex': '#c7c4bc',
+      '--et-tint': '30 28 34',
+      '--et-ink': '46 44 52',
+    },
+  },
+  {
+    id: 'ash',
+    label: 'Ash Grey',
+    group: 'Light',
+    light: true,
+    vars: {
+      '--et-root-bg': '#d8dce0',
+      '--et-shade': '150 158 168',
+      '--et-canvas': '#dfe2e6',
+      '--et-panel': '#d3d7dc',
+      '--et-popup': '#e9ecef',
+      '--et-line': '38 44 52',
+      '--et-line-hex': '#bcc2c9',
+      '--et-tint': '30 36 44',
+      '--et-ink': '40 46 54',
+    },
+  },
+  {
+    id: 'paper',
+    label: 'Paper',
+    group: 'Light',
+    light: true,
+    vars: {
+      '--et-root-bg': '#efe8db',
+      '--et-shade': '196 184 162',
+      '--et-canvas': '#f2ece1',
+      '--et-panel': '#e9e2d4',
+      '--et-popup': '#f6f1e8',
+      '--et-line': '58 48 34',
+      '--et-line-hex': '#d4cbb9',
+      '--et-tint': '46 38 26',
+      '--et-ink': '56 46 34',
+    },
+  },
+  // ── Pastel ────────────────────────────────────────────────────────────
+  {
+    id: 'mint',
+    label: 'Pastel Mint',
+    group: 'Pastel',
+    light: true,
+    vars: {
+      '--et-root-bg': 'linear-gradient(160deg,#eaf4ee,#dcefe4)',
+      '--et-shade': '150 194 172',
+      '--et-canvas': '#e6f1ea',
+      '--et-panel': '#d8ebe0',
+      '--et-popup': '#eef6f1',
+      '--et-line': '26 66 50',
+      '--et-line-hex': '#c0ded0',
+      '--et-tint': '24 60 46',
+      '--et-ink': '28 62 48',
+    },
+  },
+  {
+    id: 'lavender',
+    label: 'Pastel Lavender',
+    group: 'Pastel',
+    light: true,
+    vars: {
+      '--et-root-bg': 'linear-gradient(160deg,#efedf9,#e4def2)',
+      '--et-shade': '176 166 216',
+      '--et-canvas': '#ece9f5',
+      '--et-panel': '#e2ddf1',
+      '--et-popup': '#f3f0fb',
+      '--et-line': '48 38 84',
+      '--et-line-hex': '#d3ccec',
+      '--et-tint': '46 36 82',
+      '--et-ink': '50 40 84',
+    },
+  },
+  {
+    id: 'peach',
+    label: 'Pastel Peach',
+    group: 'Pastel',
+    light: true,
+    vars: {
+      '--et-root-bg': 'linear-gradient(160deg,#f8efe8,#f1e2d6)',
+      '--et-shade': '224 176 150',
+      '--et-canvas': '#f6ece4',
+      '--et-panel': '#f0e0d4',
+      '--et-popup': '#faf2ec',
+      '--et-line': '86 50 34',
+      '--et-line-hex': '#e6d2c4',
+      '--et-tint': '84 48 32',
+      '--et-ink': '86 52 38',
+    },
+  },
+  {
+    id: 'sky',
+    label: 'Pastel Sky',
+    group: 'Pastel',
+    light: true,
+    vars: {
+      '--et-root-bg': 'linear-gradient(160deg,#eaf2f9,#dce9f4)',
+      '--et-shade': '150 186 220',
+      '--et-canvas': '#e5eef6',
+      '--et-panel': '#d8e6f2',
+      '--et-popup': '#eef4fa',
+      '--et-line': '24 52 84',
+      '--et-line-hex': '#c2d6ea',
+      '--et-tint': '22 50 82',
+      '--et-ink': '26 54 86',
+    },
+  },
+  // ── Gradient ──────────────────────────────────────────────────────────
+  {
+    id: 'aurora',
+    label: 'Aurora',
+    group: 'Gradient',
+    vars: {
+      '--et-root-bg': 'linear-gradient(135deg,#0d1030 0%,#241a3e 45%,#0b1a2e 100%)',
+      '--et-shade': '30 26 60',
+      '--et-canvas': 'rgba(8,8,18,0.66)',
+      '--et-panel': 'rgba(20,18,38,0.86)',
+      '--et-popup': 'rgba(10,8,20,0.92)',
+      '--et-line': '150 140 210',
+      '--et-line-hex': '#2c2650',
+      '--et-tint': '160 150 220',
+    },
+  },
+  {
+    id: 'sunset',
+    label: 'Sunset',
+    group: 'Gradient',
+    vars: {
+      '--et-root-bg': 'linear-gradient(135deg,#2a1020 0%,#3a1a22 45%,#160810 100%)',
+      '--et-shade': '60 24 34',
+      '--et-canvas': 'rgba(16,6,12,0.68)',
+      '--et-panel': 'rgba(38,18,26,0.86)',
+      '--et-popup': 'rgba(18,8,12,0.92)',
+      '--et-line': '224 150 150',
+      '--et-line-hex': '#4a2028',
+      '--et-tint': '224 160 150',
+    },
+  },
+  {
+    id: 'deepsea',
+    label: 'Deep Sea',
+    group: 'Gradient',
+    vars: {
+      '--et-root-bg': 'linear-gradient(160deg,#04121a 0%,#062634 45%,#03101a 100%)',
+      '--et-shade': '18 44 56',
+      '--et-canvas': 'rgba(4,14,20,0.66)',
+      '--et-panel': 'rgba(8,30,40,0.86)',
+      '--et-popup': 'rgba(4,16,22,0.92)',
+      '--et-line': '130 190 210',
+      '--et-line-hex': '#123642',
+      '--et-tint': '140 196 214',
+    },
+  },
+];
+
+/** Translucent-scrim vars used when a custom background image is active, so the
+ *  image shows through the timeline while surfaces stay readable. */
+const CUSTOM_IMAGE_VARS: Record<string, string> = {
+  '--et-shade': '10 10 16',
+  '--et-canvas': 'rgba(8,8,12,0.62)',
+  '--et-panel': 'rgba(14,14,20,0.84)',
+  '--et-popup': 'rgba(8,8,12,0.92)',
+  '--et-line': '220 224 235',
+  '--et-line-hex': '#2a2a34',
+  '--et-tint': '224 228 238',
+};
+
+export const CUSTOM_IMAGE_ID = 'custom-image';
+
+export const editThemeById = (id: string): EditTheme | undefined =>
+  EDIT_THEMES.find((t) => t.id === id);
+
+export interface ResolvedEditTheme {
+  vars: Record<string, string>;
+  light: boolean;
+}
+
+/**
+ * Merge a theme id (and optional custom image data URL) into the full set of
+ * `--et-*` variables to spread onto the editor root's inline style.
+ */
+export function resolveEditThemeVars(
+  id: string,
+  customImage: string | null,
+): ResolvedEditTheme {
+  if (id === CUSTOM_IMAGE_ID && customImage) {
+    return {
+      vars: {
+        ...DEFAULT_ET_VARS,
+        ...CUSTOM_IMAGE_VARS,
+        // Scrim gradient over the image keeps foreground content legible.
+        '--et-root-bg': `linear-gradient(rgba(6,6,10,0.45), rgba(6,6,10,0.45)), url("${customImage}") center / cover no-repeat`,
+      },
+      light: false,
+    };
+  }
+  const theme = editThemeById(id) ?? EDIT_THEMES[0];
+  return {
+    vars: { ...DEFAULT_ET_VARS, ...theme.vars },
+    light: !!theme.light,
+  };
+}

--- a/frontend/src/state/editThemeStore.ts
+++ b/frontend/src/state/editThemeStore.ts
@@ -1,0 +1,32 @@
+/**
+ * EDIT-layout theme selection. Persists which color theme the multitrack
+ * editor uses, plus an optional custom background image (stored as a data URL
+ * so it survives reloads without a disk path). Consumed by WaveformEditor via
+ * resolveEditThemeVars() in lib/editThemes.ts.
+ */
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { CUSTOM_IMAGE_ID } from '../lib/editThemes';
+
+interface EditThemeState {
+  themeId: string;
+  customImage: string | null; // data URL of a user-picked background image
+  setTheme: (id: string) => void;
+  setCustomImage: (dataUrl: string | null) => void;
+}
+
+export const useEditThemeStore = create<EditThemeState>()(
+  persist(
+    (set) => ({
+      themeId: 'midnight',
+      customImage: null,
+      setTheme: (id) => set({ themeId: id }),
+      setCustomImage: (dataUrl) =>
+        set({
+          customImage: dataUrl,
+          themeId: dataUrl ? CUSTOM_IMAGE_ID : 'midnight',
+        }),
+    }),
+    { name: 'thedaw-edit-theme-v1', version: 1 },
+  ),
+);


### PR DESCRIPTION
A THEME control in the EDIT toolbar recolors the whole editor layout's backgrounds and borders. Sixteen presets across Dark / Metal / Light / Pastel / Gradient groups, plus a custom background image.

- editThemes.ts: each preset is a set of --et-* CSS variables. The default "Midnight" values reproduce the original hardcoded palette exactly, so the editor is pixel-identical until a theme is chosen.
- index.css: unlayered .edit-theme-scope rules remap the layout's neutral chrome (bg-black/*, bg-white/*, border-white/*, and the hex surface/border tokens) onto those variables, so no per-element class edits are needed. Light themes also darken the dim label/value text for legibility.
- editThemeStore.ts: persisted theme id + custom background image (data URL).
- EditThemePicker.tsx: toolbar popover of theme swatches + "choose image" (accessible file input). Portaled to body so it stays neutral chrome.
- WaveformEditor root now carries .edit-theme-scope + inline --et-* vars.