### PR TITLE
Add IN-THE-WORKS task list and update HANDOFF and SKIP features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,6 @@ integration-package/backend/logs/
 integration-package/backend/results/
 integration-package/backend/larsnet/pretrained_larsnet_models/
 integration-package/backend/larsnet/pretrained_larsnet_models.zip
+
+# Untracked video/marketing scripts (local working material, not part of the product).
+video-scripts/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+Shipped and verified work. An item lands here when it leaves
+[IN-THE-WORKS.md](IN-THE-WORKS.md) — the user called it done, or it was verified
+by build, test, or observed behaviour.
+
+Newest first.
+
+## 2026-08-26
+
+### Ableton `.als` import
+
+- **Imported projects can actually play.** No importer registered its project's
+  media with `media_access`, so every clip fetch returned 403 and the Perform
+  grid rendered correctly and played silence. Because media roots persist to
+  disk, the same set was silent on a clean install and worked afterwards if any
+  earlier save had touched that folder — the source of the "it's inconsistent"
+  report. All nine importers now register the source folder and every clip path.
+- **Saving from Perform no longer destroys the project file.** It wrote zero
+  clips: `tasmoToSession` stamps a scene index on every clip and the save path
+  filtered exactly those out (and `0 == null` is false, so even row 0 went).
+- **`.tasmo` can represent a clip-launch grid.** Added scene/slot/track placement
+  to `Clip` and a `scenes` list to `TasmoProject`; an 8×6 grid used to reload as
+  an 8×1 "Scene 1" ladder. Legacy files still validate. The session-clip filter
+  moved from save to load.
+- **Session clips honour their trim, loop, and warp.** Length is now
+  `CurrentEnd - CurrentStart` with the trim carried as an offset; `<Loop><LoopOn>`
+  is read; `<IsWarped>` plus warp markers give the sample's own tempo so loops
+  recorded at different BPMs stay together.
+- **Live's colour palette is decoded** — the parser emitted the literal string
+  `"index:26"`, which the grid ignored and the editor accepted as valid CSS.
+- **Dead tempo XPath fixed.** The primary lookup missed in every real Live Set
+  and time signature had no Live-12 `<MainTrack>` coverage, so a 6/8 project
+  silently parsed as 4/4.
+- **Frozen tracks no longer bleed into the arrangement** — an unscoped clip-slot
+  walk reached `<FreezeSequencer>` and imported "FROZEN RENDER" as content.
+- Solo parsing no longer depends on a falsy-Element footgun; MIDI velocity of
+  exactly 1 is no longer inflated to 127; time signature, locators and source
+  version now survive a save.
+
+### Perform tab
+
+- **Per-clip launch and per-track stop.** Every cell used to fire the whole row,
+  so there was no way to hold a bassline while changing drums. Empty slots are
+  stop buttons, as in Live.
+- **Mute, solo and pan reach the audio graph** for the first time — there was no
+  panner at all, and gain folded in only the Sway modulation mute. The S/M
+  buttons now work and carry ARIA state.
+- **Real launch quantization.** "1 Bar" was literal text while every launch fired
+  immediately; the time signature was the literal "4 / 4".
+- **Playback runs through the imported device chains** — the grid had zero device
+  references, so an imported mix was completely dry. Metering moved post-FX.
+- Missing samples are named instead of failing anonymously; an arrangement-only
+  set explains itself instead of rendering a wall of dead cells; prefetch warms
+  only launchable clips instead of decoding the whole project.
+
+### EDIT tab
+
+- **Clip add/delete no longer kills the transport.** `playEditorTimeline` closed
+  over `clips.length`, so its identity changed on every edit and tore down the
+  mixer mid-playback; `dispose()` never cleared `isPlaying`, leaving the footer
+  stuck on Pause forever. The attach effect is now mount-only.
+- **Trimmed clips survive a save.** `offset_into_source` was never persisted while
+  the full untrimmed source was embedded, so a split vocal reloaded at the right
+  position and length playing the wrong words.
+- **Ctrl+D no longer corrupts the document** — duplicates reused the source clip's
+  id, so two clips shared one id and every later update hit both.
+- **Coordinate-space fix.** The shell applies CSS `zoom`, so pointer maths mixed
+  viewport and local pixels: every seek, split point, loop edge, marker drop and
+  drag read short, and clip drags picked the wrong lane.
+- **Unsaved-changes guard**: a dirty flag, a `beforeunload` prompt and Ctrl+S.
+- **Real pause** — Space and the transport button rewound to zero.
+- **Per-clip gain**, applied identically live and in all three offline bounces,
+  and persisted.
+- **Editing additions**: clip clipboard, split at playhead, grid nudge,
+  cross-track move, select-all, zoom-to-fit, follow-playhead, vertical zoom,
+  a 13-division snap grid with triplets and dotted, BPM field and tap tempo,
+  per-track VST3 inserts, and a `?` shortcut overlay.
+- **LUFS meter reads the programme, not the monitor.** The listening fader was at
+  the head of the graph, so turning the speakers down lowered the reading; it now
+  sits last, with metering tapped post-FX and pre-monitor.
+- **MIDI**: split clips no longer play the pattern twice; an instrument assigned
+  after insert no longer plays one sound and exports another; live MIDI runs
+  through the track's fader, pan, inserts and master rack instead of bypassing
+  the mixer.
+- Master VST freeze sends its captured plugin state instead of rendering at
+  factory defaults; DAW-imported MIDI is no longer silent; empty-timeline clicks
+  deselect; double-clicking a fader returns it to unity instead of silence;
+  the delay's Mix control crossfades like every other wet/dry.
+- `navigate('edit')` opens EDIT — it mapped to MIX, so the arrangement workspace
+  was unreachable by name and the assistant could not open the tab it drives.
+
+### SwayCommand
+
+- **New SWAY tab** embedding the SwayCommand cockpit, served at `/sway-app` and
+  shown in a same-origin iframe (cross-origin freezes its rAF transport clock
+  when hidden).
+- **Electron kept in lockstep**: main-process route, dev proxy, packaging
+  resources, and `fetch:sway` wired into every dist chain — it was defined but
+  never called, so a built installer would have shipped without the cockpit.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,8 +1,45 @@
 # Handoff
 
