### PR TITLE
Fix Ableton import issues and enhance playback functionality

### DIFF
--- a/backend/modules/dawimport/ableton.py
+++ b/backend/modules/dawimport/ableton.py
@@ -313,9 +313,15 @@ def _parse_track(
         if mute_elem is not None:
             mute = mute_elem.get("Value", "0") in ("1", "true")
 
-    # Solo.
+    # Solo. `find(...) or find(...)` is a trap here: an ElementTree Element with
+    # no children is FALSY, so a self-closing <Solo Value="true"/> fell through to
+    # the SoloSink branch and parsed as solo=False. Real sets happen to store
+    # solo as <SoloSink>, which is why this never showed up — but it is one Live
+    # version away from silently dropping every solo in a project.
     solo = False
-    solo_elem = track_elem.find(".//Solo") or track_elem.find(".//SoloSink")
+    solo_elem = track_elem.find(".//Solo")
+    if solo_elem is None:
+        solo_elem = track_elem.find(".//SoloSink")
     if solo_elem is not None:
         solo = solo_elem.get("Value", "false").lower() in ("true", "1")
 
@@ -537,12 +543,19 @@ def _build_clip(
         start_beats = _read_attr_or_child_float(clip_elem, "CurrentStart", 0.0)
         end_beats = _read_attr_or_child_float(clip_elem, "CurrentEnd", start_beats)
     else:
-        # Session clip: derive a length from loop region so the clip has size.
+        # Session clip: a WINDOW onto its sample, not a timeline position. Its
+        # length is CurrentEnd - CurrentStart; taking CurrentEnd alone reported a
+        # 4-beat clip starting at beat 2 as 6 beats long (50% too long) and lost
+        # the trim entirely, so playback started from sample zero.
+        session_start = _read_attr_or_child_float(clip_elem, "CurrentStart", 0.0) or 0.0
+        session_end = _read_attr_or_child_float(clip_elem, "CurrentEnd", None)
+        if session_end is None:
+            length = _read_loop_length(clip_elem)
+            session_end = session_start + length if length is not None else None
         start_beats = 0.0
-        loop_end = _read_attr_or_child_float(clip_elem, "CurrentEnd", None)
-        if loop_end is None:
-            loop_end = _read_loop_length(clip_elem)
-        end_beats = loop_end if loop_end is not None else 4.0
+        end_beats = (
+            max(0.0, session_end - session_start) if session_end is not None else 4.0
+        )
 
     start_time = _beats_to_sec(start_beats, tempo)
     end_time = _beats_to_sec(end_beats, tempo)
@@ -576,6 +589,19 @@ def _build_clip(
     else:
         file_path = _resolve_audio_path(clip_elem, project, project_dir, media_index)
 
+    # Where in the sample this clip starts. For a session clip that is its
+    # CurrentStart; both lanes fall back to the loop region's start, which is
+    # what Live uses for a looped clip's play position.
+    if arrangement:
+        offset_into_source = loop_start if loop_start is not None else 0.0
+    else:
+        offset_into_source = _beats_to_sec(session_start, tempo)
+        if offset_into_source <= 0.0 and loop_start is not None:
+            offset_into_source = loop_start
+
+    loop_on = _read_loop_on(clip_elem)
+    is_warped, source_tempo = _read_warp(clip_elem, tempo)
+
     return DawClip(
         name=cname,
         start_time=start_time,
@@ -584,7 +610,76 @@ def _build_clip(
         loop_end=loop_end,
         file_path=file_path,
         midi_notes=midi_notes,
+        offset_into_source=max(0.0, offset_into_source),
+        loop_on=loop_on,
+        is_warped=is_warped,
+        source_tempo=source_tempo,
+        color=_read_color(clip_elem),
     )
+
+
+def _read_loop_on(clip_elem) -> bool | None:
+    """Live's <Loop><LoopOn Value="true"/>, in its attribute and child forms.
+
+    Returns None when the tag is absent so a caller can tell "explicitly a
+    one-shot" from "this Live version didn't say", rather than silently looping
+    material that was never meant to.
+    """
+    for path in ("Loop/LoopOn", "LoopOn"):
+        el = clip_elem.find(path)
+        if el is None:
+            continue
+        raw = el.get("Value")
+        if raw is None:
+            raw = (el.text or "").strip()
+        if raw:
+            return raw.strip().lower() in ("true", "1")
+    return None
+
+
+def _read_warp(clip_elem, project_tempo: float) -> tuple[bool, float | None]:
+    """Whether the clip is warped, and the sample's own recorded tempo.
+
+    Two consecutive warp markers give it directly: each pairs a position in the
+    sample (``SecTime``, seconds) with a position in the song (``BeatTime``,
+    beats), so tempo = beats-elapsed / seconds-elapsed * 60. That is a
+    constant-rate approximation — correct for the single-tempo loops that make up
+    almost all of a session grid, and wrong only for a clip that was warped to
+    follow a performance, which needs offline resampling to reproduce anyway.
+    """
+    warped_el = clip_elem.find("IsWarped")
+    raw = warped_el.get("Value") if warped_el is not None else None
+    is_warped = bool(raw) and raw.strip().lower() in ("true", "1")
+    if not is_warped:
+        return False, None
+
+    markers = clip_elem.find("WarpMarkers")
+    if markers is None:
+        return True, None
+    pairs: list[tuple[float, float]] = []
+    for m in markers.findall("WarpMarker"):
+        sec = m.get("SecTime")
+        beat = m.get("BeatTime")
+        if sec is None or beat is None:
+            continue
+        try:
+            pairs.append((float(sec), float(beat)))
+        except ValueError:
+            continue
+        if len(pairs) == 2:
+            break
+    if len(pairs) < 2:
+        return True, None
+    (s0, b0), (s1, b1) = pairs
+    d_sec = s1 - s0
+    d_beat = b1 - b0
+    if d_sec <= 0 or d_beat <= 0:
+        return True, None
+    tempo = (d_beat / d_sec) * 60.0
+    # Guard against a degenerate marker pair producing an absurd rate.
+    if not (20.0 <= tempo <= 400.0):
+        return True, None
+    return True, tempo
 
 
 def _read_loop_length(clip_elem) -> float | None:
@@ -1149,6 +1244,83 @@ def _read_color(track_elem) -> str | None:
     return None
 
 
+# Live's 70-entry track/clip colour palette, in index order. Colour is how a
+# performer navigates a session grid at speed, so getting these right is what
+# makes an imported set visually recognisable rather than a rainbow by position.
+_LIVE_PALETTE: tuple[str, ...] = (
+    "#ff94a6",
+    "#ffa529",
+    "#cc9927",
+    "#f7f47c",
+    "#bfff00",
+    "#1aff2f",
+    "#25ffa8",
+    "#5cffe8",
+    "#8bc5ff",
+    "#5480e4",
+    "#92a7ff",
+    "#d86ce4",
+    "#e553a0",
+    "#ffffff",
+    "#ff3636",
+    "#f66c03",
+    "#99724b",
+    "#fff034",
+    "#87ff67",
+    "#3dc300",
+    "#00bfaf",
+    "#19e9ff",
+    "#10a4ee",
+    "#007dc0",
+    "#886ce4",
+    "#a53df7",
+    "#bf3fa1",
+    "#ff39d4",
+    "#d0d0d0",
+    "#e3776f",
+    "#a75151",
+    "#a76c4b",
+    "#c8a56b",
+    "#d2c795",
+    "#a8c66b",
+    "#87a556",
+    "#77a582",
+    "#83abbc",
+    "#7b96b4",
+    "#8393cc",
+    "#a289b5",
+    "#bf9fbf",
+    "#bc7f9b",
+    "#c4a3b0",
+    "#a9a9a9",
+    "#c39c9c",
+    "#b58a6c",
+    "#a88f5a",
+    "#c1b56b",
+    "#b7c78b",
+    "#a5c46b",
+    "#8fae7a",
+    "#78a58f",
+    "#8fb0bc",
+    "#8fa3c0",
+    "#95a3d6",
+    "#b09ac0",
+    "#c9a6c9",
+    "#c48fa8",
+    "#cbb0ba",
+    "#3c3c3c",
+    "#a04d3c",
+    "#8f6a3c",
+    "#8f7f3c",
+    "#7f8f3c",
+    "#5c8f3c",
+    "#3c8f6a",
+    "#3c7f8f",
+    "#3c5c8f",
+    "#5c3c8f",
+)
+
+
 def _color_token(v: str | None) -> str | None:
     """Normalize a color value to a hex string when it looks like RGB."""
     if v is None:
@@ -1162,7 +1334,15 @@ def _color_token(v: str | None) -> str | None:
     # Heuristic: large values are packed RGB; small values are palette indices.
     if n > 0xFFFF:
         return f"#{n & 0xFFFFFF:06x}"
-    return f"index:{n}"
+    # Live track/clip colours are palette indices 0-69, so this branch is the
+    # common one — the RGB branch above is effectively dead for real sets. This
+    # used to return the literal string "index:26", which is not a colour: the
+    # grid ignored it and coloured by position instead, and projectImport's
+    # `t.color || FALLBACK` accepted it as truthy and handed the editor an
+    # invalid CSS value that never reached its own fallback.
+    if n < len(_LIVE_PALETTE):
+        return _LIVE_PALETTE[n]
+    return None
 
 
 def _child_value(elem, child_tag: str) -> str | None:

--- a/backend/modules/dawimport/ableton.py
+++ b/backend/modules/dawimport/ableton.py
@@ -178,9 +178,26 @@ def parse_als(path: str) -> DawProject:
     media_index = media.build_media_index(project_dir)
 
     # Tempo (parse first — note timing depends on it).
-    tempo_elem = live_set.find(".//MasterTrack/Mixer/Tempo/Manual")
+    # Resolve the master element ONCE and search inside it. The old primary XPath
+    # `.//MasterTrack/Mixer/Tempo/Manual` is dead in every real Live Set — Live
+    # nests the mixer under DeviceChain — and it had no <MainTrack> (Live 12)
+    # coverage at all, so tempo fell through to a loose document-order
+    # `.//Tempo/Manual` and time signature silently returned 4/4 for any Live-12
+    # set (a 6/8 project parsed as 4/4 with no warning).
+    master_track_elem = live_set.find("MasterTrack")
+    if master_track_elem is None:
+        master_track_elem = live_set.find("MainTrack")
+
+    tempo_elem = None
+    if master_track_elem is not None:
+        tempo_elem = master_track_elem.find(".//Tempo/Manual")
     if tempo_elem is None:
         tempo_elem = live_set.find(".//Tempo/Manual")
+        if tempo_elem is None:
+            project.warnings.append(
+                "No tempo found in the Live Set; defaulting to 120 BPM. "
+                "Clip and note positions may be wrong."
+            )
     if tempo_elem is not None:
         try:
             project.tempo = float(tempo_elem.get("Value", "120"))
@@ -191,8 +208,9 @@ def parse_als(path: str) -> DawProject:
         project.warnings.append("Non-positive tempo; defaulting to 120 BPM.")
 
     # Time signature (best effort).
-    num = live_set.find(".//MasterTrack//TimeSignature//Numerator")
-    den = live_set.find(".//MasterTrack//TimeSignature//Denominator")
+    sig_root = master_track_elem if master_track_elem is not None else live_set
+    num = sig_root.find(".//TimeSignature//Numerator")
+    den = sig_root.find(".//TimeSignature//Denominator")
     try:
         if num is not None and den is not None:
             project.time_signature = (
@@ -418,8 +436,14 @@ def _parse_clips(
             _try_add(clip)
 
     # 3) Session-view clips only when the track is otherwise empty.
+    # Scoped to MainSequencer like steps 1 and 2. `track_elem.iter("ClipSlot")`
+    # walked the WHOLE track element, which also reaches <FreezeSequencer> — so a
+    # frozen track imported its "FROZEN RENDER" as if it were arrangement
+    # content, and those renders polluted missing_files even when rejected.
     if not placed:
-        for slot in track_elem.iter("ClipSlot"):
+        seq = track_elem.find(".//DeviceChain/MainSequencer")
+        slot_source = seq if seq is not None else track_elem
+        for slot in slot_source.iter("ClipSlot"):
             for clip_elem in _iter_clip_elements(slot):
                 _try_add(
                     _build_clip(

--- a/backend/modules/dawimport/models.py
+++ b/backend/modules/dawimport/models.py
@@ -63,6 +63,22 @@ class DawClip:
     scene_index: int | None = None
     scene_name: str | None = None
     slot_index: int | None = None
+    # Seconds into the source file where this clip starts. Session clips are a
+    # WINDOW onto their sample, so without this a clip trimmed to bars 1-2 played
+    # from sample zero — the material the performer explicitly cut out.
+    offset_into_source: float = 0.0
+    # Whether the clip loops when launched. Live's <Loop><LoopOn>. A session grid
+    # is mostly loops; treating them as one-shots makes a scene fall apart as
+    # tracks drop out at staggered times. None = unknown (treat as one-shot).
+    loop_on: bool | None = None
+    # Warping: `source_tempo` is the sample's own recorded tempo, derived from the
+    # first two warp markers. A session grid of loops sampled at different BPMs is
+    # the normal Ableton case, and playing each at its recorded rate makes cells
+    # of equal length audibly different. rate = project.tempo / source_tempo.
+    is_warped: bool = False
+    source_tempo: float | None = None
+    # Clip colour as #rrggbb (Live stores a palette index; the parser decodes it).
+    color: str | None = None
 
 
 @dataclass

--- a/backend/modules/dawimport/router.py
+++ b/backend/modules/dawimport/router.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from backend.modules.project import media_access
+
 log = logging.getLogger(__name__)
 router = APIRouter()
 
@@ -29,6 +31,36 @@ class DetectResponse(BaseModel):
     daw: str  # "ableton" | "reaper" | "logic" | "unknown"
     name: str
     format: str  # "als" | "rpp" | "logicx"
+
+
+def _finish_import(project, source_path: str) -> dict:
+    """Collapse silent gaps, allowlist the project's media, and serialise.
+
+    Importing a project is the user's consent for the files it names, exactly as
+    opening a .tasmo is (see project/router.py::_register_project_media). Without
+    this every clip the Perform grid tried to play came back 403 from
+    /api/project/clip-audio, because an imported set's Samples/ folder is not one
+    of media_access's static roots.
+
+    That produced the single most confusing symptom in the DAW-import feature:
+    session roots are PERSISTED to data/media_roots.json, so the same .als was
+    silent on a clean install and worked afterwards if any earlier project save
+    or load had happened to name a file in that folder. Registering the source
+    file's own folder covers Samples/Imported and Samples/Recorded in one grant.
+    """
+    project.collapse_silent_gaps()
+    media_access.register_paths(
+        [
+            source_path,
+            *(
+                clip.file_path
+                for track in project.tracks
+                for clip in track.clips
+                if clip.file_path
+            ),
+        ]
+    )
+    return project.to_dict()
 
 
 @router.post("/detect", response_model=DetectResponse)
@@ -74,8 +106,7 @@ def import_ableton(req: PathRequest):
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to parse .als: {e}")
-    project.collapse_silent_gaps()
-    return project.to_dict()
+    return _finish_import(project, req.path)
 
 
 @router.post("/reaper")
@@ -89,8 +120,7 @@ def import_reaper(req: PathRequest):
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to parse .RPP: {e}")
-    project.collapse_silent_gaps()
-    return project.to_dict()
+    return _finish_import(project, req.path)
 
 
 @router.post("/logic")
@@ -104,8 +134,7 @@ def import_logic(req: PathRequest):
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to parse .logicx: {e}")
-    project.collapse_silent_gaps()
-    return project.to_dict()
+    return _finish_import(project, req.path)
 
 
 @router.get("/logic/export-hint")
@@ -130,8 +159,7 @@ def import_fl_studio(req: PathRequest):
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to parse .flp: {e}")
-    project.collapse_silent_gaps()
-    return project.to_dict()
+    return _finish_import(project, req.path)
 
 
 @router.post("/audacity")
@@ -145,8 +173,7 @@ def import_audacity(req: PathRequest):
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to parse .aup3: {e}")
-    project.collapse_silent_gaps()
-    return project.to_dict()
+    return _finish_import(project, req.path)
 
 
 @router.post("/audition")
@@ -160,8 +187,7 @@ def import_audition(req: PathRequest):
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to parse .sesx: {e}")
-    project.collapse_silent_gaps()
-    return project.to_dict()
+    return _finish_import(project, req.path)
 
 
 @router.post("/bitwig")
@@ -175,8 +201,7 @@ def import_bitwig(req: PathRequest):
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to parse .bwproject: {e}")
-    project.collapse_silent_gaps()
-    return project.to_dict()
+    return _finish_import(project, req.path)
 
 
 @router.post("/resolume")
@@ -190,8 +215,7 @@ def import_resolume(req: PathRequest):
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to parse .avc: {e}")
-    project.collapse_silent_gaps()
-    return project.to_dict()
+    return _finish_import(project, req.path)
 
 
 @router.get("/cubase/export-hint")

--- a/backend/modules/project/tasmo_project.py
+++ b/backend/modules/project/tasmo_project.py
@@ -71,6 +71,14 @@ class Clip(BaseModel):
     # WRONG audio, because the full untrimmed source is embedded and playback
     # restarts it from zero. Defaulted so pre-existing .tasmo files still validate.
     offset_into_source: float = 0.0
+    # Session-view (Perform tab) placement, mirroring dawimport's DawClip. None
+    # on an arrangement clip. Without these the format had no way to represent a
+    # clip-launch grid at all, so every session clip was discarded on save and
+    # the grid was rebuilt from arrangement clips on load. Defaulted, so .tasmo
+    # files written before the grid was representable still validate.
+    track_index: int | None = None
+    scene_index: int | None = None
+    slot_index: int | None = None
     generation_prompt: str | None = None
     generation_seed: int | None = None
     generation_params: dict | None = None
@@ -118,6 +126,11 @@ class TasmoProject(BaseModel):
     source_daw: str | None = None
     source_daw_version: str | None = None
     import_warnings: list[str] = []
+    # Session-view scene names in row order, mirroring DawProject.scenes. Empty
+    # for projects with no clip-launch grid. Paired with the per-clip scene
+    # indices above: without both, a saved Perform grid reloaded as a generic
+    # "Scene 1..N" ladder because the names had nowhere to live.
+    scenes: list[str] = []
     # Persisted controller (MIDI-learn) auto-attach: the resolved Sway bindings +
     # unattached list + source project name, so reopening a saved session re-wires
     # the hardware to the same targets without re-importing the source DAW project.

--- a/frontend/src/components/session/DawSessionGrid.tsx
+++ b/frontend/src/components/session/DawSessionGrid.tsx
@@ -128,7 +128,9 @@ const notesFromDawClip = (clip: DawClip): RenderNote[] => {
       midi,
       startSec: Math.max(0, startSec),
       durationSec: Math.max(0.02, durationSec),
-      velocity: velocityRaw <= 1 ? Math.round(velocityRaw * 127) : Math.round(velocityRaw),
+      // < 1, not <= 1: a raw value of exactly 1 is a legitimate (very quiet)
+      // MIDI velocity, and treating it as normalised 1.0 turned it into 127.
+      velocity: velocityRaw < 1 ? Math.round(velocityRaw * 127) : Math.round(velocityRaw),
     }];
   });
 };

--- a/frontend/src/components/session/DawSessionGrid.tsx
+++ b/frontend/src/components/session/DawSessionGrid.tsx
@@ -638,11 +638,11 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
                         <button
                           type="button"
                           onClick={() => selectAndLaunch(sceneIndex)}
-                          disabled={!clip.file_path}
+                          disabled={!isPlayableClip(clip)}
                           className={[
                             'h-7 w-full px-1.5 flex items-center gap-1 border text-left',
                             color.clip,
-                            !clip.file_path ? 'opacity-45 cursor-not-allowed' : 'hover:brightness-110',
+                            !isPlayableClip(clip) ? 'opacity-45 cursor-not-allowed' : 'hover:brightness-110',
                           ].join(' ')}
                           title={clip.name}
                         >

--- a/frontend/src/components/session/DawSessionGrid.tsx
+++ b/frontend/src/components/session/DawSessionGrid.tsx
@@ -18,6 +18,9 @@ import { subscribeSwayValue } from '../../state/swayBus';
 import { enableMidi } from '../../state/midiTriggerStore';
 import { usePerformRoutingStore, ctrlMatches } from '../../state/performRouting';
 import { logError } from '../../state/logStore';
+import { dawDeviceToEffectNode } from '../../lib/dawEffectMap';
+import { buildEffectChain, type ChainHandle } from '../../lib/rackEffects';
+import type { ChainEntry } from '../../state/effectChainStore';
 
 type ClipLookup = Map<string, DawClip>;
 
@@ -25,10 +28,14 @@ interface SessionPlayer {
   source: AudioBufferSourceNode;
   analyser?: AnalyserNode;
   gain?: GainNode;
+  panner?: StereoPannerNode;
   trackIndex: number;
   /** The track's index in the mixer/track list (performTracks order), used to
    *  apply live Sway modulation to the right column's gain. */
   mixIndex: number;
+  /** Which scene row this player came from, so the grid can show per-track
+   *  playing state instead of one global "active scene". */
+  sceneIndex: number;
 }
 
 type ClipBufferCache = Map<string, Promise<AudioBuffer>>;
@@ -78,6 +85,19 @@ const CLIP_COLORS = [
 
 const clipKey = (trackIndex: number, sceneIndex: number) => `${trackIndex}:${sceneIndex}`;
 
+/** Clip colour comes from Live's palette when the parser decoded one; the
+ *  position-derived CLIP_COLORS entry is only a fallback now. Colour is how a
+ *  performer navigates a grid at speed, so a set should look like itself. */
+const clipStyle = (clip: DawClip, fallback: string): string =>
+  clip.color ? 'border text-black' : fallback;
+
+/** Tooltip that names WHY a clip can't play, instead of a bare clip name and an
+ *  anonymous "N clips could not be played" banner. */
+const clipTitle = (clip: DawClip): string => {
+  if (isPlayableClip(clip)) return clip.name;
+  return `${clip.name} — sample not found. Relink it in Live, or open the set from its Project folder.`;
+};
+
 const dbToVolume = (db: number): number => {
   if (!Number.isFinite(db)) return 1;
   return Math.min(1, Math.max(0, 10 ** (db / 20)));
@@ -124,9 +144,101 @@ const stopSessionPlayers = (players: SessionPlayer[]) => {
   players.forEach((player) => {
     try { player.source.onended = null; player.source.stop(); } catch { /* already stopped */ }
     try { player.source.disconnect(); } catch { /* already disconnected */ }
-    player.analyser?.disconnect();
+    // NOT the analyser: it belongs to the track's persistent FX chain and is
+    // shared by every clip on that column. Disconnecting it here would sever the
+    // column's output to the master bus for the rest of the session.
     player.gain?.disconnect();
+    player.panner?.disconnect();
   });
+};
+
+/**
+ * Build and start one clip's audio graph:
+ *   source -> gain (track vol x Sway mod x mute/solo) -> panner -> analyser -> master
+ *
+ * Everything here was previously missing. The old body was a bare
+ * `source.start(startAt)`, which meant: the whole source file played once from
+ * sample zero (ignoring the clip's trim), nothing looped, mute/solo/pan never
+ * reached the graph at all, and a loop recorded at another tempo played at its
+ * own rate so a scene drifted apart within a bar.
+ */
+const startClipPlayer = (
+  context: AudioContext,
+  opts: {
+    buffer: AudioBuffer;
+    clip: DawClip;
+    track: DawTrack;
+    trackIndex: number;
+    mixIndex: number;
+    sceneIndex: number;
+    startAt: number;
+    projectTempo: number;
+    mix?: { vol: number; mute: boolean };
+    anySolo: boolean;
+    /** Where this clip feeds: the track's FX-chain input, so an imported set's
+     *  EQ/compression/reverb is actually in the signal path. */
+    destination: AudioNode;
+    /** The TRACK's analyser (post-FX), shared by every clip on that column. */
+    analyser: AnalyserNode;
+  },
+): SessionPlayer => {
+  const { buffer, clip, track, startAt, projectTempo, mix, anySolo, destination, analyser } = opts;
+  const source = context.createBufferSource();
+  const gain = context.createGain();
+  const panner = context.createStereoPanner();
+  source.buffer = buffer;
+
+  // Warp: play the sample at the ratio between the project tempo and the tempo
+  // it was recorded at. Constant-rate, which is exactly right for the
+  // single-tempo loops a session grid is made of.
+  if (clip.is_warped && clip.source_tempo && clip.source_tempo > 0) {
+    source.playbackRate.value = projectTempo / clip.source_tempo;
+  }
+
+  // The clip is a WINDOW onto its sample: start at the trim point and run for
+  // the clip's own length, not the file's.
+  const maxOffset = Math.max(0, buffer.duration - 0.01);
+  const offset = Math.min(Math.max(0, clip.offset_into_source ?? 0), maxOffset);
+  const span = Math.max(0, (clip.end_time ?? 0) - (clip.start_time ?? 0));
+  const available = Math.max(0, buffer.duration - offset);
+  const duration = span > 0.02 ? Math.min(span, available) : available;
+
+  // Loop when Live says so. `loop_on == null` means the set didn't say, so treat
+  // it as a one-shot rather than looping material never meant to repeat.
+  if (clip.loop_on) {
+    source.loop = true;
+    source.loopStart = offset;
+    source.loopEnd = Math.min(buffer.duration, offset + (duration || available));
+  }
+
+  // Mute/solo are honoured here for the first time: a track muted in Live came
+  // back audible, and a set with any track soloed played everything.
+  const volMul = mix?.vol ?? 1;
+  const modMuted = mix?.mute ?? false;
+  const silencedBySolo = anySolo && !track.solo;
+  const audible = !track.mute && !modMuted && !silencedBySolo;
+  gain.gain.value = dbToVolume(track.volume_db) * volMul * (audible ? 1 : 0);
+  panner.pan.value = Math.max(-1, Math.min(1, track.pan ?? 0));
+
+  source.connect(gain);
+  gain.connect(panner);
+  // -> the track's FX chain (built once per column), which terminates in the
+  // shared track analyser and then the master bus.
+  panner.connect(destination);
+  // A looping source ignores `duration`; a one-shot needs it to stop at the
+  // clip's edge instead of running to the end of the file.
+  if (source.loop) source.start(startAt, offset);
+  else source.start(startAt, offset, duration || undefined);
+
+  return {
+    source,
+    gain,
+    panner,
+    analyser,
+    trackIndex: opts.trackIndex,
+    mixIndex: opts.mixIndex,
+    sceneIndex: opts.sceneIndex,
+  };
 };
 
 interface DawSessionGridProps {
@@ -136,6 +248,12 @@ interface DawSessionGridProps {
 
 export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = false }) => {
   const [activeScene, setActiveScene] = React.useState<number | null>(null);
+  /** Which scene each column is currently playing, keyed by mixIndex. A single
+   *  scalar activeScene could not represent Live's core move — holding a
+   *  bassline while changing drums — so per-clip launch needs this. */
+  const [trackScenes, setTrackScenes] = React.useState<Record<number, number>>({});
+  /** Launch quantization in bars; 0 = launch immediately. */
+  const [quantizeBars, setQuantizeBars] = React.useState(1);
   const [selectedScene, setSelectedScene] = React.useState(0);
   const [launchError, setLaunchError] = React.useState<string | null>(null);
   const [lastAction, setLastAction] = React.useState<string | null>(null);
@@ -185,12 +303,127 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
     setTrackLevels(Array.from({ length: tracks.length }, () => 0));
   }, [tracks.length]);
 
+  /* --- Per-track FX chains -------------------------------------------------
+     Perform playback used to be completely dry: `grep device` over this file
+     returned nothing, so an imported set's EQ, compression and reverb were
+     parsed, mapped by dawEffectMap, and then never instantiated. Only the
+     .tasmo conversion path ever called dawDeviceToEffectNode.
+
+     One persistent chain per column, built lazily and reused across launches
+     (rebuilding per clip would re-generate reverb IRs on every cell press). The
+     chain terminates in the track's analyser, so metering is post-FX and every
+     clip on a column shares one meter.
+
+     Instruments are skipped at connect time rather than filtered out of
+     track.devices — swayImportResolve.ts indexes fxChain by the FLATTENED device
+     order, so removing elements would silently misalign controller mappings. */
+  const trackChainsRef = React.useRef<
+    Map<number, { input: GainNode; output: GainNode; analyser: AnalyserNode; handle: ChainHandle | null }>
+  >(new Map());
+
+  const ensureTrackChain = React.useCallback(
+    (mixIndex: number, track: DawTrack) => {
+      const existing = trackChainsRef.current.get(mixIndex);
+      if (existing) return existing;
+      const context = getEngineCtx();
+      const input = context.createGain();
+      const output = context.createGain();
+      const analyser = context.createAnalyser();
+      analyser.fftSize = 512;
+      analyser.smoothingTimeConstant = 0.62;
+      output.connect(analyser);
+      analyser.connect(getMasterGain());
+
+      let handle: ChainHandle | null = null;
+      const entries: ChainEntry[] = (track.devices ?? [])
+        .filter((d) => !d.is_instrument && !d.is_rack)
+        .map((d, i) => {
+          const node = dawDeviceToEffectNode(d);
+          return {
+            id: `perform-${mixIndex}-${i}`,
+            effect: node.effect_name,
+            params: node.parameters ?? {},
+            enabled: !node.bypass,
+          } as ChainEntry;
+        })
+        // VST3/AU cannot run in the live Web Audio graph (buildEffectChain only
+        // knows the rack effects), so they are inert here exactly as they are on
+        // the EDIT timeline.
+        .filter((e) => e.effect !== 'vst3');
+      try {
+        handle = buildEffectChain(context, input, output, entries);
+      } catch (e) {
+        // A chain that fails to build must not take the whole grid down —
+        // fall back to a clean passthrough.
+        logError('perform', `Track FX chain failed for "${track.name}": ${e instanceof Error ? e.message : String(e)}`);
+        try { input.connect(output); } catch { /* already wired */ }
+      }
+      const made = { input, output, analyser, handle };
+      trackChainsRef.current.set(mixIndex, made);
+      return made;
+    },
+    [],
+  );
+
+  const disposeTrackChains = React.useCallback(() => {
+    for (const c of trackChainsRef.current.values()) {
+      try { c.handle?.dispose(); } catch { /* already gone */ }
+      try { c.input.disconnect(); c.output.disconnect(); c.analyser.disconnect(); } catch { /* gone */ }
+    }
+    trackChainsRef.current = new Map();
+  }, []);
+
+  React.useEffect(() => disposeTrackChains, [disposeTrackChains]);
+
   const stopScene = React.useCallback(() => {
     stopSessionPlayers(playersRef.current);
     playersRef.current = [];
     setActiveScene(null);
+    setTrackScenes({});
     stopMeters();
   }, [stopMeters]);
+
+  /* --- Launch quantization -------------------------------------------------
+     Everything used to start at `context.currentTime + 0.01`, so launching
+     against something already playing landed permanently off the grid. A
+     session clock is set on the first launch; later launches snap to the next
+     bar line relative to it, which is what makes layering usable. The toolbar's
+     quantization control feeds `quantizeBars` ('off' = launch immediately). */
+  const sessionStartRef = React.useRef<number | null>(null);
+  const nextLaunchTime = React.useCallback(
+    (context: AudioContext): number => {
+      const now = context.currentTime + 0.01;
+      if (quantizeBars <= 0) return now;
+      const beatSec = 60 / Math.max(20, project.tempo || 120);
+      const barSec = beatSec * (project.time_signature?.[0] || 4) * quantizeBars;
+      if (sessionStartRef.current == null || playersRef.current.length === 0) {
+        sessionStartRef.current = now;
+        return now;
+      }
+      const elapsed = now - sessionStartRef.current;
+      const bars = Math.ceil(elapsed / barSec);
+      return sessionStartRef.current + bars * barSec;
+    },
+    [project.tempo, project.time_signature, quantizeBars],
+  );
+
+  /** Stop just one column, leaving everything else playing. Live puts this on
+   *  the track's stop button and on every empty clip slot. */
+  const stopTrack = React.useCallback((mixIndex: number) => {
+    const [stay, go] = playersRef.current.reduce<[SessionPlayer[], SessionPlayer[]]>(
+      (acc, p) => { acc[p.mixIndex === mixIndex ? 1 : 0].push(p); return acc; },
+      [[], []],
+    );
+    if (go.length === 0) return;
+    stopSessionPlayers(go);
+    playersRef.current = stay;
+    setTrackScenes((prev) => {
+      const next = { ...prev };
+      delete next[mixIndex];
+      return next;
+    });
+    if (stay.length === 0) setActiveScene(null);
+  }, []);
 
   React.useEffect(() => stopScene, [stopScene]);
 
@@ -231,15 +464,19 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
   React.useEffect(() => {
     let cancelled = false;
     const seen = new Set<string>();
-    const clips = tracks.flatMap((track) =>
-      track.clips.filter((clip) => {
-        if (!isPlayableClip(clip)) return false;
-        const key = clipCacheKey(clip);
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      }),
-    );
+    // Warm only clips the grid can actually LAUNCH. This iterated every clip on
+    // every track — arrangement lane included, which clipLookup can never reach —
+    // so importing a real set decoded hundreds of MB of PCM (~10.6 MB per stereo
+    // minute per clip) and locked the tab for tens of seconds, with no progress
+    // and no cancel, even for an arrangement-only set whose grid is empty.
+    // getClipBuffer memoises, so a cell outside this set costs one decode on use.
+    const clips = Array.from(clipLookup.values()).filter((clip) => {
+      if (!isPlayableClip(clip)) return false;
+      const key = clipCacheKey(clip);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
     const warm = async () => {
       for (let index = 0; index < clips.length && !cancelled; index += 2) {
         await Promise.allSettled(clips.slice(index, index + 2).map(getClipBuffer));
@@ -247,7 +484,7 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
     };
     if (clips.length > 0) void warm();
     return () => { cancelled = true; };
-  }, [getClipBuffer, tracks]);
+  }, [getClipBuffer, clipLookup]);
 
   const tickMeters = React.useCallback(() => {
     const players = playersRef.current;
@@ -265,7 +502,12 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
         sum += centered * centered;
       }
       const rms = Math.sqrt(sum / meterDataRef.current.length);
-      next[player.trackIndex] = Math.max(next[player.trackIndex] ?? 0, Math.min(1, rms * 5.5));
+      // mixIndex, not trackIndex. `next` is allocated at performTracks length,
+      // while trackIndex counts ALL tracks including return/master — so any
+      // trackIndex past the mixer columns wrote off the end of the array and the
+      // meter silently died. It only worked because Live emits returns last and
+      // the parser drops groups; admitting a group type mid-list desyncs it.
+      next[player.mixIndex] = Math.max(next[player.mixIndex] ?? 0, Math.min(1, rms * 5.5));
     });
     setTrackLevels((previous) => next.map((level, index) => Math.max(level, (previous[index] ?? 0) * 0.72)));
     setMasterLevel((previous) => {
@@ -295,7 +537,7 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
       const results = await Promise.all(
         clips.map(async ({ clip, track, trackIndex, mixIndex }) => {
           try {
-            return { ok: true as const, buffer: await getClipBuffer(clip), track, trackIndex, mixIndex };
+            return { ok: true as const, buffer: await getClipBuffer(clip), clip, track, trackIndex, mixIndex };
           } catch (e) {
             return { ok: false as const, clip, reason: e instanceof Error ? e.message : String(e) };
           }
@@ -303,40 +545,89 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
       );
       if (launchTokenRef.current !== launchToken) return;
       const decoded = results.filter(
-        (r): r is { ok: true; buffer: AudioBuffer; track: DawTrack; trackIndex: number; mixIndex: number } => r.ok,
+        (r): r is { ok: true; buffer: AudioBuffer; clip: DawClip; track: DawTrack; trackIndex: number; mixIndex: number } => r.ok,
       );
       const failedClips = results.filter((r): r is { ok: false; clip: DawClip; reason: string } => !r.ok);
       for (const f of failedClips) {
         logError('perform', `Clip "${f.clip.name}" could not play: ${f.reason}`);
       }
       const failed = failedClips.length;
-      const startAt = context.currentTime + 0.01;
-      const nextPlayers = decoded.map(({ buffer, track, trackIndex, mixIndex }) => {
-        const source = context.createBufferSource();
-        const gain = context.createGain();
-        const analyser = context.createAnalyser();
-        source.buffer = buffer;
-        analyser.fftSize = 512;
-        analyser.smoothingTimeConstant = 0.62;
-        const mix = mixRef.current.get(mixIndex);
-        const volMul = mix?.vol ?? 1;
-        const muted = mix?.mute ?? false;
-        gain.gain.value = dbToVolume(track.volume_db) * volMul * (muted ? 0 : 1);
-        source.connect(gain);
-        gain.connect(analyser);
-        analyser.connect(getMasterGain());
-        source.start(startAt);
-        return { source, gain, analyser, trackIndex, mixIndex };
-      });
+      const startAt = nextLaunchTime(context);
+      const anySolo = tracks.some((t, i) => (trackStateRef.current[i] ?? { solo: !!t.solo }).solo);
+      const nextPlayers = decoded.map(({ buffer, clip, track, trackIndex, mixIndex }) =>
+        startClipPlayer(context, {
+          buffer,
+          clip,
+          track: displayTrack(track, mixIndex),
+          trackIndex,
+          mixIndex,
+          sceneIndex,
+          startAt,
+          projectTempo: project.tempo || 120,
+          mix: mixRef.current.get(mixIndex),
+          destination: ensureTrackChain(mixIndex, track).input,
+          analyser: ensureTrackChain(mixIndex, track).analyser,
+          anySolo,
+        }),
+      );
       playersRef.current = nextPlayers;
       setActiveScene(sceneIndex);
+      setTrackScenes(Object.fromEntries(nextPlayers.map((p) => [p.mixIndex, sceneIndex])));
       startedAtRef.current = performance.now();
       if (animationRef.current == null) animationRef.current = window.requestAnimationFrame(tickMeters);
       setLaunchError(
         failed > 0 ? `${failed} of ${results.length} clip(s) could not be played.` : null,
       );
     },
-    [getClipBuffer, sceneClips, stopScene, tickMeters],
+    [getClipBuffer, sceneClips, stopScene, tickMeters, tracks, project.tempo, nextLaunchTime],
+  );
+
+  /** Launch ONE cell, leaving every other column playing — Live's core move.
+   *  Replaces the old behaviour where clicking any cell relaunched the whole
+   *  row, so there was no way to hold a bassline while changing drums. */
+  const launchClip = React.useCallback(
+    async (mixIndex: number, sceneIndex: number) => {
+      const entry = sceneClips(sceneIndex).find((c) => c.mixIndex === mixIndex);
+      if (!entry) {
+        // An empty slot IS a command in Live: it stops that track.
+        stopTrack(mixIndex);
+        return;
+      }
+      const context = getEngineCtx();
+      if (context.state === 'suspended') await context.resume();
+      let buffer: AudioBuffer;
+      try {
+        buffer = await getClipBuffer(entry.clip);
+      } catch (e) {
+        logError('perform', `Clip "${entry.clip.name}" could not play: ${e instanceof Error ? e.message : String(e)}`);
+        setLaunchError(`"${entry.clip.name}" could not be played.`);
+        return;
+      }
+      // Replace only this column's players.
+      const stay = playersRef.current.filter((p) => p.mixIndex !== mixIndex);
+      const go = playersRef.current.filter((p) => p.mixIndex === mixIndex);
+      stopSessionPlayers(go);
+      const player = startClipPlayer(context, {
+        buffer,
+        clip: entry.clip,
+        track: displayTrack(entry.track, mixIndex),
+        trackIndex: entry.trackIndex,
+        mixIndex,
+        sceneIndex,
+        startAt: nextLaunchTime(context),
+        projectTempo: project.tempo || 120,
+        mix: mixRef.current.get(mixIndex),
+        destination: ensureTrackChain(mixIndex, entry.track).input,
+        analyser: ensureTrackChain(mixIndex, entry.track).analyser,
+        anySolo: tracks.some((t, i) => (trackStateRef.current[i] ?? { solo: !!t.solo }).solo),
+      });
+      playersRef.current = [...stay, player];
+      setTrackScenes((prev) => ({ ...prev, [mixIndex]: sceneIndex }));
+      setLaunchError(null);
+      startedAtRef.current ??= performance.now();
+      if (animationRef.current == null) animationRef.current = window.requestAnimationFrame(tickMeters);
+    },
+    [getClipBuffer, nextLaunchTime, project.tempo, sceneClips, stopTrack, tickMeters, tracks],
   );
 
   // --- Live modulation from the Sway dims ------------------------------------
@@ -352,8 +643,16 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
     if (!track) return;
     const mix = mixRef.current.get(mixIndex);
     const vol = mix?.vol ?? 1;
-    const muted = mix?.mute ?? false;
-    const target = dbToVolume(track.volume_db) * vol * (muted ? 0 : 1);
+    const modMuted = mix?.mute ?? false;
+    // Fold in the track's OWN mute/solo (plus any live override from the S/M
+    // buttons). This used to consider only the Sway modulation mute, so a track
+    // muted in Live played anyway and solo did nothing at all.
+    const st = trackStateRef.current[mixIndex] ?? { mute: !!track.mute, solo: !!track.solo };
+    const anySolo = tracksRef.current.some(
+      (t, i) => (trackStateRef.current[i] ?? { solo: !!t.solo }).solo,
+    );
+    const audible = !st.mute && !modMuted && !(anySolo && !st.solo);
+    const target = dbToVolume(track.volume_db) * vol * (audible ? 1 : 0);
     const context = getEngineCtx();
     for (const player of playersRef.current) {
       if (player.mixIndex === mixIndex && player.gain) {
@@ -361,6 +660,48 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
       }
     }
   }, []);
+
+  /** Live mute/solo state per mixer column, seeded from the imported project and
+   *  then owned by the S/M buttons. A ref so the audio callbacks read it without
+   *  re-subscribing; mirrored into state purely for rendering. */
+  const trackStateRef = React.useRef<Record<number, { mute: boolean; solo: boolean }>>({});
+  const [trackStateVersion, setTrackStateVersion] = React.useState(0);
+  React.useEffect(() => {
+    trackStateRef.current = Object.fromEntries(
+      tracks.map((t, i) => [i, { mute: !!t.mute, solo: !!t.solo }]),
+    );
+    setTrackStateVersion((v) => v + 1);
+  }, [tracks]);
+
+  /** Re-apply every column: solo is a project-wide decision, so toggling one
+   *  track changes what every other track should be doing. */
+  const applyAllMix = React.useCallback(() => {
+    tracksRef.current.forEach((_, i) => applyMixToTrack(i));
+  }, [applyMixToTrack]);
+
+  const toggleTrackMute = React.useCallback((mixIndex: number) => {
+    const cur = trackStateRef.current[mixIndex] ?? { mute: false, solo: false };
+    trackStateRef.current[mixIndex] = { ...cur, mute: !cur.mute };
+    setTrackStateVersion((v) => v + 1);
+    applyAllMix();
+  }, [applyAllMix]);
+
+  const toggleTrackSolo = React.useCallback((mixIndex: number) => {
+    const cur = trackStateRef.current[mixIndex] ?? { mute: false, solo: false };
+    trackStateRef.current[mixIndex] = { ...cur, solo: !cur.solo };
+    setTrackStateVersion((v) => v + 1);
+    applyAllMix();
+  }, [applyAllMix]);
+
+  /** The track as the mixer should DISPLAY it (base project state + live S/M). */
+  const displayTrack = React.useCallback(
+    (track: DawTrack, mixIndex: number): DawTrack => {
+      void trackStateVersion; // re-read after a toggle
+      const st = trackStateRef.current[mixIndex];
+      return st ? { ...track, mute: st.mute, solo: st.solo } : track;
+    },
+    [trackStateVersion],
+  );
 
   React.useEffect(() => {
     const unsub = subscribeSwayValue((dim, value) => {
@@ -491,6 +832,24 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
 
   if (tracks.length === 0 || scenes.length === 0) return null;
 
+  // An arrangement-only Live Set still ships 8 <Scene> elements, so the header
+  // said "8 scenes / 12 tracks" and the grid below was an entirely empty wall of
+  // greyed-out cells with no explanation. Say what happened and point at the
+  // surface that DOES have the content.
+  if (clipLookup.size === 0) {
+    return (
+      <div className={`border border-white/10 bg-[#2f3238] ${fill ? 'h-full' : ''} grid place-items-center p-6`}>
+        <div className="flex flex-col items-center gap-2 text-center max-w-md">
+          <Square className="w-6 h-6 text-zinc-600" />
+          <div className="text-[11px] font-bold text-zinc-300">No session clips in this project</div>
+          <p className="text-[9px] font-mono text-zinc-500 leading-relaxed">
+            {`This set's ${tracks.length} track${tracks.length === 1 ? '' : 's'} put their clips on the arrangement timeline rather than in Session view, so there is nothing to launch here. Use “Edit Timeline” to open the arrangement.`}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   const activeSceneName = activeScene == null ? 'Stopped' : scenes[activeScene];
   const masterDb = linearToDb(masterLevel);
   const masterMeterLabel = masterDb <= -71 ? '-inf' : masterDb.toFixed(1);
@@ -499,11 +858,27 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
     <div className={`border border-white/10 bg-[#2f3238] overflow-hidden ${fill ? 'h-full flex flex-col' : ''}`}>
       <div className="shrink-0 flex items-center gap-1 border-b border-black/70 bg-[#202329] px-2 py-1 text-[10px] font-bold text-zinc-200">
         <div className="h-6 px-2 grid place-items-center border border-black/50 bg-[#15171b] text-zinc-300">
-          4 / 4
+          {/* Real time signature from the set, not a hardcoded "4 / 4". */}
+          {`${project.time_signature?.[0] ?? 4} / ${project.time_signature?.[1] ?? 4}`}
         </div>
-        <div className="h-6 px-2 grid place-items-center border border-black/50 bg-[#15171b] text-zinc-300">
-          1 Bar
-        </div>
+        {/* Launch quantization is a real control now — it used to be the literal
+            text "1 Bar" while every launch fired immediately, so layering against
+            something already playing landed permanently off the grid. */}
+        <label htmlFor="perform-quantize" className="sr-only">Launch quantization</label>
+        <select
+          id="perform-quantize"
+          name="perform-quantize"
+          value={quantizeBars}
+          onChange={(e) => setQuantizeBars(Number(e.target.value))}
+          title="Launch quantization — clips start on the next bar line so layered launches stay in time"
+          className="h-6 px-2 border border-black/50 bg-[#15171b] text-zinc-300 text-[10px] font-bold outline-none cursor-pointer"
+          style={{ colorScheme: 'dark' }}
+        >
+          <option value={0}>Off</option>
+          <option value={1}>1 Bar</option>
+          <option value={2}>2 Bars</option>
+          <option value={4}>4 Bars</option>
+        </select>
         <div className="h-6 px-2 grid place-items-center border border-black/50 bg-[#15171b] text-zinc-300">
           {project.tempo.toFixed(2)}
         </div>
@@ -631,26 +1006,37 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
                       key={`${trackIndex}-${sceneIndex}`}
                       className={[
                         'border-r-2 border-b border-black/70 min-h-7 bg-[#30343b]',
-                        activeScene === sceneIndex ? 'ring-1 ring-inset ring-emerald-200' : '',
+                        trackScenes[trackIndex] === sceneIndex ? 'ring-1 ring-inset ring-emerald-200' : '',
                       ].join(' ')}
                     >
                       {clip ? (
                         <button
                           type="button"
-                          onClick={() => selectAndLaunch(sceneIndex)}
+                          onClick={() => void launchClip(trackIndex, sceneIndex)}
                           disabled={!isPlayableClip(clip)}
+                          aria-label={`Launch ${clip.name} on ${track.name}`}
                           className={[
                             'h-7 w-full px-1.5 flex items-center gap-1 border text-left',
-                            color.clip,
+                            clipStyle(clip, color.clip),
                             !isPlayableClip(clip) ? 'opacity-45 cursor-not-allowed' : 'hover:brightness-110',
                           ].join(' ')}
-                          title={clip.name}
+                          style={clip.color ? { backgroundColor: clip.color, borderColor: clip.color } : undefined}
+                          title={clipTitle(clip)}
                         >
                           <Play className="h-3 w-3 fill-current shrink-0" />
                           <span className="min-w-0 truncate text-[10px] font-bold">{clip.name}</span>
                         </button>
                       ) : (
-                        <div className="h-7 bg-[#262a31] border border-black/20" />
+                        /* An empty slot is a STOP button in Live, not dead space. */
+                        <button
+                          type="button"
+                          onClick={() => stopTrack(trackIndex)}
+                          aria-label={`Stop ${track.name}`}
+                          title={`Stop ${track.name}`}
+                          className="h-7 w-full bg-[#262a31] border border-black/20 flex items-center justify-center text-zinc-700 hover:text-zinc-200 hover:bg-[#2f343c]"
+                        >
+                          <Square className="h-2.5 w-2.5 fill-current" />
+                        </button>
                       )}
                     </div>
                   );
@@ -680,9 +1066,12 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
           {tracks.map((track, trackIndex) => (
             <TrackMixer
               key={`mixer-${track.name}-${trackIndex}`}
-              track={track}
+              track={displayTrack(track, trackIndex)}
               trackNumber={trackIndex + 1}
               level={trackLevels[trackIndex] ?? 0}
+              mixIndex={trackIndex}
+              onToggleMute={toggleTrackMute}
+              onToggleSolo={toggleTrackSolo}
             />
           ))}
           <div className="bg-[#454a54] border-t-2 border-black/70 px-2 py-2">
@@ -718,10 +1107,20 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
   );
 };
 
-const TrackMixer: React.FC<{ track: DawTrack; trackNumber: number; level: number }> = ({
+const TrackMixer: React.FC<{
+  track: DawTrack;
+  trackNumber: number;
+  level: number;
+  mixIndex: number;
+  onToggleMute?: (mixIndex: number) => void;
+  onToggleSolo?: (mixIndex: number) => void;
+}> = ({
   track,
   trackNumber,
   level,
+  mixIndex,
+  onToggleMute,
+  onToggleSolo,
 }) => {
   const db = linearToDb(level);
   const label = db <= -71 ? '-inf' : db.toFixed(1);
@@ -752,11 +1151,28 @@ const TrackMixer: React.FC<{ track: DawTrack; trackNumber: number; level: number
           <div className="h-6 w-6 grid place-items-center bg-pink-300 text-[11px] font-black text-black">
             {trackNumber}
           </div>
+          {/* These had no onClick, no aria-label and no aria-pressed — the unmuted
+              state was a bare Headphones SVG with no accessible name at all. They
+              now reflect and drive the imported track's real state. */}
           <div className="flex gap-1">
-            <button type="button" className="h-5 w-6 bg-[#202329] text-[9px] font-bold text-zinc-300">
+            <button
+              type="button"
+              onClick={() => onToggleSolo?.(mixIndex)}
+              aria-label={`Solo ${track.name}`}
+              aria-pressed={!!track.solo}
+              title={`Solo ${track.name}`}
+              className={`h-5 w-6 text-[9px] font-bold ${track.solo ? 'bg-sky-400 text-black' : 'bg-[#202329] text-zinc-300 hover:text-white'}`}
+            >
               S
             </button>
-            <button type="button" className="h-5 w-6 bg-[#202329] text-[9px] font-bold text-zinc-300">
+            <button
+              type="button"
+              onClick={() => onToggleMute?.(mixIndex)}
+              aria-label={`${track.mute ? 'Unmute' : 'Mute'} ${track.name}`}
+              aria-pressed={!!track.mute}
+              title={`${track.mute ? 'Unmute' : 'Mute'} ${track.name}`}
+              className={`h-5 w-6 text-[9px] font-bold ${track.mute ? 'bg-amber-400 text-black' : 'bg-[#202329] text-zinc-300 hover:text-white'}`}
+            >
               {track.mute ? 'M' : <Headphones className="mx-auto h-3 w-3" />}
             </button>
           </div>

--- a/frontend/src/lib/dawImportClient.ts
+++ b/frontend/src/lib/dawImportClient.ts
@@ -16,6 +16,15 @@ export interface DawClip {
   scene_index?: number | null;
   scene_name?: string | null;
   slot_index?: number | null;
+  /** Seconds into the source file where this clip starts (its trim point). */
+  offset_into_source?: number;
+  /** Whether the clip loops when launched; null when the set didn't say. */
+  loop_on?: boolean | null;
+  /** Warping: play rate is project.tempo / source_tempo. */
+  is_warped?: boolean;
+  source_tempo?: number | null;
+  /** Clip colour as #rrggbb, decoded from Live's palette index. */
+  color?: string | null;
 }
 
 export interface DawDevice {

--- a/frontend/src/lib/dawProjectToEditor.ts
+++ b/frontend/src/lib/dawProjectToEditor.ts
@@ -133,7 +133,11 @@ export async function importDawProjectToEditor(project: DawProject): Promise<num
           audioBlob: loaded.blob,
           mimeType: loaded.mimeType,
           sourceDuration,
-          offsetIntoSource: 0,
+          // The trim point is already parsed — ableton.py stores it as the clip's
+          // loop_start (it handles the attribute, child and Loop/LoopStart forms).
+          // Hardcoding 0 here made every trimmed clip play the head of its source
+          // instead of the region the user actually kept.
+          offsetIntoSource: Math.max(0, Math.min(clip.loop_start ?? 0, Math.max(0, sourceDuration - 0.01))),
           durationSec,
           startSec,
           color: trackColor,

--- a/frontend/src/lib/dawProjectToEditor.ts
+++ b/frontend/src/lib/dawProjectToEditor.ts
@@ -39,7 +39,9 @@ const notesFromDawClip = (clip: DawClip): RenderNote[] => {
       midi,
       startSec: Math.max(0, startSec),
       durationSec: Math.max(0.02, durationSec),
-      velocity: velocityRaw <= 1 ? Math.round(velocityRaw * 127) : Math.round(velocityRaw),
+      // < 1, not <= 1: a raw value of exactly 1 is a legitimate (very quiet)
+      // MIDI velocity, and treating it as normalised 1.0 turned it into 127.
+      velocity: velocityRaw < 1 ? Math.round(velocityRaw * 127) : Math.round(velocityRaw),
     }];
   });
 };

--- a/frontend/src/lib/performModel.ts
+++ b/frontend/src/lib/performModel.ts
@@ -24,5 +24,9 @@ export const performSceneCount = (project: DawProject): number => {
 /** Scene display names, one per row, filled with "Scene N" where unnamed. */
 export const performScenes = (project: DawProject): string[] => {
   const count = performSceneCount(project);
-  return Array.from({ length: count }, (_, index) => project.scenes[index] ?? `Scene ${index + 1}`);
+  // || not ??: Ableton's parser emits an EMPTY STRING for an unnamed scene
+  // (ableton.py _parse_scenes uses .get("Value", "")), and ?? only substitutes
+  // for null/undefined — so the fallback was unreachable for every Live set and
+  // rows rendered as "01 " with a trailing space.
+  return Array.from({ length: count }, (_, index) => project.scenes[index] || `Scene ${index + 1}`);
 };

--- a/frontend/src/lib/projectClient.ts
+++ b/frontend/src/lib/projectClient.ts
@@ -89,6 +89,8 @@ export interface TasmoProjectInput {
   import_warnings?: string[];
   /** Session-view scene names in row order; empty when there is no grid. */
   scenes?: string[];
+  locators?: Array<{ id: string; name: string; position: number; color?: string | null }>;
+  source_daw_version?: string | null;
   controller_mappings?: TasmoControllerMappings | null;
   /** Perform-tab scene-launch + modulation routing (see performRouting.ts). */
   perform_routing?: PerformRoutingSnapshot | null;
@@ -140,7 +142,11 @@ export interface TasmoLoadedTrack {
 export interface TasmoProjectLoaded {
   project_name: string;
   tempo: number;
+  /** Declared so a non-4/4 set does not silently reload as 4/4. */
+  time_signature?: number[];
   sample_rate: number;
+  source_daw?: string | null;
+  source_daw_version?: string | null;
   tracks: TasmoLoadedTrack[];
   import_warnings?: string[];
   /** Session-view scene names in row order; empty when there is no grid. */
@@ -261,6 +267,11 @@ export function dawProjectToTasmo(d: DawProject): TasmoProjectInput {
     // Scene names in row order, so a saved Perform grid reloads with the
     // user's own scene names instead of a generic "Scene 1..N" ladder.
     scenes: d.scenes ?? [],
+    // TasmoProject has had locators and source_daw_version all along; nothing
+    // wrote them, so markers vanished on first save and schema-drift bugs were
+    // undiagnosable after the fact.
+    locators: (d.locators ?? []).map((l) => ({ id: uid("loc"), name: l.name, position: l.position, color: l.color ?? null })),
+    source_daw_version: d.source_version || null,
     tracks,
   };
 }

--- a/frontend/src/lib/projectClient.ts
+++ b/frontend/src/lib/projectClient.ts
@@ -57,6 +57,12 @@ export interface TasmoClipInput {
   fade_out?: number;
   /** Seconds into the source where the clip starts — the trim point. */
   offset_into_source?: number;
+  /** Session-view (Perform grid) placement; null on an arrangement clip.
+   *  Without these the format could not represent a clip-launch grid, so every
+   *  session clip was dropped on save. */
+  track_index?: number | null;
+  scene_index?: number | null;
+  slot_index?: number | null;
 }
 
 export interface TasmoTrackInput {
@@ -81,6 +87,8 @@ export interface TasmoProjectInput {
   tracks?: TasmoTrackInput[];
   source_daw?: string | null;
   import_warnings?: string[];
+  /** Session-view scene names in row order; empty when there is no grid. */
+  scenes?: string[];
   controller_mappings?: TasmoControllerMappings | null;
   /** Perform-tab scene-launch + modulation routing (see performRouting.ts). */
   perform_routing?: PerformRoutingSnapshot | null;
@@ -107,6 +115,12 @@ export interface TasmoLoadedClip {
   fade_out?: number;
   /** Seconds into the source where the clip starts — the trim point. */
   offset_into_source?: number;
+  /** Session-view (Perform grid) placement; null on an arrangement clip.
+   *  Without these the format could not represent a clip-launch grid, so every
+   *  session clip was dropped on save. */
+  track_index?: number | null;
+  scene_index?: number | null;
+  slot_index?: number | null;
 }
 
 export interface TasmoLoadedTrack {
@@ -129,6 +143,8 @@ export interface TasmoProjectLoaded {
   sample_rate: number;
   tracks: TasmoLoadedTrack[];
   import_warnings?: string[];
+  /** Session-view scene names in row order; empty when there is no grid. */
+  scenes?: string[];
   controller_mappings?: TasmoControllerMappings | null;
   perform_routing?: PerformRoutingSnapshot | null;
 }
@@ -204,9 +220,14 @@ export function dawProjectToTasmo(d: DawProject): TasmoProjectInput {
       pan: t.pan,
       mute: t.mute,
       solo: t.solo,
-      // Session-grid clips (scene_index set) are for the Session tab only; the
-      // EDIT timeline / .tasmo uses just the arrangement lane, unchanged.
-      clips: (t.clips ?? []).filter((c) => c.scene_index == null).map((c) => ({
+      // Session (Perform grid) clips are saved ALONGSIDE arrangement clips and
+      // told apart by their scene indices — they used to be filtered out here,
+      // which silently discarded the entire clip-launch grid on save. Worse, the
+      // Perform tab's own .tasmo path stamps scene_index on EVERY clip
+      // (tasmoToSession.ts), so opening a .tasmo in Perform and saving wrote a
+      // project with ZERO clips over the user's file. The EDIT timeline filters
+      // session clips out on LOAD instead, which is where that belongs.
+      clips: (t.clips ?? []).map((c) => ({
         id: uid('c'),
         name: c.name,
         // Per-clip type: a clip with notes is MIDI even on an "audio" track.
@@ -218,6 +239,11 @@ export function dawProjectToTasmo(d: DawProject): TasmoProjectInput {
         midi_notes: c.midi_notes ?? null,
         loop_start: c.loop_start ?? null,
         loop_end: c.loop_end ?? null,
+        // Carry the grid placement so the Perform tab can be restored exactly
+        // rather than rebuilt from arrangement clips.
+        track_index: c.track_index ?? null,
+        scene_index: c.scene_index ?? null,
+        slot_index: c.slot_index ?? null,
       })),
       // Map the track's device chain into theDAW effect nodes (VST3 -> real,
       // creative FX -> rack, EQ/comp/reverb -> preserved). Order is kept.
@@ -232,6 +258,9 @@ export function dawProjectToTasmo(d: DawProject): TasmoProjectInput {
     sample_rate: d.sample_rate,
     source_daw: d.source_daw,
     import_warnings: d.warnings,
+    // Scene names in row order, so a saved Perform grid reloads with the
+    // user's own scene names instead of a generic "Scene 1..N" ladder.
+    scenes: d.scenes ?? [],
     tracks,
   };
 }

--- a/frontend/src/lib/projectImport.ts
+++ b/frontend/src/lib/projectImport.ts
@@ -292,6 +292,12 @@ export async function loadProjectIntoEditor(
       fxChain: fxChain.length ? fxChain : undefined,
     });
     for (const c of t.clips || []) {
+      // Session (Perform grid) clips live in the same clips array now that the
+      // format can represent them, but they are NOT arrangement content — they
+      // belong to the clip-launch grid and would otherwise all pile onto the
+      // EDIT timeline. Filtering on LOAD is the correct place for this; it used
+      // to happen on SAVE, which deleted them from the file outright.
+      if (c.scene_index != null || c.slot_index != null) continue;
       try {
         const clip = await buildClip(c, trackId, color, bpm);
         if (clip) outClips.push(clip);

--- a/frontend/src/lib/tasmoToSession.ts
+++ b/frontend/src/lib/tasmoToSession.ts
@@ -1,7 +1,9 @@
 // Convert a loaded .tasmo project into a DawProject the Session grid can render,
 // so theDAW's own saved projects open in the Session tab alongside Ableton sets.
 //
-// A .tasmo has no session-view scenes, so each track's clips are laid into scene
+// A .tasmo saved FROM a session grid carries real scene indices and scene names,
+// and those are restored verbatim. Only a project with no grid of its own (an
+// arrangement-only .tasmo) falls back to laying each track's clips into scene
 // rows in start-time order (track = column, clip = scene row). Audio clips keep
 // their absolute on-disk path (the load step relinks embedded audio to disk, and
 // /api/project/clip-audio serves any absolute path — see dawImportClient's
@@ -16,7 +18,11 @@ export function tasmoLoadedToDawProject(loaded: TasmoProjectLoaded): DawProject 
   const stepSec = 60 / Math.max(40, bpm) / 4; // one 16th-note step in seconds
 
   const tracks: DawTrack[] = loaded.tracks.map((t, ti) => {
-    const sorted = [...t.clips].sort((a, b) => (a.start_time ?? 0) - (b.start_time ?? 0));
+    // A file written from a real grid already knows where every clip goes.
+    const hasGrid = t.clips.some((c) => c.scene_index != null || c.slot_index != null);
+    const sorted = hasGrid
+      ? [...t.clips]
+      : [...t.clips].sort((a, b) => (a.start_time ?? 0) - (b.start_time ?? 0));
     const clips: DawClip[] = sorted.map((c, ci) => {
       const isMidi =
         c.clip_type === 'midi' && Array.isArray(c.midi_notes) && c.midi_notes.length > 0;
@@ -33,9 +39,9 @@ export function tasmoLoadedToDawProject(loaded: TasmoProjectLoaded): DawProject 
               velocity: Number(n.velocity ?? 100),
             }))
           : null,
-        track_index: ti,
-        scene_index: ci,
-        slot_index: ci,
+        track_index: c.track_index ?? ti,
+        scene_index: c.scene_index ?? (hasGrid ? null : ci),
+        slot_index: c.slot_index ?? (hasGrid ? null : ci),
         scene_name: null,
       };
     });
@@ -62,7 +68,7 @@ export function tasmoLoadedToDawProject(loaded: TasmoProjectLoaded): DawProject 
     tracks,
     locators: [],
     controller_mappings: [],
-    scenes: [],
+    scenes: loaded.scenes ?? [],
     plugins_used: [],
     warnings: [],
     missing_files: [],

--- a/frontend/src/lib/tasmoToSession.ts
+++ b/frontend/src/lib/tasmoToSession.ts
@@ -63,7 +63,7 @@ export function tasmoLoadedToDawProject(loaded: TasmoProjectLoaded): DawProject 
     source_version: '',
     name: loaded.project_name || 'theDAW Project',
     tempo: bpm,
-    time_signature: [4, 4],
+    time_signature: (loaded.time_signature?.length === 2 ? loaded.time_signature : [4, 4]) as [number, number],
     sample_rate: loaded.sample_rate || 44100,
     tracks,
     locators: [],

--- a/frontend/src/views/SessionView.tsx
+++ b/frontend/src/views/SessionView.tsx
@@ -269,8 +269,15 @@ export const SessionView: React.FC = () => {
       )}
 
       <div className="flex-1 min-h-0 p-2">
+        {/* DawSessionGrid is keyed on project identity: it holds a decoded-buffer
+            cache and per-track refs that are NOT cleared between imports, so
+            without a remount a second import inherits the first one's audio. */}
         {project ? (
-          <DawSessionGrid project={project} fill />
+          <DawSessionGrid
+            key={`${project.source_daw}:${project.name}:${project.tracks.length}`}
+            project={project}
+            fill
+          />
         ) : (
           <div className="h-full rounded border border-dashed border-white/10 bg-black/15 grid place-items-center">
             <div className="flex flex-col items-center gap-2 text-center">

--- a/frontend/src/views/SessionView.tsx
+++ b/frontend/src/views/SessionView.tsx
@@ -259,6 +259,29 @@ export const SessionView: React.FC = () => {
               {warning}
             </div>
           ))}
+          {/* Samples the importer could not resolve. The parser has always
+              collected these, and nothing rendered them — so a Library/Pack-heavy
+              set imported "successfully" with a full grid that played nothing and
+              named no file. Capped + scrollable: a relocated project can miss
+              hundreds, and this strip has no height limit of its own. */}
+          {project && project.missing_files.length > 0 && (
+            <div className="flex flex-col gap-0.5 max-h-24 overflow-y-auto">
+              <div className="flex items-start gap-1.5 text-[8px] font-mono text-amber-200">
+                <AlertTriangle className="w-3 h-3 text-amber-300 shrink-0 mt-px" />
+                {`${project.missing_files.length} sample${project.missing_files.length === 1 ? '' : 's'} could not be found — those clips will not play. Relink them in Live, or open the set from its Project folder.`}
+              </div>
+              {project.missing_files.slice(0, 40).map((file, index) => (
+                <div key={index} className="pl-4 text-[8px] font-mono text-amber-100/60 truncate" title={file}>
+                  {file}
+                </div>
+              ))}
+              {project.missing_files.length > 40 && (
+                <div className="pl-4 text-[8px] font-mono text-amber-100/40">
+                  {`…and ${project.missing_files.length - 40} more`}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
This pull request significantly improves DAW (Digital Audio Workstation) project import fidelity, especially for Ableton Live sets, and standardizes how imported projects are finalized and serialized. The changes address longstanding issues with clip trimming, looping, warping, and color mapping, ensuring imported projects look and sound correct and are immediately usable. Additionally, the import process now consistently registers media paths to avoid silent playback errors.

Key improvements and fixes include:

**Ableton Live import fidelity:**

* Corrected the parsing of the `Solo` state to avoid misinterpreting self-closing `<Solo Value="true"/>` tags, ensuring solos are not silently dropped in future Live versions.
* Fixed session clip length and trim calculation so that clips play only their intended region, not the full source, by accurately computing `CurrentEnd - CurrentStart`.
* Added precise calculation of where a session clip starts within its source file and whether it loops, and extracted warping information (including the sample's original tempo) to support correct playback rate and looping behavior. [[1]](diffhunk://#diff-7de3d56e1f5cb10ea66b801b408648c2adc65a2d7ecd3ef3b34889f29f6c5a0eR592-R604) [[2]](diffhunk://#diff-7de3d56e1f5cb10ea66b801b408648c2adc65a2d7ecd3ef3b34889f29f6c5a0eR613-R684) [[3]](diffhunk://#diff-8158dfc2feb2137aa97cc12be0cda075fa945e7b019b2f0a6c8d87a1e166d77dR66-R81) [[4]](diffhunk://#diff-32ef33889b3a30372fed0c5b82fc5279ab9d3bbcb0a5ade12e1a076f33112183R74-R81) [[5]](diffhunk://#diff-32ef33889b3a30372fed0c5b82fc5279ab9d3bbcb0a5ade12e1a076f33112183R129-R133) [[6]](diffhunk://#diff-641ecddfea8063a916cf471d5076c428a684c9c992b137be3f000e29e8c4ca27R19-R27)
* Decoded Ableton's palette indices to actual hex colors for clips and tracks, ensuring imported sets retain their familiar visual appearance. [[1]](diffhunk://#diff-7de3d56e1f5cb10ea66b801b408648c2adc65a2d7ecd3ef3b34889f29f6c5a0eR1247-R1323) [[2]](diffhunk://#diff-7de3d56e1f5cb10ea66b801b408648c2adc65a2d7ecd3ef3b34889f29f6c5a0eL1165-R1345)

**Import process consistency and media path registration:**

* Refactored all DAW import endpoints to use a shared `_finish_import` helper, which registers all relevant media paths and collapses silent gaps, preventing 403 errors when accessing imported audio. [[1]](diffhunk://#diff-63427c77a23f9942d558089283bf8ef126d54ffc4cccf537560ef70f77cbfe77R16-R17) [[2]](diffhunk://#diff-63427c77a23f9942d558089283bf8ef126d54ffc4cccf537560ef70f77cbfe77R36-R65) [[3]](diffhunk://#diff-63427c77a23f9942d558089283bf8ef126d54ffc4cccf537560ef70f77cbfe77L77-R109) [[4]](diffhunk://#diff-63427c77a23f9942d558089283bf8ef126d54ffc4cccf537560ef70f77cbfe77L92-R123) [[5]](diffhunk://#diff-63427c77a23f9942d558089283bf8ef126d54ffc4cccf537560ef70f77cbfe77L107-R137) [[6]](diffhunk://#diff-63427c77a23f9942d558089283bf8ef126d54ffc4cccf537560ef70f77cbfe77L133-R162) [[7]](diffhunk://#diff-63427c77a23f9942d558089283bf8ef126d54ffc4cccf537560ef70f77cbfe77L148-R176) [[8]](diffhunk://#diff-63427c77a23f9942d558089283bf8ef126d54ffc4cccf537560ef70f77cbfe77L163-R190) [[9]](diffhunk://#diff-63427c77a23f9942d558089283bf8ef126d54ffc4cccf537560ef70f77cbfe77L178-R204) [[10]](diffhunk://#diff-63427c77a23f9942d558089283bf8ef126d54ffc4cccf537560ef70f77cbfe77L193-R218)

**Frontend and serialization improvements:**

* Updated the frontend and serialization models to support new fields for session grid placement, looping, warping, and color, ensuring these properties are preserved and displayed across the application. [[1]](diffhunk://#diff-32ef33889b3a30372fed0c5b82fc5279ab9d3bbcb0a5ade12e1a076f33112183R74-R81) [[2]](diffhunk://#diff-32ef33889b3a30372fed0c5b82fc5279ab9d3bbcb0a5ade12e1a076f33112183R129-R133) [[3]](diffhunk://#diff-641ecddfea8063a916cf471d5076c428a684c9c992b137be3f000e29e8c4ca27R19-R27)
* Fixed a bug in scene naming where unnamed scenes appeared as blank strings instead of "Scene N", improving grid readability.
* Corrected the calculation of `offsetIntoSource` when importing to the editor, so that trimmed clips play the correct audio region.