### PR TITLE
feat(companion): phone web companion (Phase 3 Slice 1) + shared control contract

### DIFF
--- a/backend/modules/xrcontrol/router.py
+++ b/backend/modules/xrcontrol/router.py
@@ -1,28 +1,41 @@
-"""FastAPI router for the XR control bus (spatialization P0).
+"""FastAPI router for the XR / companion control bus (spatialization P0).
 
-A transport-only relay between theDAW (the browser, which owns the control
-manifest and the wired setters) and a theDAW-XR headset (which requests the
-manifest and sends control changes). The relay holds no manifest and no control
-state: it forwards each JSON frame to every OTHER connected peer, so the browser
-host and the XR controller exchange messages without the backend understanding
-them.
+A relay between theDAW (the browser, which owns the control manifest and the
+wired setters) and controller peers: a theDAW-XR headset and, from Phase 3, the
+web-mobile and Flutter companions. The relay forwards each control JSON frame to
+every OTHER authenticated peer, so the browser host and its controllers exchange
+messages without the backend understanding them.
+
+The relay holds no manifest and no control state. It holds only the session
+pairing posture (set by the host) and which peers have passed the pairing gate,
+so a host can require a code before a controller drives the desktop audio. See
+docs/companion-control-contract.md for the full protocol.
 
 Endpoints (prefix /api/xr/control):
     GET  /status   connected-peer count
-    WS   /ws       peer relay (browser host <-> XR controller)
+    WS   /ws       peer relay (browser host <-> controllers)
 
-Message shapes (defined by the manifest contract in the frontend, not enforced
-here):
-    host -> controller : {"type":"manifest", "version":N, "entries":[...]}
-                         {"type":"control-changed", "id":..., "value":...}
+Pairing handshake (relay-handled, never forwarded):
+    host       -> relay : {"type":"host-hello","posture":{"mode":"open"|"code","code":...}}
+    relay      -> host  : {"type":"host-ack","posture":...,"peers":[{"peerId","label"}]}
+    controller -> relay : {"type":"controller-hello","label":...,"code":...}
+    relay      -> ctrl  : {"type":"pair-ok","peerId":N} | {"type":"pair-rejected","reason":...}
+    relay      -> host  : {"type":"peer-joined","peerId":N,"label":...} | {"type":"peer-left","peerId":N}
+    host       -> relay : {"type":"kick","peerId":N}
+
+Control frames (forwarded between authenticated peers, shapes defined in the
+frontend contract, not enforced here):
+    host -> controller : {"type":"manifest","version":N,"entries":[...]}
+                         {"type":"control-changed","id":...,"value":...}
     controller -> host : {"type":"request-controls"}
-                         {"type":"control-set", "id":..., "value":...}
+                         {"type":"control-set","id":...,"value":...}
                          {"type":"pad"|"jog"|"trigger", ...}
 """
 
 from __future__ import annotations
 
 import logging
+import os
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
@@ -30,10 +43,72 @@ log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["xrcontrol"])
 
-# Every connected peer (browser hosts and XR controllers alike). A frame from
-# any peer is relayed to all the others. Single-host is the intended topology;
-# extra hosts would each apply inbound control-sets, which is idempotent.
+# The host role is privileged: it sets the pairing posture. In the shipped
+# topology the desktop browser is co-located with the backend (theDAW.bat,
+# Electron, or dev via the Vite proxy), so it reaches the relay as localhost.
+# Restricting host-hello to localhost stops a LAN companion from claiming the
+# host role and resetting posture to open to bypass code pairing. A remote-host
+# deployment (e.g. a Docker container served to a browser on another machine)
+# opts in with THEDAW_XR_ALLOW_REMOTE_HOST=1.
+_LOCAL_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
+# Every connected peer (browser hosts and controllers alike).
 _clients: set[WebSocket] = set()
+
+# Per-peer metadata: {"role": "host"|"controller"|"legacy", "label": str,
+# "peerId": int, "authed": bool}. A peer that never sends a hello stays "legacy"
+# and is authed under the posture in force when it connected.
+_meta: dict[WebSocket, dict] = {}
+
+# The current host peer (last socket to send host-hello), if any.
+_host: WebSocket | None = None
+
+# Session pairing posture. Default "open" preserves the pre-v1 behavior so the
+# existing theDAW-XR headset keeps working until a host opts into code pairing.
+_posture: dict = {"mode": "open", "code": None}
+
+# Monotonic peer id counter (id() would be reused after GC).
+_next_peer_id = 0
+
+
+def _new_peer_id() -> int:
+    global _next_peer_id
+    _next_peer_id += 1
+    return _next_peer_id
+
+
+def _is_authed(peer: WebSocket) -> bool:
+    m = _meta.get(peer)
+    return bool(m and m.get("authed"))
+
+
+def _is_local(peer: WebSocket) -> bool:
+    client = getattr(peer, "client", None)
+    host = getattr(client, "host", None) if client else None
+    return host in _LOCAL_HOSTS
+
+
+def _may_host(peer: WebSocket) -> bool:
+    """Whether `peer` is allowed to (become / stay) the host and set posture.
+
+    An established host can only be replaced by itself; a LAN companion can
+    never seize it. Establishing a fresh host requires a localhost origin
+    unless remote hosts are explicitly allowed.
+    """
+    if _host is not None and peer is not _host:
+        return False
+    if _is_local(peer):
+        return True
+    return os.environ.get("THEDAW_XR_ALLOW_REMOTE_HOST") == "1"
+
+
+def _peer_list() -> list[dict]:
+    """Authenticated controller peers, for the host's connected-devices view."""
+    out: list[dict] = []
+    for peer, m in _meta.items():
+        if m.get("role") == "controller" and m.get("authed"):
+            out.append({"peerId": m.get("peerId"), "label": m.get("label") or "device"})
+    return out
 
 
 @router.get("/status")
@@ -41,33 +116,128 @@ async def status() -> dict:
     return {"clients": len(_clients)}
 
 
+async def _send(peer: WebSocket, msg: object) -> bool:
+    try:
+        await peer.send_json(msg)
+        return True
+    except Exception:  # noqa: BLE001 — peer went away
+        _drop(peer)
+        return False
+
+
 async def _relay(origin: WebSocket, msg: object) -> None:
-    """Forward one frame to every peer except its sender."""
-    dead: list[WebSocket] = []
+    """Forward one control frame to every OTHER authenticated peer."""
+    if not _is_authed(origin):
+        return  # an unauthenticated peer cannot inject control frames
     for peer in list(_clients):
-        if peer is origin:
+        if peer is origin or not _is_authed(peer):
             continue
-        try:
-            await peer.send_json(msg)
-        except Exception:  # noqa: BLE001 — drop peers that went away
-            dead.append(peer)
-    for d in dead:
-        _clients.discard(d)
+        await _send(peer, msg)
+
+
+def _drop(peer: WebSocket) -> None:
+    global _host
+    _clients.discard(peer)
+    _meta.pop(peer, None)
+    if peer is _host:
+        _host = None
+
+
+async def _notify_host(msg: object) -> None:
+    if _host is not None:
+        await _send(_host, msg)
+
+
+async def _handle_host_hello(peer: WebSocket, msg: dict) -> None:
+    """A browser declares itself the host and sets the session posture."""
+    global _host, _posture
+    _host = peer
+    m = _meta.setdefault(peer, {})
+    m.update(role="host", authed=True)
+    posture = msg.get("posture")
+    if isinstance(posture, dict):
+        mode = "code" if posture.get("mode") == "code" else "open"
+        code = posture.get("code")
+        _posture = {"mode": mode, "code": str(code) if code else None}
+    await _send(peer, {"type": "host-ack", "posture": _posture, "peers": _peer_list()})
+
+
+async def _handle_controller_hello(peer: WebSocket, msg: dict) -> None:
+    """A controller requests to join; gate it on the current posture."""
+    label = msg.get("label")
+    m = _meta.setdefault(peer, {})
+    m.update(role="controller", label=(str(label) if label else None))
+    if "peerId" not in m:
+        m["peerId"] = _new_peer_id()
+    if _posture["mode"] == "code":
+        authed = (
+            bool(_posture["code"]) and str(msg.get("code") or "") == _posture["code"]
+        )
+    else:
+        authed = True
+    m["authed"] = authed
+    if authed:
+        await _send(peer, {"type": "pair-ok", "peerId": m["peerId"]})
+        await _notify_host(
+            {
+                "type": "peer-joined",
+                "peerId": m["peerId"],
+                "label": m.get("label") or "device",
+            }
+        )
+        # The relay holds no manifest, so ask the host to re-publish; its manifest
+        # frame is then forwarded to every authed peer, seeding this controller.
+        await _notify_host({"type": "request-controls"})
+    else:
+        await _send(peer, {"type": "pair-rejected", "reason": "code"})
+
+
+async def _handle_kick(msg: dict) -> None:
+    target_id = msg.get("peerId")
+    for peer, m in list(_meta.items()):
+        if m.get("peerId") == target_id and m.get("role") == "controller":
+            try:
+                await peer.close()
+            except Exception:  # noqa: BLE001 — already closing
+                pass
+            _drop(peer)
+            await _notify_host({"type": "peer-left", "peerId": target_id})
+            return
 
 
 @router.websocket("/ws")
 async def ws(websocket: WebSocket) -> None:
     await websocket.accept()
     _clients.add(websocket)