-Branch: `dev/audit-p0-notation-2026-08`. Read `docs/BACKLOG.md` first. It is the source of truth:
-106 audited items plus user-requested additions, stable permanent ids, priority and effort on every
-line.
+Branch: `dev/audit-p0-notation-2026-08`.
+
+Read `docs/IN-THE-WORKS.md` first. It is the ACTIVE QUEUE: what we decided to do next, in priority
+order, every item carrying a `file:line` so it can be picked up cold. An item leaves it only when
+the user says done or it is verified by build, test, or observed behaviour, and lands in
+`docs/CHANGELOG.md` on the way out.
+
+`docs/BACKLOG.md` remains the long-lived inventory: 106 audited items plus user-requested
+additions, stable permanent ids, priority and effort on every line. Do not duplicate a BACKLOG id
+into IN-THE-WORKS; reference the id.
+
+## Session 2026-08-26 — what just landed
+
+Three audits ran (EDIT tab, Ableton `.als` import, a 7-agent sweep of the other tabs). Findings were
+adversarially verified before any fix. Everything shipped is in `docs/CHANGELOG.md`; everything
+outstanding is in `docs/IN-THE-WORKS.md`. Headlines:
+
+- EDIT transport no longer dies on clip add/delete, trimmed clips survive a save, Ctrl+D no longer
+  corrupts the document, and the coordinate-space bug under the shell's CSS `zoom` is fixed.
+- Ableton import: imported media is now allowlisted (nothing played before), saving from Perform no
+  longer writes zero clips over the user's file, and `.tasmo` can finally represent a clip grid.
+- Perform: per-clip launch, per-track stop, looping, warp, mute/solo/pan, launch quantization, and
+  the imported device chains are all live.
+- New SWAY tab embedding the SwayCommand cockpit, with Electron kept in lockstep.
+
+**Top of the queue** is the `activeView` cluster (IN-THE-WORKS P0). `activeView` is never written by
+the tab bar, so the footer's main action button fires a generation on the EDIT tab, and one
+assistant `navigate("train")` turns it into a dead TRAIN button for the rest of the session.
+
+## Video scripts and clip capture
+
+`video-scripts/` is UNTRACKED (gitignored) and holds four scripts plus a capture plan, each with a
+rendered PDF. Two are promotional, two are product walkthroughs written as ordered shot lists.
+`video-scripts/make-pdfs.mjs` regenerates every PDF from the Markdown.
+
+`video-scripts/CAPTURE-PLAN.md` is the shoot plan. The harness already exists at
+`frontend/_capture_clips.mjs` (65 scenes, one warm session, one continuous recording sliced
+afterwards). A `SKIP=` env var was added alongside the existing `ONLY=` so the model-dependent
+scenes can be excluded without listing the other 58. A scene that throws is logged into
+`showcase/clips-recorded/_capture-log.json` and the run continues.
 
 ## Where things stand
 
