### PR TITLE
feat(levels): master loudness + metering tab (LUFS / true-peak / stereo)

### DIFF
--- a/backend/rag.py
+++ b/backend/rag.py
@@ -54,6 +54,7 @@ DOC_PATHS = [
     PROJECT_ROOT / "docs" / "guides" / "electron-desktop-app.md",
     PROJECT_ROOT / "docs" / "guides" / "pinokio-launcher.md",
     PROJECT_ROOT / "docs" / "guides" / "audimate.md",
+    PROJECT_ROOT / "docs" / "guides" / "levels.md",
     # The manual is indexed once, from docs/USER_GUIDE.md. The byte-identical
     # frontend/public/USER_GUIDE.md mirror that Vite serves for the in-app Docs
     # modal is intentionally not indexed here, to avoid embedding the manual twice.

--- a/docs/guides/levels.md
+++ b/docs/guides/levels.md
@@ -1,0 +1,46 @@
+# Levels — loudness and metering
+
+The **Levels** tab is the first tab of the lower panel (the meter-gauge icon). It
+shows master metering of whatever is currently audible — it taps the shared
+master output, so it reflects playback on any tab (MAKE, EDIT, DJ, the Sequencer,
+and so on), not just one workspace.
+
+## The views
+
+A row of round buttons switches between six views; the choice, the LUFS target,
+and the true-peak ceiling are remembered across restarts.
+
+- **Radial** — the combined circular readout, with spokes for Peak, LUFS, LRA,
+  Dynamic Range, Stereo Field, and Bass, and the integrated LUFS in the center.
+- **LUFS** — momentary (400 ms), short-term (3 s), and gated integrated loudness
+  as bars, with a target line and the loudness range (LRA). Bars turn green near
+  the target, amber when quiet, red when over.
+- **Peak** — sample peak, true peak (oversampled), and RMS bars, with a ceiling
+  line and a live headroom readout.
+- **Dynamic Range** — the crest factor (peak minus RMS) as a big number plus a
+  scrolling ribbon.
+- **Stereo Field** — a goniometer/vectorscope (rotated so mono reads vertical)
+  and a correlation strip (+1 = mono-compatible, negative = out of phase).
+- **Bass Space** — per-band level at 40 / 80 / 120 / 160 Hz for low-end balance.
+
+## How it works
+
+Loudness is measured to ITU-R BS.1770-4 (K-weighting with the high-shelf
+pre-filter + RLB high-pass, gated integrated loudness), true peak is 4x
+oversampled, and the DSP runs in one audio worklet fanned non-destructively off
+the master — it observes the signal without changing it. If the browser has no
+AudioWorklet, the tab falls back to RMS/peak only (the LUFS fields read "—") and
+shows an "RMS only" note.
+
+## Targets
+
+The LUFS view offers quick target presets: **-14** (streaming), **-16**, and
+**-23** (broadcast). The target line and the color coding follow the selected
+value.
+
+## Notes
+
+- Metering starts when the Levels tab is open and stops when you leave it, so the
+  integrated LUFS reading restarts each time you open the tab.
+- Per-track lane meters and automation-mode controls are planned as a later
+  addition; today the tab meters the master output.

--- a/frontend/public/worklets/levels-meter.js
+++ b/frontend/public/worklets/levels-meter.js
@@ -1,0 +1,300 @@
+/**
+ * levels-meter — an AudioWorkletProcessor that measures the master signal for
+ * theDAW's Levels tab. Tapped non-destructively off the master gain (its output
+ * feeds a silent sink, so it observes without altering the audio).
+ *
+ * Per ~100 ms it posts a compact readings frame:
+ *   - LUFS: momentary (400 ms), short-term (3 s), and gated integrated (BS.1770-4
+ *     K-weighting: high-shelf pre-filter + RLB high-pass, computed for the actual
+ *     sample rate).
+ *   - True peak (4x oversampled via Catmull-Rom) + sample peak, in dBTP/dBFS.
+ *   - RMS + crest factor (for the Dynamic Range view).
+ *   - Inter-channel correlation + a decimated L/R scatter (for the goniometer).
+ *   - Per-band RMS at 40 / 80 / 120 / 160 Hz (for Bass Space).
+ *   - Loudness range (LRA) from the short-term loudness distribution.
+ */
+
+function kWeightingCoeffs(fs) {
+  // Stage 1 — high-shelf pre-filter.
+  const db = 3.999843853973347;
+  const f1 = 1681.9744509555319;
+  const Q1 = 0.7071752369554193;
+  const K1 = Math.tan(Math.PI * f1 / fs);
+  const Vh = Math.pow(10, db / 20);
+  const Vb = Math.pow(Vh, 0.4996667741545416);
+  const a01 = 1 + K1 / Q1 + K1 * K1;
+  const s1 = [
+    (Vh + (Vb * K1) / Q1 + K1 * K1) / a01,
+    (2 * (K1 * K1 - Vh)) / a01,
+    (Vh - (Vb * K1) / Q1 + K1 * K1) / a01,
+    (2 * (K1 * K1 - 1)) / a01,
+    (1 - K1 / Q1 + K1 * K1) / a01,
+  ];
+  // Stage 2 — RLB high-pass.
+  const f2 = 38.13547087613982;
+  const Q2 = 0.5003270373253953;
+  const K2 = Math.tan(Math.PI * f2 / fs);
+  const a02 = 1 + K2 / Q2 + K2 * K2;
+  const s2 = [1, -2, 1, (2 * (K2 * K2 - 1)) / a02, (1 - K2 / Q2 + K2 * K2) / a02];
+  return [s1, s2];
+}
+
+function bandpass(f0, fs, Q) {
+  const w0 = (2 * Math.PI * f0) / fs;
+  const alpha = Math.sin(w0) / (2 * Q);
+  const cosw = Math.cos(w0);
+  const a0 = 1 + alpha;
+  return [alpha / a0, 0, -alpha / a0, (-2 * cosw) / a0, (1 - alpha) / a0];
+}
+
+class Biquad {
+  constructor(c) {
+    this.b0 = c[0];
+    this.b1 = c[1];
+    this.b2 = c[2];
+    this.a1 = c[3];
+    this.a2 = c[4];
+    this.z1 = 0;
+    this.z2 = 0;
+  }
+  process(x) {
+    const y = this.b0 * x + this.z1;
+    this.z1 = this.b1 * x - this.a1 * y + this.z2;
+    this.z2 = this.b2 * x - this.a2 * y;
+    return y;
+  }
+}
+
+const ABS_GATE = -70; // LUFS absolute gate
+const MAX_BLOCKS = 36000; // ~1 hr of 100 ms gating blocks
+
+function catmull(p0, p1, p2, p3, t) {
+  return (
+    p1 +
+    0.5 *
+      t *
+      (p2 - p0 + t * (2 * p0 - 5 * p1 + 4 * p2 - p3 + t * (3 * (p1 - p2) + p3 - p0)))
+  );
+}
+
+class LevelsMeter extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    const fs = sampleRate;
+    const k = kWeightingCoeffs(fs);
+    this.kL = [new Biquad(k[0]), new Biquad(k[1])];
+    this.kR = [new Biquad(k[0]), new Biquad(k[1])];
+    this.bandFreqs = [40, 80, 120, 160];
+    this.bandFilters = this.bandFreqs.map((f) => new Biquad(bandpass(f, fs, 4)));
+
+    this.hop = Math.max(1, Math.round(fs * 0.1)); // 100 ms
+    this.hopCount = 0;
+    this.hopSumSq = 0; // K-weighted sum of squares (both channels) this 100 ms
+    this.subBlocks = []; // recent per-100ms {ms} for momentary/short windows
+
+    this.gatingMs = []; // 400 ms block mean-squares that pass the absolute gate
+    this.shortLoud = []; // 3 s short-term loudness values (for LRA)
+
+    // per-100ms accumulators
+    this.samplePeak = 0;
+    this.truePeak = 0;
+    this.rmsSum = 0;
+    this.rmsN = 0;
+    this.corrLL = 0;
+    this.corrRR = 0;
+    this.corrLR = 0;
+    this.bandSum = [0, 0, 0, 0];
+
+    // true-peak history (Catmull-Rom needs 4 points) per channel
+    this.hl = [0, 0, 0, 0];
+    this.hr = [0, 0, 0, 0];
+
+    // decimated scope ring (interleaved L,R)
+    this.scope = new Float32Array(512);
+    this.scopeIdx = 0;
+    this.scopeDecim = Math.max(1, Math.round(this.hop / 256));
+    this.scopeCtr = 0;
+  }
+
+  pushTruePeak(hist, x) {
+    hist[0] = hist[1];
+    hist[1] = hist[2];
+    hist[2] = hist[3];
+    hist[3] = x;
+    const a = Math.abs(hist[3]);
+    if (a > this.truePeak) this.truePeak = a;
+    for (let j = 1; j < 4; j += 1) {
+      const v = Math.abs(catmull(hist[0], hist[1], hist[2], hist[3], j / 4));
+      if (v > this.truePeak) this.truePeak = v;
+    }
+  }
+
+  emitHop() {
+    const ms = this.hopCount > 0 ? this.hopSumSq / this.hopCount : 0;
+    this.subBlocks.push(ms);
+    if (this.subBlocks.length > 40) this.subBlocks.shift(); // keep 4 s
+
+    // Gating block = last 400 ms (4 sub-blocks).
+    if (this.subBlocks.length >= 4) {
+      const w = this.subBlocks.slice(-4);
+      const gm = (w[0] + w[1] + w[2] + w[3]) / 4;
+      const loud = gm > 0 ? -0.691 + 10 * Math.log10(gm) : -Infinity;
+      if (loud > ABS_GATE) {
+        this.gatingMs.push(gm);
+        if (this.gatingMs.length > MAX_BLOCKS) this.gatingMs.shift();
+      }
+    }
+    // Short-term = last 3 s (30 sub-blocks).
+    if (this.subBlocks.length >= 30) {
+      const w = this.subBlocks.slice(-30);
+      let sum = 0;
+      for (let i = 0; i < 30; i += 1) sum += w[i];
+      const sm = sum / 30;
+      const loud = sm > 0 ? -0.691 + 10 * Math.log10(sm) : -Infinity;
+      if (loud > ABS_GATE) {
+        this.shortLoud.push(loud);
+        if (this.shortLoud.length > MAX_BLOCKS) this.shortLoud.shift();
+      }
+    }
+
+    this.hopSumSq = 0;
+    this.hopCount = 0;
+  }
+
+  momentary() {
+    const w = this.subBlocks.slice(-4);
+    if (!w.length) return -Infinity;
+    let s = 0;
+    for (const v of w) s += v;
+    const ms = s / w.length;
+    return ms > 0 ? -0.691 + 10 * Math.log10(ms) : -Infinity;
+  }
+
+  shortTerm() {
+    const w = this.subBlocks.slice(-30);
+    if (!w.length) return -Infinity;
+    let s = 0;
+    for (const v of w) s += v;
+    const ms = s / w.length;
+    return ms > 0 ? -0.691 + 10 * Math.log10(ms) : -Infinity;
+  }
+
+  integrated() {
+    if (!this.gatingMs.length) return -Infinity;
+    let sum = 0;
+    for (const m of this.gatingMs) sum += m;
+    const ungated = sum / this.gatingMs.length;
+    const relGate = -0.691 + 10 * Math.log10(ungated) - 10;
+    let s2 = 0;
+    let n2 = 0;
+    for (const m of this.gatingMs) {
+      const loud = -0.691 + 10 * Math.log10(m);
+      if (loud > relGate) {
+        s2 += m;
+        n2 += 1;
+      }
+    }
+    if (!n2) return -Infinity;
+    return -0.691 + 10 * Math.log10(s2 / n2);
+  }
+
+  lra() {
+    if (this.shortLoud.length < 10) return 0;
+    const sorted = [...this.shortLoud].sort((a, b) => a - b);
+    const lo = sorted[Math.floor(sorted.length * 0.1)];
+    const hi = sorted[Math.floor(sorted.length * 0.95)];
+    return Math.max(0, hi - lo);
+  }
+
+  postFrame() {
+    const toDb = (v) => (v > 0 ? 20 * Math.log10(v) : -Infinity);
+    const rms = this.rmsN > 0 ? Math.sqrt(this.rmsSum / this.rmsN) : 0;
+    const rmsDb = toDb(rms);
+    const samplePeakDb = toDb(this.samplePeak);
+    const crestDb = Number.isFinite(samplePeakDb) && Number.isFinite(rmsDb) ? samplePeakDb - rmsDb : 0;
+    const corrDen = Math.sqrt(this.corrLL * this.corrRR);
+    const correlation = corrDen > 1e-12 ? this.corrLR / corrDen : 0;
+    const bands = this.bandSum.map((s) => toDb(this.rmsN > 0 ? Math.sqrt(s / this.rmsN) : 0));
+
+    this.port.postMessage({
+      momentary: this.momentary(),
+      short: this.shortTerm(),
+      integrated: this.integrated(),
+      lra: this.lra(),
+      samplePeakDb,
+      truePeakDb: toDb(this.truePeak),
+      rmsDb,
+      crestDb,
+      correlation,
+      bands,
+      bandFreqs: this.bandFreqs,
+      scope: this.scope.slice(0, this.scopeIdx),
+    });
+
+    this.samplePeak = 0;
+    this.truePeak = 0;
+    this.rmsSum = 0;
+    this.rmsN = 0;
+    this.corrLL = 0;
+    this.corrRR = 0;
+    this.corrLR = 0;
+    this.bandSum = [0, 0, 0, 0];
+    this.scopeIdx = 0;
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+    const L = input[0];
+    const R = input.length > 1 ? input[1] : input[0];
+    const n = L.length;
+    for (let i = 0; i < n; i += 1) {
+      const l = L[i];
+      const r = R[i];
+      const kl = this.kL[1].process(this.kL[0].process(l));
+      const kr = this.kR[1].process(this.kR[0].process(r));
+      this.hopSumSq += kl * kl + kr * kr;
+      this.hopCount += 1;
+
+      const ap = Math.abs(l) > Math.abs(r) ? Math.abs(l) : Math.abs(r);
+      if (ap > this.samplePeak) this.samplePeak = ap;
+      this.pushTruePeak(this.hl, l);
+      this.pushTruePeak(this.hr, r);
+
+      this.rmsSum += (l * l + r * r) * 0.5;
+      this.rmsN += 1;
+      this.corrLL += l * l;
+      this.corrRR += r * r;
+      this.corrLR += l * r;
+
+      const mono = (l + r) * 0.5;
+      for (let b = 0; b < 4; b += 1) {
+        const bv = this.bandFilters[b].process(mono);
+        this.bandSum[b] += bv * bv;
+      }
+
+      this.scopeCtr += 1;
+      if (this.scopeCtr >= this.scopeDecim && this.scopeIdx < 510) {
+        this.scopeCtr = 0;
+        this.scope[this.scopeIdx] = l;
+        this.scope[this.scopeIdx + 1] = r;
+        this.scopeIdx += 2;
+      }
+
+      this.hopCounter = (this.hopCounter || 0) + 1;
+      if (this.hopCounter >= this.hop) {
+        this.hopCounter = 0;
+        this.emitHop();
+      }
+    }
+    // Post a frame roughly every 100 ms (aligned to the hop).
+    this.postCounter = (this.postCounter || 0) + n;
+    if (this.postCounter >= this.hop) {
+      this.postCounter = 0;
+      this.postFrame();
+    }
+    return true;
+  }
+}
+
+registerProcessor('levels-meter', LevelsMeter);