+    # Provisional posture snapshot: a peer that never sends a hello (a legacy
+    # headset build) is authed iff the posture was open when it connected.
+    _meta[websocket] = {"role": "legacy", "authed": _posture["mode"] == "open"}
     log.info("xrcontrol: peer connected (%d total)", len(_clients))
     try:
         while True:
             msg = await websocket.receive_json()
-            await _relay(websocket, msg)
+            if not isinstance(msg, dict):
+                continue
+            t = msg.get("type")
+            if t == "host-hello":
+                # Only the co-located desktop may claim the host role / set
+                # posture; a LAN companion sending host-hello is ignored so it
+                # cannot reset posture to open and bypass code pairing.
+                if _may_host(websocket):
+                    await _handle_host_hello(websocket, msg)
+            elif t == "controller-hello":
+                await _handle_controller_hello(websocket, msg)
+            elif t == "kick" and websocket is _host:
+                await _handle_kick(msg)
+            else:
+                await _relay(websocket, msg)
     except WebSocketDisconnect:
         pass
     except Exception as e:  # noqa: BLE001 — peer went away mid-message
         log.debug("xrcontrol: ws error: %s", e)
     finally:
-        _clients.discard(websocket)
+        was = _meta.get(websocket, {})
+        _drop(websocket)
+        if was.get("role") == "controller" and was.get("authed"):
+            await _notify_host({"type": "peer-left", "peerId": was.get("peerId")})
         log.info("xrcontrol: peer disconnected (%d total)", len(_clients))

--- a/backend/server.py
+++ b/backend/server.py
@@ -2017,20 +2017,36 @@ try:
 except Exception as _vj_mount_err:  # noqa: BLE001 — never block boot on VJ
     logger.warning("vj: static mount skipped: %s", _vj_mount_err)
 
-# Optional single-container UI serving (the Docker release image sets
-# theDAW_SERVE_UI=1). Every API route lives under /api and is registered
-# above, BEFORE this mount, so the SPA catch-all can never shadow an
-# endpoint. Without the env var (theDAW.bat, manual dev servers, electron)
-# this block is a no-op and dev behavior is unchanged: Vite serves the UI on
-# :5173 and proxies /api to :8600.
-if os.environ.get("theDAW_SERVE_UI") == "1":
-    _ui_dist = PROJECT_ROOT / "frontend" / "dist"
+# Single-container / companion UI serving. Every API route lives under /api and
+# is registered above, BEFORE this mount, so the SPA catch-all can never shadow
+# an endpoint.
+#
+# This fires when a built frontend/dist exists (Docker sets theDAW_SERVE_UI=1;
+# packaged desktop bundles ship a dist), so the desktop UI AND the phone
+# companion entry (frontend/mobile.html -> /mobile.html, with /assets at root)
+# are both reachable over http on the LAN. In pure dev (no dist) it is a no-op:
+# Vite serves the UI on :5173, proxies /api to :8600, and the phone loads
+# http://<lan-ip>:5173/mobile.html directly.
+_ui_dist = PROJECT_ROOT / "frontend" / "dist"
+_serve_ui = (
+    os.environ.get("theDAW_SERVE_UI") == "1" or (_ui_dist / "index.html").is_file()
+)
+if _serve_ui:
     if (_ui_dist / "index.html").is_file():
+        from fastapi.responses import RedirectResponse
         from fastapi.staticfiles import StaticFiles
 
+        # Short, phone-typeable alias for the companion entry. Registered BEFORE
+        # the "/" mount below so the mount cannot shadow it. Redirects (rather
+        # than serving mobile.html here) so the browser loads /mobile.html and
+        # its root-relative /assets/* resolve.
+        @app.get("/m", include_in_schema=False)
+        async def _mobile_entry() -> "RedirectResponse":
+            return RedirectResponse(url="/mobile.html")
+
         app.mount("/", StaticFiles(directory=_ui_dist, html=True), name="ui")
-        logger.info("ui: serving %s at / (theDAW_SERVE_UI=1)", _ui_dist)
-    else:
+        logger.info("ui: serving %s at / (companion entry at /m)", _ui_dist)
+    elif os.environ.get("theDAW_SERVE_UI") == "1":
         logger.warning(
             "ui: theDAW_SERVE_UI=1 but %s is missing; UI mount skipped", _ui_dist
         )