@@ -41,7 +78,16 @@ Do not mark any of these done without running them.
 - **React 19 StrictMode is on in dev.** It has already caused one shipped bug (a blob URL revoked by
   a cleanup the remount reused). Every effect must survive mount, cleanup, remount.
 - **The shell applies CSS `zoom` on `.dense-layout`.** `getBoundingClientRect()` returns scaled
-  values. Use `frontend/src/lib/canvasScale.ts`, do not redo the arithmetic.
+  values. Use `frontend/src/lib/canvasScale.ts`, do not redo the arithmetic. This bit the EDIT
+  timeline's pointer maths: `clientX` is viewport px while `scrollLeft` is local px, so every seek,
+  split point and drag read short. Fixed 2026-08-26; the same trap applies to any new gesture.
+- **A message produced is not a message shown.** The commonest defect in this codebase by a wide
+  margin. DJ alone builds 15 status/error strings that no component renders; MIX, VJ, Underfit and
+  the settings modal all do the same. Before claiming a failure path works, find the component that
+  renders it.
+- **Dead state is everywhere.** `activeView`, `trainingStore`, `midiIgnoreStore`, the assistant's
+  whole approval stack, `djSamplerStore` pad options. A store field with no writer, or an action
+  with no caller, reads as a working feature. Grep for the caller before trusting it.
 - **Licences are permissive only.** MIT, BSD, Apache, ISC, OFL. verovio and svglib were removed for
   being LGPL. Do not reintroduce copyleft.
 - **Never downgrade a model id, library or API version.** The stack is newer than a model's training