--- a/frontend/src/components/audio/levels/LevelsPanel.tsx
+++ b/frontend/src/components/audio/levels/LevelsPanel.tsx
@@ -1,0 +1,177 @@
+/**
+ * Levels tab — master loudness / peak / stereo metering. A single AudioWorklet
+ * (levels-meter.js), fanned non-destructively off the master gain, feeds all
+ * six views. The active view is painted on one <canvas> by a single rAF loop
+ * reading the module-scope readings frame (never through React), so metering
+ * never re-renders the tree.
+ *
+ * Meters whatever is audible on any tab (MAKE / EDIT / DJ / Sequencer / …),
+ * because they all route through the shared master gain.
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Gauge, Volume2, Activity, Waves, Radar, BarChart3 } from 'lucide-react';
+import {
+  useLevelsStore,
+  ensureMeter,
+  disposeMeter,
+  getLevelsFrame,
+  isWorkletMeter,
+  type LevelsView,
+} from '../../../state/levelsStore';
+import {
+  drawRadial,
+  drawLufs,
+  drawPeak,
+  drawDynamicRange,
+  drawStereo,
+  drawBass,
+  type ViewCtx,
+} from './levelsViews';
+
+const VIEWS: Array<{ id: LevelsView; icon: React.ComponentType<{ className?: string }>; title: string }> = [
+  { id: 'radial', icon: Gauge, title: 'Radial — combined readout' },
+  { id: 'lufs', icon: Volume2, title: 'LUFS — loudness' },
+  { id: 'peak', icon: Activity, title: 'Peak — sample + true peak' },
+  { id: 'dr', icon: Waves, title: 'Dynamic Range' },
+  { id: 'stereo', icon: Radar, title: 'Stereo field + correlation' },
+  { id: 'bass', icon: BarChart3, title: 'Bass Space — low-end bands' },
+];
+
+const LUFS_TARGETS = [-14, -16, -23];
+
+const PAINTERS: Record<LevelsView, (v: ViewCtx) => void> = {
+  radial: drawRadial,
+  lufs: drawLufs,
+  peak: drawPeak,
+  dr: drawDynamicRange,
+  stereo: drawStereo,
+  bass: drawBass,
+};
+
+export const LevelsPanel: React.FC = () => {
+  const view = useLevelsStore((s) => s.view);
+  const setView = useLevelsStore((s) => s.setView);
+  const lufsTarget = useLevelsStore((s) => s.lufsTarget);
+  const setLufsTarget = useLevelsStore((s) => s.setLufsTarget);
+  const truePeakCeiling = useLevelsStore((s) => s.truePeakCeiling);
+
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [fallback, setFallback] = useState(false);
+
+  // Refs so the rAF loop reads the latest view/target without re-subscribing.
+  const stateRef = useRef({ view, lufsTarget, truePeakCeiling });
+  stateRef.current = { view, lufsTarget, truePeakCeiling };
+
+  useEffect(() => {
+    void ensureMeter().then(() => setFallback(!isWorkletMeter()));
+    return () => disposeMeter();
+  }, []);
+
+  // Size the canvas to its container (DPR-aware).
+  useEffect(() => {
+    const wrap = wrapRef.current;
+    const cnv = canvasRef.current;
+    if (!wrap || !cnv) return;
+    const dpr = window.devicePixelRatio || 1;
+    const ro = new ResizeObserver(() => {
+      const r = wrap.getBoundingClientRect();
+      cnv.width = Math.max(1, Math.round(r.width * dpr));
+      cnv.height = Math.max(1, Math.round(r.height * dpr));
+      cnv.style.width = `${r.width}px`;
+      cnv.style.height = `${r.height}px`;
+    });
+    ro.observe(wrap);
+    return () => ro.disconnect();
+  }, []);
+
+  // Single rAF paint loop.
+  useEffect(() => {
+    let raf = 0;
+    const dpr = window.devicePixelRatio || 1;
+    const draw = () => {
+      const cnv = canvasRef.current;
+      const ctx = cnv?.getContext('2d');
+      if (cnv && ctx) {
+        const w = cnv.width / dpr;
+        const h = cnv.height / dpr;
+        ctx.save();
+        ctx.scale(dpr, dpr);
+        const frame = getLevelsFrame();
+        if (frame) {
+          const st = stateRef.current;
+          PAINTERS[st.view]({ ctx, w, h, frame, lufsTarget: st.lufsTarget, truePeakCeiling: st.truePeakCeiling });
+        } else {
+          ctx.fillStyle = '#0b0912';
+          ctx.fillRect(0, 0, w, h);
+          ctx.fillStyle = '#7a7390';
+          ctx.font = '10px ui-monospace, monospace';
+          ctx.textAlign = 'center';
+          ctx.fillText('waiting for audio…', w / 2, h / 2);
+        }
+        ctx.restore();
+      }
+      raf = requestAnimationFrame(draw);
+    };
+    raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  const showTarget = useMemo(() => view === 'lufs' || view === 'radial', [view]);
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-[#0b0912]">
+      {/* Switcher + target */}
+      <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-white/5 shrink-0">
+        {VIEWS.map((vw) => {
+          const Icon = vw.icon;
+          const active = view === vw.id;
+          return (
+            <button
+              key={vw.id}
+              onClick={() => setView(vw.id)}
+              title={vw.title}
+              aria-label={vw.title}
+              aria-pressed={active}
+              className={`w-7 h-7 grid place-items-center rounded-full border transition-colors ${
+                active ? 'border-purple-500/60 bg-purple-500/15 text-purple-200' : 'border-white/10 text-zinc-500 hover:text-white hover:bg-white/5'
+              }`}
+            >
+              <Icon className="w-3.5 h-3.5" />
+            </button>
+          );
+        })}
+
+        {showTarget && (
+          <div className="flex items-center gap-1 ml-2">
+            <span className="text-[8px] font-mono uppercase tracking-widest text-zinc-600">target</span>
+            {LUFS_TARGETS.map((t) => (
+              <button
+                key={t}
+                onClick={() => setLufsTarget(t)}
+                aria-pressed={lufsTarget === t}
+                className={`px-1.5 py-0.5 rounded text-[9px] font-mono border transition-colors ${
+                  lufsTarget === t ? 'border-purple-500/50 bg-purple-500/15 text-purple-200' : 'border-white/10 text-zinc-500 hover:text-white hover:bg-white/5'
+                }`}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="flex-1" />
+        {fallback && (
+          <span className="text-[8px] font-mono text-amber-400/80" title="AudioWorklet unavailable — RMS/peak only, no gated LUFS">
+            RMS only
+          </span>
+        )}
+      </div>
+
+      {/* Meter canvas */}
+      <div ref={wrapRef} className="flex-1 min-h-0 relative">
+        <canvas ref={canvasRef} className="absolute inset-0" />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/audio/levels/levelsViews.ts
+++ b/frontend/src/components/audio/levels/levelsViews.ts
@@ -1,0 +1,320 @@
+/**
+ * Canvas painters for the Levels tab's six meter views. Each takes the current
+ * readings frame and draws to a 2D context. Pure drawing — no React, no state;
+ * called from LevelsPanel's single rAF loop.
+ */
+import type { LevelsFrame } from '../../../state/levelsStore';
+
+export interface ViewCtx {
+  ctx: CanvasRenderingContext2D;
+  w: number;
+  h: number;
+  frame: LevelsFrame;
+  lufsTarget: number;
+  truePeakCeiling: number;
+}
+
+const BG = '#0b0912';
+const GRID = 'rgba(255,255,255,0.08)';
+const TEXT = '#cfc9dd';
+const DIM = '#7a7390';
+const ACCENT = '#a855f7';
+const GOOD = '#34d399';
+const WARN = '#f59e0b';
+const HOT = '#f43f5e';
+
+const fmt = (v: number, unit = ''): string => (Number.isFinite(v) ? v.toFixed(1) + unit : '—');
+const clamp01 = (x: number): number => Math.max(0, Math.min(1, x));
+/** Map a dB value to 0..1 over [min,max]. */
+const dbNorm = (db: number, min: number, max: number): number =>
+  Number.isFinite(db) ? clamp01((db - min) / (max - min)) : 0;
+
+function bg(v: ViewCtx): void {
+  v.ctx.fillStyle = BG;
+  v.ctx.fillRect(0, 0, v.w, v.h);
+}
+
+function label(v: ViewCtx, text: string, x: number, y: number, color = DIM, size = 9, align: CanvasTextAlign = 'left'): void {
+  v.ctx.fillStyle = color;
+  v.ctx.font = `${size}px ui-monospace, monospace`;
+  v.ctx.textAlign = align;
+  v.ctx.fillText(text, x, y);
+}
+
+function lufsColor(lufs: number, target: number): string {
+  if (!Number.isFinite(lufs)) return DIM;
+  const d = lufs - target;
+  if (d > 1) return HOT;
+  if (d > -1) return GOOD;
+  return WARN;
+}
+
+// ── Peak ────────────────────────────────────────────────────────────────────
+export function drawPeak(v: ViewCtx): void {
+  bg(v);
+  const { ctx, w, h, frame } = v;
+  const min = -60;
+  const max = 3;
+  const padL = 34;
+  const padR = 90;
+  const top = 14;
+  const barH = 18;
+  const gap = 12;
+  const trackW = w - padL - padR;
+
+  const rows = [
+    { name: 'PEAK', db: frame.samplePeakDb, col: ACCENT },
+    { name: 'TRUE', db: frame.truePeakDb, col: '#22d3ee' },
+    { name: 'RMS', db: frame.rmsDb, col: GOOD },
+  ];
+  rows.forEach((r, i) => {
+    const y = top + i * (barH + gap);
+    ctx.fillStyle = 'rgba(255,255,255,0.05)';
+    ctx.fillRect(padL, y, trackW, barH);
+    const n = dbNorm(r.db, min, max);
+    ctx.fillStyle = r.col;
+    ctx.fillRect(padL, y, trackW * n, barH);
+    label(v, r.name, padL - 4, y + barH - 5, DIM, 9, 'right');
+    label(v, fmt(r.db, ' dB'), padL + trackW + 8, y + barH - 5, TEXT, 11, 'left');
+  });
+
+  // Ceiling line + headroom readout.
+  const cn = dbNorm(v.truePeakCeiling, min, max);
+  const cx = padL + trackW * cn;
+  ctx.strokeStyle = HOT;
+  ctx.setLineDash([3, 3]);
+  ctx.beginPath();
+  ctx.moveTo(cx, top - 4);
+  ctx.lineTo(cx, top + rows.length * (barH + gap) - gap + 4);
+  ctx.stroke();
+  ctx.setLineDash([]);
+  const headroom = Number.isFinite(frame.truePeakDb) ? v.truePeakCeiling - frame.truePeakDb : NaN;
+  label(v, `ceiling ${v.truePeakCeiling.toFixed(1)} dBTP`, w - 6, h - 18, DIM, 9, 'right');
+  label(v, `headroom ${fmt(headroom, ' dB')}`, w - 6, h - 6, headroom < 0 ? HOT : GOOD, 10, 'right');
+}
+
+// ── LUFS ──────────────────────────────────────────────────────────────────
+export function drawLufs(v: ViewCtx): void {
+  bg(v);
+  const { ctx, w, h, frame, lufsTarget } = v;
+  const min = -40;
+  const max = 0;
+  const padL = 44;
+  const padR = 16;
+  const top = 14;
+  const barH = 20;
+  const gap = 14;
+  const trackW = w - padL - padR;
+
+  const rows = [
+    { name: 'M', db: frame.momentary },
+    { name: 'S', db: frame.short },
+    { name: 'I', db: frame.integrated },
+  ];
+  rows.forEach((r, i) => {
+    const y = top + i * (barH + gap);
+    ctx.fillStyle = 'rgba(255,255,255,0.05)';
+    ctx.fillRect(padL, y, trackW, barH);
+    const n = dbNorm(r.db, min, max);
+    ctx.fillStyle = lufsColor(r.db, lufsTarget);
+    ctx.fillRect(padL, y, trackW * n, barH);
+    label(v, r.name, padL - 6, y + barH - 6, DIM, 11, 'right');
+    label(v, `${fmt(r.db)} LUFS`, padL + 6, y + barH - 6, '#0b0912', 11, 'left');
+  });
+
+  // Target line.
+  const tn = dbNorm(lufsTarget, min, max);
+  const tx = padL + trackW * tn;
+  ctx.strokeStyle = ACCENT;
+  ctx.setLineDash([4, 3]);
+  ctx.beginPath();
+  ctx.moveTo(tx, top - 4);
+  ctx.lineTo(tx, top + rows.length * (barH + gap) - gap + 4);
+  ctx.stroke();
+  ctx.setLineDash([]);
+  label(v, `target ${lufsTarget} LUFS  ·  LRA ${fmt(frame.lra, ' LU')}`, w - 6, h - 6, DIM, 9, 'right');
+  label(v, 'M omentary · S hort · I ntegrated', padL, h - 6, DIM, 8, 'left');
+}
+
+// ── Dynamic Range ───────────────────────────────────────────────────────────
+const drHistory: number[] = [];
+export function drawDynamicRange(v: ViewCtx): void {
+  bg(v);
+  const { ctx, w, h, frame } = v;
+  const dr = frame.crestDb;
+  drHistory.push(Number.isFinite(dr) ? dr : 0);
+  if (drHistory.length > w) drHistory.shift();
+
+  // Big DR number.
+  ctx.fillStyle = TEXT;
+  ctx.font = '600 40px ui-monospace, monospace';
+  ctx.textAlign = 'left';
+  ctx.fillText(fmt(dr), 14, 48);
+  label(v, 'DR (crest, dB)', 16, 62, DIM, 9, 'left');
+
+  // Crest ribbon along the bottom.
+  const base = h - 10;
+  const scale = 2.2;
+  ctx.strokeStyle = GOOD;
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  drHistory.forEach((d, i) => {
+    const y = base - clamp01(d / 24) * (h * 0.5) * scale;
+    if (i === 0) ctx.moveTo(i, y);
+    else ctx.lineTo(i, y);
+  });
+  ctx.stroke();
+  ctx.lineWidth = 1;
+  label(v, `peak ${fmt(frame.samplePeakDb)}  rms ${fmt(frame.rmsDb)}`, w - 6, 18, DIM, 9, 'right');
+}
+
+// ── Stereo Field (goniometer + correlation) ─────────────────────────────────
+export function drawStereo(v: ViewCtx): void {
+  bg(v);
+  const { ctx, w, h, frame } = v;
+  const size = Math.min(w - 90, h - 20);
+  const cx = 10 + size / 2;
+  const cy = h / 2;
+  const r = size / 2;
+
+  ctx.strokeStyle = GRID;
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(cx - r, cy);
+  ctx.lineTo(cx + r, cy);
+  ctx.moveTo(cx, cy - r);
+  ctx.lineTo(cx, cy + r);
+  ctx.stroke();
+
+  // Scatter (rotate 45° so mono = vertical).
+  const rot = Math.PI / 4;
+  const cos = Math.cos(rot);
+  const sin = Math.sin(rot);
+  ctx.fillStyle = ACCENT;
+  const s = frame.scope;
+  for (let i = 0; i + 1 < s.length; i += 2) {
+    const l = s[i];
+    const rr = s[i + 1];
+    const x = (l - rr) * r * cos - (l + rr) * r * sin;
+    const y = (l - rr) * r * sin + (l + rr) * r * cos;
+    ctx.fillRect(cx + x * 0.7, cy - y * 0.7, 1.4, 1.4);
+  }
+
+  // Correlation strip.
+  const bx = cx + r + 16;
+  const bw = w - bx - 12;
+  const by = cy - 8;
+  ctx.fillStyle = 'rgba(255,255,255,0.05)';
+  ctx.fillRect(bx, by, bw, 16);
+  const corr = Number.isFinite(frame.correlation) ? frame.correlation : 0;
+  const mid = bx + bw / 2;
+  ctx.fillStyle = corr < 0 ? HOT : corr < 0.4 ? WARN : GOOD;
+  ctx.fillRect(mid, by, (bw / 2) * corr, 16);
+  ctx.strokeStyle = GRID;
+  ctx.beginPath();
+  ctx.moveTo(mid, by - 3);
+  ctx.lineTo(mid, by + 19);
+  ctx.stroke();
+  label(v, 'correlation', bx, by - 6, DIM, 9, 'left');
+  label(v, corr.toFixed(2), bx + bw, by + 30, TEXT, 12, 'right');
+  label(v, '-1', bx, by + 30, DIM, 8, 'left');
+  label(v, '+1', bx + bw, by - 6, DIM, 8, 'right');
+}
+
+// ── Bass Space (per-band histogram) ─────────────────────────────────────────
+export function drawBass(v: ViewCtx): void {
+  bg(v);
+  const { ctx, w, h, frame } = v;
+  const bands = frame.bands;
+  const freqs = frame.bandFreqs;
+  if (!bands.length) {
+    label(v, 'band metering needs the worklet', w / 2, h / 2, DIM, 10, 'center');
+    return;
+  }
+  const min = -60;
+  const max = 0;
+  const padL = 12;
+  const padR = 12;
+  const top = 14;
+  const bottom = h - 20;
+  const n = bands.length;
+  const slot = (w - padL - padR) / n;
+  bands.forEach((db, i) => {
+    const x = padL + i * slot + 4;
+    const bw = slot - 8;
+    const nn = dbNorm(db, min, max);
+    const bh = (bottom - top) * nn;
+    ctx.fillStyle = 'rgba(255,255,255,0.05)';
+    ctx.fillRect(x, top, bw, bottom - top);
+    const g = ctx.createLinearGradient(0, bottom, 0, top);
+    g.addColorStop(0, '#22d3ee');
+    g.addColorStop(1, ACCENT);
+    ctx.fillStyle = g;
+    ctx.fillRect(x, bottom - bh, bw, bh);
+    label(v, `${freqs[i] ?? '?'}Hz`, x + bw / 2, bottom + 14, DIM, 9, 'center');
+    label(v, fmt(db), x + bw / 2, top + 10, TEXT, 9, 'center');
+  });
+}
+
+// ── Radial (combined) ───────────────────────────────────────────────────────
+export function drawRadial(v: ViewCtx): void {
+  bg(v);
+  const { ctx, w, h, frame, lufsTarget } = v;
+  const cx = w / 2;
+  const cy = h / 2;
+  const rOuter = Math.min(w, h) / 2 - 16;
+  const rInner = rOuter * 0.42;
+
+  const spokes = [
+    { name: 'PEAK', val: dbNorm(frame.samplePeakDb, -60, 3), col: ACCENT, text: fmt(frame.samplePeakDb) },
+    { name: 'LUFS', val: dbNorm(frame.momentary, -40, 0), col: lufsColor(frame.momentary, lufsTarget), text: fmt(frame.momentary) },
+    { name: 'LRA', val: clamp01(frame.lra / 20), col: '#22d3ee', text: fmt(frame.lra) },
+    { name: 'DR', val: clamp01(frame.crestDb / 24), col: GOOD, text: fmt(frame.crestDb) },
+    { name: 'FIELD', val: clamp01((frame.correlation + 1) / 2), col: WARN, text: (Number.isFinite(frame.correlation) ? frame.correlation.toFixed(2) : '—') },
+    { name: 'BASS', val: frame.bands.length ? dbNorm(frame.bands[1] ?? frame.bands[0], -60, 0) : 0, col: '#fb7185', text: frame.bands.length ? fmt(frame.bands[1] ?? frame.bands[0]) : '—' },
+  ];
+  const step = (Math.PI * 2) / spokes.length;
+  ctx.strokeStyle = GRID;
+  ctx.beginPath();
+  ctx.arc(cx, cy, rInner, 0, Math.PI * 2);
+  ctx.stroke();
+
+  spokes.forEach((s, i) => {
+    const ang = -Math.PI / 2 + i * step;
+    const x0 = cx + Math.cos(ang) * rInner;
+    const y0 = cy + Math.sin(ang) * rInner;
+    const rr = rInner + (rOuter - rInner) * clamp01(s.val);
+    const x1 = cx + Math.cos(ang) * rr;
+    const y1 = cy + Math.sin(ang) * rr;
+    // full-length track
+    ctx.strokeStyle = 'rgba(255,255,255,0.06)';
+    ctx.lineWidth = 8;
+    ctx.beginPath();
+    ctx.moveTo(x0, y0);
+    ctx.lineTo(cx + Math.cos(ang) * rOuter, cy + Math.sin(ang) * rOuter);
+    ctx.stroke();
+    // value
+    ctx.strokeStyle = s.col;
+    ctx.lineWidth = 8;
+    ctx.beginPath();
+    ctx.moveTo(x0, y0);
+    ctx.lineTo(x1, y1);
+    ctx.stroke();
+    // labels at the rim
+    const lx = cx + Math.cos(ang) * (rOuter + 4);
+    const ly = cy + Math.sin(ang) * (rOuter + 4);
+    ctx.textAlign = Math.cos(ang) > 0.2 ? 'left' : Math.cos(ang) < -0.2 ? 'right' : 'center';
+    label(v, s.name, lx, ly, DIM, 8, ctx.textAlign);
+    label(v, s.text, lx, ly + 10, TEXT, 10, ctx.textAlign);
+  });
+  ctx.lineWidth = 1;
+
+  // Center integrated LUFS.
+  ctx.textAlign = 'center';
+  ctx.fillStyle = TEXT;
+  ctx.font = '600 22px ui-monospace, monospace';
+  ctx.fillText(fmt(frame.integrated), cx, cy + 2);
+  label(v, 'LUFS integrated', cx, cy + 16, DIM, 8, 'center');
+}

--- a/frontend/src/components/layout/BottomMultiTabPanel.tsx
+++ b/frontend/src/components/layout/BottomMultiTabPanel.tsx
@@ -9,7 +9,7 @@
 import React, { useState, lazy, Suspense } from 'react';
 import {
   Activity, Info, Piano, Layers, FolderOpen, SlidersVertical, ExternalLink, Maximize2, Minimize2,
-  FileMusic, Waves, Brush,
+  FileMusic, Waves, Brush, Gauge,
 } from 'lucide-react';
 import { AdvancedVisualizer } from '../audio/AdvancedVisualizer';
 import { StepSequencer } from '../audio/StepSequencer';
@@ -18,6 +18,7 @@ import { ScoreView } from './ScoreView';
 import { MediaBucketView } from './MediaBucketView';
 import { SlidePanel } from './SlidePanel';
 import { SwayPanel } from './SwayPanel';
+import { LevelsPanel } from '../audio/levels/LevelsPanel';
 // Lazy: the MIDI tab (piano roll + vocal2midi) drags in @google/genai
 // (AI compose + gemini vocal services). Keep it out of first paint; the chunk
 // loads only when the user first opens the MIDI tab.
@@ -28,6 +29,7 @@ import { useBottomPanelStore, type BottomPanelTab } from '../../state/bottomPane
 import { useSlideStore } from '../../state/slideStore';
 
 const TAB_DEFS: Array<{ id: BottomPanelTab; label: string; desc: string; icon: React.ComponentType<{ className?: string }>; colorActive: string }> = [
+  { id: 'levels',     label: 'Levels',     desc: 'Master loudness, peak, dynamics and stereo metering (LUFS / true-peak)',  icon: Gauge,      colorActive: 'border-teal-500 text-teal-300' },
   { id: 'spectral',   label: 'Visualize',  desc: 'Live spectrum + waveform visualizer of the playing audio',                 icon: Activity,   colorActive: 'border-purple-500 text-purple-300' },
   { id: 'midi',       label: 'MIDI',       desc: 'Piano roll: sing in, record or analyze notes, edit them, export MIDI',     icon: Piano,      colorActive: 'border-cyan-500 text-cyan-300' },
   { id: 'step-seq',   label: 'Sequence',   desc: 'Program drum and note patterns step by step on a grid',                    icon: Layers,     colorActive: 'border-cyan-500 text-cyan-300' },
@@ -128,6 +130,11 @@ export const BottomMultiTabPanel: React.FC = () => {
 
       {/* Tab content */}
       <div className="flex-1 min-h-0 relative">
+        {activeTab === 'levels' && (
+          <div className="absolute inset-0">
+            <LevelsPanel />
+          </div>
+        )}
         {activeTab === 'spectral' && (
           <div className="absolute inset-0 p-1">
             <AdvancedVisualizer />

--- a/frontend/src/state/bottomPanelStore.ts
+++ b/frontend/src/state/bottomPanelStore.ts
@@ -14,6 +14,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export type BottomPanelTab =
+  | 'levels'
   | 'spectral'
   | 'details'
   | 'score'

--- a/frontend/src/state/levelsStore.ts
+++ b/frontend/src/state/levelsStore.ts
@@ -1,0 +1,177 @@
+/**
+ * Levels metering store.
+ *
+ * Persisted UI state (which view, LUFS target, true-peak ceiling) lives in the
+ * Zustand store. The DSP tap is module-scope (like playerStore's engine): a
+ * single AudioWorklet fanned non-destructively off the master gain, its output
+ * feeding a silent sink so the graph pulls it without altering the audio. The
+ * latest readings frame is held in a module variable and read by the panel's
+ * rAF loop (never through React), so metering never triggers re-renders.
+ *
+ * When AudioWorklet is unavailable, an AnalyserNode fallback supplies RMS/peak
+ * only (no gated LUFS); the LUFS fields come back NaN and the views degrade.
+ */
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { getEngineCtx, getMasterGain } from './playerStore';
+
+export type LevelsView = 'radial' | 'lufs' | 'peak' | 'dr' | 'stereo' | 'bass';
+
+export interface LevelsFrame {
+  momentary: number;
+  short: number;
+  integrated: number;
+  lra: number;
+  samplePeakDb: number;
+  truePeakDb: number;
+  rmsDb: number;
+  crestDb: number;
+  correlation: number;
+  bands: number[];
+  bandFreqs: number[];
+  scope: Float32Array;
+}
+
+interface LevelsState {
+  view: LevelsView;
+  lufsTarget: number;
+  truePeakCeiling: number;
+  setView: (v: LevelsView) => void;
+  setLufsTarget: (v: number) => void;
+  setTruePeakCeiling: (v: number) => void;
+}
+
+export const useLevelsStore = create<LevelsState>()(
+  persist(
+    (set) => ({
+      view: 'radial',
+      lufsTarget: -14,
+      truePeakCeiling: -1,
+      setView: (v) => set({ view: v }),
+      setLufsTarget: (v) => set({ lufsTarget: v }),
+      setTruePeakCeiling: (v) => set({ truePeakCeiling: v }),
+    }),
+    { name: 'thedaw-levels-v1', version: 1 },
+  ),
+);
+
+// ── module-scope DSP tap ────────────────────────────────────────────────────
+let workletNode: AudioWorkletNode | null = null;
+let sink: GainNode | null = null;
+let moduleAdded = false;
+let latestFrame: LevelsFrame | null = null;
+
+let fbAnalyser: AnalyserNode | null = null;
+let fbBuf: Float32Array | null = null;
+
+let ensuring: Promise<void> | null = null;
+
+async function setup(): Promise<void> {
+  if (workletNode || fbAnalyser) return;
+  const ctx = getEngineCtx();
+  const master = getMasterGain();
+  if (ctx.audioWorklet) {
+    try {
+      if (!moduleAdded) {
+        await ctx.audioWorklet.addModule('/worklets/levels-meter.js');
+        moduleAdded = true;
+      }
+      const node = new AudioWorkletNode(ctx, 'levels-meter', {
+        numberOfInputs: 1,
+        numberOfOutputs: 1,
+        outputChannelCount: [2],
+      });
+      node.port.onmessage = (e: MessageEvent) => {
+        latestFrame = e.data as LevelsFrame;
+      };
+      master.connect(node);
+      const s = ctx.createGain();
+      s.gain.value = 0;
+      node.connect(s);
+      s.connect(ctx.destination);
+      workletNode = node;
+      sink = s;
+      return;
+    } catch {
+      // fall through to the analyser fallback
+    }
+  }
+  const an = ctx.createAnalyser();
+  an.fftSize = 2048;
+  master.connect(an);
+  fbAnalyser = an;
+  fbBuf = new Float32Array(an.fftSize);
+}
+
+/** Ensure the meter tap exists. Idempotent + concurrency-safe. */
+export function ensureMeter(): Promise<void> {
+  if (workletNode || fbAnalyser) return Promise.resolve();
+  if (!ensuring) ensuring = setup().finally(() => (ensuring = null));
+  return ensuring;
+}
+
+/** Detach the meter from the master path. */
+export function disposeMeter(): void {
+  try {
+    if (workletNode) getMasterGain().disconnect(workletNode);
+  } catch {
+    /* already gone */
+  }
+  try {
+    if (fbAnalyser) getMasterGain().disconnect(fbAnalyser);
+  } catch {
+    /* already gone */
+  }
+  try {
+    if (workletNode && sink) workletNode.disconnect(sink);
+    if (sink) sink.disconnect();
+  } catch {
+    /* already gone */
+  }
+  workletNode = null;
+  sink = null;
+  fbAnalyser = null;
+  fbBuf = null;
+  latestFrame = null;
+}
+
+const EMPTY_SCOPE = new Float32Array(0);
+
+/** Latest readings frame (worklet) or a live RMS/peak-only frame (fallback). */
+export function getLevelsFrame(): LevelsFrame | null {
+  if (workletNode) return latestFrame;
+  if (fbAnalyser && fbBuf) {
+    fbAnalyser.getFloatTimeDomainData(fbBuf);
+    let peak = 0;
+    let sumSq = 0;
+    for (let i = 0; i < fbBuf.length; i += 1) {
+      const v = fbBuf[i];
+      const a = Math.abs(v);
+      if (a > peak) peak = a;
+      sumSq += v * v;
+    }
+    const rms = Math.sqrt(sumSq / fbBuf.length);
+    const rmsDb = rms > 0 ? 20 * Math.log10(rms) : -Infinity;
+    const peakDb = peak > 0 ? 20 * Math.log10(peak) : -Infinity;
+    return {
+      momentary: NaN,
+      short: NaN,
+      integrated: NaN,
+      lra: 0,
+      samplePeakDb: peakDb,
+      truePeakDb: peakDb,
+      rmsDb,
+      crestDb: Number.isFinite(peakDb) && Number.isFinite(rmsDb) ? peakDb - rmsDb : 0,
+      correlation: 0,
+      bands: [],
+      bandFreqs: [],
+      scope: EMPTY_SCOPE,
+    };
+  }
+  return null;
+}
+
+/** True when the full BS.1770 worklet is running (vs the RMS-only fallback). */
+export function isWorkletMeter(): boolean {
+  return !!workletNode;
+}


### PR DESCRIPTION
New "Levels" tab (first in the lower panel) with master metering of whatever is audible on any tab, since everything routes through the shared master gain.

- public/worklets/levels-meter.js: one AudioWorklet fanned non-destructively off the master gain. BS.1770-4 K-weighting (high-shelf pre-filter + RLB high-pass, computed for the actual sample rate) -> momentary / short-term / gated integrated LUFS + LRA; 4x-oversampled true peak; RMS + crest; inter-channel correlation + a decimated L/R scatter; per-band RMS at 40/80/120/160 Hz.
- state/levelsStore.ts: persisted view / LUFS target / true-peak ceiling, plus module-scope tap singletons (silent sink keeps the worklet pulled) and a readings-frame accessor. AnalyserNode fallback (RMS/peak only) when no worklet.
- components/audio/levels/levelsViews.ts: six canvas painters — Radial, LUFS, Peak, Dynamic Range, Stereo Field, Bass Space.
- components/audio/levels/LevelsPanel.tsx: round-button switcher + LUFS target presets + one rAF loop reading the frame (never through React).
- Registered as the first bottom-panel tab (bottomPanelStore, BottomMultiTabPanel).
- docs/guides/levels.md + registered in backend/rag.py DOC_PATHS.

Per-track lane meters + automation-mode controls are a planned follow-up; this ships the master metering + all six views.