--- a/docs/companion-control-contract.md
+++ b/docs/companion-control-contract.md
@@ -1,0 +1,179 @@
+# theDAW companion control contract (v1)
+
+The single wire contract shared by the web-mobile client (Phase 3) and the
+Flutter companion (Phase 4). Both are LAN clients of the desktop app running on
+the GPU host. The desktop browser is the audio/visual host; companions are thin
+remote surfaces plus a standalone REST reader.
+
+This document is the source of truth. Change it here first, bump the version,
+then update every client.
+
+## Topology
+
+```
+ phone / Flutter (controller peer)          theDAW-XR headset (controller peer)
+              |                                          |
+              +----------------+       +-----------------+
+                               v       v
+                    backend relay  /api/xr/control/ws
+                               ^
+                               |
+                    desktop browser (HOST peer)
+                    owns the control manifest + wired setters
+```
+
+- The relay (`backend/modules/xrcontrol/router.py`) forwards JSON frames between
+  peers. It holds only the session pairing posture and the set of authenticated
+  peers; it does not understand control semantics.
+- The desktop browser is the HOST: it aggregates `XrControlSource`s into one
+  manifest and applies inbound `control-set` frames. A control surfaces on any
+  companion the moment its source contributes a manifest entry, with no
+  companion-side code.
+- Companions (phone, Flutter, headset) are CONTROLLER peers: they request the
+  manifest, render widgets from it, and send `control-set`.
+
+## Two companion roles
+
+1. **Standalone REST reader** (works with no desktop browser open): Library
+   browse and playback, MAKE generate. Talks the REST surface below directly and
+   plays audio on the companion's own player. Not gated by pairing.
+2. **Remote surface** (requires the desktop app open as host): transport remote,
+   DJ remote, VJ remote. Sends control frames over the WebSocket bus. Gated by
+   the pairing posture.
+
+## REST surface (standalone reader)
+
+Origin-relative from the LAN address the companion loaded from, so the shared
+`lib/backendBase.ts` helpers resolve it with no companion-specific config.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/library/entries` | List library entries. |
+| GET | `/api/library/audio/{id}` | Stream one entry's audio. |
+| GET | `/api/library/media/{id}` | Stream non-audio media. |
+| POST | `/api/generate-jobs` | Submit a MAKE job. |
+| GET | `/api/jobs/{id}` | Poll a job to completion. |
+| POST | `/api/magenta/generate` | Magenta generation path. |
+| GET | `/api/vj/lan-ip` | This host's LAN IPv4 (for QR building). |
+| GET | `/api/xr/control/status` | `{clients}` peer count. Drives the "desktop host offline" state on remote tabs. |
+
+## WebSocket bus (`/api/xr/control/ws`)
+
+All frames are JSON objects with a `type` field.
+
+### Pairing handshake (relay-handled, not forwarded)
+
+The relay intercepts these; they never reach other peers.
+
+Host to relay, on connect and whenever posture changes:
+```json
+{ "type": "host-hello", "posture": { "mode": "open" | "code", "code": "1234" | null } }
+```
+Relay replies:
+```json
+{ "type": "host-ack", "posture": {...}, "peers": [ { "peerId": 7, "label": "Pixel" } ] }
+```
+
+Controller to relay, on connect:
+```json
+{ "type": "controller-hello", "label": "Pixel 8", "code": "1234" | null }
+```
+Relay replies with exactly one of:
+```json
+{ "type": "pair-ok", "peerId": 7 }
+{ "type": "pair-rejected", "reason": "code" }
+```
+
+Relay to host, as peers come and go:
+```json
+{ "type": "peer-joined", "peerId": 7, "label": "Pixel 8" }
+{ "type": "peer-left", "peerId": 7 }
+```
+
+Host to relay, to revoke a controller:
+```json
+{ "type": "kick", "peerId": 7 }
+```
+
+### Pairing posture semantics
+
+- Default posture is `open` (preserves the pre-v1 relay behavior). A peer that
+  never sends a hello is a legacy peer and is authenticated under the current
+  posture at connect time (so the existing theDAW-XR headset keeps working while
+  posture is `open`).
+- In `open` mode any controller is authenticated immediately.
+- In `code` mode a controller is authenticated only if its `code` matches the
+  host's posture code. The host sets the posture BEFORE handing out the QR; the
+  QR carries `?pair=<code>` so scanning auto-fills it.
+- The REST surface is never gated. Only the control bus is. A companion can
+  browse Library without pairing; transport/DJ/VJ remotes require it.
+- Only authenticated peers exchange control frames. Frames from an
+  unauthenticated peer are dropped.
+- The host role is privileged (it sets the posture). The relay accepts
+  `host-hello` only from a localhost origin, and never lets a second peer seize
+  an established host. In the shipped topology the desktop browser is
+  co-located with the backend, so it is localhost; a LAN companion cannot claim
+  the host role and reset the posture to open. A remote-host deployment (a
+  container served to a browser on another machine) opts in with the
+  `THEDAW_XR_ALLOW_REMOTE_HOST=1` environment variable.
+
+### Control frames (relayed between authenticated peers)
+
+Host to controllers:
+```json
+{ "type": "manifest", "version": 12, "entries": [ XrManifestEntry, ... ] }
+{ "type": "control-changed", "id": "transport.playpause", "value": true }
+```
+
+Controller to host:
+```json
+{ "type": "request-controls" }
+{ "type": "control-set", "id": "transport.seek", "value": 0.42 }
+{ "type": "pad", "id": "...", ... }
+{ "type": "jog", "id": "...", ... }
+{ "type": "trigger", "id": "...", ... }
+```
+
+`XrManifestEntry` (from `frontend/src/state/xrControlClient.ts`):
+```ts
+{ id, area, group, label, kind, min?, max?, step?, options?, unit?, value?, readonly? }
+// kind in: knob | fader | button | toggle | crossfader | select | xy | xyz | jog | grid
+```
+
+Id namespacing: `"<area>.<name>[.<suffix>]"`. The leading segment is the source
+area (`transport`, `dj`, `make`, `vj`, ...). The host routes an inbound
+`control-set` to the source that owns that area.
+
+### Value types
+
+- `button`: any truthy `value` triggers the action.
+- `toggle`: boolean.
+- `knob` / `fader` / `crossfader`: number within `[min, max]` (transport uses
+  `0..1` fractions).
+- `select`: one of `options`.
+
+## URL / serving
+
+- Dev: the companion loads at `http://<lan-ip>:5173/mobile.html`; Vite proxies
+  `/api` to `:8600`.
+- Packaged (Electron/Docker): the backend serves `frontend/dist` at `/` when it
+  exists, so `http://<lan-ip>:8600/mobile.html` (and its root-relative
+  `/assets/*`) resolve. `GET /m` redirects to `/mobile.html` as a short,
+  phone-typeable alias.
+- WebSocket URL is derived from `window.location` when served over http from the
+  LAN, and falls back to `ws://localhost:8600` only for the `app://` desktop
+  renderer.
+
+## Areas defined in v1
+
+| Area | Source file | Role |
+|---|---|---|
+| `transport` | `frontend/src/state/transportControlSource.ts` | play/pause/seek/volume/loop/stop of the desktop footer player. Shared with Phase 7 B1. |
+| `dj` | `frontend/src/state/xrControlDjSource.ts` | existing DJ controls (Phase 3 Slice 2 consumes them). |
+| `make` | `frontend/src/state/makeControlSource.ts` | existing MAKE params (Phase 3 Slice 3). |
+
+## Versioning
+
+Bump the `manifest.version` on any manifest-shape change and this document's
+title version on any frame-protocol change. Clients tolerate unknown `kind`
+values by skipping the widget, and unknown frame `type`s by ignoring them.

