### PR TITLE
fix(questmidi + dj): bind-spam guard + high-contrast deck A/B badges (v0.1.3)

### DIFF
--- a/backend/modules/questmidi/bridge.py
+++ b/backend/modules/questmidi/bridge.py
@@ -17,6 +17,7 @@ Wire format on the TCP socket (matches QuestMidiSender / the Node bridge):
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import os
 import subprocess
@@ -52,6 +53,7 @@ class _State:
     adb_reverse_ok: bool = False
     started: bool = False
     starting: bool = False
+    port_in_use: bool = False
 
 
 _s = _State()
@@ -155,8 +157,8 @@ def _run_adb_reverse(port: int) -> bool:
             check=True,
         )
         return True
-    except Exception as e:  # noqa: BLE001
-        log.info("questmidi: adb reverse failed: %s", e)
+    except Exception as e:  # noqa: BLE001 — expected when no headset is plugged in
+        log.debug("questmidi: adb reverse failed: %s", e)
         return False
 
 
@@ -176,8 +178,26 @@ async def ensure_started() -> None:
     try:
         port = _port()
         await reattach_adb()
-        _s.server = await asyncio.start_server(_handle_quest, "127.0.0.1", port)
+        try:
+            _s.server = await asyncio.start_server(_handle_quest, "127.0.0.1", port)
+        except OSError as e:
+            # EADDRINUSE (WSAEADDRINUSE 10048 on Windows): the port is already
+            # bound — almost always a second theDAW instance or a --reload
+            # leftover that still owns the listener. Treat it as started so we
+            # don't re-attempt the bind (and re-log) on every WebSocket connect;
+            # the existing listener relays the headset.
+            if e.errno in (errno.EADDRINUSE, 10048):
+                _s.started = True
+                _s.port_in_use = True
+                log.info(
+                    "questmidi: port %d already in use — an existing bridge "
+                    "owns it; not starting a second listener",
+                    port,
+                )
+                return
+            raise
         _s.started = True