--- a/docs/IN-THE-WORKS.md
+++ b/docs/IN-THE-WORKS.md
@@ -1,0 +1,135 @@
+# In The Works
+
+The running list of what we are going to do. Read this before starting work.
+
+Distinct from [BACKLOG.md](BACKLOG.md): the backlog is the long-lived,
+id-stable inventory of everything known to be wrong. **This** file is the active
+queue — the things we have decided to do next, in order, with enough evidence
+attached to start immediately.
+
+## How to use this doc
+
+- **Items leave only when done.** "Done" means the user said so, or it was
+  verified — build, tests, or observed behaviour. Editing a file is not done.
+- **On removal, add a line to [CHANGELOG.md](CHANGELOG.md).** Nothing is deleted
+  silently.
+- **Every item carries a `file:line`.** An item without evidence cannot be picked
+  up cold, which defeats the point of the list.
+- **Effort** is XS (<2h), S (half day), M (1–3 days), L (1–2 weeks), XL (multi-week).
+- New findings get appended to the right section as they are discovered.
+- If an item already has a permanent BACKLOG id, reference the id rather than
+  restating it here.
+
+Sources: the EDIT-tab audit, the Ableton `.als` import audit, and the tab sweep
+(2026-08-26). Findings were adversarially verified before landing here.
+
+---
+
+## P0 — breaks the app's primary action
+
+- [ ] **Footer CREATE/PROCESS/TRAIN button is driven by `activeView`, which the tab bar never writes.** Every writer sets it to `'create'`, so on EDIT the footer button fires a text-to-audio generation instead of processing the arrangement. The same stale field means `inEditorMode` is never true (footer PLAY never triggers the editor render path) and the assistant is always told the user is on CREATE. — M — `frontend/src/components/layout/ProcessingLog.tsx:316`, `frontend/src/components/audio/PlayerFooter.tsx:84`, `frontend/src/orb-kit/appContext.ts:58`
+- [ ] **One assistant `navigate("train")` permanently bricks CREATE.** Sets `activeView='train'`; nothing resets it, so the footer stays a red TRAIN button on every tab for the session — and TRAIN posts to a hard 501. — S — `frontend/src/components/layout/ProcessingLog.tsx:316`, `frontend/src/state/appUiStore.ts:39`
+- [ ] **The assistant's entire confirmation/approval stack is dead code.** `pendingAction` is read and cleared but never assigned; `orb-kit/tool-tiers.ts` and `state/assistantBridgeStore.ts` have zero importers. Every tool call — including `generate` (spends GPU) and `abort` (kills a job) — executes ungated. — M — `frontend/src/orb-kit/AssistantPanel.tsx:1011`
+- [ ] **ABORT is client-side only.** No cancel route exists; the job finishes on the GPU, writes artifacts to the library, and holds `_generation_job_lock` so the next CREATE queues behind it. — M — `frontend/src/state/generateStore.ts:807`
+- [ ] **Footer CREATE silently runs local SA3 when Suno/Lyria is selected**, then labels the SA3 result with the cloud model's name. — S — `frontend/src/components/layout/ProcessingLog.tsx:370`
+
+## P1 — user-visible defects
+
+### Feedback that never reaches the user
+
+> The single most common failure in this codebase: a message is produced and never rendered.
+
+- [ ] **DJ: 15 distinct status/error messages are produced and never rendered** — bad file drop, "create a set first", BPM out of range, sync/eject confirmations. All read as buttons that do nothing. — XS — `frontend/src/views/DJView.tsx:561`
+- [ ] **MIX: PROCESS CHAIN fails with zero visible feedback** — no toast, no log, nothing. — S
+- [ ] **MAKE: empty-prompt CREATE is a silent no-op** — the `error` field is rendered by no component. — XS — `frontend/src/state/generateStore.ts:457`
+- [ ] **MAKE: Magenta's actionable setup message is swallowed into "HTTP 412"** — `detail` is a dict, the unwrapper only handles strings. — XS — `backend/modules/magenta/router.py:265`
+- [ ] **Underfit: "Start Underfit" discards the backend's precise 503 diagnosis**; the same panel returns forever. — XS — `frontend/src/views/UnderfitView.tsx:102`
+- [ ] **VJ: failure path is a 40-second silent retry then a bare message**; the backend's reason is discarded and the `detail` state is never rendered. SwayView does this correctly. — XS — `frontend/src/views/VJView.tsx:296`
+- [ ] **Settings: a failed PATCH is swallowed** — toggles appear saved and silently revert. — S — `frontend/src/state/featureToggleStore.ts:177`
+
+### Dead controls and dead state
+
+- [ ] **DJ: MIDI "Ignore" buttons persist to localStorage and are never consulted.** — XS — `frontend/src/state/midiIgnoreStore.ts:99`
+- [ ] **DJ: `DeckRack` (~180 lines) is defined and never rendered** — including the only Abort button, so a running stem separation cannot be cancelled. — M — `frontend/src/views/DJView.tsx:1414`
+- [ ] **DJ: "Send to DJ" automix handoff has no consumer**; `pendingStart` is write-only. — S — `frontend/src/state/djAutomixStore.ts:52`
+- [ ] **DJ: automix never beatmatches** — the `setInterval` captures a stale `syncDeck` closure. — S — `frontend/src/views/DJView.tsx:987`
+- [ ] **DJ: sampler per-pad gain / loop / choke are dead state** — `setPadOpts` has no caller. — S — `frontend/src/state/djSamplerStore.ts:23`
+- [ ] **MAKE: the `DL` auto-download toggle has no consumer** — nothing is ever downloaded. — XS — `frontend/src/views/AdvancedGenPanel.tsx:1077`
+- [ ] **Underfit: `trainingStore` is dead state** — no writer for the payload, no callers for 6 of 9 actions (~250 lines). — M — `frontend/src/state/trainingStore.ts:105`
+- [ ] **`thedaw:set-left-panel` has three dispatchers and no listener**; the assistant reports success anyway. — XS — `frontend/src/orb-kit/actionHandlers.ts:108`
+- [ ] **Assistant navigate reaches only 3 of 12 workspaces** — the backend tool enum still lists retired legacy view names; unknown tabs no-op while the handler returns "Navigated to X". — S — `backend/assistant_routes.py:1400`
+- [ ] **Assistant quick-commands advertise features that do not exist** ("Trending", "Full Sync", "discovery radio") — leftovers from a different product. — XS — `frontend/src/orb-kit/AssistantPanel.tsx:65`
+- [ ] **Media bucket "Send to INIT" navigates to a view that does not exist** (`'generate'`). — XS — `frontend/src/components/layout/MediaBucketView.tsx:111`
+
+### Wrong output
+
+- [ ] **MIX: the rack is applied twice to the processed output you audition.** — S
+- [ ] **MIX: "Send to Edit" sends nothing.** — S
+- [ ] **Library: bulk "Download → MIDI" always 404s** (wrong id space — the route wants a midis-row id). — S — `frontend/src/views/LibraryView.tsx:1322`
+- [ ] **Audimate: the Effect node 400s on first run** — displayed params are never stored, and the default node cannot be fixed without switching effect away and back. — S — `frontend/src/lib/audimateTypes.ts:148`
+- [ ] **Audimate: wires can never be deleted** — `removeEdge` has no caller and the edge layer is `pointer-events-none`. — S — `frontend/src/state/audimateStore.ts:133`
+- [ ] **LEARN: node menu "Open lineage rooted here" / "Open in Library" silently no-op** whenever the library rail is closed (the default on a fresh install). — S — `frontend/src/components/library/LineageModal.tsx:3365`
+- [ ] **LEARN: the Track tab fetches a 4-hop lineage and renders 1 hop.** — M — `frontend/src/components/library/LineageModal.tsx:762`
+- [ ] **MAKE: the seed actually used is never captured** — default-seed takes are unreproducible, filenames emit `seed_-1`, metadata records `-1`. — M — `backend/server.py:1620`
+- [ ] **DJ: transport pads are live during decode**, so the first PLAY press silently does nothing. — S — `frontend/src/views/DJView.tsx:343`
+- [ ] **MAKE: `RF-Inv` is an exposed option that guarantees a 501.** — S — `backend/server.py:390`
+- [ ] **Underfit: the port is hardcoded to `8791`** while the live port is fetched and displayed right above the Start button. — XS — `frontend/src/views/UnderfitView.tsx:20`
+
+### Sway / VJ
+
+- [ ] **The Sway DAW-control toggle arbitrates nothing** — one pad fires theDAW's synth AND the cockpit; auto-enabled by default for exactly this hardware. — S — `frontend/src/views/SwayView.tsx:195`
+- [ ] **While VJ is popped out (the headline live mode) every inbound message is discarded** — the SET chip spins forever, export errors vanish. — S — `frontend/src/views/VJView.tsx:224`
+- [ ] **The staged SwayCommand build ignores `sway/visibility`** — the host posts it, the child never reads it, so a hidden cockpit keeps rendering WebGL. — M — `frontend/src/views/SwayView.tsx:184`
+- [ ] **SWAY "Input device" does not open an input device** — visuals react to the cockpit's internal 120 BPM groove. — M — `frontend/src/views/SwayView.tsx:204`
+
+## P1 — Ableton import (remaining)
+
+- [ ] **MIDI notes are not rebased onto the loop window**, and looped regions are never expanded — notes land outside the clip; an 8-bar region over a 1-bar loop yields 1 bar and 7 of silence. — M — `backend/modules/dawimport/ableton.py:552,670`
+- [ ] **`<Disabled>` clips are unread** — a deactivated clip will sound. — XS
+- [ ] **Group tracks are dropped with no warning**; children surface as unrelated top-level tracks. — S (warning) / M (support) — `backend/modules/dawimport/ableton.py:42`
+- [ ] **Sends / returns**: return tracks import with nothing feeding them; every imported mix is dry. `send_amounts` has zero producers and zero consumers. — L (needs a bus model)
+- [ ] **Nested device parameters are invisible** — direct children only, capped at 12, so an Eq8's whole curve is lost; VST/AU params hardcoded `{}`. — M — `backend/modules/dawimport/ableton.py:935`
+- [ ] **Device parameter names are never translated** — Ableton emits `Threshold`, the rack expects `threshold`, so mapped effects instantiate at rack defaults. — M — `frontend/src/lib/dawEffectMap.ts:70`
+- [ ] **Live Library / Pack sample refs are unresolvable** — `RelativePathType`, `SearchHint`, CRC all unread. — M
+- [ ] **`media_status` on `DawClip`** — `resolve_audio` returns the same shape for a hit and a miss, so no caller can distinguish resolved / relinked / missing. — M — `backend/modules/dawimport/media.py:102`
+- [ ] **`performRouting` leaks between projects** — globally persisted, keyed by bare track index, `hydrate` only called on the `.tasmo` path. — S — `frontend/src/state/performRouting.ts:96`
+- [ ] **Automation envelopes and tempo map** — zero grep hits. Tempo automation is the dangerous subset: it makes every clip, locator and note progressively wrong down the timeline. — XL
+- [ ] **No `.als` fixture in the test suite** — coverage is `assert callable(parse_als)`. Commit the synthetic-set builders used during the audit. — M — `tests/test_vst_daw_tasmo.py:152`
+
+## P1 — EDIT (remaining)
+
+- [ ] **`.tasmo` still drops automation lanes, master FX and master VST chains** — the backend model already validates automation and locators; nothing writes them. — M
+- [ ] **Export is one hardcoded 16-bit WAV.** `/api/edit/delivery` is a complete loudness/dither/SRC/6-codec backend with zero frontend callers. Blocked on extracting `renderRange()` out of `commitEdit`, which is also the prerequisite for stem export and region-regenerate. — M
+- [ ] **Live MIDI reverb/chorus still bypasses the track chain** — dry signal routes correctly; output 0 is a shared effects bus. — M
+- [ ] **Automation lanes can only be born by riding a control with WRITE armed**; no curve shapes, no hold. — M
+- [ ] **No per-track metering or master fader in EDIT.** — M
+
+## P2 — larger builds
+
+- [ ] **Autosave and crash recovery** via a content-addressed OPFS asset layer. Clip audio is in-memory Blobs; a refresh destroys the arrangement. The dirty flag + `beforeunload` + Ctrl+S guard is in place as interim insurance. — L
+- [ ] **Tempo map and time-signature model.** BPM + tap tempo shipped; a bars/beats ruler is M, a real tempo map is L. — M–L
+- [ ] **Buses**: sends, returns, groups, sidechain. `liveMixer` hard-codes every track's destination and there is no seam. — XL
+- [ ] **Recording at the playhead**: armed-track targeting, punch, takes. Gated on the transport fix (already landed). — XL
+- [ ] **Marquee / time-range selection and ripple edit.** — L
+- [ ] **LoRA training endpoints are hard 501 stubs behind a live TRAIN button**; real training only exists in the vendored Underfit sidecar. — M — `backend/server.py:1945`
+- [ ] **Underfit's upstream updater is fully implemented in the backend with zero frontend callers.** — S — `backend/modules/underfit/router.py:72`
+
+## P2 — frontier (uniquely enabled by the resident model)
+
+- [ ] **Generative extend / continue** — drag a clip's edge past its source and the model writes the continuation. Needs no backend change: `CAUSAL_MASK` is already a trained mask type and the server accepts `inpaint_audio` plus bounds. — M
+- [ ] **Clip variation ladder (SDEdit re-roll with a strength dial)** — `init_audio` + `init_noise_level` are already on the wire; EDIT sends neither. — M
+- [ ] **Stem separation on a timeline clip → explode to tracks** — the Demucs sidecar exists, keyed only on library entries. — M
+- [ ] **SAME latent workspace** — `/api/autoencoder/encode`, `/decode` and `/api/jobs/pre-encode` are 501 stubs. — L
+- [ ] **Non-destructive generative lineage** — record `{parent, prompt, mask, seed, model, LoRA, strength}` per clip. The schema already waits: `Clip.generation_prompt` / `generation_seed` / `generation_params` are unwritten. — M
+- [ ] **Agentic assistant with a real `editor.*` tool vocabulary** — three of four layers exist; the model is architecturally blind because `buildtheDAWAppContext` never reports a track, clip, playhead or selection. Gated on the P0 approval-stack and navigate items. — L
+
+## Deliberately not doing
+
+Recorded so they are not re-proposed:
+
+- Full plugin delay compensation — no lookahead processor exists in the rack; VST3 cannot run live.
+- MIDI clock / Ableton Link / MTC — no hardware-sync workflow in the app; Link has no browser implementation.
+- Take lanes / comping — needs non-uniform per-track heights, which `editorStore` documents as a deliberate deferral.
+- Real-time multiplayer CRDT editing — gated on the asset layer, and EDIT unmounts on tab switch.
+- Neural restoration marketed as such — SA3 is not a super-resolution model; it hallucinates rather than restores.
+- A bespoke export/encode DSP layer — `/api/edit/delivery` and `/api/convert/file` already do this properly.

