### PR TITLE
Release/v0.1.2

### DIFF
--- a/electron-ui/electron.vite.config.ts
+++ b/electron-ui/electron.vite.config.ts
@@ -46,6 +46,12 @@ export default defineConfig({
     },
     server: {
       port: 5173,
+      // Bind ALL interfaces (not loopback) so a phone on the LAN can reach the
+      // companion (mobile.html + the /api control-bus proxy) while the DESKTOP
+      // app is the host. electron-vite/Vite default to localhost-only, which is
+      // why the phone got connection-refused whenever the desktop app was open.
+      // Never leave this loopback-only.
+      host: '0.0.0.0',
       fs: {
         allow: [resolve(__dirname, '../frontend'), resolve(__dirname, '..')]
       },

--- a/frontend/src/components/layout/ProcessingLog.tsx
+++ b/frontend/src/components/layout/ProcessingLog.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
-import { Trash2, Download, X, Zap, Cast } from 'lucide-react';
+import { Trash2, Download, X, Zap, Cast, CircleAlert } from 'lucide-react';
 import { useLogStore, type LogLevel, type LogEntry } from '../../state/logStore';
 import { useLibraryStore } from '../../state/libraryStore';
 import { buildGenerateParamsFromState, useGenerateStore } from '../../state/generateStore';
@@ -85,14 +85,22 @@ export const LogBody: React.FC = () => {
   const verbose = useBottomPanelStore((s) => s.logVerbose);
   const setLogVerbose = useBottomPanelStore((s) => s.setLogVerbose);
   const bodyRef = useRef<HTMLDivElement>(null);
+  // Only auto-scroll to the newest line when the user is already parked at the
+  // bottom. Once they scroll up, new entries no longer yank the view back.
+  const pinnedRef = useRef(true);
+
+  // Show only error lines when on, so failures are readable without scrolling.
+  const [errorsOnly, setErrorsOnly] = useState(false);
+  const errorCount = useMemo(() => entries.reduce((n, e) => n + (e.level === 'error' ? 1 : 0), 0), [entries]);
 
   // SIMPLE mode hides debug entries and folds consecutive identical
   // level+source+msg runs into one row. The row keeps the FIRST entry of the
   // run so its React key stays stable while the count grows in place.
   const displayRows = useMemo<Array<{ entry: LogEntry; count: number }>>(() => {
-    if (verbose) return entries.map((entry) => ({ entry, count: 1 }));
+    const src = errorsOnly ? entries.filter((e) => e.level === 'error') : entries;
+    if (verbose) return src.map((entry) => ({ entry, count: 1 }));
     const rows: Array<{ entry: LogEntry; count: number }> = [];
-    for (const entry of entries) {
+    for (const entry of src) {
       if (entry.level === 'debug') continue;
       const last = rows[rows.length - 1];
       if (last && last.entry.level === entry.level && last.entry.source === entry.source && last.entry.msg === entry.msg) {
@@ -102,7 +110,7 @@ export const LogBody: React.FC = () => {
       }
     }
     return rows;
-  }, [entries, verbose]);
+  }, [entries, verbose, errorsOnly]);
 
   const isBackendReady = useStatusBarStore((s) => s.isBackendReady);
   const [stats, setStats] = useState<SystemStats | null>(null);
@@ -143,13 +151,22 @@ export const LogBody: React.FC = () => {
     return () => clearInterval(t);
   }, [fetchStats, isBackendReady]);
 
-  // Keyed on the raw entries (not the folded view) so collapsed repeats still
-  // autoscroll; verbose is included so toggling modes re-pins to the newest
-  // entries after the list height changes.
+  // Auto-scroll to the newest line ONLY when the user is pinned to the bottom;
+  // if they have scrolled up to read, their position is preserved. Keyed on the
+  // raw entries (not the folded view) so collapsed repeats still autoscroll;
+  // verbose/errorsOnly are included so switching modes re-pins after the list
+  // height changes.
   useEffect(() => {
     const el = bodyRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [entries, verbose]);
+    if (el && pinnedRef.current) el.scrollTop = el.scrollHeight;
+  }, [entries, verbose, errorsOnly]);
+
+  // Track whether the view is parked at (or near) the bottom.
+  const onBodyScroll = useCallback(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+  }, []);
 
   return (
     <div className="h-full flex flex-col min-h-0 bg-black/40">
@@ -170,6 +187,23 @@ export const LogBody: React.FC = () => {
           {verbose ? 'VERBOSE' : 'SIMPLE'}
         </button>
         <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setErrorsOnly((v) => !v)}
+            aria-pressed={errorsOnly}
+            aria-label={errorsOnly ? 'Show all log entries' : 'Show only errors'}
+            className={`flex items-center gap-1 px-1.5 py-0.5 rounded uppercase text-[8px] font-mono font-black tracking-widest transition-colors ${
+              errorsOnly
+                ? 'bg-red-500/20 text-red-300 border border-red-500/40'
+                : errorCount > 0
+                  ? 'text-red-400 hover:text-red-300 border border-transparent'
+                  : 'text-zinc-600 hover:text-red-300 border border-transparent'
+            }`}
+            title={errorsOnly ? 'Showing errors only — click to show all entries' : 'Show only error entries'}
+          >
+            <CircleAlert className="w-3 h-3" />
+            Errors{errorCount > 0 ? ` ${errorCount}` : ''}
+          </button>
           <button
             type="button"
             onClick={() => downloadLog(entries)}
@@ -194,10 +228,11 @@ export const LogBody: React.FC = () => {
       <div className="relative flex-1 min-h-0">
         <div
           ref={bodyRef}
-          className="h-full overflow-y-auto px-2 py-1 font-mono text-[9px] space-y-0.5 pr-22"
+          onScroll={onBodyScroll}
+          className="log-scroll h-full overflow-y-auto px-2 py-1 font-mono text-[9px] space-y-0.5 pr-22"
         >
-          {entries.length === 0
-            ? <p className="text-zinc-700 italic">Waiting for signal...</p>
+          {displayRows.length === 0
+            ? <p className="text-zinc-700 italic">{errorsOnly ? 'No errors.' : 'Waiting for signal...'}</p>
             : displayRows.map(({ entry: e, count }) => verbose
                 ? (
                   <p key={e.id} className={`pl-2 ${levelStyles[e.level]}`}>

--- a/frontend/src/components/surface/widgetTypes.ts
+++ b/frontend/src/components/surface/widgetTypes.ts
@@ -116,6 +116,10 @@ export interface BindableTarget {
   /** Push a value: a number for ranges, a boolean for toggles; triggers (pads)
    *  ignore the argument. */
   invoke: (v: number | boolean) => void;
+  /** Read the current value, when the target can report one. Lets a manifest
+   *  consumer (e.g. the XR / companion bus) seed a widget with true state
+   *  instead of a guess — important for stateful toggles like the limiter. */
+  read?: () => number | boolean;
 }
 
 export type VisualizerKind = 'spectrum';

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -64,6 +64,33 @@
     display: none;                  /* Chromium/WebKit */
   }
 
+  /* Always-visible scrollbar for the LOG (and anywhere legibility beats
+     minimalism). Hardcoded colors so it reads on ANY theme — the global 5px
+     bg-white/5 thumb vanishes on both dark and light surfaces. */
+  .log-scroll {
+    scrollbar-width: thin;                                    /* Firefox */
+    scrollbar-color: rgba(139, 92, 246, 0.75) rgba(120, 120, 140, 0.18);
+    scrollbar-gutter: stable;
+  }
+  .log-scroll::-webkit-scrollbar {
+    width: 10px;
+  }
+  .log-scroll::-webkit-scrollbar-track {
+    background: rgba(120, 120, 140, 0.18);
+    border-radius: 6px;
+  }
+  .log-scroll::-webkit-scrollbar-thumb {
+    background: rgba(139, 92, 246, 0.75);
+    border-radius: 6px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+    min-height: 32px;
+  }
+  .log-scroll::-webkit-scrollbar-thumb:hover {
+    background: rgba(139, 92, 246, 0.95);
+    background-clip: padding-box;
+  }
+
   /* Fluid zoom for high-density - adjusts based on viewport height/width.
      --layout-zoom mirrors the zoom factor so `calc(... / var(--layout-zoom))`
      can pre-compensate for the rendering scale (e.g. so a child sized to fill

--- a/frontend/src/mobile/MobileApp.tsx
+++ b/frontend/src/mobile/MobileApp.tsx
@@ -1,16 +1,18 @@
 /** theDAW companion root (phone). Standalone Library + a transport remote that
  *  rides the control bus. No cinematic, no MIDI/XR/sway boot — just the shell. */
 import { useEffect, useState } from 'react';
-import { Library, SlidersHorizontal } from 'lucide-react';
+import { Library, SlidersHorizontal, Disc3 } from 'lucide-react';
 import { MobileScreen } from './ui/MobileScreen';
 import { TabBar, type TabDef } from './ui/TabBar';
 import { MobileLibrary } from './tabs/MobileLibrary';
 import { MobileTransport } from './tabs/MobileTransport';
+import { MobileDj } from './tabs/MobileDj';
 import { useControlStore } from './net/controlClient';
 
 const TABS: TabDef[] = [
   { id: 'library', label: 'Library', icon: <Library size={20} /> },
   { id: 'remote', label: 'Remote', icon: <SlidersHorizontal size={20} /> },
+  { id: 'dj', label: 'DJ', icon: <Disc3 size={20} /> },
 ];
 
 function statusClass(status: string): string {
@@ -50,7 +52,13 @@ export function MobileApp() {
       }
       tabBar={<TabBar tabs={TABS} active={tab} onSelect={setTab} />}
     >
-      {tab === 'library' ? <MobileLibrary /> : <MobileTransport />}
+      {tab === 'library' ? (
+        <MobileLibrary />
+      ) : tab === 'dj' ? (
+        <MobileDj />
+      ) : (
+        <MobileTransport />
+      )}
     </MobileScreen>
   );
 }

--- a/frontend/src/mobile/mobile.css
+++ b/frontend/src/mobile/mobile.css
@@ -338,6 +338,82 @@ body {
 .m-state .m-btn {
   margin-top: 16px;
 }
+/* ── DJ remote (static; fits without page scroll) ── */
+.m-dj {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  /* Safety net for very short viewports: the control region (not the page)
+     scrolls only if the decks genuinely cannot fit, instead of clipping. */
+  overflow-y: auto;
+}
+.m-decks {
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.m-deck {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--m-border);
+  border-radius: 12px;
+  background: var(--m-panel);
+}
+.m-deck-head {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m-accent);
+}
+.m-deck-btns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+.m-deck-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 10px 4px;
+  border-radius: 10px;
+  border: 1px solid var(--m-border);
+  background: var(--m-panel-2);
+  color: var(--m-text);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.m-deck-btn:active {
+  transform: scale(0.97);
+}
+.m-field-compact .m-field-label {
+  font-size: 9px;
+  margin-bottom: 2px;
+}
+.m-field-compact .m-range {
+  height: 26px;
+}
+.m-dj-global {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid var(--m-border);
+  border-radius: 12px;
+  background: var(--m-panel);
+}
+
 .m-pair {
   margin-top: 12px;
   display: flex;

--- a/frontend/src/mobile/tabs/MobileDj.tsx
+++ b/frontend/src/mobile/tabs/MobileDj.tsx
@@ -1,0 +1,100 @@
+/** DJ remote: drives the desktop's two-deck DJ engine over the control bus.
+ *  Renders from the dj.* manifest entries (djControlSource on the desktop), so
+ *  it stays in sync as DJ_TARGETS grows. Needs the desktop app open as host.
+ *
+ *  One-way for now (phone -> desktop): the desktop does not mirror DJ moves back,
+ *  so faders seed to a cosmetic default and command absolute values on touch. */
+import { Play, Headphones } from 'lucide-react';
+import { RemoteGate } from '../ui/RemoteGate';
+import { RangeControl } from '../ui/RangeControl';
+import { useControlStore } from '../net/controlClient';
+import type { ManifestEntry } from '../net/controlClient';
+
+const DECKS = ['A', 'B'] as const;
+
+function defaultFor(e: ManifestEntry): number {
+  if (typeof e.value === 'number') return e.value;
+  const min = e.min ?? 0;
+  const max = e.max ?? 1;
+  if (min < 0 && max > 0) return 0; // bipolar EQ / filter / crossfader
+  return min + (max - min) * 0.5;
+}
+
+export function MobileDj() {
+  const entries = useControlStore((s) => s.entries);
+  const values = useControlStore((s) => s.values);
+  const setControl = useControlStore((s) => s.setControl);
+
+  const byId = new Map(entries.filter((e) => e.area === 'dj').map((e) => [e.id, e]));
+  const hasDj = byId.size > 0;
+
+  const range = (id: string, label: string) => {
+    const e = byId.get(id);
+    if (!e) return null;
+    const v = typeof values[id] === 'number' ? (values[id] as number) : defaultFor(e);
+    return (
+      <RangeControl
+        id={id}
+        label={label}
+        min={e.min ?? 0}
+        max={e.max ?? 1}
+        step={e.step ?? 0.01}
+        value={v}
+        unit={e.unit}
+        compact
+        onChange={(nv) => setControl(id, nv)}
+      />
+    );
+  };
+
+  const deck = (d: (typeof DECKS)[number]) => (
+    <section className="m-deck" key={d} aria-label={`Deck ${d}`}>
+      <span className="m-deck-head">Deck {d}</span>
+      <div className="m-deck-btns">
+        {byId.has(`dj.play.${d}`) && (
+          <button type="button" className="m-deck-btn" onClick={() => setControl(`dj.play.${d}`, true)}>
+            <Play size={14} /> Play
+          </button>
+        )}
+        {byId.has(`dj.cue.${d}`) && (
+          <button type="button" className="m-deck-btn" onClick={() => setControl(`dj.cue.${d}`, true)}>
+            <Headphones size={14} /> Cue
+          </button>
+        )}
+      </div>
+      {range(`dj.vol.${d}`, 'Volume')}
+      {range(`dj.eqHi.${d}`, 'EQ Hi')}
+      {range(`dj.eqMid.${d}`, 'EQ Mid')}
+      {range(`dj.eqLo.${d}`, 'EQ Lo')}
+      {range(`dj.filter.${d}`, 'Filter')}
+    </section>
+  );
+
+  return (
+    <RemoteGate>
+      {!hasDj ? (
+        <div className="m-state">
+          <h2>No DJ controls</h2>
+          <p>Connected, but the desktop published no DJ controls yet.</p>
+        </div>
+      ) : (
+        <div className="m-dj">
+          <div className="m-decks">{DECKS.map(deck)}</div>
+          <div className="m-dj-global">
+            {range('dj.crossfade', 'Crossfade')}
+            {byId.has('dj.limiter') && (
+              <button
+                type="button"
+                className={`m-btn${values['dj.limiter'] === true ? ' is-on' : ''}`}
+                aria-pressed={values['dj.limiter'] === true}
+                onClick={() => setControl('dj.limiter', values['dj.limiter'] !== true)}
+              >
+                Master Limiter
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </RemoteGate>
+  );
+}

--- a/frontend/src/mobile/tabs/MobileTransport.tsx
+++ b/frontend/src/mobile/tabs/MobileTransport.tsx
@@ -2,6 +2,7 @@
  *  the desktop app open as host. Renders from the transport.* manifest entries. */
 import { Play, Pause, Square } from 'lucide-react';
 import { Scroller } from '../ui/Scroller';
+import { RemoteGate } from '../ui/RemoteGate';
 import { useControlStore } from '../net/controlClient';
 import type { ControlValue } from '../net/controlClient';
 
@@ -15,35 +16,17 @@ function bool(v: ControlValue | undefined): boolean {
 }
 
 export function MobileTransport() {
-  const status = useControlStore((s) => s.status);
+  return (
+    <RemoteGate>
+      <TransportBody />
+    </RemoteGate>
+  );
+}
+
+function TransportBody() {
   const values = useControlStore((s) => s.values);
   const setControl = useControlStore((s) => s.setControl);
-  const retry = useControlStore((s) => s.retry);
   const hasTransport = useControlStore((s) => s.entries.some((e) => e.area === AREA));
-
-  if (status !== 'paired') {
-    return (
-      <div className="m-state">
-        <h2>
-          {status === 'rejected'
-            ? 'Pairing needed'
-            : status === 'offline'
-              ? 'Desktop offline'
-              : 'Connecting…'}
-        </h2>
-        <p>
-          {status === 'rejected'
-            ? 'This host requires a pairing code. Rescan the QR from the desktop, or open the URL with ?pair=<code>.'
-            : 'Open theDAW on your computer and keep it on this network. The remote drives its player.'}
-        </p>
-        {status !== 'connecting' ? (
-          <button type="button" className="m-btn" onClick={() => retry()}>
-            Retry
-          </button>
-        ) : null}
-      </div>
-    );
-  }
 
   if (!hasTransport) {
     return (

--- a/frontend/src/mobile/ui/RangeControl.tsx
+++ b/frontend/src/mobile/ui/RangeControl.tsx
@@ -1,0 +1,47 @@
+/** A labeled range bound to one manifest control id. Wrapping <label> gives the
+ *  native input an accessible name (HARD RULE 3). */
+export function RangeControl({
+  id,
+  label,
+  min,
+  max,
+  step,
+  value,
+  unit,
+  display,
+  compact,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  unit?: string;
+  /** Overrides the numeric readout (e.g. a percentage). */
+  display?: string;
+  compact?: boolean;
+  onChange: (v: number) => void;
+}) {
+  const readout = display ?? `${Math.round(value * 100) / 100}${unit ? ' ' + unit : ''}`;
+  return (
+    <label className={`m-field${compact ? ' m-field-compact' : ''}`}>
+      <span className="m-field-label">
+        <span>{label}</span>
+        <span>{readout}</span>
+      </span>
+      <input
+        id={`m-${id}`}
+        name={id}
+        className="m-range"
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+    </label>
+  );
+}

--- a/frontend/src/mobile/ui/RemoteGate.tsx
+++ b/frontend/src/mobile/ui/RemoteGate.tsx
@@ -1,0 +1,33 @@
+/** Shared gate for remote tabs (Transport, DJ, …). Shows a connection state
+ *  card until the control bus is paired, then renders its children. */
+import type { ReactNode } from 'react';
+import { useControlStore } from '../net/controlClient';
+
+export function RemoteGate({ children }: { children: ReactNode }) {
+  const status = useControlStore((s) => s.status);
+  const retry = useControlStore((s) => s.retry);
+
+  if (status === 'paired') return <>{children}</>;
+
+  return (
+    <div className="m-state">
+      <h2>
+        {status === 'rejected'
+          ? 'Pairing needed'
+          : status === 'offline'
+            ? 'Desktop offline'
+            : 'Connecting…'}
+      </h2>
+      <p>
+        {status === 'rejected'
+          ? 'This host requires a pairing code. Rescan the QR from the desktop, or open the URL with ?pair=<code>.'
+          : 'Open theDAW on your computer and keep it on this network. The remote drives its live rig.'}
+      </p>
+      {status !== 'connecting' ? (
+        <button type="button" className="m-btn" onClick={() => retry()}>
+          Retry
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/state/bindableTargets.ts
+++ b/frontend/src/state/bindableTargets.ts
@@ -35,5 +35,5 @@ const perDeck = (d: dj.DeckId): BindableTarget[] => {
 export const DJ_TARGETS: BindableTarget[] = [
   ...DECKS.flatMap(perDeck),
   { id: 'dj.crossfade', label: 'Crossfader', group: 'Mixer', kind: 'crossfader', min: -1, max: 1, step: 0.01, invoke: (v) => dj.setCrossfade(Number(v)) },
-  { id: 'dj.limiter', label: 'Master Limiter', group: 'Mixer', kind: 'toggle', invoke: (v) => dj.setLimiter(Boolean(v)) },
+  { id: 'dj.limiter', label: 'Master Limiter', group: 'Mixer', kind: 'toggle', invoke: (v) => dj.setLimiter(Boolean(v)), read: () => dj.getLimiter() },
 ];

--- a/frontend/src/state/xrControlDjSource.ts
+++ b/frontend/src/state/xrControlDjSource.ts
@@ -48,6 +48,9 @@ export const djControlSource: XrControlSource = {
       max: t.max,
       step: t.step,
       unit: t.unit,
+      // Seed true state when the target can report it (e.g. the limiter), so a
+      // consumer's widget does not misrepresent a stateful control.
+      value: t.read ? t.read() : undefined,
     }));
   },
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -78,6 +78,10 @@ export default defineConfig(({mode}) => {
       },
     },
     server: {
+      // Bind ALL interfaces so the phone companion is LAN-reachable even if the
+      // dev server is launched without the --host flag. Must never be
+      // loopback-only. (The npm "dev" script also passes --host=0.0.0.0.)
+      host: '0.0.0.0',
       // Auto-reload is OFF BY DEFAULT so agent edits don't nuke app state.
       // To turn live reload back on: set ENABLE_HMR=true in the environment.
       port: 5173,


### PR DESCRIPTION
[feat(companion): DJ remote (Phase 3 Slice 2)]

Adds a phone DJ tab that drives the desktop's two-deck engine over the control
bus. Renders from the dj.* manifest (djControlSource), so it tracks DJ_TARGETS.

- mobile/tabs/MobileDj.tsx: two decks (Play/Cue, Volume, EQ Hi/Mid/Lo, Filter)
  plus global Crossfade and Master Limiter; static layout that fits without page
  scroll (control region scrolls only if a very short viewport forces it)
- mobile/ui/RemoteGate.tsx + RangeControl.tsx: shared pairing gate and a
  labeled range control; MobileTransport refactored onto the gate
- seed true state into the DJ manifest: BindableTarget.read getter, wired for
  the limiter (getLimiter), so the phone shows the clip-safety limiter's real
  ON state instead of guessing OFF (adversarial-review finding)

Verified: DJ manifest renders, controls fire over the bus, limiter seeds ON,
no page errors. Reviewed; the one confirmed finding (limiter misrepresentation)
and a short-viewport clip risk are both fixed.

[fix(dev): bind Vite + electron-vite dev servers to 0.0.0.0]

Both dev servers defaulted to loopback-only, so the phone companion got
connection-refused whenever the standalone web dev server OR the Electron
desktop app was the LAN host. Pin host:'0.0.0.0' in both configs so 5173
is never loopback-only again regardless of launch path.


[feat(log): errors-only filter, theme-visible scrollbar, sticky scroll]

- Errors toggle button shows only error-level entries with a live count,
  so failures are reachable without scrolling the full stream.
- .log-scroll gives the log body an explicit thin purple scrollbar
  (scrollbar-width + ::-webkit-scrollbar) visible under every theme.
- Autoscroll is now gated on a pinned ref: the body only snaps to bottom
  when already pinned there, so a dragged/scrolled position is preserved
  when new entries arrive.