+        _s.port_in_use = False
         log.info(
             "questmidi: listening on 127.0.0.1:%d (adb reverse %s)",
             port,
@@ -211,6 +231,7 @@ def status() -> dict:
     return {
         "started": _s.started,
         "port": _port(),
+        "port_in_use": _s.port_in_use,
         "adb_path": _adb_path(),
         "adb_reverse_ok": _s.adb_reverse_ok,
         "quest_connected": _s.quest_writer is not None,

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-04T23:27:16.514Z",
+  "generatedAt": "2026-07-06T08:25:22.248Z",
   "entries": [
     {
       "file": "01-shell-make.png",

--- a/electron-ui/package-lock.json
+++ b/electron-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thedaw-desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thedaw-desktop",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.1",
         "@vitejs/plugin-react": "^5.0.4",

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -440,7 +440,7 @@ function EditableBpmField({
  * panels (hero waveforms, sampler, FX racks, Next lane, source tree, library)
  * host a whole component; every mixer + deck control is an individual widget the
  * user can relocate in Design Mode. Nothing moves until the user drags. */
-const DJ_LAYOUT_VERSION = 23;
+const DJ_LAYOUT_VERSION = 24;
 
 const defaultDjLayout: SurfaceLayout = {
   version: DJ_LAYOUT_VERSION,
@@ -457,7 +457,7 @@ const defaultDjLayout: SurfaceLayout = {
     center: { id: 'center', type: 'container', axis: 'column', children: ['deckmix', 'fxrow'], fr: { deckmix: 5, fxrow: 2 } },
     deckmix: { id: 'deckmix', type: 'container', axis: 'row', children: ['deckAcont', 'mixer', 'deckBcont'], fr: { deckAcont: 4.17953863997903, mixer: 5.180662235484642, deckBcont: 4.439799124536327 } },
     // ── Deck A (pad-rows wrapped with spacer panels in cont-* containers) ──
-    deckAcont: { id: 'deckAcont', type: 'container', axis: 'column', children: ['pdA-head', 'waveAOverview', 'cont-10-e11250c4', 'cont-A-transport', 'cont-A-stems', 'fxAP', 'perfAP'], fr: { 'pdA-head': 1.12, waveAOverview: 0.72, 'cont-10-e11250c4': 4.9, 'cont-A-transport': 1.02, 'cont-A-stems': 1.1, fxAP: 3.15, perfAP: 1.35 }, framed: true, frameTitle: 'A' },
+    deckAcont: { id: 'deckAcont', type: 'container', axis: 'column', children: ['pdA-head', 'waveAOverview', 'cont-10-e11250c4', 'cont-A-transport', 'cont-A-stems', 'fxAP', 'perfAP'], fr: { 'pdA-head': 1.12, waveAOverview: 0.72, 'cont-10-e11250c4': 4.9, 'cont-A-transport': 1.02, 'cont-A-stems': 1.1, fxAP: 3.15, perfAP: 1.35 }, framed: true },
     'pdA-head': { id: 'pdA-head', type: 'panel', title: 'A', flow: 'row', widgets: ['spacer:s-2-7f6f8905', 'keylockA', 'keyA', 'bpmA', 'headerA'], widgetFr: { keylockA: 0.49871465295629847, keyA: 0.8892624085426142, bpmA: 0.8514435436029266, headerA: 2.255932370970932, 'spacer:s-2-7f6f8905': 0.8892624085426142 }, widgetJustify: { headerA: 'start' }, widgetMargins: { 'spacer:s-2-7f6f8905': { t: 0, r: 8, b: 0, l: 0 } }, mirror: false, uniform: false },
     'pdA-jog': { id: 'pdA-jog', type: 'panel', title: 'A · Jog', flow: 'row', widgets: ['jogA'], widgetMargins: { jogA: { t: 1, r: 4, b: 3, l: 4 } }, mirror: true },
     'pdA-mode': { id: 'pdA-mode', type: 'panel', title: 'A · Mode', flow: 'column', widgets: ['syncLockA', 'headCueA'], mirror: true, uniform: true },
@@ -467,7 +467,7 @@ const defaultDjLayout: SurfaceLayout = {
     'pdA-loop': { id: 'pdA-loop', type: 'panel', title: 'A · Loop', flow: 'row', widgets: ['loopA_0', 'loopA_1', 'loopA_2', 'loopA_3', 'loopA_4', 'loopOutA'], uniform: true, mirror: true },
     'pdA-perf': { id: 'pdA-perf', type: 'panel', title: 'A · Perf', flow: 'row', widgets: ['rollA_0', 'rollA_1', 'rollA_2', 'slipA', 'jumpA_0', 'jumpA_1', 'jumpA_2', 'jumpA_3'], uniform: true, mirror: true },
     // ── Deck B ──
-    deckBcont: { id: 'deckBcont', type: 'container', axis: 'column', children: ['pdB-head', 'waveBOverview', 'cont-2-a0e79010', 'cont-B-transport', 'cont-B-stems', 'fxBP', 'perfBP'], fr: { 'pdB-head': 1.12, waveBOverview: 0.72, 'cont-2-a0e79010': 4.9, 'cont-B-transport': 1.02, 'cont-B-stems': 1.1, fxBP: 3.15, perfBP: 1.35 }, framed: true, frameTitle: 'B' },
+    deckBcont: { id: 'deckBcont', type: 'container', axis: 'column', children: ['pdB-head', 'waveBOverview', 'cont-2-a0e79010', 'cont-B-transport', 'cont-B-stems', 'fxBP', 'perfBP'], fr: { 'pdB-head': 1.12, waveBOverview: 0.72, 'cont-2-a0e79010': 4.9, 'cont-B-transport': 1.02, 'cont-B-stems': 1.1, fxBP: 3.15, perfBP: 1.35 }, framed: true },
     waveAOverview: { id: 'waveAOverview', type: 'panel', title: 'A · Overview', flow: 'row', widgets: [], pinned: 'waveAOverview', mirror: true },
     waveBOverview: { id: 'waveBOverview', type: 'panel', title: 'B · Overview', flow: 'row', widgets: [], pinned: 'waveBOverview' },
     'pdB-head': { id: 'pdB-head', type: 'panel', title: 'B', flow: 'row', widgets: ['spacer:s-1-95993441', 'keylockB', 'keyB', 'bpmB', 'headerB'], widgetFr: { keylockB: 0.5522110739502047, keyB: 1.1040505388331472, bpmB: 1.039483463396507, headerB: 2.209123002601264, 'spacer:s-1-95993441': 0.4797473058342624 }, widgetJustify: { headerB: 'end' }, widgetMargins: { 'spacer:s-1-95993441': { t: 0, r: 0, b: 0, l: 64 } }, mirror: true, uniform: false },
@@ -2836,8 +2836,8 @@ function buildDjRegistry(p: DjRegArgs): WidgetRegistry {
 
     reg[`header${d}`] = { id: `header${d}`, label: `Deck ${d} Info`, group: grp, kind: 'fixed', source: 'builtin', render: (_s, opts) => (
       <div className={`h-full w-full flex items-center gap-1.5 px-1 overflow-hidden ${opts?.mirror ? 'flex-row-reverse' : ''}`}>
-        <div className="shrink-0 grid place-items-center rounded border w-7 h-7" style={{ borderColor: rgba(rgbc, 0.4), background: rgba(rgbc, 0.12) }} title={`Deck ${d}`}>
-          <Music2 className="w-3.5 h-3.5" style={{ color: rgb(rgbc) }} />
+        <div className="shrink-0 grid place-items-center rounded border w-7 h-7" style={{ borderColor: rgba(rgbc, 0.6), background: rgba(rgbc, 0.2) }} title={`Deck ${d}`}>
+          <span className="text-[18px] font-black leading-none text-white" style={{ textShadow: `0 0 6px ${rgba(rgbc, 0.9)}, 0 1px 2px rgba(0,0,0,0.9)` }}>{d}</span>
         </div>
         <div className={`min-w-0 flex-1 flex flex-col ${opts?.mirror ? 'items-end text-right' : ''}`}>
           <span


### PR DESCRIPTION
Follow-up fixes for the v0.1.3 release: questmidi no longer spams the log when port 8765 is already held; DJ decks show a high-contrast A/B letter inside the header instead of a cut-off corner badge.