### PR TITLE
Fix DJ EQ stack ordering

### DIFF
--- a/frontend/src/components/audio/SlideFader.tsx
+++ b/frontend/src/components/audio/SlideFader.tsx
@@ -45,9 +45,11 @@ interface SlideFaderProps {
   tint?: number;
   /** Value a double-click resets to. Defaults to 0 (clamped into range). */
   defaultValue?: number;
+  /** Slimmer presentation for dense mixer strips. */
+  compact?: boolean;
 }
 
-const SlideFaderImpl: React.FC<SlideFaderProps> = ({ label, value, onChange, min, max, step = 0.01, tipKey, rulerSide = 'left', tint, defaultValue }) => {
+const SlideFaderImpl: React.FC<SlideFaderProps> = ({ label, value, onChange, min, max, step = 0.01, tipKey, rulerSide = 'left', tint, defaultValue, compact = false }) => {
   const trackRef = useRef<HTMLDivElement | null>(null);
   const dragging = useRef(false);
   const [drag, setDrag] = useState(false);
@@ -103,11 +105,11 @@ const SlideFaderImpl: React.FC<SlideFaderProps> = ({ label, value, onChange, min
   // magnifying as the handle nears them (the SLIDE "bulge").
   const marks: React.ReactNode[] = [];
   const markDir = rulerSide === 'right' ? 1 : -1; // magnify outward (away from the track)
-  const TICKS = 20;                     // dense ruler — many ticks
+  const TICKS = compact ? 8 : 20;       // dense ruler; lighter in compact mixers
   for (let i = 0; i <= TICKS; i++) {
     const tt = i / TICKS;
     const p = smoothstep(1 - Math.abs(tt - t) / FOCUS);
-    const isMajor = i % 4 === 0;        // number every 4th tick (6 numbers)
+    const isMajor = !compact && i % 4 === 0; // compact mixer strips use ticks only
     const txt: RGB = [lerp(150, 255, p), lerp(150, 255, p), lerp(155, 255, p)];
     const tickCol: RGB = [lerp(150, base[0], p), lerp(150, base[1], p), lerp(155, base[2], p)];
     marks.push(
@@ -132,15 +134,15 @@ const SlideFaderImpl: React.FC<SlideFaderProps> = ({ label, value, onChange, min
 
   return (
     <div
-      className="flex flex-col items-center gap-1 min-w-0 h-full select-none"
+      className={`flex flex-col items-center min-w-0 h-full select-none ${compact ? 'gap-0.5' : 'gap-1'}`}
       style={{
         ...accentVars(colorT),
-        ['--body-w' as string]: '26px',
-        ['--track-w' as string]: '14px',
-        ['--track-inset' as string]: '8px',
-        ['--knob-cap' as string]: '18px',
-        ['--scale-w' as string]: '16px',
-        ['--scale-gap' as string]: '2px',
+        ['--body-w' as string]: compact ? '15px' : '26px',
+        ['--track-w' as string]: compact ? '7px' : '14px',
+        ['--track-inset' as string]: compact ? '4px' : '8px',
+        ['--knob-cap' as string]: compact ? '10px' : '18px',
+        ['--scale-w' as string]: compact ? '7px' : '16px',
+        ['--scale-gap' as string]: compact ? '0px' : '2px',
       }}
     >
       {tip ? <HoverTip text={tip}>{labelEl}</HoverTip> : labelEl}
@@ -175,18 +177,20 @@ const SlideFaderImpl: React.FC<SlideFaderProps> = ({ label, value, onChange, min
           </div>
         </div>
       </div>
-      <span
-        className="font-mono tabular-nums leading-none"
-        style={{
-          fontSize: active ? '11px' : '8.5px',
-          fontWeight: active ? 800 : 700,
-          color: 'var(--accent)',
-          textShadow: active ? '0 0 10px var(--accent-glow)' : 'none',
-          transition: 'font-size 0.1s ease, text-shadow 0.1s ease',
-        }}
-      >
-        {fmtNum(value)}
-      </span>
+      {!compact && (
+        <span
+          className="font-mono tabular-nums leading-none"
+          style={{
+            fontSize: active ? '11px' : '8.5px',
+            fontWeight: active ? 800 : 700,
+            color: 'var(--accent)',
+            textShadow: active ? '0 0 10px var(--accent-glow)' : 'none',
+            transition: 'font-size 0.1s ease, text-shadow 0.1s ease',
+          }}
+        >
+          {fmtNum(value)}
+        </span>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/surface/SurfacePanel.tsx
+++ b/frontend/src/components/surface/SurfacePanel.tsx
@@ -9,7 +9,7 @@
  * Uniform chrome: widget panels adopt the hardware-card border/bg so every
  * panel edge reads the same; pinned panels stay transparent (their hosted
  * component supplies its own card). Per-panel padding (padPx) and mirror
- * (reversed widget order + per-widget mirror opt) come from the layout store.
+ * (horizontal order + per-widget mirror opt) come from the layout store.
  */
 import React, { useEffect, useRef, useState } from 'react';
 import { GripVertical, FlipHorizontal, Rows3, Columns3, SeparatorHorizontal, SplitSquareHorizontal, SplitSquareVertical, Grid2x2, CirclePlus, Link2, Combine, X } from 'lucide-react';
@@ -115,7 +115,7 @@ const PanelHeader: React.FC<{
       </button>
       <button
         onClick={() => store.getState().togglePanelMirror(nodeId)}
-        title={mirror ? 'Mirrored — click to un-mirror' : 'Mirror this panel (reverse order, flip icons)'}
+        title={mirror ? 'Mirrored — click to un-mirror' : 'Mirror this panel (horizontal order, flip icons)'}
         className={mirror ? 'text-amber-200' : 'text-purple-50/80 hover:text-white'}
       >
         <FlipHorizontal className="w-3 h-3" />
@@ -219,10 +219,12 @@ export const SurfacePanel: React.FC<{ nodeId: NodeId }> = ({ nodeId }) => {
   // (empty) gap instead of being clipped at the panel edge.
   const clip = isPinned ? 'overflow-hidden' : 'overflow-visible';
 
-  // Mirror reverses the visible widget order; the true store index is still
-  // passed to each cell so drag-reorder + resize stay correct.
+  // Mirror reverses horizontal widget order; vertical stacks keep their
+  // declared top-to-bottom order (for controls such as HI/MID/LO EQ bands).
+  // The true store index is still passed to each cell so drag-reorder + resize
+  // stay correct.
   const widgets = node.widgets;
-  const displayIds = node.mirror ? [...widgets].reverse() : widgets;
+  const displayIds = node.mirror && node.flow === 'row' ? [...widgets].reverse() : widgets;
 
   // Which edge a dragged panel/row is hovering, for directional docking.
   const computeEdge = (e: React.DragEvent): EdgeDir => {

--- a/frontend/src/components/surface/widgetTypes.ts
+++ b/frontend/src/components/surface/widgetTypes.ts
@@ -50,7 +50,7 @@ export type ButtonShape =
 
 /** Render-time hints the surface passes per cell. */
 export interface WidgetRenderOpts {
-  /** Mirror composite controls (reverse order + flip icon/name side). */
+  /** Mirror composite controls (flip icon/name side, horizontal internals). */
   mirror?: boolean;
   /** Content alignment within the cell. */
   justify?: 'start' | 'center' | 'end';

--- a/frontend/src/state/djCuesStore.ts
+++ b/frontend/src/state/djCuesStore.ts
@@ -12,7 +12,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export const HOTCUE_SLOTS = 4;
+export const HOTCUE_SLOTS = 8;
 
 /** Each track maps to a fixed-length array of cue positions (sec) or null. */
 type CueArray = (number | null)[];

--- a/frontend/src/state/surfaceLayoutStore.ts
+++ b/frontend/src/state/surfaceLayoutStore.ts
@@ -68,8 +68,8 @@ export interface PanelNode {
   widgetMargins?: Record<WidgetId, { t: number; r: number; b: number; l: number }>;
   /** Per-widget pad/button shape override. */
   widgetShapes?: Record<WidgetId, ButtonShape>;
-  /** Mirror this panel: reverse widget order + flip composite controls/icons
-   *  (left/right deck symmetry). */
+  /** Mirror this panel: reverse horizontal widget order + flip composite
+   *  controls/icons (left/right deck symmetry). */
   mirror?: boolean;
   /** Uniform control sizing: match same-kind control sizes (fill + equalize)
    *  within this panel. */

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -54,7 +54,6 @@ import { SlideKnob } from '../components/audio/SlideKnob';
 import { SlideFader } from '../components/audio/SlideFader';
 import { SlidePad } from '../components/audio/SlidePad';
 import { SlideCrossfader } from '../components/audio/SlideCrossfader';
-import { RoundToggle } from '../components/audio/RoundToggle';
 import { JogWheel } from '../components/audio/JogWheel';
 import { ContextMenu, useContextMenu, type ContextMenuItem } from '../components/ui/ContextMenu';
 import { sendSetToVj, sendTrackToVj, isVjSetTargetActive, type VjSetItem } from '../state/vjSetBus';
@@ -444,14 +443,14 @@ function EditableBpmField({
  * panels (hero waveforms, sampler, FX racks, Next lane, source tree, library)
  * host a whole component; every mixer + deck control is an individual widget the
  * user can relocate in Design Mode. Nothing moves until the user drags. */
-const DJ_LAYOUT_VERSION = 28;
+const DJ_LAYOUT_VERSION = 31;
 
 const defaultDjLayout: SurfaceLayout = {
   version: DJ_LAYOUT_VERSION,
   root: 'root',
   nodes: {
     root: { id: 'root', type: 'container', axis: 'column', children: ['topDecks', 'heroP', 'browserDock'], fr: { topDecks: 5.5, heroP: 1.25, browserDock: 3.25 } },
-    topDecks: { id: 'topDecks', type: 'container', axis: 'row', children: ['deckAcont', 'mixer', 'deckBcont'], fr: { deckAcont: 4.35, mixer: 2.9, deckBcont: 4.35 } },
+    topDecks: { id: 'topDecks', type: 'container', axis: 'row', children: ['deckAcont', 'mixer', 'deckBcont'], fr: { deckAcont: 4, mixer: 3.8, deckBcont: 4 } },
     heroP: { id: 'heroP', type: 'panel', title: 'Waveforms', flow: 'row', widgets: [], pinned: 'hero' },
     browserDock: { id: 'browserDock', type: 'container', axis: 'row', children: ['browserLeft', 'libraryP'], fr: { browserLeft: 2.45, libraryP: 9.6 }, framed: true, frameTitle: 'Browser' },
     browserLeft: { id: 'browserLeft', type: 'container', axis: 'column', children: ['sourceTreeP', 'nextP'], fr: { sourceTreeP: 3.4, nextP: 1.25 } },
@@ -483,13 +482,13 @@ const defaultDjLayout: SurfaceLayout = {
     'pdB-loop': { id: 'pdB-loop', type: 'panel', title: 'B · Loop', flow: 'row', widgets: ['loopB_0', 'loopB_1', 'loopB_2', 'loopB_3', 'loopB_4', 'loopOutB'], uniform: true },
     'pdB-perf': { id: 'pdB-perf', type: 'panel', title: 'B · Perf', flow: 'row', widgets: ['rollB_0', 'rollB_1', 'rollB_2', 'slipB', 'jumpB_0', 'jumpB_1', 'jumpB_2', 'jumpB_3'], uniform: true },
     // ── Mixer ──
-    mixer: { id: 'mixer', type: 'container', axis: 'column', children: ['mixToggles', 'mixChans', 'mixXfade'], fr: { mixToggles: 1.05, mixChans: 6.05, mixXfade: 1.1 }, framed: true },
-    mixToggles: { id: 'mixToggles', type: 'panel', title: 'Modes', flow: 'row', widgets: ['pitchRange', 'qtz', 'autoGain', 'automix', 'lim', 'midiMap'], widgetMargins: { pitchRange: { t: 0, r: 1, b: 0, l: 1 }, qtz: { t: 0, r: 1, b: 0, l: 1 }, autoGain: { t: 0, r: 1, b: 0, l: 1 }, automix: { t: 0, r: 1, b: 0, l: 1 }, lim: { t: 0, r: 1, b: 0, l: 1 }, midiMap: { t: 0, r: 1, b: 0, l: 1 } }, uniform: true },
-    mixChans: { id: 'mixChans', type: 'container', axis: 'row', children: ['eqAP', 'chAP', 'chBP', 'eqBP'], fr: { eqAP: 1.35, chAP: 1.15, chBP: 1.15, eqBP: 1.35 } },
+    mixer: { id: 'mixer', type: 'container', axis: 'column', children: ['mixToggles', 'mixChans', 'mixXfade'], fr: { mixToggles: 0.82, mixChans: 6.45, mixXfade: 0.9 }, framed: true },
+    mixToggles: { id: 'mixToggles', type: 'panel', title: 'Modes', flow: 'row', widgets: ['pitchRange', 'qtz', 'autoGain', 'automix', 'lim', 'midiMap'], widgetFr: { pitchRange: 1.05, qtz: 0.82, autoGain: 0.9, automix: 1.08, lim: 0.82, midiMap: 0.92 }, widgetMargins: { pitchRange: { t: 0, r: 1, b: 0, l: 1 }, qtz: { t: 0, r: 1, b: 0, l: 1 }, autoGain: { t: 0, r: 1, b: 0, l: 1 }, automix: { t: 0, r: 1, b: 0, l: 1 }, lim: { t: 0, r: 1, b: 0, l: 1 }, midiMap: { t: 0, r: 1, b: 0, l: 1 } }, uniform: false },
+    mixChans: { id: 'mixChans', type: 'container', axis: 'row', children: ['eqAP', 'chAP', 'chBP', 'eqBP'], fr: { eqAP: 1.6, chAP: 0.8, chBP: 0.8, eqBP: 1.6 } },
     pchAP: { id: 'pchAP', type: 'panel', title: 'Pitch A', flow: 'column', widgets: ['pitchA'], widgetMargins: { pitchA: { t: 3, r: 4, b: 3, l: 4 } }, mirror: true },
     eqAP: { id: 'eqAP', type: 'panel', title: 'EQ A', flow: 'column', widgets: ['eqA.hi', 'eqA.mid', 'eqA.lo', 'fltA'] },
-    chAP: { id: 'chAP', type: 'panel', title: 'Ch A', flow: 'column', widgets: ['volA', 'gainA'], widgetFr: { gainA: 1, volA: 3 }, widgetMargins: { volA: { t: 8, r: 0, b: 8, l: 24 } }, mirror: true },
-    chBP: { id: 'chBP', type: 'panel', title: 'Ch B', flow: 'column', widgets: ['gainB', 'volB'], widgetFr: { gainB: 1, volB: 3 }, widgetMargins: { volB: { t: 8, r: 24, b: 8, l: 0 } } },
+    chAP: { id: 'chAP', type: 'panel', title: 'Ch A', flow: 'column', widgets: ['gainA', 'volA'], widgetFr: { gainA: 0.9, volA: 3.4 }, widgetMargins: { gainA: { t: 0, r: 0, b: 2, l: 0 }, volA: { t: 2, r: 0, b: 2, l: 4 } }, mirror: true },
+    chBP: { id: 'chBP', type: 'panel', title: 'Ch B', flow: 'column', widgets: ['gainB', 'volB'], widgetFr: { gainB: 0.9, volB: 3.4 }, widgetMargins: { gainB: { t: 0, r: 0, b: 2, l: 0 }, volB: { t: 2, r: 4, b: 2, l: 0 } } },
     eqBP: { id: 'eqBP', type: 'panel', title: 'EQ B', flow: 'column', widgets: ['eqB.hi', 'eqB.mid', 'eqB.lo', 'fltB'] },
     pchBP: { id: 'pchBP', type: 'panel', title: 'Pitch B', flow: 'column', widgets: ['pitchB'], widgetMargins: { pitchB: { t: 3, r: 4, b: 3, l: 4 } }, uniform: false },
     mixXfade: { id: 'mixXfade', type: 'panel', title: 'Crossfade', flow: 'row', widgets: ['spacer:s-22-ffca8259', 'crossfader', 'spacer:s-21-cb584c7d'], widgetFr: { 'spacer:s-22-ffca8259': 0.4556701030927834, crossfader: 2.039175257731959, 'spacer:s-21-cb584c7d': 0.5051546391752577 }, widgetMargins: { crossfader: { t: 16, r: 0, b: 0, l: 0 } }, uniform: false },
@@ -520,7 +519,7 @@ const defaultDjLayout: SurfaceLayout = {
     'cont-9-aebcd780': { id: 'cont-9-aebcd780', type: 'container', axis: 'row', children: ['pdB-perf', 'panel-8-81228019'], fr: { 'pdB-perf': 1.5358851674641145, 'panel-8-81228019': 0.46411483253588537 } },
     // ── Deck A pad-row wrappers ──
     'cont-10-e11250c4': { id: 'cont-10-e11250c4', type: 'container', axis: 'row', children: ['panel-11-95a4a261', 'pchAP', 'pdA-jog', 'pdA-mode'], fr: { 'panel-11-95a4a261': 0.7, pchAP: 0.45, 'pdA-jog': 1.87, 'pdA-mode': 0.5 } },
-    deckABody: { id: 'deckABody', type: 'container', axis: 'row', children: ['deckControlsA', 'pdA-jog', 'pchAP'], fr: { deckControlsA: 3.45, 'pdA-jog': 1.12, pchAP: 0.4 } },
+    deckABody: { id: 'deckABody', type: 'container', axis: 'row', children: ['deckControlsA', 'pdA-jog', 'pchAP'], fr: { deckControlsA: 3.45, 'pdA-jog': 0.95, pchAP: 0.36 } },
     'panel-11-95a4a261': { id: 'panel-11-95a4a261', type: 'panel', title: 'Panel', flow: 'row', widgets: ['spacer:s-26-79f129b0'] },
     'panel-A-transport-head': { id: 'panel-A-transport-head', type: 'panel', title: 'Panel', flow: 'row', widgets: ['spacer:s-A-transport-head'] },
     'cont-A-transport': { id: 'cont-A-transport', type: 'container', axis: 'row', children: ['panel-A-transport-head', 'pdA-trans'], fr: { 'panel-A-transport-head': 1.15, 'pdA-trans': 2.37 } },
@@ -532,7 +531,7 @@ const defaultDjLayout: SurfaceLayout = {
     'cont-16-c9fc3a59': { id: 'cont-16-c9fc3a59', type: 'container', axis: 'row', children: ['panel-15-4eb1b108', 'pdA-loop'], fr: { 'pdA-loop': 1.3664122137404573, 'panel-15-4eb1b108': 0.6335877862595417 } },
     'panel-17-44cba1fb': { id: 'panel-17-44cba1fb', type: 'panel', title: 'Panel', flow: 'row', widgets: ['spacer:s-27-8799ff7e'] },
     'cont-18-cd01de17': { id: 'cont-18-cd01de17', type: 'container', axis: 'row', children: ['panel-17-44cba1fb', 'pdA-perf'], fr: { 'pdA-perf': 1.4885496183206104, 'panel-17-44cba1fb': 0.5114503816793893 } },
-    deckBBody: { id: 'deckBBody', type: 'container', axis: 'row', children: ['pchBP', 'pdB-jog', 'deckControlsB'], fr: { pchBP: 0.4, 'pdB-jog': 1.12, deckControlsB: 3.45 } },
+    deckBBody: { id: 'deckBBody', type: 'container', axis: 'row', children: ['pchBP', 'pdB-jog', 'deckControlsB'], fr: { pchBP: 0.36, 'pdB-jog': 0.95, deckControlsB: 3.45 } },
   },
 };
 
@@ -2914,9 +2913,28 @@ function buildDjRegistry(p: DjRegArgs): WidgetRegistry {
       : Math.min(byW, byH);
     return Math.min(base, byW, byH, cap);
   };
-  const knobSize = (s: { w: number; h: number }, opts?: SizeOpts) => Math.max(20, fitDim(s, opts, 26, 112));
-  const toggleBox = (s: { w: number; h: number }, opts?: SizeOpts) => Math.max(24, fitDim(s, opts, 12, 84));
+  const knobSize = (s: { w: number; h: number }, opts?: SizeOpts) => Math.max(18, fitDim(s, opts, 22, 54));
   const center = (node: React.ReactNode) => <div className="h-full w-full grid place-items-center overflow-hidden">{node}</div>;
+  const compactModeToggle = (
+    label: string,
+    Icon: React.ComponentType<{ className?: string }>,
+    on: boolean,
+    onChange: (v: boolean) => void,
+  ) => center(
+    <button
+      type="button"
+      onClick={() => onChange(!on)}
+      title={label}
+      className={`h-full max-h-9 w-full min-w-0 rounded-md border px-1 grid grid-rows-[1fr_auto] place-items-center transition-colors ${
+        on
+          ? 'border-purple-400/60 bg-purple-500/20 text-purple-100 shadow-[0_0_10px_rgba(168,85,247,0.38)]'
+          : 'border-white/10 bg-black/25 text-zinc-500 hover:border-white/25 hover:text-zinc-200'
+      }`}
+    >
+      <Icon className="h-3.5 w-3.5 min-h-0" />
+      <span className="max-w-full truncate text-[6.5px] font-black uppercase leading-none tracking-wider">{label}</span>
+    </button>
+  );
   // Pads render LANDSCAPE (like CUE/PLAY): fill the cell width, cap the height so
   // the button stays wider than tall, centred vertically in its cell.
   const padBox = (s: { w: number; h: number }, node: React.ReactNode) => (
@@ -3209,7 +3227,7 @@ function buildDjRegistry(p: DjRegArgs): WidgetRegistry {
       eqKnob(`flt${d}`, 'Flt', d === 'A' ? p.filterA : p.filterB, (v) => p.onFilter(d, v), -1, 1, 0.01);
     }
     knob(`gain${d}`, 'Gain', grp, d === 'A' ? p.gainA : p.gainB, (v) => p.onGain(d, v), -12, 12, 0.5);
-    reg[`vol${d}`] = { id: `vol${d}`, label: `Vol ${d}`, group: grp, kind: 'fader', source: 'builtin', render: () => faderWrap(<SlideFader label={d} value={d === 'A' ? p.volA : p.volB} onChange={(v) => p.onVol(d, v)} min={0} max={1} step={0.01} rulerSide={d === 'B' ? 'right' : 'left'} />) };
+    reg[`vol${d}`] = { id: `vol${d}`, label: `Vol ${d}`, group: grp, kind: 'fader', source: 'builtin', render: () => faderWrap(<SlideFader label={d} value={d === 'A' ? p.volA : p.volB} onChange={(v) => p.onVol(d, v)} min={0} max={1} step={0.01} rulerSide={d === 'B' ? 'right' : 'left'} compact />) };
     const pitch = d === 'A' ? p.pitchA : p.pitchB;
     const bpm = d === 'A' ? p.bpmA : p.bpmB;
     const effBpm = bpm != null ? (bpm * (1 + pitch / 100)).toFixed(1) : '—';
@@ -3229,16 +3247,16 @@ function buildDjRegistry(p: DjRegArgs): WidgetRegistry {
       type="button"
       onClick={() => p.setPitchRange(p.pitchRange === 10 ? 15 : 10)}
       title="Pitch range"
-      className="flex flex-col items-center justify-center gap-0.5 min-w-12 px-2 py-1 rounded-md border border-amber-400/50 bg-amber-500/15 text-amber-100 shadow-[0_0_14px_rgba(245,158,11,0.25)] hover:bg-amber-500/25 transition-colors"
+      className="h-full max-h-9 w-full min-w-0 rounded-md border border-amber-400/50 bg-amber-500/15 px-1 py-0.5 text-amber-100 shadow-[0_0_12px_rgba(245,158,11,0.22)] hover:bg-amber-500/25 transition-colors grid place-items-center"
     >
-      <span className="text-[7px] font-black uppercase tracking-wider leading-none">Range</span>
-      <span className="text-[12px] font-black font-mono tabular-nums leading-none">±{p.pitchRange}%</span>
+      <span className="text-[6.5px] font-black uppercase tracking-wider leading-none">Range</span>
+      <span className="text-[10px] font-black font-mono tabular-nums leading-none">±{p.pitchRange}%</span>
     </button>
   ) };
-  reg.qtz = { id: 'qtz', label: 'Quantize', group: 'Mixer', kind: 'toggle', source: 'builtin', render: (s, opts) => center(<RoundToggle label="Qtz" icon={Magnet} on={p.quantize} onChange={p.setQuantize} box={toggleBox(s, opts)} />) };
-  reg.autoGain = { id: 'autoGain', label: 'Auto-gain', group: 'Mixer', kind: 'toggle', source: 'builtin', render: (s, opts) => center(<RoundToggle label="Gain" icon={Gauge} on={p.autoGain} onChange={p.setAutoGain} box={toggleBox(s, opts)} />) };
-  reg.lim = { id: 'lim', label: 'Limiter', group: 'Mixer', kind: 'toggle', source: 'builtin', render: (s, opts) => center(<RoundToggle label="Lim" icon={Shield} on={p.limiterOn} onChange={(v) => { p.setLimiterOn(v); djEngine.setLimiter(v); }} box={toggleBox(s, opts)} />) };
-  reg.midiMap = { id: 'midiMap', label: 'MIDI Map', group: 'Mixer', kind: 'toggle', source: 'builtin', render: (s, opts) => center(<RoundToggle label="MIDI" icon={Piano} on={p.midiMapOn} onChange={() => p.onToggleMidiMap()} box={toggleBox(s, opts)} />) };
+  reg.qtz = { id: 'qtz', label: 'Quantize', group: 'Mixer', kind: 'toggle', source: 'builtin', render: () => compactModeToggle('Qtz', Magnet, p.quantize, p.setQuantize) };
+  reg.autoGain = { id: 'autoGain', label: 'Auto-gain', group: 'Mixer', kind: 'toggle', source: 'builtin', render: () => compactModeToggle('Gain', Gauge, p.autoGain, p.setAutoGain) };
+  reg.lim = { id: 'lim', label: 'Limiter', group: 'Mixer', kind: 'toggle', source: 'builtin', render: () => compactModeToggle('Lim', Shield, p.limiterOn, (v) => { p.setLimiterOn(v); djEngine.setLimiter(v); }) };
+  reg.midiMap = { id: 'midiMap', label: 'MIDI Map', group: 'Mixer', kind: 'toggle', source: 'builtin', render: () => compactModeToggle('MIDI', Piano, p.midiMapOn, () => p.onToggleMidiMap()) };
 
   reg.crossfader = { id: 'crossfader', label: 'Crossfader', group: 'Mixer', kind: 'crossfader', source: 'builtin', render: () => (
     <div className="h-full w-full flex flex-col justify-center px-1">
@@ -3252,7 +3270,7 @@ function buildDjRegistry(p: DjRegArgs): WidgetRegistry {
   ) };
 
   reg.automix = { id: 'automix', label: 'Automix', group: 'Mixer', kind: 'button', source: 'builtin', render: () => center(
-    <button onClick={p.onToggleAutomix} title="Automix — auto-sequence + beatmatch-crossfade the active set" className={`px-3 py-0.5 rounded text-[8px] font-black uppercase tracking-widest border transition-colors ${p.automixOn ? 'border-emerald-400/60 bg-emerald-500/15 text-emerald-200 animate-pulse' : 'border-white/10 text-zinc-400 hover:text-zinc-100 hover:border-white/25'}`}>{p.automixOn ? 'Automix ●' : 'Automix'}</button>
+    <button onClick={p.onToggleAutomix} title="Automix — auto-sequence + beatmatch-crossfade the active set" className={`h-full max-h-9 w-full min-w-0 rounded-md px-1 py-0.5 text-[6.5px] font-black uppercase tracking-wider border transition-colors ${p.automixOn ? 'border-emerald-400/60 bg-emerald-500/15 text-emerald-200 animate-pulse' : 'border-white/10 bg-black/25 text-zinc-500 hover:text-zinc-100 hover:border-white/25'}`}>{p.automixOn ? 'Auto On' : 'Automix'}</button>
   ) };
 
   reg.keymatch = { id: 'keymatch', label: 'Key Match', group: 'Mixer', kind: 'button', source: 'builtin', render: () => center(

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -76,10 +76,10 @@ const EjectSymbol: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
 );
 
 const BEAT_SIZES: Array<{ beats: number; label: string }> = [
-  { beats: 0.25, label: '¼' }, { beats: 0.5, label: '½' }, { beats: 1, label: '1' }, { beats: 2, label: '2' }, { beats: 4, label: '4' },
+  { beats: 0.25, label: '1/4' }, { beats: 0.5, label: '1/2' }, { beats: 1, label: '1' }, { beats: 2, label: '2' }, { beats: 4, label: '4' },
 ];
 const ROLL_SIZES: Array<{ beats: number; label: string }> = [
-  { beats: 0.25, label: '¼' }, { beats: 0.5, label: '½' }, { beats: 1, label: '1' },
+  { beats: 0.25, label: '1/4' }, { beats: 0.5, label: '1/2' }, { beats: 1, label: '1' },
 ];
 const STEM_PAD_SLOTS = 6;
 const AUTO_GAIN_TARGET_DB = -12;
@@ -264,7 +264,11 @@ function useDeck(deckId: djEngine.DeckId, entryId: string | null, hasTrack: bool
   const gridBeats = grid?.beats ?? beats;
   const firstBeat = beats && beats.length > 0 ? beats[0] : null;
 
-  const cues = useDjCuesStore((s) => (entryId ? s.byEntry[entryId] : undefined));
+  const storedCues = useDjCuesStore((s) => (entryId ? s.byEntry[entryId] : undefined));
+  const cues = useMemo(
+    () => Array.from({ length: HOTCUE_SLOTS }, (_, i) => storedCues?.[i] ?? null),
+    [storedCues],
+  );
   const setCue = useDjCuesStore((s) => s.setCue);
   const clearCue = useDjCuesStore((s) => s.clearCue);
 
@@ -1688,7 +1692,7 @@ const CompactPerformancePads: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cy
       <div className="h-full w-full min-h-0 grid grid-cols-[0.8fr_1.15fr_1.35fr] gap-1.5 items-stretch">
         <div className="min-w-0 flex flex-col gap-1">
           <div className={`text-[7px] font-black uppercase tracking-widest ${accentText}`}>Hot Cues</div>
-          <div className="grid grid-cols-4 gap-1 flex-1 min-h-0">
+          <div className="grid grid-cols-4 grid-rows-2 gap-1 flex-1 min-h-0">
             {Array.from({ length: HOTCUE_SLOTS }, (_, i) => {
               const c = ctl.cues?.[i] ?? null;
               const set = c != null;
@@ -1703,7 +1707,7 @@ const CompactPerformancePads: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cy
                   onContextMenu={(e) => { e.preventDefault(); ctl.dropHotcue(i); }}
                   title={set ? `Hot cue ${i + 1} at ${fmtTime(c)} — click to jump, right-click to clear` : `Set hot cue ${i + 1}`}
                 >
-                  {padLabel('Cue', String(i + 1))}
+                  <span className="font-black leading-none">{`Cue${i + 1}`}</span>
                 </SlidePad>
               );
             })}

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -444,14 +444,14 @@ function EditableBpmField({
  * panels (hero waveforms, sampler, FX racks, Next lane, source tree, library)
  * host a whole component; every mixer + deck control is an individual widget the
  * user can relocate in Design Mode. Nothing moves until the user drags. */
-const DJ_LAYOUT_VERSION = 24;
+const DJ_LAYOUT_VERSION = 28;
 
 const defaultDjLayout: SurfaceLayout = {
   version: DJ_LAYOUT_VERSION,
   root: 'root',
   nodes: {
-    root: { id: 'root', type: 'container', axis: 'column', children: ['topDecks', 'heroP', 'browserDock'], fr: { topDecks: 5.25, heroP: 1.45, browserDock: 3.45 } },
-    topDecks: { id: 'topDecks', type: 'container', axis: 'row', children: ['deckAcont', 'mixer', 'deckBcont'], fr: { deckAcont: 4.25, mixer: 2.75, deckBcont: 4.25 } },
+    root: { id: 'root', type: 'container', axis: 'column', children: ['topDecks', 'heroP', 'browserDock'], fr: { topDecks: 5.5, heroP: 1.25, browserDock: 3.25 } },
+    topDecks: { id: 'topDecks', type: 'container', axis: 'row', children: ['deckAcont', 'mixer', 'deckBcont'], fr: { deckAcont: 4.35, mixer: 2.9, deckBcont: 4.35 } },
     heroP: { id: 'heroP', type: 'panel', title: 'Waveforms', flow: 'row', widgets: [], pinned: 'hero' },
     browserDock: { id: 'browserDock', type: 'container', axis: 'row', children: ['browserLeft', 'libraryP'], fr: { browserLeft: 2.45, libraryP: 9.6 }, framed: true, frameTitle: 'Browser' },
     browserLeft: { id: 'browserLeft', type: 'container', axis: 'column', children: ['sourceTreeP', 'nextP'], fr: { sourceTreeP: 3.4, nextP: 1.25 } },
@@ -461,33 +461,33 @@ const defaultDjLayout: SurfaceLayout = {
     center: { id: 'center', type: 'container', axis: 'column', children: ['deckmix', 'fxrow'], fr: { deckmix: 5, fxrow: 2 } },
     deckmix: { id: 'deckmix', type: 'container', axis: 'row', children: ['deckAcont', 'mixer', 'deckBcont'], fr: { deckAcont: 4.17953863997903, mixer: 5.180662235484642, deckBcont: 4.439799124536327 } },
     // ── Deck A (pad-rows wrapped with spacer panels in cont-* containers) ──
-    deckAcont: { id: 'deckAcont', type: 'container', axis: 'column', children: ['pdA-head', 'waveAOverview', 'cont-10-e11250c4', 'cont-A-transport', 'cont-A-stems', 'fxAP', 'perfAP'], fr: { 'pdA-head': 1.12, waveAOverview: 0.72, 'cont-10-e11250c4': 4.9, 'cont-A-transport': 1.02, 'cont-A-stems': 1.1, fxAP: 3.15, perfAP: 1.35 }, framed: true },
-    'pdA-head': { id: 'pdA-head', type: 'panel', title: 'A', flow: 'row', widgets: ['spacer:s-2-7f6f8905', 'keylockA', 'keyA', 'bpmA', 'headerA'], widgetFr: { keylockA: 0.49871465295629847, keyA: 0.8892624085426142, bpmA: 0.8514435436029266, headerA: 2.255932370970932, 'spacer:s-2-7f6f8905': 0.8892624085426142 }, widgetJustify: { headerA: 'start' }, widgetMargins: { 'spacer:s-2-7f6f8905': { t: 0, r: 8, b: 0, l: 0 } }, mirror: false, uniform: false },
+    deckAcont: { id: 'deckAcont', type: 'container', axis: 'column', children: ['pdA-head', 'waveAOverview', 'deckABody', 'pdA-trans'], fr: { 'pdA-head': 0.95, waveAOverview: 0.62, deckABody: 4.85, 'pdA-trans': 0.88 }, framed: true },
+    'pdA-head': { id: 'pdA-head', type: 'panel', title: 'A', flow: 'row', widgets: ['headerA', 'keylockA', 'keyA', 'bpmA'], widgetFr: { headerA: 2.35, keylockA: 0.45, keyA: 0.85, bpmA: 0.9 }, widgetJustify: { headerA: 'start' }, mirror: false, uniform: false },
     'pdA-jog': { id: 'pdA-jog', type: 'panel', title: 'A · Jog', flow: 'row', widgets: ['jogA'], widgetMargins: { jogA: { t: 1, r: 4, b: 3, l: 4 } }, mirror: true },
     'pdA-mode': { id: 'pdA-mode', type: 'panel', title: 'A · Mode', flow: 'column', widgets: ['syncLockA', 'headCueA'], mirror: true, uniform: true },
-    'pdA-trans': { id: 'pdA-trans', type: 'panel', title: 'A · Transport', flow: 'row', widgets: ['cueA', 'playA', 'stopA', 'ejectA', 'syncA'], uniform: true, mirror: true },
+    'pdA-trans': { id: 'pdA-trans', type: 'panel', title: 'A · Transport', flow: 'row', widgets: ['cueA', 'playA', 'syncA', 'stopA', 'ejectA'], uniform: true, mirror: true },
     'pdA-stems': { id: 'pdA-stems', type: 'panel', title: 'A · Stems', flow: 'row', widgets: ['stemBankA'], mirror: true },
     'pdA-hc': { id: 'pdA-hc', type: 'panel', title: 'A · Hotcues', flow: 'row', widgets: ['hcA1', 'hcA2', 'hcA3', 'hcA4'], uniform: true, mirror: true },
     'pdA-loop': { id: 'pdA-loop', type: 'panel', title: 'A · Loop', flow: 'row', widgets: ['loopA_0', 'loopA_1', 'loopA_2', 'loopA_3', 'loopA_4', 'loopOutA'], uniform: true, mirror: true },
     'pdA-perf': { id: 'pdA-perf', type: 'panel', title: 'A · Perf', flow: 'row', widgets: ['rollA_0', 'rollA_1', 'rollA_2', 'slipA', 'jumpA_0', 'jumpA_1', 'jumpA_2', 'jumpA_3'], uniform: true, mirror: true },
     // ── Deck B ──
-    deckBcont: { id: 'deckBcont', type: 'container', axis: 'column', children: ['pdB-head', 'waveBOverview', 'cont-2-a0e79010', 'cont-B-transport', 'cont-B-stems', 'fxBP', 'perfBP'], fr: { 'pdB-head': 1.12, waveBOverview: 0.72, 'cont-2-a0e79010': 4.9, 'cont-B-transport': 1.02, 'cont-B-stems': 1.1, fxBP: 3.15, perfBP: 1.35 }, framed: true },
+    deckBcont: { id: 'deckBcont', type: 'container', axis: 'column', children: ['pdB-head', 'waveBOverview', 'deckBBody', 'pdB-trans'], fr: { 'pdB-head': 0.95, waveBOverview: 0.62, deckBBody: 4.85, 'pdB-trans': 0.88 }, framed: true },
     waveAOverview: { id: 'waveAOverview', type: 'panel', title: 'A · Overview', flow: 'row', widgets: [], pinned: 'waveAOverview', mirror: true },
     waveBOverview: { id: 'waveBOverview', type: 'panel', title: 'B · Overview', flow: 'row', widgets: [], pinned: 'waveBOverview' },
-    'pdB-head': { id: 'pdB-head', type: 'panel', title: 'B', flow: 'row', widgets: ['spacer:s-1-95993441', 'keylockB', 'keyB', 'bpmB', 'headerB'], widgetFr: { keylockB: 0.5522110739502047, keyB: 1.1040505388331472, bpmB: 1.039483463396507, headerB: 2.209123002601264, 'spacer:s-1-95993441': 0.4797473058342624 }, widgetJustify: { headerB: 'end' }, widgetMargins: { 'spacer:s-1-95993441': { t: 0, r: 0, b: 0, l: 64 } }, mirror: true, uniform: false },
+    'pdB-head': { id: 'pdB-head', type: 'panel', title: 'B', flow: 'row', widgets: ['bpmB', 'keyB', 'keylockB', 'headerB'], widgetFr: { keylockB: 0.45, keyB: 0.85, bpmB: 0.9, headerB: 2.35 }, widgetJustify: { headerB: 'end' }, mirror: true, uniform: false },
     'pdB-jog': { id: 'pdB-jog', type: 'panel', title: 'B · Jog', flow: 'row', widgets: ['jogB'], widgetMargins: { jogB: { t: 1, r: 4, b: 3, l: 4 } } },
     'pdB-mode': { id: 'pdB-mode', type: 'panel', title: 'B · Mode', flow: 'column', widgets: ['syncLockB', 'headCueB'], uniform: true },
-    'pdB-trans': { id: 'pdB-trans', type: 'panel', title: 'B · Transport', flow: 'row', widgets: ['cueB', 'playB', 'stopB', 'ejectB', 'syncB'], uniform: true },
+    'pdB-trans': { id: 'pdB-trans', type: 'panel', title: 'B · Transport', flow: 'row', widgets: ['ejectB', 'stopB', 'syncB', 'playB', 'cueB'], uniform: true },
     'pdB-stems': { id: 'pdB-stems', type: 'panel', title: 'B · Stems', flow: 'row', widgets: ['stemBankB'] },
     'pdB-hc': { id: 'pdB-hc', type: 'panel', title: 'B · Hotcues', flow: 'row', widgets: ['hcB1', 'hcB2', 'hcB3', 'hcB4'], uniform: true },
     'pdB-loop': { id: 'pdB-loop', type: 'panel', title: 'B · Loop', flow: 'row', widgets: ['loopB_0', 'loopB_1', 'loopB_2', 'loopB_3', 'loopB_4', 'loopOutB'], uniform: true },
     'pdB-perf': { id: 'pdB-perf', type: 'panel', title: 'B · Perf', flow: 'row', widgets: ['rollB_0', 'rollB_1', 'rollB_2', 'slipB', 'jumpB_0', 'jumpB_1', 'jumpB_2', 'jumpB_3'], uniform: true },
     // ── Mixer ──
-    mixer: { id: 'mixer', type: 'container', axis: 'column', children: ['mixToggles', 'mixChans', 'mixXfade'], fr: { mixToggles: 1, mixChans: 6, mixXfade: 1.6 }, framed: true },
-    mixToggles: { id: 'mixToggles', type: 'panel', title: 'Modes', flow: 'row', widgets: ['spacer:s-24-02c5d864', 'pitchRange', 'qtz', 'autoGain', 'automix', 'lim', 'midiMap', 'spacer:s-23-936b468e'], widgetMargins: { pitchRange: { t: 0, r: 5, b: 0, l: 5 }, qtz: { t: 0, r: 5, b: 0, l: 5 }, autoGain: { t: 0, r: 5, b: 0, l: 5 }, automix: { t: 0, r: 5, b: 0, l: 5 }, lim: { t: 0, r: 5, b: 0, l: 5 }, midiMap: { t: 0, r: 5, b: 0, l: 5 } }, uniform: true },
+    mixer: { id: 'mixer', type: 'container', axis: 'column', children: ['mixToggles', 'mixChans', 'mixXfade'], fr: { mixToggles: 1.05, mixChans: 6.05, mixXfade: 1.1 }, framed: true },
+    mixToggles: { id: 'mixToggles', type: 'panel', title: 'Modes', flow: 'row', widgets: ['pitchRange', 'qtz', 'autoGain', 'automix', 'lim', 'midiMap'], widgetMargins: { pitchRange: { t: 0, r: 1, b: 0, l: 1 }, qtz: { t: 0, r: 1, b: 0, l: 1 }, autoGain: { t: 0, r: 1, b: 0, l: 1 }, automix: { t: 0, r: 1, b: 0, l: 1 }, lim: { t: 0, r: 1, b: 0, l: 1 }, midiMap: { t: 0, r: 1, b: 0, l: 1 } }, uniform: true },
     mixChans: { id: 'mixChans', type: 'container', axis: 'row', children: ['eqAP', 'chAP', 'chBP', 'eqBP'], fr: { eqAP: 1.35, chAP: 1.15, chBP: 1.15, eqBP: 1.35 } },
     pchAP: { id: 'pchAP', type: 'panel', title: 'Pitch A', flow: 'column', widgets: ['pitchA'], widgetMargins: { pitchA: { t: 3, r: 4, b: 3, l: 4 } }, mirror: true },
-    eqAP: { id: 'eqAP', type: 'panel', title: 'EQ A', flow: 'column', widgets: ['eqA.hi', 'eqA.mid', 'eqA.lo', 'fltA'], mirror: true },
+    eqAP: { id: 'eqAP', type: 'panel', title: 'EQ A', flow: 'column', widgets: ['eqA.hi', 'eqA.mid', 'eqA.lo', 'fltA'] },
     chAP: { id: 'chAP', type: 'panel', title: 'Ch A', flow: 'column', widgets: ['volA', 'gainA'], widgetFr: { gainA: 1, volA: 3 }, widgetMargins: { volA: { t: 8, r: 0, b: 8, l: 24 } }, mirror: true },
     chBP: { id: 'chBP', type: 'panel', title: 'Ch B', flow: 'column', widgets: ['gainB', 'volB'], widgetFr: { gainB: 1, volB: 3 }, widgetMargins: { volB: { t: 8, r: 24, b: 8, l: 0 } } },
     eqBP: { id: 'eqBP', type: 'panel', title: 'EQ B', flow: 'column', widgets: ['eqB.hi', 'eqB.mid', 'eqB.lo', 'fltB'] },
@@ -497,9 +497,11 @@ const defaultDjLayout: SurfaceLayout = {
     fxrow: { id: 'fxrow', type: 'container', axis: 'row', children: ['fxAP', 'nextP', 'fxBP'], fr: { fxAP: 0.7703206562266971, nextP: 1.9175988068605512, fxBP: 0.812080536912752 } },
     fxAP: { id: 'fxAP', type: 'panel', title: 'Onboard FX A', flow: 'row', widgets: [], pinned: 'fxA', mirror: true },
     perfAP: { id: 'perfAP', type: 'panel', title: 'Performance Pads A', flow: 'row', widgets: [], pinned: 'perfA', mirror: true },
+    deckControlsA: { id: 'deckControlsA', type: 'panel', title: 'Deck Controls A', flow: 'row', widgets: [], pinned: 'deckControlsA', mirror: true },
     nextP: { id: 'nextP', type: 'panel', title: 'Next', flow: 'row', widgets: [], pinned: 'next' },
     fxBP: { id: 'fxBP', type: 'panel', title: 'Onboard FX B', flow: 'row', widgets: [], pinned: 'fxB', uniform: false },
     perfBP: { id: 'perfBP', type: 'panel', title: 'Performance Pads B', flow: 'row', widgets: [], pinned: 'perfB', uniform: false },
+    deckControlsB: { id: 'deckControlsB', type: 'panel', title: 'Deck Controls B', flow: 'row', widgets: [], pinned: 'deckControlsB', uniform: false },
     browser: { id: 'browser', type: 'container', axis: 'column', children: ['sourceTreeP', 'libraryP'], fr: { sourceTreeP: 2, libraryP: 3 } },
     sourceTreeP: { id: 'sourceTreeP', type: 'panel', title: 'Sources', flow: 'row', widgets: [], pinned: 'sourceTree' },
     libraryP: { id: 'libraryP', type: 'panel', title: 'Library', flow: 'row', widgets: [], pinned: 'library', uniform: true },
@@ -518,6 +520,7 @@ const defaultDjLayout: SurfaceLayout = {
     'cont-9-aebcd780': { id: 'cont-9-aebcd780', type: 'container', axis: 'row', children: ['pdB-perf', 'panel-8-81228019'], fr: { 'pdB-perf': 1.5358851674641145, 'panel-8-81228019': 0.46411483253588537 } },
     // ── Deck A pad-row wrappers ──
     'cont-10-e11250c4': { id: 'cont-10-e11250c4', type: 'container', axis: 'row', children: ['panel-11-95a4a261', 'pchAP', 'pdA-jog', 'pdA-mode'], fr: { 'panel-11-95a4a261': 0.7, pchAP: 0.45, 'pdA-jog': 1.87, 'pdA-mode': 0.5 } },
+    deckABody: { id: 'deckABody', type: 'container', axis: 'row', children: ['deckControlsA', 'pdA-jog', 'pchAP'], fr: { deckControlsA: 3.45, 'pdA-jog': 1.12, pchAP: 0.4 } },
     'panel-11-95a4a261': { id: 'panel-11-95a4a261', type: 'panel', title: 'Panel', flow: 'row', widgets: ['spacer:s-26-79f129b0'] },
     'panel-A-transport-head': { id: 'panel-A-transport-head', type: 'panel', title: 'Panel', flow: 'row', widgets: ['spacer:s-A-transport-head'] },
     'cont-A-transport': { id: 'cont-A-transport', type: 'container', axis: 'row', children: ['panel-A-transport-head', 'pdA-trans'], fr: { 'panel-A-transport-head': 1.15, 'pdA-trans': 2.37 } },
@@ -529,6 +532,7 @@ const defaultDjLayout: SurfaceLayout = {
     'cont-16-c9fc3a59': { id: 'cont-16-c9fc3a59', type: 'container', axis: 'row', children: ['panel-15-4eb1b108', 'pdA-loop'], fr: { 'pdA-loop': 1.3664122137404573, 'panel-15-4eb1b108': 0.6335877862595417 } },
     'panel-17-44cba1fb': { id: 'panel-17-44cba1fb', type: 'panel', title: 'Panel', flow: 'row', widgets: ['spacer:s-27-8799ff7e'] },
     'cont-18-cd01de17': { id: 'cont-18-cd01de17', type: 'container', axis: 'row', children: ['panel-17-44cba1fb', 'pdA-perf'], fr: { 'pdA-perf': 1.4885496183206104, 'panel-17-44cba1fb': 0.5114503816793893 } },
+    deckBBody: { id: 'deckBBody', type: 'container', axis: 'row', children: ['pchBP', 'pdB-jog', 'deckControlsB'], fr: { pchBP: 0.4, 'pdB-jog': 1.12, deckControlsB: 3.45 } },
   },
 };
 
@@ -1758,6 +1762,174 @@ const CompactPerformancePads: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cy
   );
 };
 
+const DeckControlStrip: React.FC<{ deck: 'A' | 'B'; accent: 'purple' | 'cyan'; entryId: string | null; ctl: DeckCtl }> = ({ deck, accent, entryId, ctl }) => {
+  const color = DECK_RGB[accent];
+  const accentText = accent === 'purple' ? 'text-purple-300' : 'text-cyan-300';
+  const hasTrack = !!entryId;
+  const [fx, setFx] = useState<Record<djEngine.DjFx, number>>({ flanger: 0, reverb: 0, wahwah: 0 });
+  const [loopIndex, setLoopIndex] = useState(2);
+  const selectedLoop = BEAT_SIZES[loopIndex] ?? BEAT_SIZES[2];
+  const onFx = (k: djEngine.DjFx, v: number) => {
+    setFx((p) => ({ ...p, [k]: v }));
+    djEngine.setDeckFx(deck, k, v);
+  };
+  const fxRows: Array<{ key: djEngine.DjFx; label: string }> = [
+    { key: 'flanger', label: 'Beat Grid' },
+    { key: 'reverb', label: 'Reverb' },
+    { key: 'wahwah', label: 'Up Echo' },
+  ];
+  const visibleCueRows = 4;
+
+  return (
+    <div className="hardware-card h-full w-full min-h-0 min-w-0 overflow-hidden p-0 bg-[#111116] border-white/10">
+      <div className="h-full min-h-0 grid grid-cols-[2.65rem_minmax(0,1fr)]">
+        <div className="grid grid-rows-2 border-r border-white/8 bg-black/20">
+          <div className="relative border-b border-white/8 grid place-items-center">
+            <span className="rotate-[-90deg] text-[10px] font-black uppercase tracking-widest text-zinc-500">FX</span>
+            <span className="absolute bottom-2 h-2.5 w-2.5 rounded-full border border-white/20 bg-black shadow-inner" />
+          </div>
+          <div className="relative grid place-items-center">
+            <span className="rotate-[-90deg] text-[10px] font-black uppercase tracking-widest text-zinc-500">Pads</span>
+            <span className="absolute bottom-2 h-2.5 w-2.5 rounded-full border border-white/20 bg-black shadow-inner" />
+          </div>
+        </div>
+        <div className="min-w-0 min-h-0 grid grid-rows-[1fr_1fr]">
+          <div className="min-h-0 grid grid-cols-[1.55fr_0.72fr] border-b border-white/10">
+            <div className="min-w-0 min-h-0 flex flex-col justify-center gap-1.5 p-2">
+              {fxRows.map(({ key, label }) => (
+                <div key={key} className="grid grid-cols-[minmax(4.6rem,0.95fr)_minmax(2.75rem,0.72fr)_1.25rem] items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={() => onFx(key, fx[key] > 0.001 ? 0 : key === 'reverb' ? 0.62 : 0.72)}
+                    disabled={!hasTrack}
+                    className={`h-8 min-w-0 border bg-black/70 px-2 text-left text-[10px] font-black uppercase tracking-wide transition-colors ${
+                      fx[key] > 0.001 ? `${accentText} border-current` : 'border-white/10 text-zinc-400 hover:border-white/25 hover:text-zinc-200'
+                    } disabled:opacity-30`}
+                    title={`Toggle ${label} on Deck ${deck}`}
+                  >
+                    <span className="block truncate">{label}</span>
+                  </button>
+                  <input
+                    type="range"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={fx[key]}
+                    disabled={!hasTrack}
+                    onChange={(e) => onFx(key, Number(e.currentTarget.value))}
+                    className="w-full min-w-0 accent-cyan-500 disabled:opacity-30"
+                    title={`${label} amount`}
+                  />
+                  <button
+                    type="button"
+                    disabled={!hasTrack}
+                    onClick={() => onFx(key, fx[key] > 0.001 ? 0 : 0.7)}
+                    className="h-7 w-5 grid place-items-center rounded border border-white/10 bg-black/50 text-zinc-500 hover:text-zinc-100 disabled:opacity-30"
+                    title={`${label} settings`}
+                  >
+                    <Gauge className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+            <div className="min-w-0 min-h-0 border-l border-white/8 p-2 flex flex-col justify-center gap-1">
+              {Array.from({ length: visibleCueRows }, (_, i) => {
+                const c = ctl.cues?.[i] ?? null;
+                const set = c != null;
+                return (
+                  <div key={i} className="grid grid-cols-[1.8rem_minmax(0,1fr)_1.35rem] h-7">
+                    <button
+                      type="button"
+                      onClick={() => ctl.setHotcue(i)}
+                      disabled={!hasTrack}
+                      className={`border border-white/10 bg-black/60 text-[12px] font-black tabular-nums ${set ? accentText : 'text-zinc-500'} disabled:opacity-30`}
+                      title={set ? `Jump to cue ${i + 1} at ${fmtTime(c)}` : `Set cue ${i + 1}`}
+                    >
+                      {i + 1}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => ctl.setHotcue(i)}
+                      disabled={!hasTrack}
+                      className="min-w-0 border-y border-white/10 bg-[#17171c] px-1.5 text-left text-[10px] font-mono text-zinc-400 hover:text-zinc-100 disabled:opacity-30"
+                      title={set ? `Cue ${i + 1}: ${fmtTime(c)}` : `Empty cue ${i + 1}`}
+                    >
+                      <span className="block truncate">{set ? fmtTime(c) : ''}</span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => ctl.dropHotcue(i)}
+                      disabled={!set}
+                      className="grid place-items-center border border-white/10 bg-black/60 text-zinc-500 hover:text-rose-300 disabled:opacity-30"
+                      title={`Clear cue ${i + 1}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          <div className="min-h-0 grid grid-cols-[1.55fr_0.72fr]">
+            <div className="min-w-0 min-h-0 p-2">
+              <div className="h-8 mb-2 border border-white/10 bg-black/70 px-2 flex items-center gap-2">
+                <span className={`text-[11px] font-black uppercase tracking-wide ${accentText}`}>Stems 2.0</span>
+                <Scissors className="ml-auto h-3.5 w-3.5 text-zinc-500" />
+              </div>
+              <div className="h-[calc(100%-2.5rem)] min-h-0">
+                <StemPadBank deck={deck} entryId={entryId} color={color} ctl={ctl} />
+              </div>
+            </div>
+            <div className="min-w-0 min-h-0 border-l border-white/8 p-2 flex flex-col">
+              <div className="h-7 flex items-center justify-center text-center text-[7px] font-black uppercase tracking-normal text-zinc-500 leading-tight">Sample Record</div>
+              <div className="mt-auto grid grid-cols-[1.8rem_1fr_1.8rem] gap-1 h-9">
+                <button
+                  type="button"
+                  onClick={() => setLoopIndex((i) => Math.max(0, i - 1))}
+                  className="grid place-items-center border border-white/10 bg-black/60 text-zinc-400 hover:text-zinc-100"
+                  title="Shorter loop"
+                >
+                  <ChevronRight className="h-4 w-4 rotate-180" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => ctl.toggleBeatLoop(selectedLoop.beats)}
+                  disabled={!hasTrack}
+                  className={`border text-[14px] font-black tabular-nums ${
+                    ctl.loopActive && ctl.activeLoopBeats === selectedLoop.beats
+                      ? `${accentText} border-current bg-white/10`
+                      : 'border-white/10 bg-black/70 text-zinc-300 hover:text-white'
+                  } disabled:opacity-30`}
+                  title={`${selectedLoop.label}-beat loop`}
+                >
+                  {selectedLoop.label}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setLoopIndex((i) => Math.min(BEAT_SIZES.length - 1, i + 1))}
+                  className="grid place-items-center border border-white/10 bg-black/60 text-zinc-400 hover:text-zinc-100"
+                  title="Longer loop"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={() => ctl.loopActive ? ctl.exitLoop() : ctl.toggleBeatLoop(selectedLoop.beats)}
+                disabled={!hasTrack}
+                className="mt-2 h-8 border border-white/10 bg-black/70 text-[10px] font-black uppercase tracking-wide text-zinc-300 hover:text-white disabled:opacity-30"
+                title={ctl.loopActive ? 'Exit loop' : 'Record/arm loop'}
+              >
+                {ctl.loopActive ? 'Loop Out' : 'Rec'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 /* ═══════════════════════════════ SideListLane ═══════════════════════════════ */
 
 /** Staging queue ("prepare / play-next") — a compact card in the center-bottom
@@ -2814,6 +2986,8 @@ function buildDjRegistry(p: DjRegArgs): WidgetRegistry {
   pinned('fxB', 'Onboard FX B', <OnboardFxPanel deck="B" accent="cyan" entryId={p.deckBTrack} ctl={p.ctlB} />);
   pinned('perfA', 'Performance Pads A', <CompactPerformancePads deck="A" accent="purple" entryId={p.deckATrack} ctl={p.ctlA} />);
   pinned('perfB', 'Performance Pads B', <CompactPerformancePads deck="B" accent="cyan" entryId={p.deckBTrack} ctl={p.ctlB} />);
+  pinned('deckControlsA', 'Deck Controls A', <DeckControlStrip deck="A" accent="purple" entryId={p.deckATrack} ctl={p.ctlA} />);
+  pinned('deckControlsB', 'Deck Controls B', <DeckControlStrip deck="B" accent="cyan" entryId={p.deckBTrack} ctl={p.ctlB} />);
   pinned('next', 'Next / Staging', <SideListLane onLoadDeck={p.loadDeck} />);
   pinned('sourceTree', 'Source Tree', <SourceTree source={p.source} setSource={p.setSource} libCount={p.libCount} />);
   pinned('library', 'Library', <TrackBrowser source={p.source} setSource={p.setSource} onLoadDeck={p.loadDeck} />);


### PR DESCRIPTION
## Summary
- Fixes the DJ mixer EQ stack so HI renders above MID and LO on both decks.
- Keeps mirrored surface panels from reversing vertical control stacks, while preserving horizontal mirror behavior for left/right symmetry.
- Bumps the DJ surface layout version so existing saved layouts refresh to the corrected default.

## Root Cause
The left EQ panel was marked as mirrored, and the shared surface panel renderer reversed widget order for all mirrored panels. That made a vertical EQ stack render bottom-to-top, so LO appeared above HI.

## Validation
- `npm run lint`
- `npm run build`
- Playwright/Chrome visual probe on the DJ tab confirmed both EQ columns render HI above MID above LO.