--- a/frontend/_capture_clips.mjs
+++ b/frontend/_capture_clips.mjs
@@ -438,12 +438,12 @@ async function applyScene(spec) {
   return { tracks: editor.getState().tracks.length, clips: editor.getState().clips.length, playing: player.getState().isPlaying, log };
 }
 
-const onlyIds = (process.env.ONLY || '').split(',').filter(Boolean);
+const onlyIds = (process.env.ONLY || '').split(',').map((s) => s.trim()).filter(Boolean);
 // SKIP is the inverse of ONLY, for "capture everything except these". Needed for
 // a no-GPU pass: the handful of scenes that run a real model are excluded, and
 // listing the ~58 that remain in ONLY would be unreadable. SKIP applies after
 // ONLY, so the two compose.
-const skipIds = (process.env.SKIP || '').split(',').filter(Boolean);
+const skipIds = (process.env.SKIP || '').split(',').map((s) => s.trim()).filter(Boolean);
 const VJ_SOURCE = path.join(OUT, '_vjsource.mp4');
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const clickByTitle = (page, re) => page.evaluate((src) => { const rx = new RegExp(src, 'i'); const b = [...document.querySelectorAll('button')].find((x) => rx.test(x.getAttribute('title') || '')); if (b) b.click(); }, re.source).catch(() => {});