--- a/frontend/mobile.html
+++ b/frontend/mobile.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!-- viewport-fit=cover so safe-area insets work under the notch/home bar;
+         no user scaling so the no-scroll layout law holds on the phone. -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="theme-color" content="#07050a" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=4" />
+    <title>theDAW companion</title>
+    <style>
+      #boot-splash {
+        position: fixed;
+        inset: 0;
+        z-index: 2147483647;
+        background: #07050a;
+      }
+      html,
+      body {
+        margin: 0;
+        background: #07050a;
+        overscroll-behavior: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="boot-splash"></div>
+    <div id="root"></div>
+    <script type="module" src="/src/mobile/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import { djControlSource } from './state/xrControlDjSource';
 import { makeControlSource } from './state/makeControlSource';
 import { processControlSource } from './state/processControlSource';
 import { liveFxControlSource } from './state/liveFxControlSource';
+import { transportControlSource } from './state/transportControlSource';
 import { swayControlSource, startSwayXrMirror } from './state/swayControlSource';
 import { startSwayBus } from './state/swayBus';
 import { startSwayRouting } from './state/swayRouting';
@@ -311,6 +312,9 @@ export default function App() {
     // LIVE (master FX): always-available, non-destructive sound shaping on the
     // player output — the VST-Foundry demo-mode bind-test surface.
     registerXrControlSource(liveFxControlSource);
+    // Transport: footer play/pause/seek/volume/loop for the phone companion
+    // (Phase 3) and the headset (Phase 7 B1).
+    registerXrControlSource(transportControlSource);
     startXrControl();
     return () => {
       stopXrControl();

--- a/frontend/src/components/layout/Shell.tsx
+++ b/frontend/src/components/layout/Shell.tsx
@@ -27,6 +27,7 @@ import { useOnboardingStore } from '../../onboarding/onboardingStore';
 import FeatureGateNotices from '../../notices/FeatureGateNotices';
 import { useStatusBarStore } from '../../state/statusBarStore';
 import { backendHttpBase, lanReachablePort } from '../../lib/backendBase';
+import { setXrHostPosture, onXrPeersChanged, kickXrPeer, type XrPeer } from '../../state/xrControlClient';
 import { useEditThemeStore } from '../../state/editThemeStore';
 import { resolveEditThemeVars } from '../../lib/editThemes';
 
@@ -112,6 +113,46 @@ export const Shell: React.FC = () => {
     () => `https://api.qrserver.com/v1/create-qr-code/?size=220x220&margin=12&data=${encodeURIComponent(shareUrl)}`,
     [shareUrl],
   );
+
+  // Phone-companion pairing. The host picks the posture (open LAN or a required
+  // code) before handing out the QR; the code rides the URL as ?pair=<code> so
+  // scanning auto-fills it. See docs/companion-control-contract.md.
+  const [postureMode, setPostureMode] = React.useState<'open' | 'code'>('open');
+  const [pairCode, setPairCode] = React.useState('');
+  const [companionPeers, setCompanionPeers] = React.useState<XrPeer[]>([]);
+  const [copiedCompanion, setCopiedCompanion] = React.useState(false);
+
+  React.useEffect(() => onXrPeersChanged(setCompanionPeers), []);
+  React.useEffect(() => {
+    setXrHostPosture({ mode: postureMode, code: postureMode === 'code' ? pairCode : null });
+  }, [postureMode, pairCode]);
+
+  const companionUrl = useMemo(() => {
+    const base = (shareUrl || '').replace(/\/+$/, '');
+    if (!base) return '';
+    const q = postureMode === 'code' && pairCode ? `?pair=${pairCode}` : '';
+    return `${base}/mobile.html${q}`;
+  }, [shareUrl, postureMode, pairCode]);
+  const companionQrUrl = useMemo(
+    () =>
+      companionUrl
+        ? `https://api.qrserver.com/v1/create-qr-code/?size=220x220&margin=12&data=${encodeURIComponent(companionUrl)}`
+        : '',
+    [companionUrl],
+  );
+  const chooseCodePosture = () => {
+    setPairCode((c) => c || Math.floor(1000 + Math.random() * 9000).toString());
+    setPostureMode('code');
+  };
+  const copyCompanionUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(companionUrl);
+      setCopiedCompanion(true);
+      window.setTimeout(() => setCopiedCompanion(false), 1500);
+    } catch {
+      /* clipboard blocked — the URL is still visible to copy manually */
+    }
+  };
 
   const updateShareUrlOverride = (value: string) => {
     setShareUrlOverride(value);
@@ -380,6 +421,95 @@ export const Shell: React.FC = () => {
                 <p className="text-[9px] leading-relaxed text-zinc-500">
                   By default this uses <span className="font-mono text-zinc-400">{detectedShareUrl}</span>. Paste a Cloudflare Tunnel or other public URL here when your phone is not on the same network.
                 </p>
+              </div>
+
+              {/* Phone companion — a lean remote app (library + player control),
+                  separate from opening the full desktop UI above. */}
+              <div className="flex flex-col gap-2 pt-3 border-t border-white/5">
+                <div className="flex items-center justify-between">
+                  <span className="text-[9px] font-black uppercase tracking-widest text-purple-300">Phone companion</span>
+                  <span className="text-[8px] font-mono uppercase tracking-wider text-purple-300/50">library + remote</span>
+                </div>
+                <p className="text-[9px] leading-relaxed text-zinc-500">
+                  A lightweight phone app to browse and play the library and remote-control the player. Choose who may drive this desktop before you share the code.
+                </p>
+
+                {/* Posture: both options shown; the host selects before allowing a peer. */}
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    aria-pressed={postureMode === 'open'}
+                    onClick={() => setPostureMode('open')}
+                    className={`flex-1 px-2 py-1.5 rounded border text-[9px] font-black uppercase tracking-widest transition-colors ${postureMode === 'open' ? 'border-purple-400/60 bg-purple-500/20 text-purple-100' : 'border-white/10 bg-black/30 text-zinc-400 hover:text-zinc-200'}`}
+                  >
+                    Open LAN
+                  </button>
+                  <button
+                    type="button"
+                    aria-pressed={postureMode === 'code'}
+                    onClick={chooseCodePosture}
+                    className={`flex-1 px-2 py-1.5 rounded border text-[9px] font-black uppercase tracking-widest transition-colors ${postureMode === 'code' ? 'border-purple-400/60 bg-purple-500/20 text-purple-100' : 'border-white/10 bg-black/30 text-zinc-400 hover:text-zinc-200'}`}
+                  >
+                    Require code
+                  </button>
+                </div>
+
+                {postureMode === 'code' && (
+                  <div className="flex items-center justify-between px-3 py-2 rounded bg-black/40 border border-purple-500/20">
+                    <span className="text-[9px] font-mono uppercase tracking-widest text-zinc-400">Pair code</span>
+                    <span className="text-[15px] font-mono font-black tracking-[0.35em] text-purple-200">{pairCode}</span>
+                  </div>
+                )}
+
+                {companionQrUrl && (
+                  <div className="flex justify-center pt-1">
+                    <div className="p-3 rounded-lg bg-white shadow-[0_0_24px_rgba(139,92,246,0.16)]">
+                      <img src={companionQrUrl} alt="theDAW phone companion QR code" className="w-44 h-44" />
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-1.5">
+                  <label htmlFor="shell-companion-url" className="text-[9px] font-black uppercase tracking-widest text-zinc-400">Companion URL</label>
+                  <div className="flex gap-2">
+                    <input
+                      id="shell-companion-url"
+                      type="text"
+                      name="shell-companion-url"
+                      value={companionUrl}
+                      readOnly
+                      className="flex-1 bg-black/40 border border-white/10 rounded px-2 py-1.5 text-[10px] font-mono text-zinc-200 outline-none"
+                    />
+                    <button
+                      onClick={() => void copyCompanionUrl()}
+                      className="px-2 py-1.5 rounded border border-purple-500/30 bg-purple-500/10 hover:bg-purple-500/20 text-purple-200 text-[9px] font-black uppercase tracking-widest flex items-center gap-1.5"
+                      title="Copy companion URL"
+                    >
+                      <Copy className="w-3 h-3" /> {copiedCompanion ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                </div>
+
+                {companionPeers.length > 0 && (
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-[9px] font-black uppercase tracking-widest text-zinc-400">Connected ({companionPeers.length})</span>
+                    <ul className="flex flex-col gap-1">
+                      {companionPeers.map((p) => (
+                        <li key={p.peerId} className="flex items-center justify-between px-2 py-1.5 rounded bg-black/30 border border-white/10">
+                          <span className="text-[10px] font-mono text-zinc-200">{p.label}</span>
+                          <button
+                            type="button"
+                            onClick={() => kickXrPeer(p.peerId)}
+                            aria-label={`Disconnect ${p.label}`}
+                            className="px-2 py-0.5 rounded border border-red-500/30 bg-red-500/10 hover:bg-red-500/20 text-red-200 text-[8px] font-black uppercase tracking-widest"
+                          >
+                            Kick
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/mobile/MobileApp.tsx
+++ b/frontend/src/mobile/MobileApp.tsx
@@ -1,0 +1,56 @@
+/** theDAW companion root (phone). Standalone Library + a transport remote that
+ *  rides the control bus. No cinematic, no MIDI/XR/sway boot — just the shell. */
+import { useEffect, useState } from 'react';
+import { Library, SlidersHorizontal } from 'lucide-react';
+import { MobileScreen } from './ui/MobileScreen';
+import { TabBar, type TabDef } from './ui/TabBar';
+import { MobileLibrary } from './tabs/MobileLibrary';
+import { MobileTransport } from './tabs/MobileTransport';
+import { useControlStore } from './net/controlClient';
+
+const TABS: TabDef[] = [
+  { id: 'library', label: 'Library', icon: <Library size={20} /> },
+  { id: 'remote', label: 'Remote', icon: <SlidersHorizontal size={20} /> },
+];
+
+function statusClass(status: string): string {
+  if (status === 'paired') return 'm-dot is-ok';
+  if (status === 'rejected') return 'm-dot is-bad';
+  if (status === 'offline') return 'm-dot is-warn';
+  return 'm-dot';
+}
+
+function statusLabel(status: string): string {
+  if (status === 'paired') return 'linked';
+  if (status === 'rejected') return 'locked';
+  if (status === 'offline') return 'offline';
+  return 'connecting';
+}
+
+export function MobileApp() {
+  const [tab, setTab] = useState('library');
+  const status = useControlStore((s) => s.status);
+  const connect = useControlStore((s) => s.connect);
+  const disconnect = useControlStore((s) => s.disconnect);
+
+  useEffect(() => {
+    connect();
+    return () => disconnect();
+  }, [connect, disconnect]);
+
+  return (
+    <MobileScreen
+      header={
+        <>
+          <span className="m-brand">
+            theDAW<small>companion</small>
+          </span>
+          <span className={statusClass(status)}>{statusLabel(status)}</span>
+        </>
+      }
+      tabBar={<TabBar tabs={TABS} active={tab} onSelect={setTab} />}
+    >
+      {tab === 'library' ? <MobileLibrary /> : <MobileTransport />}
+    </MobileScreen>
+  );
+}

--- a/frontend/src/mobile/main.tsx
+++ b/frontend/src/mobile/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { MobileApp } from './MobileApp';
+import './mobile.css';
+
+// Remove the inline boot cover once React is ready to paint.
+document.getElementById('boot-splash')?.remove();
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  createRoot(rootEl).render(
+    <StrictMode>
+      <MobileApp />
+    </StrictMode>,
+  );
+}

--- a/frontend/src/mobile/mobile.css
+++ b/frontend/src/mobile/mobile.css
@@ -1,0 +1,357 @@
+/* theDAW companion (phone) styles. Self-contained: own reset + obsidian-derived
+   tokens + component classes, so the mobile bundle never pulls the desktop's
+   global CSS or Tailwind. The layout law: the page never scrolls; only .m-scroller
+   regions do. */
+
+:root {
+  --m-bg: #07050a;
+  --m-panel: #110e1a;
+  --m-panel-2: #17131f;
+  --m-border: #231e38;
+  --m-accent: #8b5cf6;
+  --m-accent-dim: #6d3fd4;
+  --m-accent-glow: rgba(139, 92, 246, 0.4);
+  --m-text: #f5f3ff;
+  --m-text-2: #94a3b8;
+  --m-muted: #4b4453;
+  --m-ok: #34d399;
+  --m-warn: #fbbf24;
+  --m-bad: #f87171;
+  --m-h-header: 52px;
+  --m-h-tabbar: 60px;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  background: var(--m-bg);
+  color: var(--m-text);
+  overscroll-behavior: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── Shell: fixed viewport grid, zero page scroll ── */
+.m-screen {
+  height: 100dvh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  overflow: hidden;
+  background: var(--m-bg);
+}
+
+.m-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  height: var(--m-h-header);
+  padding: 0 14px;
+  padding-top: env(safe-area-inset-top);
+  border-bottom: 1px solid var(--m-border);
+  background: var(--m-panel);
+}
+
+.m-brand {
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  font-size: 15px;
+}
+.m-brand small {
+  color: var(--m-text-2);
+  font-weight: 500;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-left: 6px;
+}
+
+.m-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--m-text-2);
+}
+.m-dot::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--m-muted);
+}
+.m-dot.is-ok::before {
+  background: var(--m-ok);
+  box-shadow: 0 0 8px var(--m-ok);
+}
+.m-dot.is-warn::before {
+  background: var(--m-warn);
+}
+.m-dot.is-bad::before {
+  background: var(--m-bad);
+}
+
+.m-content {
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* The ONLY scrollable region. */
+.m-scroller {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ── Tab bar ── */
+.m-tabbar {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  height: var(--m-h-tabbar);
+  padding-bottom: env(safe-area-inset-bottom);
+  border-top: 1px solid var(--m-border);
+  background: var(--m-panel);
+}
+.m-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  background: none;
+  border: none;
+  color: var(--m-text-2);
+  font: inherit;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.m-tab.is-active {
+  color: var(--m-accent);
+}
+.m-tab.is-active .m-tab-icon {
+  filter: drop-shadow(0 0 6px var(--m-accent-glow));
+}
+
+/* ── Library ── */
+.m-search {
+  display: block;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--m-border);
+}
+.m-search input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--m-border);
+  background: var(--m-panel-2);
+  color: var(--m-text);
+  font: inherit;
+  font-size: 14px;
+}
+.m-search input::placeholder {
+  color: var(--m-muted);
+}
+
+.m-list {
+  list-style: none;
+  padding: 6px 10px 14px;
+}
+.m-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 11px 12px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.m-row + .m-row {
+  margin-top: 4px;
+}
+.m-row.is-playing {
+  background: var(--m-panel);
+  border-color: var(--m-border);
+}
+.m-row-play {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--m-panel-2);
+  border: 1px solid var(--m-border);
+  color: var(--m-accent);
+}
+.m-row.is-playing .m-row-play {
+  background: var(--m-accent);
+  color: #fff;
+  box-shadow: 0 0 12px var(--m-accent-glow);
+}
+.m-row-body {
+  min-width: 0;
+  flex: 1;
+}
+.m-row-title {
+  display: block;
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.m-row-sub {
+  display: block;
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--m-text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.m-empty {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--m-text-2);
+  font-size: 13px;
+}
+
+/* ── Transport / remote ── */
+.m-remote {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.m-transport-main {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+}
+.m-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 18px;
+  border-radius: 14px;
+  border: 1px solid var(--m-border);
+  background: var(--m-panel);
+  color: var(--m-text);
+  font: inherit;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.m-btn:active {
+  transform: scale(0.98);
+}
+.m-btn.is-on {
+  background: var(--m-accent);
+  border-color: var(--m-accent-dim);
+  color: #fff;
+  box-shadow: 0 0 16px var(--m-accent-glow);
+}
+.m-btn.m-btn-icon {
+  width: 64px;
+  padding: 0;
+}
+
+.m-field {
+  display: block;
+}
+.m-field-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--m-text-2);
+  margin-bottom: 6px;
+}
+.m-range {
+  width: 100%;
+  height: 34px;
+  accent-color: var(--m-accent);
+}
+
+.m-toggle-row {
+  display: flex;
+  gap: 10px;
+}
+.m-toggle-row .m-btn {
+  flex: 1;
+  padding: 12px;
+  font-size: 13px;
+}
+
+.m-state {
+  margin: 40px 16px;
+  padding: 22px 18px;
+  border: 1px solid var(--m-border);
+  border-radius: 14px;
+  background: var(--m-panel);
+  text-align: center;
+}
+.m-state h2 {
+  font-size: 15px;
+  margin-bottom: 8px;
+}
+.m-state p {
+  font-size: 12px;
+  color: var(--m-text-2);
+  line-height: 1.5;
+}
+.m-state .m-btn {
+  margin-top: 16px;
+}
+.m-pair {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+}
+.m-pair input {
+  flex: 1;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--m-border);
+  background: var(--m-panel-2);
+  color: var(--m-text);
+  font: inherit;
+  font-size: 16px;
+  text-align: center;
+  letter-spacing: 0.3em;
+}

--- a/frontend/src/mobile/net/controlClient.ts
+++ b/frontend/src/mobile/net/controlClient.ts
@@ -1,0 +1,210 @@
+/**
+ * Controller-role client for the companion control bus (mobile side).
+ *
+ * The phone is a CONTROLLER peer: it opens the same `/api/xr/control/ws` relay
+ * the desktop host publishes to, presents the pairing code (when the host
+ * requires one), renders widgets from the host's manifest, and sends
+ * `control-set` frames. See docs/companion-control-contract.md.
+ *
+ * This is deliberately NOT the desktop's xrControlClient (that one is the host,
+ * publishes a manifest, and applies inbound sets). Here the roles are inverted.
+ */
+import { create } from 'zustand';
+
+export type ControlValue = number | boolean;
+
+export interface ManifestEntry {
+  id: string;
+  area: string;
+  group: string;
+  label: string;
+  kind: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  options?: string[];
+  unit?: string;
+  value?: ControlValue;
+  readonly?: boolean;
+}
+
+export type ControlStatus = 'connecting' | 'paired' | 'rejected' | 'offline';
+
+interface ControlState {
+  status: ControlStatus;
+  entries: ManifestEntry[];
+  values: Record<string, ControlValue>;
+  /** Open (and keep open) the bus. Safe to call repeatedly. */
+  connect: () => void;
+  /** Force a fresh connect (e.g. after entering a pair code). */
+  retry: () => void;
+  disconnect: () => void;
+  setControl: (id: string, value: ControlValue) => void;
+  entriesForArea: (area: string) => ManifestEntry[];
+}
+
+function wsUrl(): string {
+  const { protocol, host } = window.location;
+  const scheme = protocol === 'https:' ? 'wss' : 'ws';
+  return `${scheme}://${host}/api/xr/control/ws`;
+}
+
+function deviceLabel(): string {
+  const ua = navigator.userAgent || '';
+  if (/ipad/i.test(ua)) return 'iPad';
+  if (/iphone/i.test(ua)) return 'iPhone';
+  if (/android/i.test(ua)) return 'Android';
+  return 'Phone';
+}
+
+function pairCode(): string | null {
+  try {
+    return new URLSearchParams(window.location.search).get('pair');
+  } catch {
+    return null;
+  }
+}
+
+let ws: WebSocket | null = null;
+let running = false;
+let reconnectTimer = 0;
+// Set true on pair-rejected so we stop auto-reconnecting into the same wall;
+// retry() clears it.
+let rejected = false;
+
+export const useControlStore = create<ControlState>((set, get) => {
+  function scheduleReconnect(): void {
+    if (!running || reconnectTimer || rejected) return;
+    reconnectTimer = window.setTimeout(() => {
+      reconnectTimer = 0;
+      open();
+    }, 2000);
+  }
+
+  function open(): void {
+    if (!running || ws) return;
+    let sock: WebSocket;
+    try {
+      sock = new WebSocket(wsUrl());
+    } catch {
+      set({ status: 'offline' });
+      scheduleReconnect();
+      return;
+    }
+    ws = sock;
+    set({ status: 'connecting' });
+    sock.onopen = () => {
+      sock.send(
+        JSON.stringify({ type: 'controller-hello', label: deviceLabel(), code: pairCode() }),
+      );
+    };
+    sock.onmessage = (e) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(typeof e.data === 'string' ? e.data : '');
+      } catch {
+        return;
+      }
+      if (!parsed || typeof parsed !== 'object') return;
+      const m = parsed as {
+        type?: unknown;
+        id?: unknown;
+        value?: unknown;
+        entries?: unknown;
+      };
+      if (typeof m.type !== 'string') return;
+      if (m.type === 'pair-ok') {
+        rejected = false;
+        set({ status: 'paired' });
+        sock.send(JSON.stringify({ type: 'request-controls' }));
+      } else if (m.type === 'pair-rejected') {
+        rejected = true;
+        set({ status: 'rejected' });
+        try {
+          sock.close();
+        } catch {
+          /* already closing */
+        }
+      } else if (m.type === 'manifest' && Array.isArray(m.entries)) {
+        const entries = m.entries as ManifestEntry[];
+        const values: Record<string, ControlValue> = {};
+        for (const en of entries) {
+          if (en && typeof en.id === 'string' && en.value !== undefined) {
+            values[en.id] = en.value;
+          }
+        }
+        // The manifest is the authoritative resync (it is the only path that
+        // recovers changes made while this phone was disconnected), so the
+        // host's fresh values win over any stale local echo.
+        set({ entries, values: { ...get().values, ...values } });
+      } else if (m.type === 'control-changed' && typeof m.id === 'string') {
+        set((s) => ({ values: { ...s.values, [m.id as string]: m.value as ControlValue } }));
+      }
+    };
+    sock.onerror = () => {
+      try {
+        sock.close();
+      } catch {
+        /* already closing */
+      }
+    };
+    sock.onclose = () => {
+      if (ws === sock) ws = null;
+      if (get().status !== 'rejected') set({ status: 'offline' });
+      scheduleReconnect();
+    };
+  }
+
+  return {
+    status: 'connecting',
+    entries: [],
+    values: {},
+
+    connect: () => {
+      if (running) return;
+      running = true;
+      rejected = false;
+      open();
+    },
+
+    retry: () => {
+      rejected = false;
+      if (ws) {
+        try {
+          ws.close();
+        } catch {
+          /* already closing */
+        }
+        ws = null;
+      }
+      running = true;
+      open();
+    },
+
+    disconnect: () => {
+      running = false;
+      if (reconnectTimer) {
+        window.clearTimeout(reconnectTimer);
+        reconnectTimer = 0;
+      }
+      if (ws) {
+        try {
+          ws.close();
+        } catch {
+          /* already closing */
+        }
+        ws = null;
+      }
+    },
+
+    setControl: (id, value) => {
+      // Optimistic local echo so the widget feels instant.
+      set((s) => ({ values: { ...s.values, [id]: value } }));
+      if (ws && ws.readyState === WebSocket.OPEN && get().status === 'paired') {
+        ws.send(JSON.stringify({ type: 'control-set', id, value }));
+      }
+    },
+
+    entriesForArea: (area) => get().entries.filter((e) => e.area === area),
+  };
+});

--- a/frontend/src/mobile/tabs/MobileLibrary.tsx
+++ b/frontend/src/mobile/tabs/MobileLibrary.tsx
@@ -1,0 +1,109 @@
+/** Library tab: browse and play the desktop's library over REST. Standalone —
+ *  needs no desktop browser open. Audio streams to the phone's own <audio>. */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Play, Pause } from 'lucide-react';
+import { Scroller } from '../ui/Scroller';
+import { useLibraryStore } from '../../state/libraryStore';
+import type { LibraryEntry } from '../../state/libraryStore';
+
+function fmtDuration(sec: number): string {
+  if (!Number.isFinite(sec) || sec <= 0) return '';
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function MobileLibrary() {
+  const entries = useLibraryStore((s) => s.entries);
+  const loaded = useLibraryStore((s) => s.loaded);
+  const loading = useLibraryStore((s) => s.loading);
+  const load = useLibraryStore((s) => s.load);
+  const getAudioUrl = useLibraryStore((s) => s.getAudioUrl);
+
+  const [query, setQuery] = useState('');
+  const [playingId, setPlayingId] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    if (!loaded && !loading) void load();
+  }, [loaded, loading, load]);
+
+  const filtered = useMemo(() => {
+    const audio = entries.filter((e) => (e.kind ?? 'audio') === 'audio');
+    const q = query.trim().toLowerCase();
+    if (!q) return audio;
+    return audio.filter(
+      (e) =>
+        e.title.toLowerCase().includes(q) || (e.prompt ?? '').toLowerCase().includes(q),
+    );
+  }, [entries, query]);
+
+  function toggle(entry: LibraryEntry): void {
+    const el = audioRef.current;
+    if (!el) return;
+    if (playingId === entry.id) {
+      if (el.paused) void el.play();
+      else el.pause();
+      return;
+    }
+    el.src = getAudioUrl(entry);
+    setPlayingId(entry.id);
+    void el.play().catch(() => setPlayingId((cur) => (cur === entry.id ? null : cur)));
+  }
+
+  return (
+    <>
+      <label className="m-search">
+        <span className="sr-only">Search library</span>
+        <input
+          id="m-lib-search"
+          name="library-search"
+          type="search"
+          placeholder="Search library…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </label>
+      <Scroller>
+        {filtered.length === 0 ? (
+          <p className="m-empty">
+            {loading ? 'Loading library…' : loaded ? 'No tracks found.' : 'Connecting…'}
+          </p>
+        ) : (
+          <ul className="m-list">
+            {filtered.map((entry) => {
+              const isPlaying = playingId === entry.id;
+              return (
+                <li key={entry.id}>
+                  <button
+                    type="button"
+                    className={`m-row${isPlaying ? ' is-playing' : ''}`}
+                    onClick={() => toggle(entry)}
+                  >
+                    <span className="m-row-play" aria-hidden="true">
+                      {isPlaying ? <Pause size={16} /> : <Play size={16} />}
+                    </span>
+                    <span className="m-row-body">
+                      <span className="m-row-title">{entry.title || 'Untitled'}</span>
+                      <span className="m-row-sub">
+                        {[entry.model, fmtDuration(entry.duration)].filter(Boolean).join(' · ')}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Scroller>
+      {/* One shared element; onEnded clears the row highlight. */}
+      <audio
+        ref={audioRef}
+        onEnded={() => setPlayingId(null)}
+        onPause={() => {
+          /* keep highlight so the row shows a resumable paused state */
+        }}
+      />
+    </>
+  );
+}

--- a/frontend/src/mobile/tabs/MobileTransport.tsx
+++ b/frontend/src/mobile/tabs/MobileTransport.tsx
@@ -1,0 +1,133 @@
+/** Remote tab: drives the desktop footer transport over the control bus. Needs
+ *  the desktop app open as host. Renders from the transport.* manifest entries. */
+import { Play, Pause, Square } from 'lucide-react';
+import { Scroller } from '../ui/Scroller';
+import { useControlStore } from '../net/controlClient';
+import type { ControlValue } from '../net/controlClient';
+
+const AREA = 'transport';
+
+function num(v: ControlValue | undefined, fallback = 0): number {
+  return typeof v === 'number' ? v : fallback;
+}
+function bool(v: ControlValue | undefined): boolean {
+  return v === true;
+}
+
+export function MobileTransport() {
+  const status = useControlStore((s) => s.status);
+  const values = useControlStore((s) => s.values);
+  const setControl = useControlStore((s) => s.setControl);
+  const retry = useControlStore((s) => s.retry);
+  const hasTransport = useControlStore((s) => s.entries.some((e) => e.area === AREA));
+
+  if (status !== 'paired') {
+    return (
+      <div className="m-state">
+        <h2>
+          {status === 'rejected'
+            ? 'Pairing needed'
+            : status === 'offline'
+              ? 'Desktop offline'
+              : 'Connecting…'}
+        </h2>
+        <p>
+          {status === 'rejected'
+            ? 'This host requires a pairing code. Rescan the QR from the desktop, or open the URL with ?pair=<code>.'
+            : 'Open theDAW on your computer and keep it on this network. The remote drives its player.'}
+        </p>
+        {status !== 'connecting' ? (
+          <button type="button" className="m-btn" onClick={() => retry()}>
+            Retry
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (!hasTransport) {
+    return (
+      <div className="m-state">
+        <h2>No transport</h2>
+        <p>Connected, but the desktop published no transport controls yet.</p>
+      </div>
+    );
+  }
+
+  const playing = bool(values[`${AREA}.playpause`]);
+  const looping = bool(values[`${AREA}.loop`]);
+  const seek = num(values[`${AREA}.seek`]);
+  const volume = num(values[`${AREA}.volume`], 1);
+
+  return (
+    <Scroller>
+      <div className="m-remote">
+        <div className="m-transport-main">
+          <button
+            type="button"
+            className={`m-btn${playing ? ' is-on' : ''}`}
+            onClick={() => setControl(`${AREA}.playpause`, !playing)}
+          >
+            {playing ? <Pause size={20} /> : <Play size={20} />}
+            {playing ? 'Pause' : 'Play'}
+          </button>
+          <button
+            type="button"
+            className="m-btn m-btn-icon"
+            aria-label="Stop"
+            onClick={() => setControl(`${AREA}.stop`, true)}
+          >
+            <Square size={18} />
+          </button>
+        </div>
+
+        <label className="m-field">
+          <span className="m-field-label">
+            <span>Seek</span>
+            <span>{Math.round(seek * 100)}%</span>
+          </span>
+          <input
+            id="m-transport-seek"
+            name="transport-seek"
+            className="m-range"
+            type="range"
+            min={0}
+            max={1}
+            step={0.001}
+            value={seek}
+            onChange={(e) => setControl(`${AREA}.seek`, Number(e.target.value))}
+          />
+        </label>
+
+        <label className="m-field">
+          <span className="m-field-label">
+            <span>Volume</span>
+            <span>{Math.round(volume * 100)}%</span>
+          </span>
+          <input
+            id="m-transport-volume"
+            name="transport-volume"
+            className="m-range"
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={volume}
+            onChange={(e) => setControl(`${AREA}.volume`, Number(e.target.value))}
+          />
+        </label>
+
+        <div className="m-toggle-row">
+          <button
+            type="button"
+            className={`m-btn${looping ? ' is-on' : ''}`}
+            aria-pressed={looping}
+            onClick={() => setControl(`${AREA}.loop`, !looping)}
+          >
+            Loop
+          </button>
+        </div>
+      </div>
+    </Scroller>
+  );
+}

--- a/frontend/src/mobile/ui/MobileScreen.tsx
+++ b/frontend/src/mobile/ui/MobileScreen.tsx
@@ -1,0 +1,21 @@
+/** Fixed-viewport shell: [header][content 1fr][tab bar], zero page scroll.
+ *  Only a <Scroller> inside `children` is allowed to scroll. */
+import type { ReactNode } from 'react';
+
+export function MobileScreen({
+  header,
+  children,
+  tabBar,
+}: {
+  header?: ReactNode;
+  children: ReactNode;
+  tabBar?: ReactNode;
+}) {
+  return (
+    <div className="m-screen">
+      {header ? <header className="m-header">{header}</header> : <div />}
+      <div className="m-content">{children}</div>
+      {tabBar ?? <div />}
+    </div>
+  );
+}

--- a/frontend/src/mobile/ui/Scroller.tsx
+++ b/frontend/src/mobile/ui/Scroller.tsx
@@ -1,0 +1,6 @@
+/** The one scrollable region inside a MobileScreen's content slot. */
+import type { ReactNode } from 'react';
+
+export function Scroller({ children }: { children: ReactNode }) {
+  return <div className="m-scroller">{children}</div>;
+}

--- a/frontend/src/mobile/ui/TabBar.tsx
+++ b/frontend/src/mobile/ui/TabBar.tsx
@@ -1,0 +1,36 @@
+/** Bottom tab bar. Slice 1 ships Library + Remote; DJ/VJ/MAKE tabs land in
+ *  later slices. */
+import type { ReactNode } from 'react';
+
+export interface TabDef {
+  id: string;
+  label: string;
+  icon: ReactNode;
+}
+
+export function TabBar({
+  tabs,
+  active,
+  onSelect,
+}: {
+  tabs: TabDef[];
+  active: string;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <nav className="m-tabbar" aria-label="Sections">
+      {tabs.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          className={`m-tab${active === t.id ? ' is-active' : ''}`}
+          aria-current={active === t.id ? 'page' : undefined}
+          onClick={() => onSelect(t.id)}
+        >
+          <span className="m-tab-icon">{t.icon}</span>
+          <span className="m-tab-label">{t.label}</span>
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/state/transportControlSource.ts
+++ b/frontend/src/state/transportControlSource.ts
@@ -1,0 +1,134 @@
+/**
+ * Transport control source for the companion / XR control bus.
+ *
+ * Publishes the footer player's transport (play/pause, seek, volume, loop, stop)
+ * as manifest entries and routes inbound control-sets to the playerStore, so a
+ * phone (Phase 3 Slice 1) or a headset (Phase 7 B1) can drive playback with no
+ * per-control code. It also mirrors host-side play/loop state back to
+ * controllers so their widgets follow theDAW.
+ *
+ * Volume: playerStore has no stored master-gain value (setMasterGain writes the
+ * gain node directly), so this source tracks the last commanded volume locally
+ * to seed the widget; it defaults to 1.
+ */
+import type { XrControlSource, XrManifestEntry, XrControlValue } from './xrControlClient';
+import { publishControlChanged } from './xrControlClient';
+import { usePlayerStore } from './playerStore';
+
+const AREA = 'transport';
+let lastVolume = 1;
+let mirrorWired = false;
+
+/** Mirror host-side play/loop changes to controllers (once). */
+function ensureMirror(): void {
+  if (mirrorWired) return;
+  mirrorWired = true;
+  let prevPlaying = usePlayerStore.getState().isPlaying;
+  let prevLooping = usePlayerStore.getState().isLooping;
+  usePlayerStore.subscribe((s) => {
+    if (s.isPlaying !== prevPlaying) {
+      prevPlaying = s.isPlaying;
+      publishControlChanged(`${AREA}.playpause`, s.isPlaying);
+    }
+    if (s.isLooping !== prevLooping) {
+      prevLooping = s.isLooping;
+      publishControlChanged(`${AREA}.loop`, s.isLooping);
+    }
+  });
+}
+
+export const transportControlSource: XrControlSource = {
+  area: AREA,
+
+  buildEntries(): XrManifestEntry[] {
+    ensureMirror();
+    const s = usePlayerStore.getState();
+    return [
+      {
+        id: `${AREA}.playpause`,
+        area: AREA,
+        group: 'Transport',
+        label: 'Play / Pause',
+        kind: 'toggle',
+        value: s.isPlaying,
+      },
+      {
+        id: `${AREA}.stop`,
+        area: AREA,
+        group: 'Transport',
+        label: 'Stop',
+        kind: 'button',
+      },
+      {
+        id: `${AREA}.seek`,
+        area: AREA,
+        group: 'Transport',
+        label: 'Seek',
+        kind: 'fader',
+        min: 0,
+        max: 1,
+        step: 0.001,
+        value: s.duration > 0 ? s.currentTime / s.duration : 0,
+      },
+      {
+        id: `${AREA}.volume`,
+        area: AREA,
+        group: 'Transport',
+        label: 'Volume',
+        kind: 'knob',
+        min: 0,
+        max: 1,
+        step: 0.01,
+        value: lastVolume,
+      },
+      {
+        id: `${AREA}.loop`,
+        area: AREA,
+        group: 'Transport',
+        label: 'Loop',
+        kind: 'toggle',
+        value: s.isLooping,
+      },
+    ];
+  },
+
+  apply(id: string, value: XrControlValue): boolean {
+    const store = usePlayerStore.getState();
+    switch (id) {
+      case `${AREA}.playpause`: {
+        // Idempotent intent (never invert a matching command). A real
+        // transition is mirrored by the store subscription; the one case that
+        // never transitions — play with no track loaded — is corrected here so
+        // the controller's optimistic "playing" does not stick on.
+        const wantPlay = typeof value === 'boolean' ? value : Boolean(value);
+        if (wantPlay) {
+          if (!store.hasTrack) publishControlChanged(`${AREA}.playpause`, false);
+          else if (!store.isPlaying) store.play();
+        } else if (store.isPlaying) {
+          store.pause();
+        }
+        return true;
+      }
+      case `${AREA}.stop`:
+        if (value) store.stop();
+        return true;
+      case `${AREA}.seek`:
+        store.seekByFraction(Number(value));
+        return true;
+      case `${AREA}.volume`: {
+        lastVolume = Math.max(0, Math.min(1, Number(value)));
+        store.setMasterGain(lastVolume);
+        // playerStore keeps no master-gain state, so echo the applied value so
+        // other controllers (and a rebuilt manifest) stay in sync.
+        publishControlChanged(`${AREA}.volume`, lastVolume);
+        return true;
+      }
+      case `${AREA}.loop`:
+        // toggleLoop flips; only flip when the requested state differs.
+        if (Boolean(value) !== store.isLooping) store.toggleLoop();
+        return true;
+      default:
+        return false;
+    }
+  },
+};

--- a/frontend/src/state/xrControlClient.ts
+++ b/frontend/src/state/xrControlClient.ts
@@ -71,10 +71,16 @@ function wsUrl(): string {
     // Hosted over TLS: same-origin so the deployment's proxy carries it.
     return `wss://${host}/api/xr/control/ws`;
   }
-  // Everywhere else — desktop app:// scheme (its protocol handler proxies
-  // HTTP /api/* but cannot upgrade WebSockets), electron-vite dev
-  // (http://localhost:5173, whose proxy historically lacked ws:true), and
-  // web dev — the backend is always local on :8600, so connect directly.
+  if (protocol === 'http:' && host) {
+    // Served over http from the LAN origin (desktop web dev on
+    // localhost:5173, or a phone/companion on <lan-ip>:5173 in dev /
+    // <lan-ip>:8600 packaged). Derive from the origin so a phone connects to
+    // its host, not to itself; the Vite proxy carries the upgrade in dev
+    // (server.proxy['/api'].ws = true) and it is direct in packaged/Docker.
+    return `ws://${host}/api/xr/control/ws`;
+  }
+  // Desktop app:// renderer — its protocol handler proxies HTTP /api/* but
+  // cannot upgrade WebSockets, and the backend is always local on :8600.
   return 'ws://localhost:8600/api/xr/control/ws';
 }
 
@@ -101,6 +107,77 @@ async function publishManifest(): Promise<void> {
 export function publishControlChanged(id: string, value: XrControlValue): void {
   if (ws && ws.readyState === WebSocket.OPEN) {
     ws.send(JSON.stringify({ type: 'control-changed', id, value }));
+  }
+}
+
+// ── Pairing posture (host side) ──────────────────────────────────────────────
+// This browser is the HOST. It declares the session pairing posture to the
+// relay: "open" lets any LAN controller in; "code" requires the QR's pair code.
+// The relay gates controllers on it (see docs/companion-control-contract.md).
+
+export type XrPostureMode = 'open' | 'code';
+export interface XrHostPosture {
+  mode: XrPostureMode;
+  code: string | null;
+}
+/** A connected, authenticated controller peer (phone / companion). */
+export interface XrPeer {
+  peerId: number;
+  label: string;
+}
+
+let hostPosture: XrHostPosture = { mode: 'open', code: null };
+let peers: XrPeer[] = [];
+const peerListeners = new Set<(p: XrPeer[]) => void>();
+
+function emitPeers(): void {
+  const snapshot = peers.slice();
+  for (const l of peerListeners) {
+    try {
+      l(snapshot);
+    } catch {
+      /* a listener that throws must not break the others */
+    }
+  }
+}
+
+function sendHostHello(): void {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: 'host-hello', posture: hostPosture }));
+  }
+}
+
+/** Set the pairing posture (called from the desktop Phone panel). Persists in
+ *  memory and re-declares to the relay when connected. */
+export function setXrHostPosture(posture: XrHostPosture): void {
+  hostPosture = {
+    mode: posture.mode === 'code' ? 'code' : 'open',
+    code: posture.code || null,
+  };
+  sendHostHello();
+}
+
+export function getXrHostPosture(): XrHostPosture {
+  return hostPosture;
+}
+
+/** Subscribe to the connected-companion list; fires immediately with current. */
+export function onXrPeersChanged(cb: (peers: XrPeer[]) => void): () => void {
+  peerListeners.add(cb);
+  cb(peers.slice());
+  return () => {
+    peerListeners.delete(cb);
+  };
+}
+
+export function getXrPeers(): XrPeer[] {
+  return peers.slice();
+}
+
+/** Revoke a connected companion by id. */
+export function kickXrPeer(peerId: number): void {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: 'kick', peerId }));
   }
 }
 
@@ -136,7 +213,9 @@ function connect(): void {
   sock.onopen = () => {
     everConnected = true;
     logInfo('xrcontrol', 'XR control bus connected.');
-    // Seed any controller already waiting on the relay.
+    // Declare this browser the host + its pairing posture, then seed any
+    // controller already waiting on the relay.
+    sendHostHello();
     void publishManifest();
   };
   sock.onmessage = (e) => {
@@ -147,12 +226,31 @@ function connect(): void {
       return; /* ignore malformed frame */
     }
     if (!parsed || typeof parsed !== 'object') return;
-    const m = parsed as { type?: unknown; id?: unknown; value?: unknown };
+    const m = parsed as {
+      type?: unknown;
+      id?: unknown;
+      value?: unknown;
+      peers?: unknown;
+      peerId?: unknown;
+      label?: unknown;
+    };
     if (typeof m.type !== 'string') return;
     if (m.type === 'request-controls') {
       void publishManifest();
     } else if (m.type === 'control-set' && typeof m.id === 'string') {
       void applyControlSet(m.id, m.value as XrControlValue);
+    } else if (m.type === 'host-ack') {
+      peers = Array.isArray(m.peers) ? (m.peers as XrPeer[]) : [];
+      emitPeers();
+    } else if (m.type === 'peer-joined' && typeof m.peerId === 'number') {
+      const label = typeof m.label === 'string' ? m.label : 'device';
+      if (!peers.some((p) => p.peerId === m.peerId)) {
+        peers = [...peers, { peerId: m.peerId as number, label }];
+        emitPeers();
+      }
+    } else if (m.type === 'peer-left' && typeof m.peerId === 'number') {
+      peers = peers.filter((p) => p.peerId !== m.peerId);
+      emitPeers();
     }
   };
   sock.onerror = () => {
@@ -160,6 +258,10 @@ function connect(): void {
   };
   sock.onclose = () => {
     if (ws === sock) ws = null;
+    if (peers.length) {
+      peers = [];
+      emitPeers();
+    }
     if (running && everConnected) logWarn('xrcontrol', 'XR control bus disconnected — retrying…');
     scheduleReconnect();
   };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -47,6 +47,14 @@ export default defineConfig(({mode}) => {
       // Modern output → less transpilation across the ~3.5k modules.
       target: 'es2022',
       rollupOptions: {
+        // Two entries: the desktop app (index.html) and the phone companion
+        // (mobile.html -> src/mobile/main.tsx). The mobile tree never imports
+        // three/alphaTab/force-graph, so its chunk stays small; the phone never
+        // downloads the desktop bundle.
+        input: {
+          main: path.resolve(__dirname, 'index.html'),
+          mobile: path.resolve(__dirname, 'mobile.html'),
+        },
         output: {
           // Split the big, stable leaf vendors into their own long-cached
           // chunks so an app-code edit doesn't bust them, and the main chunk


### PR DESCRIPTION
Adds a lightweight phone-facing web client (a second Vite entry) that talks to the desktop over the LAN, plus the shared REST/WebSocket contract that Phase 4 (Flutter) will reuse.

Contract (docs/companion-control-contract.md):
- the desktop browser is the control-bus HOST; phone/headset are controllers
- pairing posture the host picks before sharing the QR: open LAN or a required code (?pair=<code>); REST library browse is never gated, only the control bus
- relay accepts host-hello only from a localhost origin and never lets a peer seize an established host, so a LAN companion cannot reset posture to bypass code pairing (THEDAW_XR_ALLOW_REMOTE_HOST=1 opts a remote host back in)

Backend:
- backend/modules/xrcontrol/router.py: per-session pairing posture + auth gating + peer list/kick, backward-compatible with the existing headset (legacy peers authed under open posture)
- backend/server.py: serve frontend/dist at / when built (so /mobile.html and its /assets resolve in packaged builds) with a /m short-alias redirect

Frontend:
- frontend/mobile.html + src/mobile/*: no-scroll phone shell, Library (REST, standalone) and a transport Remote that rides the control bus; controller-role client with pairing + reconnect
- state/transportControlSource.ts: play/pause/seek/volume/loop as bus controls (shared with Phase 7 B1); idempotent play/pause, no-track correction
- state/xrControlClient.ts: LAN-aware wsUrl(), host-hello posture, peer list
- components/layout/Shell.tsx: desktop Phone-companion QR + posture picker + connected-device list
- vite.config.ts: second rollup entry for the mobile bundle

Verified end-to-end (pairing both postures, transport drives the desktop player) and hardened against a 6-finding adversarial review (critical auth bypass fixed).