### PR TITLE
chore(release): bump version to 0.1.3

### DIFF
--- a/electron-ui/package.json
+++ b/electron-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thedaw-desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "theDAW desktop shell: an Electron front end that bootstraps and supervises the Python audio backend.",
   "author": "GANTASMO",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stable-audio-3"
-version = "0.1.2"
+version = "0.1.3"
 description = "Stable Audio 3: A state-of-the-art open platform for fast, high-quality generated audio and music"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -5654,7 +5654,7 @@ wheels = [
 
 [[package]]
 name = "stable-audio-3"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aubio", version = "0.4.9", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'arm64' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },


### PR DESCRIPTION
Release v0.1.3: DJ semantic waveforms across MAKE/EDIT/MIX, circular Audimate nodes, rounded app icon, DJ deck A/B badges. Version bump for the tagged release.