--- a/frontend/_capture_clips.mjs
+++ b/frontend/_capture_clips.mjs
@@ -14,6 +14,11 @@
 //
 // Run from frontend/:  node _capture_clips.mjs        (all scenes)
 //                      ONLY=20_train,02_dj-console node _capture_clips.mjs
+//                      SKIP=72_crispr-dna,74_magenta-live-generate node _capture_clips.mjs
+//
+// A scene that throws is logged into _capture-log.json with its error and the
+// run CONTINUES — the recording is one continuous take sliced afterwards, so a
+// failed scene costs only its own clip, never the session.
 // Output: showcase/clips-recorded/<id>_h.mp4  (+ the raw session webm, kept for re-slicing)
 import { chromium } from 'playwright';
 import path from 'node:path';
@@ -434,6 +439,11 @@ async function applyScene(spec) {
 }
 
 const onlyIds = (process.env.ONLY || '').split(',').filter(Boolean);
+// SKIP is the inverse of ONLY, for "capture everything except these". Needed for
+// a no-GPU pass: the handful of scenes that run a real model are excluded, and
+// listing the ~58 that remain in ONLY would be unreadable. SKIP applies after
+// ONLY, so the two compose.
+const skipIds = (process.env.SKIP || '').split(',').filter(Boolean);
 const VJ_SOURCE = path.join(OUT, '_vjsource.mp4');
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const clickByTitle = (page, re) => page.evaluate((src) => { const rx = new RegExp(src, 'i'); const b = [...document.querySelectorAll('button')].find((x) => rx.test(x.getAttribute('title') || '')); if (b) b.click(); }, re.source).catch(() => {});
@@ -945,7 +955,9 @@ const tRec = Date.now();       // recording starts at context/page creation → 
                                // the boot duration and lands scene 1 inside the splash.)
 page.on('filechooser', (fc) => { fc.setFiles(VJ_SOURCE).catch(() => {}); });
 
