### PR TITLE
feat(theme): apply the color theme app-wide (all tabs), not just EDIT

### DIFF
--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -46,8 +46,6 @@ import { publishSelectedTracks } from '../../state/editorSelectionBridge';
 import * as liveMixer from '../../state/liveMixer';
 import { useDjAnalysisStore } from '../../state/djAnalysisStore';
 import { ContextMenu, useContextMenu, type ContextMenuItem } from '../ui/ContextMenu';
-import { useEditThemeStore } from '../../state/editThemeStore';
-import { resolveEditThemeVars } from '../../lib/editThemes';
 
 const TRACK_HEADER_PX = 180;
 const TRACK_HEIGHT = 104;
@@ -2365,20 +2363,8 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
     }
   }, []);
 
-  const editThemeId = useEditThemeStore((s) => s.themeId);
-  const editThemeImage = useEditThemeStore((s) => s.customImage);
-  const editTheme = useMemo(
-    () => resolveEditThemeVars(editThemeId, editThemeImage),
-    [editThemeId, editThemeImage],
-  );
-
   return (
-    <div
-      className="edit-theme-scope hardware-card h-full flex flex-col overflow-hidden"
-      data-et-light={editTheme.light ? '1' : undefined}
-      style={editTheme.vars as React.CSSProperties}
-      ref={containerRef}
-    >
+    <div className="hardware-card h-full flex flex-col bg-black/40 overflow-hidden" ref={containerRef}>
       {/* Editor Toolbar */}
       <div className="flex items-center justify-between p-2 border-b border-white/5 bg-black/20 shrink-0">
         <div className="flex items-center gap-3">

--- a/frontend/src/components/layout/Shell.tsx
+++ b/frontend/src/components/layout/Shell.tsx
@@ -27,6 +27,8 @@ import { useOnboardingStore } from '../../onboarding/onboardingStore';
 import FeatureGateNotices from '../../notices/FeatureGateNotices';
 import { useStatusBarStore } from '../../state/statusBarStore';
 import { backendHttpBase, lanReachablePort } from '../../lib/backendBase';
+import { useEditThemeStore } from '../../state/editThemeStore';
+import { resolveEditThemeVars } from '../../lib/editThemes';
 
 const RIGHT_RAIL_MIN = 280;
 const RIGHT_RAIL_MAX = 640;
@@ -171,10 +173,18 @@ export const Shell: React.FC = () => {
     };
   }, [isResizingRail, setRightPanelWidth]);
 
+  const editThemeId = useEditThemeStore((s) => s.themeId);
+  const editThemeImage = useEditThemeStore((s) => s.customImage);
+  const editTheme = useMemo(
+    () => resolveEditThemeVars(editThemeId, editThemeImage),
+    [editThemeId, editThemeImage],
+  );
+
   return (
     <div
-      className="relative flex flex-col w-full bg-[#07050a] text-[#f5f3ff] overflow-hidden font-sans dense-layout"
-      style={{ height: 'calc((100vh - 5rem) / var(--layout-zoom))' }}
+      className="edit-theme-scope relative flex flex-col w-full bg-[#07050a] text-[#f5f3ff] overflow-hidden font-sans dense-layout"
+      data-et-light={editTheme.light ? '1' : undefined}
+      style={{ height: 'calc((100vh - 5rem) / var(--layout-zoom))', ...(editTheme.vars as React.CSSProperties) }}
     >
       {/* Combined header + tab bar — logo (left), workspace tabs (center),
           Mobile / Docs / app-menu (right). G-Search moved to the footer. */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -208,15 +208,16 @@ select optgroup {
 .genealogy-svg g.gen-lit[data-edge-from] path { stroke-width: 4.5; }
 
 /* ───────────────────────────────────────────────────────────────────────────
- * EDIT-LAYOUT THEMING.
- * The WaveformEditor root carries `.edit-theme-scope` and inline `--et-*`
- * variables (see lib/editThemes.ts + state/editThemeStore.ts). These UNLAYERED
- * rules remap the layout's neutral chrome — every black-opacity surface,
- * white-opacity fill, and white/hex border — onto those variables. Unlayered
- * beats Tailwind's utilities layer, so no per-element class edits are needed;
- * the default "Midnight" variables reproduce the original palette exactly, so
- * an un-themed editor is pixel-identical. Semantic accents (purple/red/amber/…)
- * are intentionally NOT remapped.
+ * APP THEMING.
+ * The Shell root carries `.edit-theme-scope` and inline `--et-*` variables (see
+ * lib/editThemes.ts + state/editThemeStore.ts), so the theme applies across the
+ * whole app (every tab + chrome). These UNLAYERED rules remap the neutral
+ * chrome — every black-opacity surface, white-opacity fill, and white/hex
+ * border — onto those variables. Unlayered beats Tailwind's utilities layer, so
+ * no per-element class edits are needed; the default "Midnight" variables
+ * reproduce the original palette exactly, so an un-themed app is pixel-identical.
+ * Semantic accents (purple/red/amber/…) are intentionally NOT remapped. Modals
+ * portaled to <body> sit outside the scope and keep the default dark chrome.
  * ─────────────────────────────────────────────────────────────────────────── */
 .edit-theme-scope { background: var(--et-root-bg); }
 
@@ -267,3 +268,6 @@ select optgroup {
 .edit-theme-scope[data-et-light="1"] .text-zinc-400,
 .edit-theme-scope[data-et-light="1"] .text-zinc-500,
 .edit-theme-scope[data-et-light="1"] .text-zinc-600 { color: rgb(var(--et-ink) / 0.70); }
+.edit-theme-scope[data-et-light="1"] .text-zinc-100,
+.edit-theme-scope[data-et-light="1"] .text-zinc-200,
+.edit-theme-scope[data-et-light="1"] .text-\[\#f5f3ff\] { color: rgb(var(--et-ink)); }

--- a/frontend/src/lib/editThemes.ts
+++ b/frontend/src/lib/editThemes.ts
@@ -33,7 +33,7 @@ export interface EditTheme {
 
 /** Midnight / default — these values reproduce the original EDIT palette. */
 export const DEFAULT_ET_VARS: Record<string, string> = {
-  '--et-root-bg': 'rgba(0,0,0,0.4)',
+  '--et-root-bg': '#07050a',
   '--et-shade': '0 0 0',
   '--et-canvas': '#07050a',
   '--et-panel': '#0c0a12',


### PR DESCRIPTION
Moves the .edit-theme-scope + inline --et-* vars from the WaveformEditor root up to the Shell root, so the selected theme recolors every tab and the app chrome. The EDIT root reverts to its original bg-black/40 (now themed by the global surface remap). Default --et-root-bg becomes #07050a (the Shell canvas) so Midnight is pixel-identical; light-theme text overrides broadened for app-wide legibility. Modals portaled to <body> stay outside the scope (default dark chrome).