-const scenes = onlyIds.length ? SCENES.filter((s) => onlyIds.includes(s.id)) : SCENES;
+const scenes = (onlyIds.length ? SCENES.filter((s) => onlyIds.includes(s.id)) : SCENES)
+  .filter((s) => !skipIds.includes(s.id));
+if (skipIds.length) console.log('skipping:', skipIds.join(', '));
 const marks = [];
 const results = [];
 


### PR DESCRIPTION
This pull request introduces a new workflow for tracking shipped and in-progress work, clarifies the audit process, and documents key recent fixes and outstanding issues. It adds a comprehensive `CHANGELOG.md` for shipped features, a live `IN-THE-WORKS.md` queue for active work, and updates `HANDOFF.md` to reflect the new process. It also improves documentation for video script capture and clarifies several persistent codebase pitfalls.

**Key changes:**

### Workflow and Documentation Overhaul

* Added `docs/CHANGELOG.md` to log all shipped and verified work, with detailed entries for the 2026-08-26 release covering major fixes and features in Ableton `.als` import, Perform, and EDIT tabs, and the new SwayCommand cockpit.
* Introduced `docs/IN-THE-WORKS.md` as the active, evidence-backed queue of work in progress, with clear policies for item lifecycle and removal.
* Updated `docs/HANDOFF.md` to point to `IN-THE-WORKS.md` as the active queue and `CHANGELOG.md` for shipped work, and to clarify the audit process and session outcomes.

### Audit Findings and Developer Guidance

* Documented the results of three audits (EDIT tab, Ableton import, tab sweep), listing what shipped and what remains, and highlighted the top-priority issue with the `activeView` state breaking the app's main action. [[1]](diffhunk://#diff-711bab18dc013939fec7a1fb0ac87c69c4cb157fda80909aa689136e64d74837L3-R42) [[2]](diffhunk://#diff-1025e13f51b1ffe9c0ada802f907427bf925bbba82db6b5d80c25088756cd753R1-R135)
* Expanded the persistent pitfalls section in `HANDOFF.md` to emphasize the prevalence of dead state, messages produced but never rendered, and coordinate-space bugs under CSS zoom, with concrete recent examples and fixes.

### Video Script and Clip Capture Process

* Documented the video script and clip capture workflow, including the new `SKIP=` environment variable for scene selection and robust error logging that allows the capture run to continue after a scene fails. [[1]](diffhunk://#diff-711bab18dc013939fec7a1fb0ac87c69c4cb157fda80909aa689136e64d74837L3-R42) [[2]](diffhunk://#diff-f3c618525034da4aa9d59fe1925084e92d94f6561629d5f148c30479edf94d59R17-R21)

**Encoded references:** [[1]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bR1-R100) [[2]](diffhunk://#diff-1025e13f51b1ffe9c0ada802f907427bf925bbba82db6b5d80c25088756cd753R1-R135) [[3]](diffhunk://#diff-711bab18dc013939fec7a1fb0ac87c69c4cb157fda80909aa689136e64d74837L3-R42) [[4]](diffhunk://#diff-711bab18dc013939fec7a1fb0ac87c69c4cb157fda80909aa689136e64d74837L44-R90) [[5]](diffhunk://#diff-f3c618525034da4aa9d59fe1925084e92d94f6561629d5f148c30479edf94d59R17-R21)