### PR TITLE
Sway/Perform integration, SwayCommand deck, boot cinematic, orb rework

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,50 @@ Newest first.
 
 ## 2026-08-26
 
+### Sway / Perform (second session)
+
+- **A plugged-in Sway is seen by theDAW.** Master MIDI gate now defaults ON
+  (persisted-store v2 migrate flips existing installs); theDAW holds the only
+  `requestMIDIAccess()` and relays to the SwayCommand cockpit, so the old OFF
+  default made hardware invisible here while standalone worked. Verified: relay
+  traffic in the cockpit, playable.
+- **SwayCommand embed splash tells the truth about MIDI.** Its `available`
+  getter ignored relay mode and reported "WebMIDI unavailable" while relayed
+  CCs played. Fixed in the staged bundle, re-applied on every
+  `fetch:sway` (BUNDLE_PATCHES), and upstream in the SwayCommand source.
+- **PERFORM auto-routes projects built for the Sway.** `.als` MIDI-learn
+  mappings become direct CC→mix routes on load; dim-named mappings seed
+  bindings; SwayCommand's factory CC map ships as overridable defaults
+  (learned > project > factory). Verified against the DNB template (110
+  mappings parsed, routes live, deck animating).
+- **The SwayCommand deck is PERFORM's assignment surface** — verbatim port of
+  `surface.js`, collapsible; pads→scenes (chromatic notes), knobs/XY/gestures→
+  volume/mute/any live FX-chain param (`handle.updateParams`), buttons→
+  transport by learn. SWAY tab reduced to the cockpit alone.
+- **Perform header: icons only.** One Open (imports on pick/Enter/recent), one
+  Save (.tasmo); detected-DAW, warnings and missing-samples are hover badges;
+  the InfiNight credit is an info icon; footer strip removed.
+
+### Boot, orb, capture (second session)
+
+- **Boot cinematic**: full-window goo sheet + wordmark in the orb's exact
+  wet-obsidian material (mirror stays a mirror — visibility comes from
+  forward-hemisphere light angles and the bright room env on the sheet); the
+  wordmark sinks into and rises out of the sheet; credits gated on formation
+  (theDAW → by → GANTASMO). Verified by screenshot at three boot phases.
+- **Orb**: 112px (−30%), all rings/halos gone, ferrofluid from the first
+  visible frame (mounts post-boot), sticky bottom-left corner surviving
+  resizes until first drag, ~2.4× slower idle cycles, footer tip bubble
+  (operational tips, greeting dwell, never truncates, fixed width so the
+  now-playing block stops jumping) replacing G-Search; Ctrl-K opens the
+  library rail.
+- **Capture harness**: video/wall-ratio slicing (fixes the one-scene-early
+  drift on long takes), stamped per-run session files (a fixed name destroyed
+  a finished take once), bounded + concurrent stem loading (285s→17s to first
+  hold), `data-boot-splash` wait, monitor pinning + CDP fullscreen, six new
+  tab scenes, driven TOUR map/routing. 67 clips reshot at 1920×1080.
+
+
 ### Ableton `.als` import
 
 - **Imported projects can actually play.** No importer registered its project's

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -11,7 +11,51 @@ the user says done or it is verified by build, test, or observed behaviour, and 
 additions, stable permanent ids, priority and effort on every line. Do not duplicate a BACKLOG id
 into IN-THE-WORKS; reference the id.
 
-## Session 2026-08-26 — what just landed
+## Session 2026-08-26 (second session) — what just landed
+
+The video shoot, the boot cinematic, the assistant orb, and the Sway/Perform integration. Verified
+items are in `docs/CHANGELOG.md` under this date; the open remainder was appended to
+`docs/IN-THE-WORKS.md`. Headlines:
+
+- **The Sway works in theDAW now.** Root cause: the master MIDI gate defaulted OFF and theDAW owns
+  the only `requestMIDIAccess()`, so the relay to the embedded SwayCommand cockpit never started
+  (`frontend/src/state/midiTriggerStore.ts`, persisted v2 migrate flips existing installs ON). The
+  cockpit's splash also lied about it (`available` ignored relay mode) — fixed in the staged bundle,
+  in `electron-ui/scripts/fetch-sway-build.mjs` (BUNDLE_PATCHES re-applies on every fetch), and
+  upstream in the SwayCommand source checkout.
+- **PERFORM auto-routes Sway-designed sets.** An imported `.als` carrying MIDI-learn mappings
+  creates direct CC→mix routes on load and seeds the six dim bindings; the factory CC layout from
+  SwayCommand's `swaymap.js` ships as overridable defaults (authority: learned > project > factory)
+  (`frontend/src/state/performRouting.ts`, `frontend/src/state/swayBus.ts`). Verified against the
+  D:\sway DNB template: 110 mappings parsed, volume routes live.
+- **The SwayCommand deck schematic is PERFORM's assignment surface** — `surface.js` ported verbatim
+  (`frontend/src/components/session/swaydeck/`), collapsible, click a pad/knob/XY/gesture/button to
+  assign scenes, volume, mute, any live FX-chain parameter, or transport
+  (`frontend/src/components/session/SwayDeck.tsx`). SWAY tab itself is now the cockpit only.
+- **Perform header is one row of icons** (one Open that imports on pick, one Save to `.tasmo`);
+  detection/hints/warnings collapsed into hover badges (`frontend/src/views/SessionView.tsx`).
+- **Boot cinematic rebuilt**: full-window black-goo sheet and the wordmark share the assistant orb's
+  exact wet-obsidian material; the logo dissolves INTO the sheet and rises out of it; credits are
+  gated on formation so the order is theDAW → by → GANTASMO
+  (`frontend/src/components/layout/LiquidChromeTitle.tsx`).
+- **Orb**: 30% smaller (112px), every ring/halo removed, ferrofluid from first visible frame,
+  welded bottom-left across resizes until first drag (`stickCorner`), slower idle, and a tip bubble
+  in the footer where G-Search was — Ctrl-K now opens the library rail
+  (`frontend/src/orb-kit/react/GantasmoOrb.tsx`, `frontend/src/components/audio/OrbTipBubble.tsx`).
+- **Capture harness hardened** (`frontend/_capture_clips.mjs`): slice marks rescaled by the
+  measured video/wall ratio (long takes drifted a full scene), per-run `_session-<stamp>.webm`
+  (a fixed name got overwritten once — a completed take was destroyed), bounded fetch/decode with
+  concurrent stem loading (285s → 17s), `data-boot-splash` wait, CAPX/CAPY monitor pinning +
+  CDP fullscreen, six new tab scenes incl. driven TOUR map/routing. 67 clips reshot; showcase cuts
+  live on gitignored paths under `showcase/`.
+- **Test loop**: `frontend/_testwin.mjs` keeps one persistent CDP-debuggable window on :9223;
+  `frontend/_probe.mjs` attaches for checks without relaunching. Drive assertions through the UI —
+  vite HMR gives `page.evaluate` dynamic imports a parallel module instance (stores diverge).
+- **Library healed**: hero entry's stems/MIDI/notation rows rebuilt in
+  `data/generations/library.db` and 2,848 rows repointed from a dead `D:` drive to `G:` (runtime
+  data, not in git).
+
+## Session 2026-08-26 (first session) — what landed earlier
 
 Three audits ran (EDIT tab, Ableton `.als` import, a 7-agent sweep of the other tabs). Findings were
 adversarially verified before any fix. Everything shipped is in `docs/CHANGELOG.md`; everything

--- a/docs/IN-THE-WORKS.md
+++ b/docs/IN-THE-WORKS.md
@@ -133,3 +133,19 @@ Recorded so they are not re-proposed:
 - Real-time multiplayer CRDT editing — gated on the asset layer, and EDIT unmounts on tab switch.
 - Neural restoration marketed as such — SA3 is not a super-resolution model; it hallucinates rather than restores.
 - A bespoke export/encode DSP layer — `/api/edit/delivery` and `/api/convert/file` already do this properly.
+
+## Added 2026-08-26 (second session)
+
+### P1
+
+- [ ] **Perform: 108 of the DNB set's 110 Sway mappings do nothing in PERFORM.** Auto-routing only lifts mixer/volume-named mappings into the mix; the device-FX mappings (DryWet/On/macros) resolve to the editor, not the Perform grid's live chains. Route `target_kind==='device'` mappings onto the grid chains via CcMod `fx` (plumbing exists — the deck already creates fx CcMods by hand). — M — `frontend/src/state/performRouting.ts:243`, `frontend/src/components/session/DawSessionGrid.tsx:713`
+- [ ] **Audimate canvas cursor offset — node ends don't match the pointer.** `screenToWorld` ignores the shell's CSS `zoom` (the same class of bug the EDIT audit fixed with `effectiveZoom`). — S — `frontend/src/views/AudimateView.tsx:234`
+- [ ] **Theme picker: selection happens under the dark overlay, so theme colors can't be judged; several themes have unreadable popups.** Drop the scrim while the picker is open, then contrast-audit every theme's overlays/popups. — M — `frontend/src/components/menu/ThemeModal.tsx:1`, `frontend/src/lib/editThemes.ts:1`
+
+### P2
+
+- [ ] **Boot: sequence the emergence** — still sheet → vibration ramps in → ONE cymatic pattern forms → the wordmark plops forward; today the waves run continuously while it rises. Also verify the GANTASMO logo no longer clips at reveal, and kill the orb's window/mask look outside the corner. — S — `frontend/src/components/layout/LiquidChromeTitle.tsx:200`, `frontend/src/components/layout/LoadingScreen.tsx:78`
+- [ ] **Audimate: standard node-editor/synth tools** (multi-select, box-select, duplicate, delete key, undo, zoom-to-fit, param inspector). — L — `frontend/src/views/AudimateView.tsx:1`
+- [ ] **Lower-panel toggles should read as part of the footer, with the panel emerging from those buttons.** — M — `frontend/src/components/audio/PlayerFooter.tsx:217`
+- [ ] **`.swayproj` import** (binary format, D:\sway examples; strings confirm the six dims + grid modes). — M — `backend/modules/library/router.py:1`
+- [ ] **Sway deck buttons have no factory CC/note map** (SwayCommand doesn't define one) — learn-only today; capture a hardware monitor session and pin them. — XS — `frontend/src/components/session/swaydeck/deckState.ts:13`

--- a/electron-ui/scripts/fetch-sway-build.mjs
+++ b/electron-ui/scripts/fetch-sway-build.mjs
@@ -26,7 +26,7 @@
 // Run:  node scripts/fetch-sway-build.mjs      (npm run fetch:sway)
 
 import { execFileSync } from 'node:child_process'
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -73,6 +73,45 @@ function resolveCheckout() {
   return null
 }
 
+// Known-bug patches applied to the staged bundle after every fetch, so pulling
+// a fresh build cannot silently reintroduce them. Each entry must match EXACTLY
+// once; zero matches means upstream fixed it (log + skip), more than once means
+// the bundle changed shape (fail loudly rather than patch blind).
+//
+// available(): in embed mode the cockpit never requests its own MIDIAccess (the
+// host relays raw bytes over postMessage), so `n` stays null and the splash's
+// MIDI row reported "WebMIDI unavailable" forever — while relayed MIDI was
+// audibly playing. `l` is the in-iframe/embed flag in the same scope; embed IS
+// available by construction. Fixed upstream in SwayCommand this stays a no-op.
+const BUNDLE_PATCHES = [
+  {
+    reason: 'embed splash: MIDI row must reflect the host relay, not the absent local MIDIAccess',
+    find: 'supported:c,get available(){return!!n}',
+    replace: 'supported:c,get available(){return l||!!n}',
+  },
+]
+
+function patchStagedBundle() {
+  const bundlePath = join(stageDir, 'embed.bundle.js')
+  if (!existsSync(bundlePath)) return
+  let js = readFileSync(bundlePath, 'utf8')
+  let applied = 0
+  for (const p of BUNDLE_PATCHES) {
+    const n = js.split(p.find).length - 1
+    if (n === 0) {
+      console.log(`[fetch-sway] patch not needed (fixed upstream?): ${p.reason}`)
+      continue
+    }
+    if (n > 1) fail(`bundle patch matched ${n} times, expected 1: ${p.reason}`)
+    js = js.replace(p.find, p.replace)
+    applied += 1
+  }
+  if (applied) {
+    writeFileSync(bundlePath, js, 'utf8')
+    console.log(`[fetch-sway] applied ${applied} bundle patch(es)`)
+  }
+}
+
 function stage(builtDir, provenance) {
   if (!existsSync(join(builtDir, 'index.html'))) {
     fail(`${builtDir} has no index.html - the embed build did not produce a servable bundle.`)
@@ -80,6 +119,7 @@ function stage(builtDir, provenance) {
   rmSync(stageDir, { recursive: true, force: true })
   mkdirSync(dirname(stageDir), { recursive: true })
   cpSync(builtDir, stageDir, { recursive: true })
+  patchStagedBundle()
   // Stamp provenance so a stale artifact is a readable version in the SWAY tab
   // rather than a mystery cockpit that is missing a scene. The backend reads
   // this via sidecar.read_build_stamp().

--- a/frontend/_capture_clips.mjs
+++ b/frontend/_capture_clips.mjs
@@ -92,6 +92,19 @@ const SCENES = [
   // ── VJ / TRAIN ──
   { id: '19_vj-visualizer',  tab: 'vj',    play: true,  vjClip: true, vjTour: true, hold: 12 },
   { id: '20_train',          tab: 'train', play: false, hold: 6 },
+  // ── the center tabs the original 65-scene list predates. CENTER_TABS is the
+  // source of truth for these ids (appUiStore.ts) — note PERFORM is 'session',
+  // and 'train' above is an ALIAS that already resolves to 'underfit', so
+  // 20_train and 81_underfit shoot the same workspace from different entry
+  // points. All are React.lazy chunks: sceneActions waits out the Suspense
+  // fallback before the hold so the clip is the view, not "loading…". ──
+  { id: '78_perform-session', tab: 'session',  play: true,  performUse: true,  hold: 9 },
+  { id: '79_sway-surface',    tab: 'sway',     play: true,  swayUse: true,     hold: 13 },
+  { id: '80_foundry',         tab: 'foundry',  play: false, foundryUse: true,  hold: 12 },
+  { id: '81_underfit',        tab: 'underfit', play: false, underfitUse: true, hold: 10 },
+  { id: '82_audimate',        tab: 'audimate', play: true,  audimateUse: true, hold: 12 },
+  { id: '83_tour',            tab: 'tour',     play: false, tourMap: true,   hold: 10 },
+  { id: '84_tour-routing',    tab: 'tour',     play: false, tourRoutes: true, hold: 11 },
   // ── LEARN: 2D click-a-node, 3D fly-around, per-track lineage ──
   { id: '01a_learn-2d-hero', tab: 'learn', play: false, learn: '2d', lineageFull: true, lineageHover: true, hold: 48 },
   { id: '01b_learn-3d-hero', tab: 'learn', play: false, learn: '3d', lineageFull: true, flyAround: true, hold: 13 },
@@ -164,6 +177,14 @@ const CX = Math.round(VW / 2), CY = Math.round(VH / 2), KX = VW / 1920, KY = VH 
 async function applyScene(spec) {
   const log = [];
   const imp = (p) => import(p);
+  // Nothing in here may await unbounded. page.evaluate has no timeout, so a single
+  // stalled fetch/decode hangs the WHOLE take: the run stops mid-scene, the marks
+  // are only written after the last scene, and the session recording keeps rolling
+  // on a frozen frame. Every network + Web Audio await below is wrapped in this.
+  const withTimeout = (p, ms, what) => Promise.race([
+    p,
+    new Promise((_, rej) => setTimeout(() => rej(new Error('timeout ' + ms + 'ms: ' + what)), ms)),
+  ]);
   const C = (window.__cap = window.__cap || {});
   const appUi = (await imp('/src/state/appUiStore.ts')).useAppUiStore;
   const lib = (await imp('/src/state/libraryStore.ts')).useLibraryStore;
@@ -179,7 +200,7 @@ async function applyScene(spec) {
     try { if (lib.getState().entries.length === 0) await lib.getState().load(); } catch (e) { log.push('lib ' + e.message); }
     try { const c = pMod.getEngineCtx && pMod.getEngineCtx(); if (c && c.resume) await c.resume(); } catch (e) {}
     try {
-      const blob = await (await fetch(spec.heroUrl)).blob();
+      const blob = await withTimeout((await fetch(spec.heroUrl)).blob(), 30000, 'fetch hero');
       await player.getState().load(blob, { label: spec.heroLabel, entryId: spec.heroId });
       C.heroLoaded = true;
     } catch (e) { log.push('hero ' + e.message); }
@@ -196,10 +217,29 @@ async function applyScene(spec) {
     const plan = { drums: [0, 22, 30], bass: [0, 22, 30], other: [3, 19, 35], vocals: [6, 16, 40] };
     let idx = 0;
     const firstIds = [];
-    for (const s of spec.stems) {
+    // Fetch + decode every stem CONCURRENTLY, then build the tracks in list order.
+    // Serially this cost ~4.5 minutes of the take: each stem is ~28 MB / 160 s and
+    // streams through the vite dev proxy at well under a MB/s, and the slowest one
+    // blew its timeout and got dropped from the arrangement entirely. The build loop
+    // below is unchanged and still runs in order, so the result is deterministic.
+    // computePeaks spins up its own AudioContext per stem; both legs stay bounded so
+    // a stem that will not load is dropped rather than taking the session down.
+    const grab = async (url, what) => {
+      const blob = await withTimeout((await fetch(url)).blob(), 90000, 'fetch ' + what);
+      const { peaks, duration } = await withTimeout(computePeaks(blob, 240), 60000, 'decode ' + what);
+      return { blob, peaks, duration };
+    };
+    // deckB is kicked off here rather than after the loop so it rides along with the
+    // stems instead of adding another serial ~50 s leg of its own.
+    const deckBPromise = grab(spec.deckB.url, 'deckB').catch((e) => { log.push('import-track ' + e.message); return null; });
+    const loaded = await Promise.all(spec.stems.map(async (s) => {
+      try { return { s, ...(await grab(s.url, s.name)) }; }
+      catch (e) { log.push('stem ' + s.name + ' ' + e.message); return null; }
+    }));
+    for (const item of loaded) {
       try {
-        const blob = await (await fetch(s.url)).blob();
-        const { peaks, duration } = await computePeaks(blob, 240);
+        if (!item) continue;              // dropped stem — idx still advances below
+        const { s, blob, peaks, duration } = item;
         const [st, dur, off] = plan[s.name] || [idx * 2, 18, 30];
         const tracks = editor.getState().tracks;
         let trackId;
@@ -213,13 +253,14 @@ async function applyScene(spec) {
         });
         editor.getState().cachePeaks(clipId, peaks);
         firstIds.push(clipId);
-      } catch (e) { log.push('stem ' + s.name + ' ' + e.message); }
+      } catch (e) { log.push('stem build ' + e.message); }
       idx++;
     }
     // a 5th track with a DIFFERENT source (an imported clip) for source variety
     try {
-      const b2 = await (await fetch(spec.deckB.url)).blob();
-      const { peaks, duration } = await computePeaks(b2, 240);
+      const db = await deckBPromise;
+      if (!db) throw new Error('deckB unavailable');
+      const { blob: b2, peaks, duration } = db;
       const tId = editor.getState().addTrack({ name: 'import', color: palette[4] });
       const cId = editor.getState().addClipToTrack({
         trackId: tId, label: 'import', audioBlob: b2, mimeType: 'audio/wav',
@@ -264,7 +305,7 @@ async function applyScene(spec) {
     } catch (e) { log.push('studio ' + e.message); }
   }
   if (spec.fillBucket && !C.bucketFilled) {
-    try { const mb = (await imp('/src/state/mediaBucketStore.ts')).useMediaBucketStore; const b = await (await fetch(spec.heroUrl)).blob(); mb.getState().add(new File([b], 'Et-Tu-Machina.wav', { type: 'audio/wav' })); C.bucketFilled = true; } catch (e) { log.push('bucket ' + e.message); }
+    try { const mb = (await imp('/src/state/mediaBucketStore.ts')).useMediaBucketStore; const b = await withTimeout((await fetch(spec.heroUrl)).blob(), 30000, 'fetch hero/bucket'); mb.getState().add(new File([b], 'Et-Tu-Machina.wav', { type: 'audio/wav' })); C.bucketFilled = true; } catch (e) { log.push('bucket ' + e.message); }
   }
 
   // ── per-scene UI state (fully specified every time) ──
@@ -290,7 +331,7 @@ async function applyScene(spec) {
         gp.getState().setField('magSeed', 42);
       } catch (e) { log.push('magcond ' + e.message); }
     }
-    if (!C.srcFile) { const b = await (await fetch(spec.heroUrl)).blob(); C.srcFile = new File([b], 'et-tu-machina.wav', { type: 'audio/wav' }); }
+    if (!C.srcFile) { const b = await withTimeout((await fetch(spec.heroUrl)).blob(), 30000, 'fetch hero/src'); C.srcFile = new File([b], 'et-tu-machina.wav', { type: 'audio/wav' }); }
     if (spec.inpaint) {
       gp.getState().setField('initAudioFile', C.srcFile);
       gp.getState().setField('inpaintAudioFile', C.srcFile);
@@ -307,7 +348,7 @@ async function applyScene(spec) {
     // stack, and 72_crispr-dna needs a fresh rebuild long after 23_chimera ran.
     if (spec.chimeraBuild && gp.getState().chimera.clips.length === 0) {
       const srcs = [{ u: spec.heroUrl, l: 'Et Tu Machina' }, { u: spec.stems[0].url, l: 'Drums' }, { u: spec.stems[2].url, l: 'Vocals' }];
-      for (const s of srcs) { try { const b = await (await fetch(s.u)).blob(); gp.getState().addChimeraClip({ blob: b, mimeType: 'audio/wav', label: s.l }); } catch (e) { log.push('chimera ' + e.message); } }
+      for (const s of srcs) { try { const b = await withTimeout((await fetch(s.u)).blob(), 30000, 'fetch chimera ' + s.l); gp.getState().addChimeraClip({ blob: b, mimeType: 'audio/wav', label: s.l }); } catch (e) { log.push('chimera ' + e.message); } }
       try { gp.getState().setChimeraField('targetBpm', 124); gp.getState().setChimeraField('alignMode', 'weave'); } catch (e) {}
       C.chimeraBuilt = true;
     } else if (!spec.chimeraBuild) {
@@ -463,17 +504,100 @@ async function realClickByTitle(page, re, nth = 0) {
 }
 
 const waitSplashGone = (page) => page.waitForFunction(() => {
-  // LoadingScreen unmounts (AnimatePresence) once the backend is ready; it is the only
-  // overlay carrying the "Stable Audio 3" wordmark. Test DOM PRESENCE, not offsetParent
-  // — position:fixed elements always report offsetParent === null, so the old check
-  // resolved instantly and the splash bled into the first clip.
-  return ![...document.querySelectorAll('.fixed.inset-0')].some((e) => /Stable Audio 3/i.test(e.textContent || ''));
-}, { timeout: 45000 }).catch(() => {});
+  // LoadingScreen unmounts (AnimatePresence) once the backend is ready AND the boot
+  // cinematic finishes. Keyed off its data-boot-splash attribute: the previous check
+  // matched the "Stable Audio 3" wordmark, which the rebrand to theDAW removed, so it
+  // matched nothing, resolved instantly, and let the splash bleed into the clips.
+  // Test DOM PRESENCE, not offsetParent — position:fixed always reports null there.
+  return !document.querySelector('[data-boot-splash]');
+}, { timeout: 60000 }).catch(() => {});
 
 // Per-scene DOM choreography that the stores can't do (graph fullscreen, analyzer
 // mode buttons, the assistant orb, the VJ source import). Runs after the view mounts.
 async function sceneActions(page, scene) {
   let err = null;
+  // Most center tabs are React.lazy chunks behind <Suspense fallback={<TabFallback/>}>,
+  // which renders a pulsing "loading…" span on first visit. Without this the whole hold
+  // can be that fallback. Resolves instantly for any tab already warmed this session.
+  await page.waitForFunction(() => ![...document.querySelectorAll('span')]
+    .some((e) => (e.textContent || '').trim() === 'loading…' && e.getClientRects().length),
+    { timeout: 25000 }).catch(() => {});
+  // ── the newer workspaces, driven rather than merely opened ──────────────────
+  // A tab held static only proves it exists. Each of these clicks the controls that
+  // are the point of the workspace, so the clip shows what the tab actually DOES.
+  const clickNth = (re, n) => page.evaluate(([src, idx]) => {
+    const rx = new RegExp(src, 'i');
+    const hits = [...document.querySelectorAll('button')]
+      .filter((b) => rx.test((b.textContent || '').trim()) && b.getClientRects().length);
+    if (hits[idx]) hits[idx].click();
+  }, [re.source, n]).catch(() => {});
+  const setSelect = (key, idx) => page.evaluate(([k, n]) => {
+    const s = document.querySelector(`#${k}, [name="${k}"], [id="${k}"]`);
+    if (s && s.options && s.options.length > n) {
+      s.selectedIndex = n;
+      s.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }, [key, idx]).catch(() => {});
+
+  if (scene.swayUse) {
+    // SWAY maps gestures and body pose onto parameters: arm MIDI, then re-route
+    // several gesture and pose slots and put two of them into learn mode.
+    await clickByText(page, /enable midi/i); await sleep(700);
+    for (const [k, n] of [['sway-route-strike', 1], ['sway-route-sway', 2], ['sway-route-pulse', 1],
+                          ['pose-route-handLeft', 1], ['pose-route-handRight', 2],
+                          ['pose-route-armSpan', 1], ['sway-pad-mode', 1]]) {
+      await setSelect(k, n); await sleep(520);
+    }
+    await clickNth(/^learn$/i, 0); await sleep(900);
+    await clickNth(/^learn$/i, 2); await sleep(900);
+  }
+  if (scene.foundryUse) {
+    // FOUNDRY hosts plugin front-ends: load one design, then the other.
+    await clickByText(page, /senpai/i); await sleep(2600);
+    await clickByText(page, /kouhai/i); await sleep(2600);
+    await clickByText(page, /senpai/i); await sleep(1500);
+  }
+  if (scene.underfitUse) {
+    await clickByText(page, /start underfit/i); await sleep(3500);
+  }
+  if (scene.audimateUse) {
+    // AUDIMATE is a node graph — build one out of the palette, then run it.
+    for (const label of [/^library$/i, /^generate$/i, /^effect$/i, /merge \/ mix/i, /^feedback$/i, /^output$/i]) {
+      await clickByText(page, label); await sleep(700);
+    }
+    await clickByText(page, /^run$/i); await sleep(2200);
+  }
+  if (scene.performUse) {
+    // No .als/.tasmo ships with the repo, so drive the import affordance itself:
+    // focusing the path field opens the recent-projects list.
+    await page.click('#session-import-path', { timeout: 4000 }).catch(() => {});
+    await sleep(900);
+    await page.keyboard.type('C:\\Sets\\EtTuMachina.als', { delay: 55 }).catch(() => {});
+    await sleep(1400);
+  }
+
+  // TOUR is a venue/routing map. Held static it reads as an empty basemap, so drive
+  // it: pick a genre, run the region search, then pan and zoom so the map is visibly
+  // a map. tourRoutes goes further and opens the VENUES / ROUTES / EV panels.
+  if (scene.tourMap || scene.tourRoutes) {
+    await clickByText(page, /electronic/i);
+    await sleep(400);
+    await clickByText(page, /^\s*search\s*$/i);
+    await sleep(2200);
+    await page.mouse.move(960, 520);
+    await page.mouse.down();
+    for (let i = 0; i < 12; i += 1) { await page.mouse.move(960 - i * 14, 520 - i * 6); await sleep(40); }
+    await page.mouse.up();
+    await sleep(500);
+    await page.mouse.wheel(0, -300);
+    await sleep(900);
+  }
+  if (scene.tourRoutes) {
+    for (const label of [/venues/i, /routes/i, /\bev\b/i]) {
+      await clickByText(page, label);
+      await sleep(1800);
+    }
+  }
   if (scene.learn === '2d') {
     await clickByText(page, /genealogy/i);
     // Wait for the family-tree to actually finish loading (nodes present), not just a
@@ -946,13 +1070,54 @@ async function holdAction(page, scene) {
 
 const launchArgs = ['--autoplay-policy=no-user-gesture-required'];
 if (HEADLESS) launchArgs.push('--use-angle=gl', '--ignore-gpu-blocklist', '--enable-gpu', '--enable-webgl', '--enable-accelerated-2d-canvas');
-else launchArgs.push('--start-fullscreen', '--start-maximized');
+// Headed: CAPX/CAPY pin the window to a specific monitor so the take runs on a
+// screen nobody is using. Chrome's --window-position is in DIP of the desktop's
+// virtual space, and it is IGNORED alongside --start-fullscreen/--start-maximized,
+// so the two paths are exclusive. CAPWINW/CAPWINH size the window to that monitor;
+// the recorded viewport stays SIZE regardless (Playwright overrides device metrics),
+// so a monitor smaller than 1920x1080 still yields a 1920x1080 clip.
+else if (process.env.CAPX !== undefined || process.env.CAPY !== undefined) {
+  const wx = +(process.env.CAPX || 0), wy = +(process.env.CAPY || 0);
+  const ww = +(process.env.CAPWINW || VW), wh = +(process.env.CAPWINH || VH);
+  launchArgs.push(`--window-position=${wx},${wy}`, `--window-size=${ww},${wh}`);
+} else launchArgs.push('--start-fullscreen', '--start-maximized');
 const browser = await chromium.launch({ headless: HEADLESS, args: launchArgs });
 const ctx = await browser.newContext({ viewport: SIZE, deviceScaleFactor: DSF, recordVideo: { dir: OUT, size: REC } });
+// Playwright launches a throwaway profile, so every run looks like a genuine first
+// run: App.tsx auto-starts the onboarding tour, and on dismissing it opens the home
+// screen. Both dim the whole UI and would sit on top of all 65 clips. Seed the two
+// zustand-persist keys before any script runs so neither ever arms.
+// (Shape: zustand/middleware persist -> {state: <partialize output>, version: 0}.)
+await ctx.addInitScript(() => {
+  const seed = (k, state) => {
+    try { localStorage.setItem(k, JSON.stringify({ state, version: 0 })); } catch (e) {}
+  };
+  seed('thedaw-onboarding', { seen: true, neverShow: true });
+  seed('thedaw-home-screen-v1', { showAtStartup: false });
+});
 const page = await ctx.newPage();
 const tRec = Date.now();       // recording starts at context/page creation → this is video t=0.
                                // (Anchoring AFTER the splash wait shifts every slice earlier by
-                               // the boot duration and lands scene 1 inside the splash.)
+                               // the boot duration and lands scene 1 inside the splash. It is
+                               // taken before the fullscreen promotion below for the same reason:
+                               // that CDP round-trip would otherwise shift every slice late.)
+// True fullscreen on the pinned monitor. --start-fullscreen cannot be combined with
+// --window-position (Chrome ignores the position), so the window is placed first and
+// promoted to fullscreen afterwards over CDP. setWindowBounds rejects windowState in
+// the same call as a geometry change, hence the two calls. Purely cosmetic for the
+// operator watching — the recorded frames are SIZE either way.
+if (!HEADLESS && process.env.CAPX !== undefined && process.env.CAPFULL !== '0') {
+  try {
+    const cdp = await ctx.newCDPSession(page);
+    const { windowId } = await cdp.send('Browser.getWindowForTarget');
+    await cdp.send('Browser.setWindowBounds', { windowId, bounds: {
+      left: +(process.env.CAPX || 0), top: +(process.env.CAPY || 0),
+      width: +(process.env.CAPWINW || VW), height: +(process.env.CAPWINH || VH),
+    } });
+    await cdp.send('Browser.setWindowBounds', { windowId, bounds: { windowState: 'fullscreen' } });
+    await cdp.detach();
+  } catch (e) { console.log('fullscreen skipped:', e.message); }
+}
 page.on('filechooser', (fc) => { fc.setFiles(VJ_SOURCE).catch(() => {}); });
 
 const scenes = (onlyIds.length ? SCENES.filter((s) => onlyIds.includes(s.id)) : SCENES)
@@ -964,6 +1129,14 @@ const results = [];
 await page.goto(APP, { waitUntil: 'domcontentloaded' });
 await sleep(2600);
 await waitSplashGone(page);    // the ONLY splash wait — once, up front
+// If it is still up, the boot stalled (no backend, or the WebGL cinematic never
+// completed). LoadingScreen exposes its escape hatch at 40s / on boot error, which
+// the 60s wait above has already outlasted — take it rather than shoot the splash.
+if (await page.$('[data-boot-splash]')) {
+  console.log('splash still up after wait — taking the boot escape hatch');
+  await clickByText(page, /continue without backend/i).catch(() => {});
+  await sleep(1500);
+}
 await page.mouse.click(8, 8);
 
 for (const scene of scenes) {
@@ -994,16 +1167,39 @@ for (const scene of scenes) {
 }
 
 const video = page.video();
+const wallTotal = (Date.now() - tRec) / 1000;   // wall-clock length of the take
 await ctx.close();             // flush the recording
 await browser.close();
-const sessionWebm = path.join(OUT, '_session.webm');
+// Session file is stamped per run: overwriting a fixed name destroyed a completed
+// take once, and with it the ability to re-slice any scene without reshooting.
+const stamp = new Date(tRec).toISOString().replace(/[-:T]/g, '').slice(0, 15);
+const sessionWebm = path.join(OUT, `_session-${stamp}.webm`);
 try { const vp = await video.path(); fs.renameSync(vp, sessionWebm); } catch (e) { console.log('session rename', e.message); }
 
-// Slice the one long recording into per-scene clips (trim the transition edges).
 const { execFileSync } = await import('node:child_process');
+const probe = (f) => {
+  try {
+    return parseFloat(execFileSync('ffprobe', ['-v', 'error', '-show_entries', 'format=duration',
+      '-of', 'default=nw=1:nk=1', f]).toString().trim());
+  } catch (e) { return NaN; }
+};
+// The recording's own timeline runs SHORTER than wall-clock — Playwright's screencast
+// drops frames under WebGL load, so a mark taken at wall T lands at roughly T*ratio in
+// the file. Slicing by raw wall marks therefore drifts further out of sync the longer
+// the run, and every clip ends up holding an EARLIER scene than its name. Rescale by
+// the measured ratio so marks map onto the video's real timeline.
+const videoDur = probe(sessionWebm);
+let ratio = 1;
+if (Number.isFinite(videoDur) && videoDur > 0 && wallTotal > 0) {
+  ratio = videoDur / wallTotal;
+  console.log(`timeline: wall ${wallTotal.toFixed(1)}s -> video ${videoDur.toFixed(1)}s  ratio ${ratio.toFixed(4)}`);
+  if (ratio < 0.5 || ratio > 1.5) { console.log('  ratio out of range — slicing 1:1 instead'); ratio = 1; }
+}
+
+// Slice the one long recording into per-scene clips (trim the transition edges).
 for (const m of marks) {
-  const ss = (m.start + 0.4).toFixed(2);
-  const dur = Math.max(0.5, m.end - m.start - 0.6).toFixed(2);
+  const ss = (m.start * ratio + 0.4).toFixed(2);
+  const dur = Math.max(0.5, (m.end - m.start) * ratio - 0.6).toFixed(2);
   const out = path.join(OUT, `${m.id}_h.mp4`);
   try {
     execFileSync('ffmpeg', ['-y', '-loglevel', 'error', '-ss', ss, '-t', dur, '-i', sessionWebm,

--- a/frontend/_probe.mjs
+++ b/frontend/_probe.mjs
@@ -1,0 +1,39 @@
+// Attach to the persistent test window (never relaunches, never reloads unless
+// asked) and run one action. Usage:
+//   node _probe.mjs perform   — import the DNB set into PERFORM, dump routing, shoot
+//   node _probe.mjs shot NAME — screenshot current state to showcase/screenshots/NAME.png
+import { chromium } from 'playwright';
+
+const b = await chromium.connectOverCDP('http://localhost:9223');
+const ctx = b.contexts()[0];
+const p = ctx.pages().find((x) => x.url().includes('localhost:5173')) ?? ctx.pages()[0];
+const cmd = process.argv[2] ?? 'perform';
+
+if (cmd === 'perform') {
+  const ALS = 'G:\\tmp\\swaytest\\Audima Labs The Sway Ableton Live 12 - DNB\\Audima Labs The Sway Ableton Live 12 - DNB.als';
+  const r = await p.evaluate(async (als) => {
+    const ui = (await import('/src/state/appUiStore.ts')).useAppUiStore;
+    ui.getState().setCenterTab('session');
+    const imp = (await import('/src/state/dawImportStore.ts')).useDawImportStore;
+    if (imp.getState().project?.name !== 'Audima Labs The Sway Ableton Live 12 - DNB') {
+      imp.getState().setSourcePath(als);
+      await imp.getState().detectAndImport();
+    }
+    return imp.getState().error ?? 'imported';
+  }, ALS);
+  console.log('import:', r);
+  await p.waitForTimeout(1200); // let React effects flush (auto-route runs in an effect)
+  const routing = await p.evaluate(async () => {
+    const pr = (await import('/src/state/performRouting.ts')).usePerformRoutingStore.getState();
+    return { ccMods: pr.ccMods.map((m) => `${m.channel < 0 ? 'omni' : `ch${m.channel + 1}`} CC${m.number} -> ${m.label}`) };
+  });
+  console.log(JSON.stringify(routing, null, 1));
+  await p.screenshot({ path: '../showcase/screenshots/perform-auto.png' });
+  console.log('shot: perform-auto.png');
+} else if (cmd === 'shot') {
+  const name = process.argv[3] ?? 'probe';
+  await p.screenshot({ path: `../showcase/screenshots/${name}.png` });
+  console.log(`shot: ${name}.png`);
+}
+// connectOverCDP: closing our client does NOT close the remote browser.
+await b.close();

--- a/frontend/_shot_boot.mjs
+++ b/frontend/_shot_boot.mjs
@@ -1,0 +1,25 @@
+// Screenshot the boot cinematic at intervals, then the app once it clears, so
+// the goo / credit order / orb changes can be eyeballed without a manual launch.
+import { chromium } from 'playwright';
+const OUT = '../showcase/screenshots';
+const b = await chromium.launch({ headless: false, args: [
+  '--autoplay-policy=no-user-gesture-required', '--window-position=0,-1080', '--window-size=1920,1080',
+]});
+const ctx = await b.newContext({ viewport: { width: 1920, height: 1080 } });
+const p = await ctx.newPage();
+p.on('console', (m) => { if (m.type() === 'error') console.log('PAGE ERROR:', m.text().slice(0, 200)); });
+p.on('pageerror', (e) => console.log('PAGE THROW:', String(e).slice(0, 200)));
+
+await p.goto('http://localhost:5173', { waitUntil: 'domcontentloaded' });
+// Nudge the pointer so the goo ripple is visible in the shots.
+for (const [t, name] of [[1200, 'boot-1'], [2600, 'boot-2'], [4200, 'boot-3'], [6200, 'boot-4'], [8200, 'boot-5']]) {
+  await p.waitForTimeout(t === 1200 ? 1200 : 1400);
+  await p.mouse.move(700 + Math.random() * 500, 400 + Math.random() * 200);
+  await p.screenshot({ path: `${OUT}/${name}.png` });
+  console.log('shot', name, 'splash?', !!(await p.$('[data-boot-splash]')));
+}
+await p.waitForFunction(() => !document.querySelector('[data-boot-splash]'), { timeout: 60000 }).catch(() => {});
+await p.waitForTimeout(4000);
+await p.screenshot({ path: `${OUT}/boot-app.png` });
+console.log('app shot done');
+await b.close();

--- a/frontend/_shot_perform.mjs
+++ b/frontend/_shot_perform.mjs
@@ -1,0 +1,53 @@
+// Load the real Sway DNB .als into PERFORM and screenshot the result:
+// compact header, auto-opened routing strip, auto CC routes from the set.
+import { chromium } from 'playwright';
+const ALS = 'G:\\tmp\\swaytest\\Audima Labs The Sway Ableton Live 12 - DNB\\Audima Labs The Sway Ableton Live 12 - DNB.als';
+
+const b = await chromium.launch({ headless: false, args: [
+  '--autoplay-policy=no-user-gesture-required', '--window-position=0,-1080', '--window-size=1920,1080',
+]});
+const ctx = await b.newContext({ viewport: { width: 1920, height: 1080 } });
+await ctx.addInitScript(() => {
+  const seed = (k, s, v = 0) => { try { localStorage.setItem(k, JSON.stringify({ state: s, version: v })); } catch {} };
+  seed('thedaw-onboarding', { seen: true, neverShow: true });
+  seed('thedaw-home-screen-v1', { showAtStartup: false });
+});
+const p = await ctx.newPage();
+p.on('pageerror', (e) => console.log('PAGE THROW:', String(e).slice(0, 300)));
+await p.goto('http://localhost:5173', { waitUntil: 'domcontentloaded' });
+await p.waitForFunction(() => !document.querySelector('[data-boot-splash]'), { timeout: 60000 }).catch(() => {});
+await p.waitForTimeout(1500);
+
+const info = await p.evaluate(async (als) => {
+  const ui = (await import('/src/state/appUiStore.ts')).useAppUiStore;
+  ui.getState().setCenterTab('session');
+  const imp = (await import('/src/state/dawImportStore.ts')).useDawImportStore;
+  imp.getState().setSourcePath(als);
+  await imp.getState().detectAndImport();
+  const st = imp.getState();
+  const routing = (await import('/src/state/performRouting.ts')).usePerformRoutingStore.getState();
+  const sway = (await import('/src/state/swayBus.ts')).useSwayStore.getState();
+  return {
+    error: st.error,
+    project: st.project ? {
+      name: st.project.name,
+      tracks: st.project.tracks.length,
+      scenes: st.project.scenes.length,
+      mappings: (st.project.controller_mappings ?? []).length,
+      missing: st.project.missing_files.length,
+    } : null,
+    ccMods: routing.ccMods.map((m) => `${m.channel}/${m.number}->${m.label}`),
+    kinds: (st.project?.controller_mappings ?? []).reduce((a, m) => {
+      const k = `${m.target_kind}|note:${m.is_note}|macro:${m.is_macro}`;
+      a[k] = (a[k] ?? 0) + 1;
+      return a;
+    }, {}),
+    sample: (st.project?.controller_mappings ?? []).slice(0, 10).map((m) =>
+      `${m.channel}/${m.number} ${m.is_note ? 'N' : 'CC'} ${m.target_kind} tk${m.track_index} "${m.track_name}" dev"${m.device_name}" par"${m.param_name}"`),
+  };
+}, ALS);
+console.log(JSON.stringify(info, null, 1));
+await p.waitForTimeout(2500);
+await p.screenshot({ path: '../showcase/screenshots/perform-auto.png' });
+console.log('shot saved');
+await b.close();

--- a/frontend/_testwin.mjs
+++ b/frontend/_testwin.mjs
@@ -1,0 +1,20 @@
+// ONE persistent test window. Launched once (background), kept alive across
+// every probe; probes attach over CDP (_probe.mjs) instead of relaunching.
+// Persistent profile dir -> permission grants stick; midi granted up front.
+import { chromium } from 'playwright';
+const profile = 'C:/Users/Cyboman/AppData/Local/Temp/claude-thedaw-testprofile';
+const ctx = await chromium.launchPersistentContext(profile, {
+  headless: false,
+  viewport: { width: 1920, height: 1080 },
+  args: [
+    '--autoplay-policy=no-user-gesture-required',
+    '--window-position=0,-1080', '--window-size=1920,1080',
+    '--remote-debugging-port=9223',
+  ],
+});
+await ctx.grantPermissions(['midi', 'midi-sysex'], { origin: 'http://localhost:5173' }).catch(() => {});
+const p = ctx.pages()[0] ?? await ctx.newPage();
+await p.goto('http://localhost:5173', { waitUntil: 'domcontentloaded' });
+console.log('test window up on :9223 — leave running');
+// Keep the process alive until killed.
+await new Promise(() => {});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -432,29 +432,40 @@ export default function App() {
       {/* Main app always mounts so state initializes, but polls are gated on isBackendReady */}
       <Shell />
       <PlayerFooter />
-      <GantasmoOrb
-        isActive={isAssistantOpen}
-        onToggle={() => setIsAssistantOpen(prev => !prev)}
-        onPositionChange={setOrbPosition}
-        processing={assistantThinking}
-        // Ferrofluid body (three.js, lazy) with the GANTASMO eyes + mouth
-        // composited on top by the orb itself. Held back until the boot
-        // screen clears so the cinematic keeps the GPU to itself.
-        coreOverlay={!showLoading ? (
-          <Suspense fallback={null}>
-            <FerroOrbCore />
-          </Suspense>
-        ) : undefined}
-        // 2x orb: the orb-2x class doubles the CSS stack (160/128/96) and
-        // bounds keeps viewport clamping honest at that size.
-        className="orb-2x"
-        bounds={160}
-        // Bottom-left corner, pulled DOWN to overlap the footer (where the
-        // music-note icon used to be). v3 key so it resets there once.
-        defaultPosition={{ x: 12, y: typeof window !== 'undefined' ? window.innerHeight - 172 : 500 }}
-        persistenceKey="thedaw-orb-pos-v3"
-      />
-      <OrbDripTrail position={orbPosition} orbBox={160} />
+      {/* The orb stays out of the boot cinematic entirely — mounting it only
+          once the splash has lifted means it never flashes over the intro AND
+          the cinematic keeps the GPU to itself. Because it first mounts after
+          boot, its ferrofluid body is present from the very first frame the
+          user sees it, so there is no CSS-gradient placeholder stage. */}
+      {!showLoading && (
+        <>
+          <GantasmoOrb
+            isActive={isAssistantOpen}
+            onToggle={() => setIsAssistantOpen(prev => !prev)}
+            onPositionChange={setOrbPosition}
+            processing={assistantThinking}
+            // Ferrofluid body (three.js, lazy) with the GANTASMO eyes + mouth
+            // composited on top by the orb itself.
+            coreOverlay={(
+              <Suspense fallback={null}>
+                <FerroOrbCore />
+              </Suspense>
+            )}
+            // orb-2x is the 112px stack (30% down from the old 160). bounds must
+            // match the CSS toggle size or viewport clamping drifts.
+            className="orb-2x"
+            bounds={112}
+            // Welded to the bottom-left corner — including across window
+            // resizes — until the user drags it out once, which releases it
+            // permanently. defaultPosition is only the pre-release fallback.
+            stickCorner="bottom-left"
+            cornerMargin={16}
+            defaultPosition={{ x: 12, y: typeof window !== 'undefined' ? window.innerHeight - 172 : 500 }}
+            persistenceKey="thedaw-orb-pos-v4"
+          />
+          <OrbDripTrail position={orbPosition} orbBox={112} />
+        </>
+      )}
       {assistantMounted && (
         <Suspense fallback={null}>
           <AssistantPanel

--- a/frontend/src/components/audio/OrbTipBubble.tsx
+++ b/frontend/src/components/audio/OrbTipBubble.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+/**
+ * The assistant orb's speech bubble.
+ *
+ * Sits in the footer slot the G-Search field used to occupy and cycles short
+ * tips about the orb itself and about theDAW. Purely ambient: it never steals
+ * focus and never opens anything on its own — clicking it advances to the next
+ * tip, and the caller can wire onOpen to raise the assistant panel.
+ *
+ * Tips rotate on a timer that PAUSES on hover, so a tip can actually be read
+ * rather than vanishing mid-sentence.
+ */
+
+/**
+ * The opening line. Shown first on every launch and held for GREETING_MS —
+ * long enough to actually be noticed — before the how-to tips start cycling.
+ */
+const GREETING = 'click me for assistance';
+
+/**
+ * How to OPERATE theDAW: each one is an action the user can take right now.
+ * Kept short so the bubble stays one or two lines.
+ */
+const TIPS: string[] = [
+  'type a description in MAKE, then hit CREATE',
+  'drop audio on MAKE to render from your own sound',
+  'paint a region, then CREATE to redo just that part',
+  'stack 2+ clips in CHIMERA to blend them',
+  'drag a clip to the EDIT timeline to arrange it',
+  'use the cut tool to split a clip, then drag its edge to fade',
+  'hit COMMIT EDIT to bounce the arrangement to one file',
+  'drag effects into the MIX chain to reorder them',
+  'load a deck, press SYNC, then move the crossfader',
+  'pull a stem fader to drop the vocal mid-track',
+  'press LEARN in SWAY, then move a control to bind it',
+  'drag controls onto the FOUNDRY canvas to build a panel',
+  'click a node in AUDIMATE, then press RUN',
+  'search a region in TOUR to find venues, then build a route',
+  'open LEARN to see what any track was made from',
+  'open SCORE to read a track as sheet music or tab',
+  'right-click a library row for stems, MIDI and export',
+  'ctrl-k opens the library',
+  'drag me anywhere — i stay put after that',
+];
+
+const ROTATE_MS = 9000;
+const GREETING_MS = 20000;
+
+interface OrbTipBubbleProps {
+  /** Raise the assistant panel. Optional — without it the bubble is inert. */
+  onOpen?: () => void;
+  className?: string;
+}
+
+export const OrbTipBubble: React.FC<OrbTipBubbleProps> = ({ onOpen, className }) => {
+  // -1 is the greeting; 0..n index into TIPS. Every launch opens on the
+  // greeting, then enters the tip rotation at a random point so it is not the
+  // same three lines each session.
+  const firstTip = useMemo(() => Math.floor(Math.random() * TIPS.length), []);
+  const [index, setIndex] = useState(-1);
+  const [visible, setVisible] = useState(true);
+  const paused = useRef(false);
+
+  const text = index < 0 ? GREETING : TIPS[index];
+
+  const swap = (next: (i: number) => number, fade = 420) => {
+    setVisible(false);
+    window.setTimeout(() => {
+      setIndex(next);
+      setVisible(true);
+    }, fade);
+  };
+
+  useEffect(() => {
+    // The greeting gets its own longer dwell before the rotation starts.
+    const delay = index < 0 ? GREETING_MS : ROTATE_MS;
+    let id = window.setTimeout(function tick() {
+      // Hovering holds the current tip so it can be read. Re-check shortly
+      // rather than returning — returning would abandon the timer and stop the
+      // rotation permanently for anyone who happened to hover as it fired.
+      if (paused.current) {
+        id = window.setTimeout(tick, 800);
+        return;
+      }
+      swap((i) => (i < 0 ? firstTip : (i + 1) % TIPS.length));
+    }, delay);
+    return () => window.clearTimeout(id);
+    // Re-armed on every index change, so each line gets a full dwell.
+  }, [index, firstTip]);
+
+  const advance = () => swap((i) => (i < 0 ? firstTip : (i + 1) % TIPS.length), 200);
+
+  return (
+    <button
+      type="button"
+      aria-live="polite"
+      aria-label={`Assistant tip: ${text}. Activate for the next tip.`}
+      onMouseEnter={() => { paused.current = true; }}
+      onMouseLeave={() => { paused.current = false; }}
+      onClick={() => (onOpen ? onOpen() : advance())}
+      className={[
+        // FIXED width, not max-width: the now-playing title, duration and
+        // sample rate sit immediately to the right, and a bubble that resized
+        // with its text dragged them back and forth on every rotation.
+        'group/tip relative shrink-0 w-56 text-left',
+        'rounded-2xl rounded-bl-sm border border-purple-500/25 bg-purple-500/8',
+        'px-3 py-1.5 hover:bg-purple-500/15 hover:border-purple-400/40',
+        'transition-colors cursor-pointer',
+        className || '',
+      ].join(' ')}
+    >
+      {/* Bubble tail, bottom-left, so it reads as speech rather than a chip. */}
+      <span
+        aria-hidden="true"
+        className="absolute -bottom-1 left-2 h-2 w-2 rotate-45 border-b border-l border-purple-500/25 bg-purple-500/8 group-hover/tip:bg-purple-500/15"
+      />
+      {/* Wraps and grows DOWNWARD; never truncates. The footer is 80px tall and
+          the bubble is vertically centred in it, so extra lines expand evenly
+          without pushing the transport off-centre. */}
+      <span
+        className={[
+          'block whitespace-normal wrap-break-word font-mono text-[9px] leading-relaxed tracking-wide text-purple-100/85',
+          'transition-opacity duration-300',
+          visible ? 'opacity-100' : 'opacity-0',
+        ].join(' ')}
+      >
+        {text}
+      </span>
+    </button>
+  );
+};
+
+export default OrbTipBubble;

--- a/frontend/src/components/audio/PlayerFooter.tsx
+++ b/frontend/src/components/audio/PlayerFooter.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Play, Pause, SkipBack, SkipForward, Volume2, Download, Share2, Heart, Repeat, VolumeX, Maximize2, MoreHorizontal, Cast, Check, Search } from 'lucide-react';
+import { Play, Pause, SkipBack, SkipForward, Volume2, Download, Share2, Heart, Repeat, VolumeX, Maximize2, MoreHorizontal, Cast, Check } from 'lucide-react';
 import { useGenerateStore } from '../../state/generateStore';
 import { usePlaybackStore } from '../../state/playbackStore';
 import { usePlayerStore } from '../../state/playerStore';
@@ -7,6 +7,7 @@ import { useLibraryStore } from '../../state/libraryStore';
 import { useAppUiStore } from '../../state/appUiStore';
 import { callEditorPlay, isEditorPlaybackRegistered } from '../../state/editorPlaybackBridge';
 import { SlideTrack } from './SlideTrack';
+import { OrbTipBubble } from './OrbTipBubble';
 import {
   toggleVjPlayback,
   subscribeToVjPlaybackState,
@@ -30,25 +31,22 @@ const formatDuration = (sec: number | null | undefined): string => {
 export const PlayerFooter: React.FC = () => {
   const [isLiked, setIsLiked] = useState(false);
   const progressRef = useRef<HTMLDivElement | null>(null);
-  const searchRef = useRef<HTMLInputElement | null>(null);
 
-  // G-Search lives in the footer now (global on every tab). Drives the library
-  // search store; typing opens the library rail. Ctrl/Cmd-K focuses it.
-  const setLibrarySearch = useLibraryStore((s) => s.setSearchQuery);
-  const librarySearch = useLibraryStore((s) => s.searchQuery);
+  // The footer's G-Search field was replaced by the orb's speech bubble, so
+  // Ctrl/Cmd-K no longer has an inline input to focus. It now opens the library
+  // rail, which carries its own search — the shortcut still lands the user in
+  // front of a search box rather than doing nothing.
   const setRightPanelOpen = useAppUiStore((s) => s.setRightPanelOpen);
-  const isRightPanelOpen = useAppUiStore((s) => s.isRightPanelOpen);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
-        searchRef.current?.focus();
-        searchRef.current?.select();
+        setRightPanelOpen(true);
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, []);
+  }, [setRightPanelOpen]);
 
   // Volume / mute live in playbackStore; they drive the engine's master gain.
   const volume = usePlaybackStore((s) => s.volume);
@@ -215,35 +213,14 @@ export const PlayerFooter: React.FC = () => {
 
   return (
     <footer className="fixed bottom-0 left-0 right-0 h-20 bg-[#0a080f]/95 backdrop-blur-xl border-t border-white/5 z-50 px-6 flex items-center gap-6 group">
-      {/* 1. G-Search + Now Playing. flex-1 (mirrors section 3) so the now-playing
-          readout fills the space between G-Search and the centred transport, and
-          the PLAY button still lands on the true viewport centre. The orb
-          assistant overlaps the bottom-left corner, so pad left to clear it. */}
-      <div className="flex items-center gap-3 flex-1 min-w-0 pl-20">
-        {/* G-Search — global library search, available on every tab. */}
-        <div className="flex items-center gap-2 px-2.5 py-1 bg-white/5 rounded-full border border-white/5 shrink-0">
-          <Search className="w-3 h-3 text-zinc-600" />
-          <input
-            id="global-search"
-            name="global-search"
-            ref={searchRef}
-            type="search"
-            aria-label="Global library search (Ctrl-K / Cmd-K)"
-            placeholder="G-SEARCH (ctrl-k)"
-            className="bg-transparent border-none outline-none text-[9px] text-zinc-300 w-24 font-mono placeholder:text-zinc-500"
-            value={librarySearch}
-            onChange={(e) => {
-              setLibrarySearch(e.target.value);
-              if (e.target.value && !isRightPanelOpen) setRightPanelOpen(true);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                setLibrarySearch('');
-                (e.target as HTMLInputElement).blur();
-              }
-            }}
-          />
-        </div>
+      {/* 1. Orb speech bubble + Now Playing. flex-1 (mirrors section 3) so the
+          now-playing readout fills the space between the bubble and the centred
+          transport, and the PLAY button still lands on the true viewport centre.
+          The orb sticks to the bottom-left corner and overlaps the footer, so
+          pad left past it: 16px margin + the 112px orb = 128, plus clearance. */}
+      <div className="flex items-center gap-3 flex-1 min-w-0 pl-36">
+        {/* The orb's speech bubble, in the slot G-Search used to hold. */}
+        <OrbTipBubble />
         <div className="flex flex-col min-w-0 flex-1">
           <h4 className="text-[13px] font-bold text-zinc-100 truncate tracking-tight">
             {displayLabel ?? 'No output loaded'}

--- a/frontend/src/components/layout/LiquidChromeTitle.tsx
+++ b/frontend/src/components/layout/LiquidChromeTitle.tsx
@@ -23,9 +23,21 @@ import { mergeVertices } from 'three/addons/utils/BufferGeometryUtils.js';
 interface LiquidChromeTitleProps {
   onActive?: (active: boolean) => void;
   onComplete?: () => void;
+  /**
+   * Fires once the wordmark has essentially resolved out of the goo. The host
+   * uses it to reveal "by" and then the GANTASMO logo AFTER theDAW, rather than
+   * on blind timers that used to run while the model was still assembling.
+   */
+  onFormed?: () => void;
+  /** Canvas class. The boot screen passes a full-bleed one so the goo covers
+   *  the entire window rather than just the wordmark's layout box. */
+  className?: string;
 }
 
-const FORM_SECONDS = 7;
+const FORM_SECONDS = 5.2;
+// The wordmark is legible well before the easing fully settles; reveal the
+// credits at this point rather than waiting for the last few percent.
+const FORMED_AT = 0.82;
 const easeOutCubic = (x: number) => 1 - Math.pow(1 - x, 3);
 const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
 
@@ -34,7 +46,11 @@ const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
 // faces the camera.
 const DAW_BASE_ROT_Y = -Math.PI / 4;
 
-export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, onComplete }) => {
+// World depth of the goo sheet. The wordmark sits in front of it at z -0.6 and
+// dissolves back INTO it, so this is also the depth the formation sinks to.
+const GOO_Z = -3.2;
+
+export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, onComplete, onFormed, className }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -60,59 +76,208 @@ export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, 
     renderer.setSize(w, h, false);
     renderer.setClearColor(0x000000, 0); // transparent — the DOM background shows through
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
-    renderer.toneMappingExposure = 1.35; // a touch stronger overall
+    // The near-perfect mirror is the POINT — the wordmark and the goo are the
+    // same wet-obsidian material and you read them purely by what the lights and
+    // the environment reflect off their surfaces. Exposure is the only lever
+    // pulled here; albedo/emissive stay black so nothing goes matte or tinted.
+    renderer.toneMappingExposure = 2.1;
 
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(42, w / h, 0.1, 100);
     camera.position.set(0, 0, 4.2);
 
-    // Cymatics chrome light rig — bumped a smidgen.
-    const key = new THREE.DirectionalLight(0xfff5ea, 1.7);
-    key.position.set(6, 9, 5);
-    // Opposing key, horizontally mirrored (-x), so a highlight rakes the model
-    // from the other side and it stays legible at any rotation.
-    const key2 = new THREE.DirectionalLight(0xfff5ea, 1.5);
-    key2.position.set(-6, 9, 5);
-    const rim = new THREE.DirectionalLight(0xb14dff, 1.1);
+    // The assistant orb's colours (FerroOrbCore) but re-AIMED, because on a
+    // near-mirror the angle is the whole image: a surface only shows a light
+    // whose reflection vector happens to reach the camera. The orb is a sphere,
+    // so some part of it always satisfies that from any angle; the wordmark is
+    // a mostly camera-facing slab, so lights parked high above it (6,9,5) only
+    // ever lit the top bevels and the readable front stayed black. Both keys now
+    // live in the FORWARD hemisphere (+z, camera side) at a raking height, and
+    // they orbit through it each frame so the highlight travels across the
+    // letterforms instead of sitting still. The goo sheet shares the material,
+    // so its wave normals catch these same lights at different angles — that
+    // difference is what separates the logo from the background.
+    const key = new THREE.DirectionalLight(0xfff5ea, 2.6);
+    key.position.set(5, 3.5, 7);
+    const key2 = new THREE.DirectionalLight(0xfff5ea, 2.2);
+    key2.position.set(-5, 3.5, 7);
+    const rim = new THREE.DirectionalLight(0xb14dff, 1.2);
     rim.position.set(-6, -3, -4);
-    const fill = new THREE.DirectionalLight(0x00d2ff, 0.5);
+    const fill = new THREE.DirectionalLight(0x00d2ff, 0.4);
     fill.position.set(0, -6, 5);
-    scene.add(key, key2, rim, fill, new THREE.AmbientLight(0x0c0714, 0.18));
+    // Two close point lights sit just in front of the sheet, off the sides of
+    // frame. On a glossy surface these are what you actually SEE moving in the
+    // liquid — the directional keys are for the wordmark's bevels.
+    const gooA = new THREE.PointLight(0xfff2e2, 260, 40, 2);
+    gooA.position.set(-7, 3.5, -0.6);
+    const gooB = new THREE.PointLight(0xb14dff, 200, 40, 2);
+    gooB.position.set(7, -2.5, -0.6);
+    scene.add(key, key2, rim, fill, gooA, gooB, new THREE.AmbientLight(0x0c0714, 0.15));
 
     // The cymatics chrome material plus a formation vertex shader
     // (uForm 0 = vertices flung out along random dirs, 1 = solid).
     let dawShader: THREE.WebGLProgramParametersWithUniforms | null = null;
-    const chrome = new THREE.MeshStandardMaterial({
+    // EXACTLY the assistant orb's wet-obsidian material (FerroOrbCore's
+    // sphereMaterial). Black albedo, no emissive, near-mirror: everything you
+    // see is reflection. envMapIntensity is the one lift, so the EXR carries
+    // enough light for the letterforms to separate from the sheet behind them.
+    const CHROME = {
       color: 0x010101,
       metalness: 0.99,
-      roughness: 0.008,
+      roughness: 0.003,
       emissive: 0x000000,
-      envMapIntensity: 1.8, // stronger reflections so the model reads at any angle
-    });
+      envMapIntensity: 4.5,
+    } as const;
+    const chrome = new THREE.MeshStandardMaterial({ ...CHROME });
+    // uForm 0 = the wordmark is still dissolved INTO the goo sheet behind it
+    // (pushed back to the sheet's depth, spread across it, riding the same
+    // standing wave); 1 = fully resolved solid logo. So the logo is not
+    // assembled from random debris any more — it rises out of the same black
+    // liquid it is made of.
     chrome.onBeforeCompile = (shader) => {
       shader.uniforms.uForm = { value: 0 };
+      shader.uniforms.uTime = { value: 0 };
+      shader.uniforms.uSink = { value: 2.6 };
       shader.vertexShader = shader.vertexShader
         .replace(
           '#include <common>',
           `#include <common>
            uniform float uForm;
+           uniform float uTime;
+           uniform float uSink;
            float h11(float n){ return fract(sin(n)*43758.5453); }`,
         )
         .replace(
           '#include <begin_vertex>',
           `#include <begin_vertex>
            float seed = dot(position, vec3(12.9898, 78.233, 37.719));
-           vec3 dir = normalize(vec3(h11(seed)-0.5, h11(seed+1.7)-0.5, h11(seed+3.1)-0.5));
            float spread = 1.0 - uForm;
-           vec3 scattered = position + dir * spread * 5.0 + normal * spread * 1.1;
-           scattered += normal * sin(uForm * 6.2832 + h11(seed) * 6.2832) * spread * 0.35;
-           transformed = mix(scattered, position, smoothstep(0.0, 1.0, uForm));`,
+           // Fan out across the sheet and sink back into it. uSink is the local
+           // -Z distance that lands the vertices exactly ON the goo plane once
+           // the group's scale is applied, so the wordmark genuinely surfaces
+           // out of the sheet rather than out of empty space in front of it.
+           vec2 lat = vec2(h11(seed) - 0.5, h11(seed + 3.1) - 0.5) * 2.0;
+           vec3 sunk = position;
+           sunk.xy += lat * spread * 1.25;
+           sunk.z -= spread * uSink;
+           // The same Chladni-style standing wave that drives the sheet, so the
+           // dissolved vertices vibrate WITH the goo instead of floating free.
+           float cym = sin(sunk.x * 3.1 + uTime * 1.8) * cos(sunk.y * 3.1 - uTime * 1.5);
+           sunk.z += cym * spread * 0.5;
+           sunk += normal * cym * spread * 0.18;
+           transformed = mix(sunk, position, smoothstep(0.0, 1.0, uForm));`,
         );
       dawShader = shader;
     };
 
+    // ── the black goo the wordmark is made of, and emerges from ──────────────
+    // A dense sheet behind the logo running Chladni-style standing waves: two
+    // crossed sine fields (the classic cymatic figure) plus a slow swell, so it
+    // reads as a vibrating liquid rather than a scrolling noise plane. It uses
+    // the same near-black metal response as the logo so the two are visibly the
+    // same substance. The pointer pushes a travelling ripple into it.
+    const gooUniforms = {
+      uTime: { value: 0 },
+      uMouse: { value: new THREE.Vector2(0, 0) },   // sheet-space world units
+      uMouseStrength: { value: 0 },                  // eases in on first move
+      uForm: { value: 0 },                           // calms as the logo resolves
+      // The sheet is a UNIT plane scaled by the model matrix, so position.xy in
+      // the shader only spans -0.5..0.5. Multiplying by this restores real world
+      // units, which keeps the wave frequency constant instead of stretching
+      // with the window.
+      uSheetSize: { value: new THREE.Vector2(1, 1) },
+    };
+    // Oversized on purpose: the sheet must fill the whole window at any aspect
+    // ratio, and it is resized again in onResize from the camera frustum so a
+    // wide monitor never sees its edges.
+    const gooGeo = new THREE.PlaneGeometry(1, 1, 360, 240);
+    // The SAME material as the wordmark — same black albedo, same near-mirror.
+    // They are one substance; the only thing separating them on screen is the
+    // angle each surface reflects the lights back at the camera.
+    const gooMat = new THREE.MeshStandardMaterial({ ...CHROME, roughness: 0.075, envMapIntensity: 1.15 });
+    gooMat.onBeforeCompile = (shader) => {
+      Object.assign(shader.uniforms, gooUniforms);
+      shader.vertexShader = shader.vertexShader
+        .replace(
+          '#include <common>',
+          `#include <common>
+           uniform float uTime;
+           uniform vec2  uMouse;
+           uniform float uMouseStrength;
+           uniform float uForm;
+           uniform vec2  uSheetSize;
+           // Crossed standing waves — a Chladni plate figure. Nodes stay put and
+           // the antinodes pump, which is what makes it read as cymatic.
+           float chladni(vec2 p, float t){
+             float a = sin(p.x * 1.55 + t * 0.85) * cos(p.y * 1.55 - t * 0.70);
+             float b = sin(p.x * 3.10 - t * 0.55) * cos(p.y * 2.85 + t * 0.45);
+             float c = sin(length(p) * 2.20 - t * 1.15) + sin(p.x * 6.5 + t * 1.9) * cos(p.y * 5.8 - t * 1.4) * 0.35;
+             return a * 0.58 + b * 0.26 + c * 0.16;
+           }`,
+        )
+        .replace(
+          '#include <begin_vertex>',
+          `#include <begin_vertex>
+           vec2 sp = position.xy * uSheetSize;
+           // Settle the sheet as the wordmark finishes resolving, so the boot
+           // ends calm instead of thrashing under the finished logo.
+           float calm = mix(1.0, 0.42, smoothstep(0.0, 1.0, uForm));
+           float h = chladni(sp, uTime) * 1.75 * calm;
+           // Pointer ripple: a decaying ring travelling out from the cursor.
+           float d = distance(sp, uMouse);
+           h += sin(d * 3.4 - uTime * 4.5) * exp(-d * 0.75) * 0.55 * uMouseStrength;
+           transformed.z += h;`,
+        )
+        // Re-derive normals from the displaced surface, otherwise the sheet
+        // displaces but lights as if it were still flat (no visible ripple).
+        .replace(
+          '#include <beginnormal_vertex>',
+          `#include <beginnormal_vertex>
+           {
+             vec2 sp0 = position.xy * uSheetSize;
+             float e = 0.06;
+             float calmN = mix(1.0, 0.42, smoothstep(0.0, 1.0, uForm));
+             float hC = chladni(sp0, uTime) * 1.75 * calmN;
+             float hX = chladni(sp0 + vec2(e, 0.0), uTime) * 1.75 * calmN;
+             float hY = chladni(sp0 + vec2(0.0, e), uTime) * 1.75 * calmN;
+             float dC = distance(sp0, uMouse);
+             float rC = sin(dC * 3.4 - uTime * 4.5) * exp(-dC * 0.75) * 0.55 * uMouseStrength;
+             hC += rC; hX += rC; hY += rC;
+             objectNormal = normalize(vec3(-(hX - hC) / e, -(hY - hC) / e, 1.0));
+           }`,
+        );
+    };
+    const goo = new THREE.Mesh(gooGeo, gooMat);
+    goo.position.set(0, 0, GOO_Z);
+    scene.add(goo);
+
+    // Scale the unit plane to exactly cover the camera frustum at the sheet's
+    // depth, so it fills the window edge to edge at any aspect ratio. The 1.5
+    // margin absorbs the camera's lookAt tilt and its slow x drift.
+    const fitGoo = () => {
+      const dist = camera.position.z - GOO_Z;
+      const height = 2 * Math.tan((camera.fov * Math.PI) / 360) * dist;
+      goo.scale.set(height * camera.aspect * 1.5, height * 1.5, 1);
+      gooUniforms.uSheetSize.value.set(goo.scale.x, goo.scale.y);
+    };
+
+    // Pointer -> sheet space. Tracked on the window so it works no matter which
+    // DOM layer of the boot screen is under the cursor.
+    let mouseEased = new THREE.Vector2(0, 0);
+    let mouseTarget = new THREE.Vector2(0, 0);
+    let mouseSeen = false;
+    const onPointerMove = (e: PointerEvent) => {
+      const nx = (e.clientX / window.innerWidth) * 2 - 1;
+      const ny = -((e.clientY / window.innerHeight) * 2 - 1);
+      // Map the pointer onto the sheet's real extent so the ripple lands under
+      // the cursor at any window size, rather than at a fixed guessed scale.
+      mouseTarget.set(nx * goo.scale.x * 0.5, ny * goo.scale.y * 0.5);
+      mouseSeen = true;
+    };
+    window.addEventListener('pointermove', onPointerMove, { passive: true });
+
     const dawGroup = new THREE.Group();
-    dawGroup.position.y = 0; // centered in its own canvas box
+    dawGroup.position.y = 1.05; // sits in the upper half; credits go beneath it
     dawGroup.position.z = -0.6; // a little further from camera: flatter, less lit-from-below
     dawGroup.rotation.y = DAW_BASE_ROT_Y; // face the camera
     dawGroup.visible = false;
@@ -126,13 +291,24 @@ export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, 
     const pmrem = new THREE.PMREMGenerator(renderer);
     pmrem.compileEquirectangularShader();
     let envRT: THREE.WebGLRenderTarget | null = null;
+    // Kept for the LIFETIME of the scene, not disposed when the EXR lands. A
+    // black mirror in a black environment is black — the wordmark gets away with
+    // it because its bevels catch the key lights edge-on, but the goo sheet is
+    // broad and camera-facing, so with only the (very dark) EXR to reflect it
+    // rendered as nothing at all. RoomEnvironment is a bright studio box, which
+    // gives the liquid something to actually show across its whole surface.
+    let roomEnvRT: THREE.WebGLRenderTarget | null = null;
     let disposed = false;
     let modelReady = false;
+    // Local-space sink distance for the formation shader; corrected once the
+    // model loads and its group scale is known.
+    let sinkLocal = 2.6;
     try {
       const roomRT = pmrem.fromScene(new RoomEnvironment(), 0.04);
       chrome.envMap = roomRT.texture;
+      gooMat.envMap = roomRT.texture;   // the sheet keeps this one permanently
       scene.environment = roomRT.texture;
-      envRT = roomRT;
+      roomEnvRT = roomRT;
     } catch {
       /* fallback environment is best-effort */
     }
@@ -143,10 +319,12 @@ export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, 
       }
       tex.mapping = THREE.EquirectangularReflectionMapping;
       const exrRT = pmrem.fromEquirectangular(tex);
+      // Only the WORDMARK upgrades to the EXR. The goo stays on the bright room
+      // env — swapping it to the dark EXR is exactly what made the sheet vanish.
       chrome.envMap = exrRT.texture;
       scene.environment = exrRT.texture;
       tex.dispose();
-      envRT?.dispose(); // drop the room fallback
+      envRT?.dispose();
       envRT = exrRT;
     });
 
@@ -178,21 +356,29 @@ export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, 
       // 2x size: the theDAW logo is doubled vs the prior fill (was 4.0). The
       // "by GANTASMO" text/image live outside this canvas (LoadingScreen DOM
       // siblings), so enlarging the model here does not move them.
-      const scale = 8.0 / Math.max(size.x, 0.001);
+      // Sized for a FULL-WINDOW canvas now. It used to render into a 1920x540 box
+      // (aspect ~3.6), where 8.0 fit horizontally; at full-screen 16:9 the frame
+      // is half as wide in world units, so the same number ran off both edges.
+      const scale = 4.2 / Math.max(size.x, 0.001);
       dawGroup.scale.setScalar(scale);
+      // Local-space distance that puts the dissolved vertices exactly on the goo
+      // plane: the group sits at z -0.6 and the sheet at GOO_Z, and the group's
+      // scale multiplies every local offset, so divide the world gap by it.
+      sinkLocal = Math.abs(GOO_Z - dawGroup.position.z) / scale;
       modelReady = true;
     });
 
     // Post: bloom gives the chrome its hot highlights.
     const composer = new EffectComposer(renderer);
     composer.addPass(new RenderPass(scene, camera));
-    const bloom = new UnrealBloomPass(new THREE.Vector2(w, h), 1.15, 0.8, 0.18);
+    const bloom = new UnrealBloomPass(new THREE.Vector2(w, h), 0.85, 0.55, 0.62);
     composer.addPass(bloom);
 
     const clockStart = performance.now(); // elapsed seconds, no deprecated THREE.Clock
     let raf = 0;
     let startedAt = -1; // formation clock starts once the model is ready
     let completed = false;
+    let formedFired = false;
 
     const animate = () => {
       raf = requestAnimationFrame(animate);
@@ -205,8 +391,28 @@ export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, 
 
       const dawForm = easeOutCubic(form);
       dawGroup.visible = dawGroup.children.length > 0;
-      if (dawShader) dawShader.uniforms.uForm.value = dawForm;
+      if (dawShader) {
+        dawShader.uniforms.uForm.value = dawForm;
+        dawShader.uniforms.uTime.value = t;
+        dawShader.uniforms.uSink.value = sinkLocal;
+      }
       dawGroup.rotation.y = DAW_BASE_ROT_Y + Math.sin(t * 0.28) * 0.05;
+
+      // Drive the goo sheet. The pointer is eased rather than tracked exactly so
+      // the ripple trails the cursor like liquid instead of snapping to it.
+      mouseEased.lerp(mouseTarget, 0.06);
+      gooUniforms.uTime.value = t;
+      gooUniforms.uMouse.value.copy(mouseEased);
+      gooUniforms.uForm.value = dawForm;
+      gooUniforms.uMouseStrength.value +=
+        ((mouseSeen ? 1 : 0) - gooUniforms.uMouseStrength.value) * 0.03;
+
+      // Reveal the credits only once the wordmark itself has resolved, so the
+      // order on screen is theDAW -> by -> GANTASMO.
+      if (!formedFired && startedAt >= 0 && form >= FORMED_AT) {
+        formedFired = true;
+        onFormed?.();
+      }
 
       // Report completion once the model has fully resolved, so the host can hold
       // for the real runtime instead of a blind timer.
@@ -218,16 +424,22 @@ export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, 
       // Orbit the key lights and sweep the environment reflections so the chrome
       // stays lit + legible the WHOLE time (it was going dark / near-invisible by
       // the end with a static rig). environmentRotation is guarded for older three.
+      // Sweep the keys through the FORWARD hemisphere only (z stays positive, in
+      // front of the model). A full 360 orbit spent half its time behind the
+      // slab, where a mirror shows the camera nothing — which is what made the
+      // wordmark pulse in and out of visibility.
       const orbit = t * 0.45;
-      key.position.set(Math.cos(orbit) * 8, 8, Math.sin(orbit) * 8 + 3);
-      key2.position.set(Math.cos(orbit + Math.PI) * 8, 8, Math.sin(orbit + Math.PI) * 8 + 3);
+      key.position.set(Math.cos(orbit) * 7, 2.5 + Math.sin(orbit * 0.7) * 2.5, Math.abs(Math.sin(orbit)) * 3 + 5.5);
+      key2.position.set(Math.cos(orbit + Math.PI) * 7, 2.5 + Math.cos(orbit * 0.6) * 2.5, Math.abs(Math.cos(orbit)) * 3 + 5.5);
+      gooA.position.set(Math.cos(t * 0.23) * 8, Math.sin(t * 0.19) * 4.5, -0.4);
+      gooB.position.set(Math.cos(t * 0.17 + 2.2) * 8, Math.sin(t * 0.27 + 1.1) * 4.5, -0.4);
       const envRot = (scene as unknown as { environmentRotation?: THREE.Euler }).environmentRotation;
       if (envRot) envRot.y = orbit * 0.6;
 
       camera.position.x = Math.sin(t * 0.18) * 0.14;
       // Look slightly up so the model sits LOW in its canvas box (its bottom near
       // the box bottom), keeping "by" tight beneath it.
-      camera.lookAt(0, 0.9, 0);
+      camera.lookAt(0, 0.55, 0);
       composer.render();
     };
     raf = requestAnimationFrame(animate);
@@ -239,7 +451,9 @@ export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, 
       composer.setSize(w, h);
       camera.aspect = w / h;
       camera.updateProjectionMatrix();
+      fitGoo();   // re-cover the window at the new aspect
     };
+    fitGoo();
     const ro = new ResizeObserver(onResize);
     ro.observe(canvas);
 
@@ -248,8 +462,12 @@ export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, 
       cancelAnimationFrame(raf);
       ro.disconnect();
       canvas.removeEventListener('webglcontextlost', onContextLost);
+      window.removeEventListener('pointermove', onPointerMove);
       envRT?.dispose();
+      roomEnvRT?.dispose();
       pmrem.dispose();
+      gooGeo.dispose();
+      gooMat.dispose();
       chrome.dispose();
       composer.dispose();
       renderer.dispose();
@@ -262,5 +480,5 @@ export const LiquidChromeTitle: React.FC<LiquidChromeTitleProps> = ({ onActive, 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return <canvas ref={canvasRef} className="block w-full h-full" />;
+  return <canvas ref={canvasRef} className={className ?? 'block w-full h-full'} />;
 };

--- a/frontend/src/components/layout/LoadingScreen.tsx
+++ b/frontend/src/components/layout/LoadingScreen.tsx
@@ -20,6 +20,11 @@ interface LoadingScreenProps {
 export const LoadingScreen: React.FC<LoadingScreenProps> = ({ onSkip, onComplete }) => {
   const [elapsed, setElapsed] = useState(0);
   const [cinematicActive, setCinematicActive] = useState(false);
+  // "by" and the GANTASMO logo are held back until the theDAW wordmark has
+  // actually resolved out of the goo, so the three credits land in order:
+  // theDAW, then by, then GANTASMO. They used to run on fixed 1.6s/2.0s timers
+  // and so appeared while the wordmark was still assembling.
+  const [formed, setFormed] = useState(false);
   const bootStatus = useBootStatusStore((s) => s.status);
   const bootLogs = useBootStatusStore((s) => s.logs);
   const bootError = useBootStatusStore((s) => s.error);
@@ -36,15 +41,32 @@ export const LoadingScreen: React.FC<LoadingScreenProps> = ({ onSkip, onComplete
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cinematicActive, elapsed]);
 
+  // Same fallback for the credit reveal: with no WebGL there is no formation to
+  // wait on, so release "by"/GANTASMO on the static branding instead of leaving
+  // the boot screen showing a lone wordmark forever.
+  useEffect(() => {
+    if (!cinematicActive && elapsed >= 2 && !formed) setFormed(true);
+  }, [cinematicActive, elapsed, formed]);
+
+  // data-boot-splash is a stable hook for the capture harness / tests to wait on.
+  // Keyed off the attribute rather than the wordmark: the old text-based check broke
+  // silently when the splash was rebranded, and let the splash bleed into every clip.
   return (
-    <div className="fixed inset-0 z-200 select-none overflow-hidden bg-black flex flex-col items-center gap-1.5 pt-10">
+    <div data-boot-splash="" className="fixed inset-0 z-200 select-none overflow-hidden bg-black flex flex-col items-center gap-1.5 pt-10">
       <style>{`@keyframes bootCreditFade{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}`}</style>
 
-      {/* theDAW — liquid-chrome 3D model, transparent over the black background.
-          Anchored to the top 50vh (the model sits LOW in it via the camera) so
-          "by" right below lands at the vertical center, tight under the model. */}
-      <div className="relative w-full shrink-0" style={{ height: '50vh' }}>
-        <LiquidChromeTitle onActive={setCinematicActive} onComplete={onComplete} />
+      {/* The cinematic canvas is FULL-BLEED behind everything, so the black goo
+          sheet covers the entire window instead of just the wordmark's layout
+          box. The credits below sit on top of it (z-10) and the 50vh block is
+          now only a spacer reserving the area the 3D wordmark renders into. */}
+      <LiquidChromeTitle
+        className="absolute inset-0 block h-full w-full"
+        onActive={setCinematicActive}
+        onComplete={onComplete}
+        onFormed={() => setFormed(true)}
+      />
+
+      <div className="relative z-10 w-full shrink-0 pointer-events-none" style={{ height: '50vh' }}>
         {/* Static fallback ONLY if WebGL never starts (model can't render). */}
         {!cinematicActive && elapsed >= 3 && (
           <span className="absolute inset-0 flex items-end justify-center pb-2 text-4xl font-black uppercase tracking-[0.36em] pl-[0.36em] text-zinc-100">
@@ -53,8 +75,12 @@ export const LoadingScreen: React.FC<LoadingScreenProps> = ({ onSkip, onComplete
         )}
       </div>
 
-      {/* by — small, 3D-ish chrome lettering. */}
+      {/* by — small, 3D-ish chrome lettering. Mounted only once the wordmark has
+          formed, so its fade-in actually plays at the moment of reveal (a
+          visibility toggle would let the animation finish while still hidden). */}
+      {formed && (
       <span
+        className="relative z-10"
         style={{
           fontFamily: "'Orbitron', system-ui, sans-serif",
           fontWeight: 700,
@@ -66,20 +92,29 @@ export const LoadingScreen: React.FC<LoadingScreenProps> = ({ onSkip, onComplete
           backgroundClip: 'text',
           color: 'transparent',
           textShadow: '0 1px 0 rgba(255,255,255,0.18), 0 3px 6px rgba(0,0,0,0.6)',
-          animation: 'bootCreditFade 1.1s ease 1.6s both',
+          // Delays are now relative to the wordmark resolving, not to page load.
+          animation: 'bootCreditFade 0.9s ease 0.05s both',
         }}
       >
         by
       </span>
+      )}
 
-      {/* GANTASMO — the animated logo, ~30% size, tight under "by". */}
-      <img
-        src="/GANTASMO_LOGO.webp"
-        alt="GANTASMO"
-        className="shrink-0 object-contain select-none"
-        draggable={false}
-        style={{ height: 'clamp(34px, 8vh, 110px)', maxWidth: '70vw', animation: 'bootCreditFade 1.3s ease 2s both' }}
-      />
+      {/* GANTASMO — the animated logo, ~30% size, tight under "by". Comes in
+          after "by", completing the theDAW -> by -> GANTASMO order. */}
+      {formed && (
+        <img
+          src="/GANTASMO_LOGO.webp"
+          alt="GANTASMO"
+          className="relative z-10 shrink-0 object-contain select-none"
+          draggable={false}
+          style={{
+            height: 'clamp(34px, 8vh, 110px)',
+            maxWidth: '70vw',
+            animation: 'bootCreditFade 1.1s ease 0.75s both',
+          }}
+        />
+      )}
 
       {/* First-run bootstrap status, so a slow or failed setup is visible
           instead of a silent hang. Low-key under the logo; errors stand out. */}

--- a/frontend/src/components/session/DawSessionGrid.tsx
+++ b/frontend/src/components/session/DawSessionGrid.tsx
@@ -705,6 +705,33 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
     [trackStateVersion],
   );
 
+  // Direct CC routes (auto-created from the set's own MIDI-learn mappings, or
+  // assigned on the Sway deck). Ref'd so the single MIDI subscription below can
+  // apply them without re-subscribing when the mix callbacks re-create.
+  const applyCcModRef = React.useRef<(cm: import('../../state/performRouting').CcMod, value01: number) => void>(() => {});
+  React.useEffect(() => {
+    applyCcModRef.current = (cm, value01) => {
+      if (cm.target === 'fx') {
+        // Reach the running chain entry. The chain is built lazily on first
+        // launch; ensure it here so a knob works before the first clip fires.
+        const track = tracksRef.current[cm.trackIndex];
+        if (!track || cm.deviceIndex == null || !cm.paramKey) return;
+        const chain = ensureTrackChain(cm.trackIndex, track);
+        const lo = cm.min ?? 0;
+        const hi = cm.max ?? 1;
+        chain.handle?.updateParams(`perform-${cm.trackIndex}-${cm.deviceIndex}`, {
+          [cm.paramKey]: lo + value01 * (hi - lo),
+        });
+        return;
+      }
+      const cur = mixRef.current.get(cm.trackIndex) ?? { vol: 1, mute: false };
+      if (cm.target === 'mute') cur.mute = value01 > 0.5;
+      else cur.vol = value01;
+      mixRef.current.set(cm.trackIndex, cur);
+      applyMixToTrack(cm.trackIndex);
+    };
+  }, [applyMixToTrack, ensureTrackChain]);
+
   React.useEffect(() => {
     const unsub = subscribeSwayValue((dim, value) => {
       const mods = usePerformRoutingStore.getState().trackMods.filter((m) => m.dim === dim);
@@ -723,16 +750,22 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
   // Removing a modulation route returns its track to neutral, so a track never
   // stays stuck at the last modulated gain/mute after its mod is deleted.
   const trackMods = usePerformRoutingStore((s) => s.trackMods);
+  const ccMods = usePerformRoutingStore((s) => s.ccMods);
   React.useEffect(() => {
     const modVol = new Set(trackMods.filter((m) => m.target === 'volume').map((m) => m.trackIndex));
     const modMute = new Set(trackMods.filter((m) => m.target === 'mute').map((m) => m.trackIndex));
+    for (const m of ccMods) {
+      if (m.target === 'volume') modVol.add(m.trackIndex);
+      else if (m.target === 'mute') modMute.add(m.trackIndex);
+      // fx routes live in the chain, not the mix layer — nothing to neutralize here
+    }
     for (const [index, mix] of mixRef.current) {
       let changed = false;
       if (!modVol.has(index) && mix.vol !== 1) { mix.vol = 1; changed = true; }
       if (!modMute.has(index) && mix.mute) { mix.mute = false; changed = true; }
       if (changed) applyMixToTrack(index);
     }
-  }, [trackMods, applyMixToTrack]);
+  }, [trackMods, ccMods, applyMixToTrack]);
 
   // --- Live scene control from assigned Sway controls ------------------------
   // Assignments live in performRouting: Scene Select moves the highlighted scene,
@@ -780,6 +813,18 @@ export const DawSessionGrid: React.FC<DawSessionGridProps> = ({ project, fill = 
         if (st.learn.kind === 'fn') st.bindFn(st.learn.fn, ctrl);
         else st.bindScene(st.learn.scene, ctrl);
         return;
+      }
+
+      // Project-derived direct routes: the imported set's own MIDI-learn
+      // mappings, applied to the live Perform mix with zero setup. Checked
+      // before transport so a fader CC that happens to share a number with a
+      // learned button still moves the fader it was mapped to in the DAW.
+      if (isCc) {
+        for (const cm of st.ccMods) {
+          if (cm.isNote || cm.number !== num) continue;
+          if (cm.channel >= 0 && cm.channel !== ch) continue;
+          applyCcModRef.current(cm, val / 127);
+        }
       }
 
       const count = sceneCountRef.current;

--- a/frontend/src/components/session/PerformRoutingPanel.tsx
+++ b/frontend/src/components/session/PerformRoutingPanel.tsx
@@ -1,268 +1,95 @@
 /**
- * Perform Routing panel.
+ * Perform routing — the SwayCommand deck schematic as the assignment surface,
+ * collapsible to a slim bar.
  *
- * Assigns the Sway (or any MIDI controller) to the Perform grid. Three sections:
- *
- *  - Transport: learn a control for Scene Select (encoder), Launch, Stop,
- *    Scene +, Scene -. Turning the Scene Select encoder moves the highlighted
- *    scene; the Launch control fires it. Pads are intentionally NOT scene
- *    triggers here.
- *  - Scenes: bind any scene row to its own control for direct launch.
- *  - Modulation: route a Sway expressive dimension (the hand-tracking sensors)
- *    to a track's live Volume or Mute in the Perform mix.
- *
- * Learn is armed from here and captured by the grid's single MIDI listener, so
- * the panel and grid must both be mounted (they are: both live in the Perform
- * tab). Nothing is guessed — every binding is something the user performed.
+ * The deck (SwayDeck, a verbatim port of SwayCommand's surface) IS the UI:
+ * click a pad to give it a scene, a knob / XY axis / gesture chip to route it
+ * to a track's volume, mute or any live FX parameter, a button to bind a
+ * transport function by pressing it. Under the deck, one chip row lists every
+ * active route (⚡ = auto-created from the project file) with one-click remove.
  */
 import React from 'react';
+import { ChevronDown, ChevronUp, X, Zap } from 'lucide-react';
 import type { DawProject } from '../../lib/dawImportClient';
-import { performScenes, performTracks } from '../../lib/performModel';
-import {
-  usePerformRoutingStore,
-  performCtrlLabel,
-  PERFORM_FUNCTIONS,
-  type PerformFn,
-  type ModTarget,
-} from '../../state/performRouting';
-import { useSwayStore, SWAY_DIMS, type SwayDim } from '../../state/swayBus';
-import { useMidiTriggerStore, enableMidi } from '../../state/midiTriggerStore';
-
-const LearnButton: React.FC<{
-  bound: string | null;
-  listening: boolean;
-  onLearn: () => void;
-  onCancel: () => void;
-  onClear: () => void;
-  label: string;
-}> = ({ bound, listening, onLearn, onCancel, onClear, label }) => (
-  <span className="flex items-center gap-1 shrink-0">
-    <button
-      type="button"
-      onClick={listening ? onCancel : onLearn}
-      aria-label={listening ? `Cancel learning ${label}` : `Learn ${label}`}
-      title={listening ? 'Listening — move the control to bind it' : 'Learn — bind the next control moved'}
-      className={`px-1.5 py-0.5 rounded border text-[8px] font-black uppercase tracking-widest ${
-        listening
-          ? 'border-amber-400/60 bg-amber-400/15 text-amber-200 animate-pulse'
-          : bound
-            ? 'border-emerald-400/40 text-emerald-200/90 hover:border-emerald-400/70'
-            : 'border-white/15 text-zinc-300 hover:border-emerald-400/50 hover:text-emerald-200'
-      }`}
-    >
-      {listening ? 'Listen' : bound ? bound : 'Learn'}
-    </button>
-    {bound && !listening && (
-      <button
-        type="button"
-        onClick={onClear}
-        aria-label={`Clear ${label} binding`}
-        title="Clear binding"
-        className="text-[10px] leading-none text-zinc-600 hover:text-rose-300"
-      >
-        x
-      </button>
-    )}
-  </span>
-);
+import { performTracks } from '../../lib/performModel';
+import { usePerformRoutingStore } from '../../state/performRouting';
+import { SWAY_DIMS, type SwayDim } from '../../state/swayBus';
+import { SwayDeck } from './SwayDeck';
 
 export const PerformRoutingPanel: React.FC<{ project: DawProject }> = ({ project }) => {
-  const scenes = React.useMemo(() => performScenes(project), [project]);
+  const [collapsed, setCollapsed] = React.useState(false);
   const tracks = React.useMemo(() => performTracks(project), [project]);
-
-  const transport = usePerformRoutingStore((s) => s.transport);
-  const sceneCtrls = usePerformRoutingStore((s) => s.sceneCtrls);
+  const ccMods = usePerformRoutingStore((s) => s.ccMods);
   const trackMods = usePerformRoutingStore((s) => s.trackMods);
-  const learn = usePerformRoutingStore((s) => s.learn);
-  const arm = usePerformRoutingStore((s) => s.arm);
-  const clearFn = usePerformRoutingStore((s) => s.clearFn);
-  const clearScene = usePerformRoutingStore((s) => s.clearScene);
-  const addMod = usePerformRoutingStore((s) => s.addMod);
+  const removeCcMod = usePerformRoutingStore((s) => s.removeCcMod);
   const removeMod = usePerformRoutingStore((s) => s.removeMod);
 
-  const swayValues = useSwayStore((s) => s.values);
-  const midiEnabled = useMidiTriggerStore((s) => s.enabled);
-
-  const [modDim, setModDim] = React.useState<SwayDim>('strike');
-  const [modTrack, setModTrack] = React.useState(0);
-  const [modTarget, setModTarget] = React.useState<ModTarget>('volume');
-
-  const dimLabel = (dim: SwayDim): string => SWAY_DIMS.find((d) => d.id === dim)?.label ?? dim;
-  const trackLabel = (index: number): string => `${String(index + 1).padStart(2, '0')} ${tracks[index]?.name ?? `Track ${index + 1}`}`;
+  const dimLabel = (d: SwayDim): string => SWAY_DIMS.find((x) => x.id === d)?.label ?? d;
+  const trackName = (i: number): string => tracks[i]?.name ?? `Track ${i + 1}`;
+  const routeCount = ccMods.length + trackMods.length;
 
   return (
-    <div className="h-full overflow-y-auto p-2.5 text-zinc-200">
-      {!midiEnabled && (
-        <div className="mb-2 flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => enableMidi()}
-            className="shrink-0 px-2 py-0.5 rounded border border-amber-400/60 bg-amber-400/15 text-amber-200 text-[8px] font-black uppercase tracking-widest hover:bg-amber-400/25"
-          >
-            Enable MIDI
-          </button>
-          <span className="text-[9px] font-mono text-amber-300/80 leading-snug">
-            MIDI input is off. Turn it on to receive the Sway, then Learn the controls below.
-          </span>
-        </div>
-      )}
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={() => setCollapsed((v) => !v)}
+        aria-expanded={!collapsed}
+        title={collapsed ? 'Expand the Sway deck' : 'Collapse the Sway deck'}
+        className="flex items-center gap-2 px-2 py-0.5 text-left hover:bg-white/5"
+      >
+        {collapsed ? <ChevronUp className="w-3 h-3 text-cyan-300" /> : <ChevronDown className="w-3 h-3 text-cyan-300" />}
+        <span className="text-[9px] font-black uppercase tracking-[0.25em] text-cyan-200">Sway</span>
+        <span className="text-[8px] font-mono text-zinc-500">
+          {routeCount > 0 ? `${routeCount} route${routeCount === 1 ? '' : 's'}` : 'click a control to assign'}
+        </span>
+      </button>
 
-      <div className="grid gap-x-4 gap-y-3 lg:grid-cols-3">
-        {/* Transport + scene control */}
-        <section>
-          <div className="flex items-center justify-between mb-1.5">
-            <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-emerald-300">Transport</h3>
-            <span className="text-[8px] font-mono uppercase tracking-widest text-zinc-500">encoder + buttons</span>
-          </div>
-          <div className="space-y-1">
-            {PERFORM_FUNCTIONS.map((fn) => {
-              const bound = transport[fn.id];
-              const listening = learn?.kind === 'fn' && learn.fn === fn.id;
-              return (
-                <div key={fn.id} className="flex items-center gap-1.5 rounded border border-white/10 bg-white/3 px-1.5 py-1">
-                  <span className="min-w-0 flex-1">
-                    <span className="block text-[10px] font-bold uppercase tracking-wider text-emerald-200">{fn.label}</span>
-                    <span className="block text-[8px] font-mono text-zinc-500 truncate">{fn.hint}</span>
-                  </span>
-                  <LearnButton
-                    label={fn.label}
-                    bound={bound ? performCtrlLabel(bound) : null}
-                    listening={listening}
-                    onLearn={() => arm({ kind: 'fn', fn: fn.id as PerformFn })}
-                    onCancel={() => arm(null)}
-                    onClear={() => clearFn(fn.id as PerformFn)}
-                  />
-                </div>
-              );
-            })}
-          </div>
-        </section>
-
-        {/* Per-scene direct launch */}
-        <section>
-          <div className="flex items-center justify-between mb-1.5">
-            <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-sky-300">Scenes</h3>
-            <span className="text-[8px] font-mono uppercase tracking-widest text-zinc-500">direct launch</span>
-          </div>
-          <div className="space-y-1 max-h-56 overflow-y-auto pr-0.5">
-            {scenes.map((sceneName, sceneIndex) => {
-              const bound = sceneCtrls[sceneIndex];
-              const listening = learn?.kind === 'scene' && learn.scene === sceneIndex;
-              return (
-                <div key={`${sceneName}-${sceneIndex}`} className="flex items-center gap-1.5 rounded border border-white/10 bg-white/3 px-1.5 py-1">
-                  <span className="min-w-0 flex-1 truncate text-[10px] font-bold text-sky-200">
-                    {String(sceneIndex + 1).padStart(2, '0')} {sceneName}
-                  </span>
-                  <LearnButton
-                    label={`scene ${sceneIndex + 1}`}
-                    bound={bound ? performCtrlLabel(bound) : null}
-                    listening={listening}
-                    onLearn={() => arm({ kind: 'scene', scene: sceneIndex })}
-                    onCancel={() => arm(null)}
-                    onClear={() => clearScene(sceneIndex)}
-                  />
-                </div>
-              );
-            })}
-          </div>
-        </section>
-
-        {/* Sway dim -> Perform-mix modulation */}
-        <section>
-          <div className="flex items-center justify-between mb-1.5">
-            <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-fuchsia-300">Modulation</h3>
-            <span className="text-[8px] font-mono uppercase tracking-widest text-zinc-500">hand sensors -&gt; mix</span>
-          </div>
-
-          {/* Live dim meters */}
-          <div className="mb-2 grid grid-cols-2 gap-x-2 gap-y-0.5">
-            {SWAY_DIMS.map((d) => (
-              <div key={d.id} className="flex items-center gap-1">
-                <span className="w-11 shrink-0 text-[8px] font-mono uppercase tracking-wider text-fuchsia-200/80">{d.label}</span>
-                <div className="flex-1 h-1.5 rounded bg-black/50 overflow-hidden" aria-hidden="true">
-                  <div className="h-full bg-fuchsia-500/70" style={{ width: `${Math.round((swayValues[d.id] ?? 0) * 100)}%` }} />
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* Add a modulation route */}
-          <div className="flex flex-wrap items-center gap-1 rounded border border-white/10 bg-white/3 px-1.5 py-1.5">
-            <label htmlFor="perform-mod-dim" className="sr-only">Sway dimension</label>
-            <select
-              id="perform-mod-dim"
-              name="perform-mod-dim"
-              value={modDim}
-              onChange={(e) => setModDim(e.target.value as SwayDim)}
-              className="bg-black/60 border border-white/10 rounded px-1 py-0.5 text-[9px] text-zinc-200 outline-none focus:border-fuchsia-500/50"
-            >
-              {SWAY_DIMS.map((d) => (
-                <option key={d.id} value={d.id}>{d.label}</option>
+      {!collapsed && (
+        <>
+          <SwayDeck project={project} />
+          {routeCount > 0 && (
+            <div className="flex items-center flex-wrap gap-1 px-2 pb-1.5" role="group" aria-label="Active routes">
+              {ccMods.map((m) => (
+                <span
+                  key={m.id}
+                  className="inline-flex items-center gap-1 h-5 pl-1 pr-0.5 rounded border border-emerald-400/25 bg-emerald-400/5 text-[8px] font-mono text-emerald-200"
+                  title={`${m.channel < 0 ? 'omni' : `ch${m.channel + 1}`} CC${m.number} → ${m.label}${m.id.startsWith('cc:') ? ' (auto, from the project file)' : ''}`}
+                >
+                  <Zap className="w-2.5 h-2.5" aria-hidden="true" />
+                  {m.label}
+                  <button
+                    type="button"
+                    onClick={() => removeCcMod(m.id)}
+                    aria-label={`Remove route ${m.label}`}
+                    title="Remove"
+                    className="h-3.5 w-3.5 grid place-items-center text-zinc-500 hover:text-rose-300"
+                  >
+                    <X className="w-2.5 h-2.5" />
+                  </button>
+                </span>
               ))}
-            </select>
-            <span className="text-[9px] text-zinc-500">-&gt;</span>
-            <label htmlFor="perform-mod-track" className="sr-only">Track</label>
-            <select
-              id="perform-mod-track"
-              name="perform-mod-track"
-              value={modTrack}
-              onChange={(e) => setModTrack(Number(e.target.value))}
-              className="bg-black/60 border border-white/10 rounded px-1 py-0.5 text-[9px] text-zinc-200 outline-none focus:border-fuchsia-500/50 max-w-32"
-            >
-              {tracks.map((t, i) => (
-                <option key={`${t.name}-${i}`} value={i}>{trackLabel(i)}</option>
-              ))}
-            </select>
-            <label htmlFor="perform-mod-target" className="sr-only">Modulation target</label>
-            <select
-              id="perform-mod-target"
-              name="perform-mod-target"
-              value={modTarget}
-              onChange={(e) => setModTarget(e.target.value as ModTarget)}
-              className="bg-black/60 border border-white/10 rounded px-1 py-0.5 text-[9px] text-zinc-200 outline-none focus:border-fuchsia-500/50"
-            >
-              <option value="volume">Volume</option>
-              <option value="mute">Mute</option>
-            </select>
-            <button
-              type="button"
-              onClick={() => addMod(modDim, modTrack, modTarget)}
-              disabled={tracks.length === 0}
-              className="shrink-0 px-1.5 py-0.5 rounded border border-fuchsia-500/40 bg-fuchsia-500/10 text-[8px] font-black uppercase tracking-widest text-fuchsia-200 hover:bg-fuchsia-500/20 disabled:opacity-40"
-            >
-              Add
-            </button>
-          </div>
-
-          {/* Existing modulation routes */}
-          {trackMods.length > 0 && (
-            <div className="mt-1.5 space-y-0.5">
               {trackMods.map((m) => (
-                <div key={m.id} className="flex items-center gap-1.5 text-[9px] font-mono">
-                  <span className="text-fuchsia-200/90">{dimLabel(m.dim)}</span>
-                  <span className="text-zinc-500">-&gt;</span>
-                  <span className="min-w-0 flex-1 truncate text-zinc-300">
-                    {trackLabel(m.trackIndex)} · {m.target === 'volume' ? 'Volume' : 'Mute'}
-                  </span>
+                <span
+                  key={m.id}
+                  className="inline-flex items-center gap-1 h-5 pl-1 pr-0.5 rounded border border-fuchsia-400/25 bg-fuchsia-400/5 text-[8px] font-mono text-fuchsia-200"
+                  title={`${dimLabel(m.dim)} → ${trackName(m.trackIndex)} · ${m.target}`}
+                >
+                  {dimLabel(m.dim)}⇢{trackName(m.trackIndex)}
                   <button
                     type="button"
                     onClick={() => removeMod(m.id)}
-                    aria-label={`Remove ${dimLabel(m.dim)} modulation of ${trackLabel(m.trackIndex)}`}
-                    className="shrink-0 text-[10px] leading-none text-zinc-600 hover:text-rose-300"
+                    aria-label={`Remove ${dimLabel(m.dim)} route to ${trackName(m.trackIndex)}`}
+                    title="Remove"
+                    className="h-3.5 w-3.5 grid place-items-center text-zinc-500 hover:text-rose-300"
                   >
-                    x
+                    <X className="w-2.5 h-2.5" />
                   </button>
-                </div>
+                </span>
               ))}
             </div>
           )}
-        </section>
-      </div>
-
-      <p className="mt-2.5 text-[8px] font-mono text-zinc-600 leading-snug">
-        Modulation reads the Sway dims after they are learned in the SWAY panel (a dim with no CC sends nothing).
-        Learn a control here by clicking Learn, then moving that control on the Sway.
-      </p>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/session/SwayDeck.tsx
+++ b/frontend/src/components/session/SwayDeck.tsx
@@ -1,0 +1,378 @@
+/**
+ * The Sway deck in PERFORM — the EXACT SwayCommand schematic (surface.js,
+ * ported verbatim) acting as the assignment surface for the loaded project.
+ *
+ * Click any control on the deck and the panel beside it shows what that
+ * control does and lets you add routes:
+ *   pads      -> launch a scene (bound by the pad's chromatic note)
+ *   knobs / XY / gestures -> a track's volume or mute, or ANY parameter of the
+ *                            track's live FX chain (the same chain the grid
+ *                            plays through), on the factory CC for that control
+ *   buttons   -> a transport function, bound by learn (press the real button)
+ *
+ * Live values animate the schematic exactly as the cockpit draws them: knob
+ * arcs, pad flashes, the XY dot riding the sensor field, gesture bars, LEDs.
+ */
+import React from 'react';
+import { X, Zap } from 'lucide-react';
+import type { DawProject } from '../../lib/dawImportClient';
+import { performScenes, performTracks } from '../../lib/performModel';
+import { dawDeviceToEffectNode } from '../../lib/dawEffectMap';
+import { getRackEffect } from '../../lib/rackEffects';
+import {
+  usePerformRoutingStore,
+  performCtrlLabel,
+  PERFORM_FUNCTIONS,
+  type CcMod,
+  type PerformFn,
+} from '../../state/performRouting';
+import { createSurface, type SurfaceHandle } from './swaydeck/surface';
+import { startDeckState, getDeckIo, deckMonitor, ctlToCc, padToNote } from './swaydeck/deckState';
+import './swaydeck/swaydeck.css';
+
+/** Human name for a control id. */
+const ctlLabel = (ctl: string): string => {
+  if (ctl.startsWith('pad:')) return `PAD ${ctl.slice(4)}`;
+  if (ctl.startsWith('knob:')) return `KNOB ${ctl.slice(5)}`;
+  if (ctl.startsWith('button:')) return `BUTTON ${ctl.slice(7)}`;
+  if (ctl === 'xy:x') return 'X';
+  if (ctl === 'xy:y') return 'Y';
+  return ctl.replace('gesture:', '').toUpperCase();
+};
+
+interface FxParamOption {
+  deviceIndex: number;
+  deviceLabel: string;
+  effect: string;
+  paramKey: string;
+  min: number;
+  max: number;
+}
+
+/** The routable FX params of one track, indexed EXACTLY like the Perform
+ *  grid's chain entries (flattened non-instrument, non-rack devices; vst3
+ *  entries exist in the index but are not routable). */
+function fxParamsForTrack(project: DawProject, trackIndex: number): FxParamOption[] {
+  const track = performTracks(project)[trackIndex];
+  if (!track) return [];
+  const out: FxParamOption[] = [];
+  const devices = (track.devices ?? []).filter((d) => !d.is_instrument && !d.is_rack);
+  devices.forEach((d, i) => {
+    const node = dawDeviceToEffectNode(d);
+    if (node.effect_name === 'vst3') return;
+    const def = getRackEffect(node.effect_name);
+    if (!def) return;
+    for (const p of def.params) {
+      out.push({
+        deviceIndex: i,
+        deviceLabel: d.name || def.label,
+        effect: node.effect_name,
+        paramKey: p.key,
+        min: p.min,
+        max: p.max,
+      });
+    }
+  });
+  return out;
+}
+
+export const SwayDeck: React.FC<{ project: DawProject }> = ({ project }) => {
+  const hostRef = React.useRef<HTMLDivElement | null>(null);
+  const surfRef = React.useRef<SurfaceHandle | null>(null);
+  const [selected, setSelected] = React.useState<string | null>(null);
+
+  const scenes = React.useMemo(() => performScenes(project), [project]);
+  const tracks = React.useMemo(() => performTracks(project), [project]);
+
+  const ccMods = usePerformRoutingStore((s) => s.ccMods);
+  const setCcMods = usePerformRoutingStore((s) => s.setCcMods);
+  const removeCcMod = usePerformRoutingStore((s) => s.removeCcMod);
+  const sceneCtrls = usePerformRoutingStore((s) => s.sceneCtrls);
+  const bindScene = usePerformRoutingStore((s) => s.bindScene);
+  const clearScene = usePerformRoutingStore((s) => s.clearScene);
+  const transport = usePerformRoutingStore((s) => s.transport);
+  const learn = usePerformRoutingStore((s) => s.learn);
+  const arm = usePerformRoutingStore((s) => s.arm);
+  const clearFn = usePerformRoutingStore((s) => s.clearFn);
+
+  // ── mount the verbatim surface + drive it per frame ──────────────────────
+  React.useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    startDeckState();
+    const surf = createSurface(host, { onSelect: (ctl) => setSelected((cur) => (cur === ctl ? null : ctl)) });
+    surfRef.current = surf;
+    let raf = 0;
+    const tick = () => {
+      raf = requestAnimationFrame(tick);
+      surf.update(getDeckIo(), deckMonitor);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(raf);
+      surfRef.current = null;
+      host.innerHTML = '';
+    };
+  }, []);
+
+  // Reticle follows the selection.
+  React.useEffect(() => {
+    surfRef.current?.select(selected);
+    surfRef.current?.setArmed(!!learn);
+  }, [selected, learn]);
+
+  // Pad labels = the scene each pad launches (bound by its chromatic note).
+  React.useEffect(() => {
+    const labels: (string | null)[] = new Array(16).fill(null);
+    for (let padIdx = 0; padIdx < 16; padIdx++) {
+      const note = padToNote(padIdx);
+      for (const [sceneKey, ctrl] of Object.entries(sceneCtrls)) {
+        if (ctrl.isNote && ctrl.number === note) {
+          labels[padIdx] = scenes[Number(sceneKey)] ?? `Scene ${Number(sceneKey) + 1}`;
+          break;
+        }
+      }
+    }
+    const lit = PERFORM_FUNCTIONS.map((f) => !!transport[f.id]);
+    surfRef.current?.refresh(labels, lit);
+    surfRef.current?.setStatus(`${scenes.length} scenes · ${tracks.length} tracks`);
+  }, [sceneCtrls, scenes, tracks.length, transport]);
+
+  // ── assignment state for the panel ───────────────────────────────────────
+  const cc = selected ? ctlToCc(selected) : null;
+  const isPad = !!selected?.startsWith('pad:');
+  const isButton = !!selected?.startsWith('button:');
+  const padIdx = isPad ? Number(selected!.slice(4)) : -1;
+
+  /** Routes already on the selected CC control. */
+  const ctlRoutes = React.useMemo(
+    () => (cc == null ? [] : ccMods.filter((m) => !m.isNote && m.number === cc)),
+    [cc, ccMods],
+  );
+  /** Scene bound to the selected pad, if any. */
+  const padScene = React.useMemo(() => {
+    if (padIdx < 0) return null;
+    const note = padToNote(padIdx);
+    for (const [k, ctrl] of Object.entries(sceneCtrls)) {
+      if (ctrl.isNote && ctrl.number === note) return Number(k);
+    }
+    return null;
+  }, [padIdx, sceneCtrls]);
+
+  const [pickTrack, setPickTrack] = React.useState(0);
+  const [pickKind, setPickKind] = React.useState<'volume' | 'mute' | 'fx'>('volume');
+  const [pickFx, setPickFx] = React.useState(0);
+  const fxOptions = React.useMemo(
+    () => fxParamsForTrack(project, pickTrack),
+    [project, pickTrack],
+  );
+
+  const addRoute = () => {
+    if (cc == null) return;
+    const trackName = tracks[pickTrack]?.name ?? `Track ${pickTrack + 1}`;
+    const base = { channel: -1, number: cc, isNote: false, trackIndex: pickTrack };
+    let mod: CcMod;
+    if (pickKind === 'fx') {
+      const fx = fxOptions[pickFx];
+      if (!fx) return;
+      mod = {
+        ...base,
+        id: `deck:${cc}:${pickTrack}:fx:${fx.deviceIndex}:${fx.paramKey}`,
+        target: 'fx',
+        deviceIndex: fx.deviceIndex,
+        paramKey: fx.paramKey,
+        min: fx.min,
+        max: fx.max,
+        label: `${trackName} · ${fx.deviceLabel} · ${fx.paramKey}`,
+      };
+    } else {
+      mod = {
+        ...base,
+        id: `deck:${cc}:${pickTrack}:${pickKind}`,
+        target: pickKind,
+        label: `${trackName} · ${pickKind === 'volume' ? 'Vol' : 'Mute'}`,
+      };
+    }
+    if (!ccMods.some((m) => m.id === mod.id)) setCcMods([...ccMods, mod]);
+  };
+
+  return (
+    <div className="flex items-stretch gap-2 min-h-0">
+      {/* the schematic */}
+      <div ref={hostRef} className="sway-deck min-w-0 grow" style={{ height: 168 }} />
+
+      {/* assignment panel — SwayCommand's right-rail idea, compact */}
+      <aside className="w-64 shrink-0 border-l border-white/10 pl-2 py-1 flex flex-col gap-1.5 text-zinc-200 overflow-y-auto">
+        {!selected ? (
+          <p className="text-[9px] font-mono leading-relaxed text-zinc-500 m-auto px-2 text-center">
+            click a control on the deck —<br />
+            pads launch scenes, knobs / XY / gestures drive volume, mute or any
+            FX parameter, buttons bind transport
+          </p>
+        ) : (
+          <>
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] font-black uppercase tracking-[0.2em] text-cyan-300">{ctlLabel(selected)}</span>
+              {cc != null && <span className="text-[8px] font-mono text-zinc-500">CC{cc}</span>}
+              {isPad && <span className="text-[8px] font-mono text-zinc-500">note {padToNote(padIdx)}</span>}
+              <button
+                type="button"
+                onClick={() => setSelected(null)}
+                aria-label="Deselect"
+                className="ml-auto h-4 w-4 grid place-items-center text-zinc-600 hover:text-zinc-200"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </div>
+
+            {/* pad -> scene */}
+            {isPad && (
+              <div className="flex flex-col gap-0.5 min-h-0 overflow-y-auto">
+                {padScene != null && (
+                  <button
+                    type="button"
+                    onClick={() => clearScene(padScene)}
+                    className="flex items-center gap-1 rounded border border-sky-400/40 bg-sky-400/10 px-1.5 py-0.5 text-[9px] font-mono text-sky-200 hover:border-rose-400/50"
+                    title="Click to unassign"
+                  >
+                    <Zap className="w-2.5 h-2.5" /> launches {scenes[padScene]} <X className="w-2.5 h-2.5 ml-auto" />
+                  </button>
+                )}
+                {scenes.map((name, i) => (
+                  <button
+                    key={`${name}-${i}`}
+                    type="button"
+                    onClick={() => bindScene(i, { isNote: true, channel: -1, number: padToNote(padIdx) })}
+                    disabled={padScene === i}
+                    className="text-left rounded border border-white/10 px-1.5 py-0.5 text-[9px] font-mono text-zinc-300 hover:border-sky-400/50 hover:text-sky-200 disabled:opacity-40"
+                  >
+                    {String(i + 1).padStart(2, '0')} {name}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* button -> transport fn (learn: press the physical button) */}
+            {isButton && (
+              <div className="flex flex-col gap-0.5">
+                {PERFORM_FUNCTIONS.map((fn) => {
+                  const bound = transport[fn.id];
+                  const listening = learn?.kind === 'fn' && learn.fn === fn.id;
+                  return (
+                    <button
+                      key={fn.id}
+                      type="button"
+                      onClick={() => arm(listening ? null : { kind: 'fn', fn: fn.id as PerformFn })}
+                      onContextMenu={(e) => { e.preventDefault(); clearFn(fn.id as PerformFn); }}
+                      title={`${fn.hint}${bound ? ` · bound ${performCtrlLabel(bound)} · right-click clears` : ''}`}
+                      className={`text-left rounded border px-1.5 py-0.5 text-[9px] font-mono ${
+                        listening
+                          ? 'border-amber-400/70 bg-amber-400/15 text-amber-200 animate-pulse'
+                          : bound
+                            ? 'border-emerald-400/40 text-emerald-200'
+                            : 'border-white/10 text-zinc-300 hover:border-white/25'
+                      }`}
+                    >
+                      {fn.label}
+                      {listening ? ' — press the button…' : bound ? ` · ${performCtrlLabel(bound)}` : ''}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* CC control -> volume / mute / fx param */}
+            {cc != null && (
+              <>
+                {ctlRoutes.length > 0 && (
+                  <div className="flex flex-col gap-0.5">
+                    {ctlRoutes.map((m) => (
+                      <span
+                        key={m.id}
+                        className="flex items-center gap-1 rounded border border-emerald-400/25 bg-emerald-400/5 px-1.5 py-0.5 text-[8px] font-mono text-emerald-200"
+                      >
+                        <Zap className="w-2.5 h-2.5 shrink-0" />
+                        <span className="truncate">{m.label}</span>
+                        <button
+                          type="button"
+                          onClick={() => removeCcMod(m.id)}
+                          aria-label={`Remove route ${m.label}`}
+                          className="ml-auto h-3.5 w-3.5 grid place-items-center text-zinc-500 hover:text-rose-300"
+                        >
+                          <X className="w-2.5 h-2.5" />
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <div className="flex flex-col gap-1">
+                  <label htmlFor="deck-route-track" className="sr-only">Track</label>
+                  <select
+                    id="deck-route-track"
+                    name="deck-route-track"
+                    value={pickTrack}
+                    onChange={(e) => { setPickTrack(Number(e.target.value)); setPickFx(0); }}
+                    className="bg-black/60 border border-white/10 rounded px-1 py-0.5 text-[9px] text-zinc-200 outline-none focus:border-cyan-500/50"
+                  >
+                    {tracks.map((t, i) => (
+                      <option key={`${t.name}-${i}`} value={i}>{String(i + 1).padStart(2, '0')} {t.name}</option>
+                    ))}
+                  </select>
+                  <div className="flex items-center gap-1">
+                    {(['volume', 'mute', 'fx'] as const).map((k) => (
+                      <button
+                        key={k}
+                        type="button"
+                        onClick={() => setPickKind(k)}
+                        aria-pressed={pickKind === k}
+                        className={`h-5 px-1.5 rounded border text-[8px] font-black uppercase tracking-wider ${
+                          pickKind === k
+                            ? 'border-cyan-400/60 bg-cyan-400/10 text-cyan-200'
+                            : 'border-white/15 text-zinc-400 hover:border-white/30'
+                        }`}
+                      >
+                        {k}
+                      </button>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={addRoute}
+                      disabled={pickKind === 'fx' && fxOptions.length === 0}
+                      aria-label="Add route"
+                      title="Add this route"
+                      className="ml-auto h-5 w-6 grid place-items-center rounded border border-cyan-500/40 bg-cyan-500/10 text-cyan-200 hover:bg-cyan-500/25 disabled:opacity-40"
+                    >
+                      <Zap className="w-3 h-3" />
+                    </button>
+                  </div>
+                  {pickKind === 'fx' && (
+                    <>
+                      <label htmlFor="deck-route-fx" className="sr-only">Effect parameter</label>
+                      <select
+                        id="deck-route-fx"
+                        name="deck-route-fx"
+                        value={pickFx}
+                        onChange={(e) => setPickFx(Number(e.target.value))}
+                        className="bg-black/60 border border-white/10 rounded px-1 py-0.5 text-[9px] text-zinc-200 outline-none focus:border-cyan-500/50"
+                      >
+                        {fxOptions.length === 0 ? (
+                          <option value={0}>no live FX on this track</option>
+                        ) : (
+                          fxOptions.map((f, i) => (
+                            <option key={`${f.deviceIndex}-${f.paramKey}`} value={i}>
+                              {f.deviceLabel} · {f.paramKey}
+                            </option>
+                          ))
+                        )}
+                      </select>
+                    </>
+                  )}
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </aside>
+    </div>
+  );
+};

--- a/frontend/src/components/session/swaydeck/deckState.ts
+++ b/frontend/src/components/session/swaydeck/deckState.ts
@@ -1,0 +1,122 @@
+/**
+ * Live IO for the ported SwayCommand deck: decodes the global midiBus into the
+ * exact `io` shape surface.js animates (knobs / pads / xy / gestures), using
+ * the same factory layout SwayCommand ships (swaymap.js). One module-level
+ * singleton — the deck is drawn per frame from here, no React state churn.
+ *
+ * Pads accept the chromatic 24..39 range AND the factory Theory-Engine note
+ * grid, on any channel (firmware variance), mirroring SwayCommand's decode.
+ */
+import { subscribeToMidi } from '../../../state/midiBus';
+import type { SurfaceIo } from './surface';
+
+export const DECK_FACTORY: {
+  knobs: number[];
+  xy: { x: number; y: number };
+  gestures: { pulse: number; press: number; sway: number };
+  pads: { chromaticBase: number; factoryNotes: number[] };
+} = {
+  knobs: [20, 21, 22, 23, 24, 25, 26, 27],
+  xy: { x: 50, y: 38 },
+  gestures: { pulse: 35, press: 36, sway: 37 },
+  pads: {
+    chromaticBase: 24,
+    factoryNotes: [47, 49, 50, 52, 54, 55, 57, 59, 61, 62, 64, 66, 67, 69, 71, 73],
+  },
+};
+
+/** Control id (surface.js grammar) -> the CC it rides in the factory layout. */
+export function ctlToCc(ctl: string): number | null {
+  if (ctl.startsWith('knob:')) return DECK_FACTORY.knobs[Number(ctl.slice(5))] ?? null;
+  if (ctl === 'xy:x') return DECK_FACTORY.xy.x;
+  if (ctl === 'xy:y') return DECK_FACTORY.xy.y;
+  if (ctl === 'gesture:pulse') return DECK_FACTORY.gestures.pulse;
+  if (ctl === 'gesture:press') return DECK_FACTORY.gestures.press;
+  if (ctl === 'gesture:sway') return DECK_FACTORY.gestures.sway;
+  return null;
+}
+
+/** Pad index -> the note number its scene binding should match (chromatic map,
+ *  which is what Audima's own Ableton packs use). */
+export function padToNote(pad: number): number {
+  return DECK_FACTORY.pads.chromaticBase + pad;
+}
+
+const io: SurfaceIo = {
+  knobs: new Array(8).fill(0),
+  pads: new Array(16).fill(0),
+  xy: { x: 0.5, y: 0.5 },
+  gestures: { pulse: 0, press: 0, sway: 0 },
+  level: 0,
+  intensity: 0.6,
+  beat: 0,
+  palette: [
+    { r: 0.18, g: 0.88, b: 0.99 },
+    { r: 0.35, g: 0.55, b: 1.0 },
+    { r: 0.65, g: 0.35, b: 1.0 },
+    { r: 1.0, g: 0.18, b: 0.58 },
+    { r: 1.0, g: 0.45, b: 0.25 },
+  ],
+};
+
+/** Monitor line (the deck's OLED): the last decoded event. */
+export const deckMonitor: string[] = [''];
+
+let started = false;
+let lastCcSeen = 0;
+
+export function getDeckIo(): SurfaceIo {
+  // Pad velocity decay + gentle level fade happen on read (the rAF driver
+  // calls this every frame) so no interval runs while the deck is hidden.
+  const now = performance.now();
+  const dt = Math.min(0.1, (now - lastFrame) / 1000);
+  lastFrame = now;
+  for (let i = 0; i < 16; i++) io.pads[i] = Math.max(0, io.pads[i] - dt * 2.2);
+  io.beat = Math.max(0, io.beat - dt * 3);
+  io.level = Math.max(0, io.level - dt * 1.5);
+  return io;
+}
+let lastFrame = performance.now();
+
+function padIndexFromNote(note: number): number {
+  const c = note - DECK_FACTORY.pads.chromaticBase;
+  if (c >= 0 && c < 16) return c;
+  return DECK_FACTORY.pads.factoryNotes.indexOf(note);
+}
+
+export function startDeckState(): void {
+  if (started) return;
+  started = true;
+  subscribeToMidi((msg) => {
+    const [status, d1, d2] = msg.data;
+    if (typeof status !== 'number') return;
+    const cmd = status & 0xf0;
+    const ch = (status & 0x0f) + 1;
+    if (cmd === 0xb0) {
+      const cc = d1 ?? 0;
+      const v = (d2 ?? 0) / 127;
+      const k = DECK_FACTORY.knobs.indexOf(cc);
+      if (k >= 0) io.knobs[k] = v;
+      else if (cc === DECK_FACTORY.xy.x) io.xy.x = v;
+      else if (cc === DECK_FACTORY.xy.y) io.xy.y = v;
+      else if (cc === DECK_FACTORY.gestures.pulse) io.gestures.pulse = v;
+      else if (cc === DECK_FACTORY.gestures.press) io.gestures.press = v;
+      else if (cc === DECK_FACTORY.gestures.sway) io.gestures.sway = v;
+      io.level = Math.min(1, io.level + 0.08);
+      const t = performance.now();
+      if (t - lastCcSeen > 90) {
+        lastCcSeen = t;
+        deckMonitor[0] = `CC${cc}=${d2 ?? 0} ch${ch}`;
+      }
+      return;
+    }
+    if (cmd === 0x90 && (d2 ?? 0) > 0) {
+      const p = padIndexFromNote(d1 ?? 0);
+      if (p >= 0) {
+        io.pads[p] = Math.max(io.pads[p], (d2 ?? 0) / 127);
+        io.beat = 1;
+        deckMonitor[0] = `PAD ${p} vel ${d2}`;
+      }
+    }
+  });
+}

--- a/frontend/src/components/session/swaydeck/surface.d.ts
+++ b/frontend/src/components/session/swaydeck/surface.d.ts
@@ -1,0 +1,26 @@
+// Types for the verbatim SwayCommand surface port (surface.js).
+export interface SurfaceIo {
+  knobs: number[]; // 8, 0..1
+  pads: number[]; // 16, velocity 0..1 (decayed by the caller)
+  xy: { x: number; y: number }; // 0..1
+  gestures: { pulse: number; press: number; sway: number }; // 0..1
+  level: number; // master audio level 0..1
+  intensity: number; // visual intensity 0..1
+  beat: number; // beat flash 0..1
+  palette: { r: number; g: number; b: number }[]; // LED gradient stops (0..1 rgb)
+}
+
+export interface SurfaceHandle {
+  el: SVGSVGElement;
+  update(io: SurfaceIo, monitor: string[]): void;
+  refresh(labels: (string | null)[], buttonLit?: boolean[] | null): void;
+  setStatus(text: string): void;
+  select(target: string | null): void;
+  setArmed(armed: boolean): void;
+}
+
+export const PAD_CELLS: { x: number; y: number }[];
+export function createSurface(
+  container: HTMLElement,
+  opts: { onSelect?: (ctl: string) => void },
+): SurfaceHandle;

--- a/frontend/src/components/session/swaydeck/surface.js
+++ b/frontend/src/components/session/swaydeck/surface.js
@@ -1,0 +1,301 @@
+// Ported VERBATIM from SwayCommand (src/renderer/ui/surface.js) so PERFORM's
+// assignment deck is the EXACT visual the standalone cockpit draws — same
+// schematic, same control-id grammar (pad:N, knob:N, button:N, xy:x, xy:y,
+// gesture:*), same reticle. Keep byte-parity with upstream where possible;
+// improvements belong in SwayCommand first, then re-port.
+//
+// The Sway deck — a stroke line-art schematic of the hardware, drawn once as
+// SVG and mutated per frame. It is the assignment surface: every interactive
+// node carries data-ctl in the shared control-id grammar (pad:N, knob:N,
+// button:N, xy:x, xy:y, gesture:*), so clicking on screen and touching the
+// hardware select the same thing.
+//
+// Geometry is a stylized 1266×160 schematic: each cluster keeps the
+// hardware's internal proportions, only the spacing between clusters
+// stretches. Mirror-symmetric about x=633: rear LED beam, IR sensor field,
+// per side 4 click knobs over a 4×2 pad block with 2×2 slim buttons inboard,
+// center preset row, display, and scroll wheel (display-only).
+
+const NS = 'http://www.w3.org/2000/svg';
+
+// Screen cell → pad index, as the user numbered the deck (2026-08-20
+// screenshot): top rows first, left to right — left cluster 0-3, right
+// cluster 4-7 — then the bottom rows, left cluster 8-11, right cluster 12-15.
+// Pads are displayed 0-based everywhere (PAD 0 … PAD 15). Nothing else
+// references the geometry; a hardware monitor session (scripts/
+// midi-session.ps1) confirms or corrects this table alone.
+export const PAD_CELLS = [
+  { x: 32, y: 92 }, { x: 104, y: 92 }, { x: 176, y: 92 }, { x: 248, y: 92 },
+  { x: 954, y: 92 }, { x: 1026, y: 92 }, { x: 1098, y: 92 }, { x: 1170, y: 92 },
+  { x: 32, y: 125 }, { x: 104, y: 125 }, { x: 176, y: 125 }, { x: 248, y: 125 },
+  { x: 954, y: 125 }, { x: 1026, y: 125 }, { x: 1098, y: 125 }, { x: 1170, y: 125 },
+];
+const PAD_W = 64;
+const PAD_H = 27;
+
+const KNOB_X = [56, 132, 208, 284, 982, 1058, 1134, 1210];
+const KNOB_Y = 72;
+const KNOB_R = 13;
+
+const BTN_CELLS = [
+  { x: 330, y: 92 }, { x: 362, y: 92 }, { x: 330, y: 125 }, { x: 362, y: 125 },
+  { x: 878, y: 92 }, { x: 910, y: 92 }, { x: 878, y: 125 }, { x: 910, y: 125 },
+];
+const BTN_W = 26;
+const BTN_H = 27;
+
+const CHIPS = [
+  { ctl: 'xy:x', label: 'X' },
+  { ctl: 'xy:y', label: 'Y' },
+  { ctl: 'gesture:pulse', label: 'PULSE' },
+  { ctl: 'gesture:press', label: 'PRESS' },
+  { ctl: 'gesture:sway', label: 'SWAY' },
+];
+const CHIP_W = 60;
+const CHIP_H = 18;
+const CHIP_Y = 58;
+const CHIP_X0 = 633 - (CHIPS.length * CHIP_W + (CHIPS.length - 1) * 8) / 2;
+
+const BEAM_X0 = 24;
+const BEAM_X1 = 1242;
+const SEG_GAP = 2;
+const SEG_W = (BEAM_X1 - BEAM_X0 - 15 * SEG_GAP) / 16;
+
+export function createSurface(container, { onSelect }) {
+  const parts = [];
+  parts.push('<svg id="sway-svg" viewBox="0 0 1266 160" preserveAspectRatio="xMidYMid meet">');
+
+  // LED beam
+  for (let i = 0; i < 16; i++) {
+    const x = BEAM_X0 + i * (SEG_W + SEG_GAP);
+    parts.push(`<rect id="led-${i}" x="${x.toFixed(1)}" y="8" width="${SEG_W.toFixed(1)}" height="10" fill="#123" opacity="0.2" />`);
+  }
+
+  // IR sensor field
+  parts.push('<rect id="sensor-field" class="etch" x="24" y="24" width="1218" height="26" />');
+  for (let i = 0; i < 16; i++) {
+    const x = BEAM_X0 + i * (SEG_W + SEG_GAP) + SEG_W / 2;
+    parts.push(`<line class="etch" x1="${x.toFixed(1)}" y1="44" x2="${x.toFixed(1)}" y2="48" />`);
+  }
+  parts.push('<circle id="xy-dot" cx="633" cy="37" r="4" fill="var(--accent)" opacity="0.9" />');
+
+  // Gesture chips
+  for (let i = 0; i < CHIPS.length; i++) {
+    const x = CHIP_X0 + i * (CHIP_W + 8);
+    const c = CHIPS[i];
+    parts.push(
+      `<g class="ctl" data-ctl="${c.ctl}" tabindex="0" role="button" aria-label="${c.ctl}">` +
+        `<rect class="etch hit-ring" x="${x}" y="${CHIP_Y}" width="${CHIP_W}" height="${CHIP_H}" />` +
+        `<text x="${x + CHIP_W / 2}" y="${CHIP_Y + 13}" text-anchor="middle">${c.label}</text>` +
+        `<rect id="dim-${c.ctl.replace(':', '-')}" x="${x + 3}" y="${CHIP_Y + CHIP_H + 3}" width="0" height="2" fill="var(--accent)" />` +
+        `<rect x="${x}" y="${CHIP_Y - 2}" width="${CHIP_W}" height="${CHIP_H + 10}" fill="transparent" />` +
+      '</g>'
+    );
+  }
+
+  // Knobs
+  const arcC = 2 * Math.PI * KNOB_R;
+  for (let i = 0; i < 8; i++) {
+    const cx = KNOB_X[i];
+    parts.push(
+      `<g class="ctl" data-ctl="knob:${i}" tabindex="0" role="button" aria-label="knob:${i}">` +
+        `<circle class="etch hit-ring" cx="${cx}" cy="${KNOB_Y}" r="${KNOB_R}" />` +
+        `<circle id="knob-arc-${i}" cx="${cx}" cy="${KNOB_Y}" r="${KNOB_R}" fill="none" stroke="var(--accent)" stroke-width="2" ` +
+          `stroke-dasharray="0 ${arcC.toFixed(1)}" transform="rotate(135 ${cx} ${KNOB_Y})" opacity="0.85" />` +
+        `<line id="knob-tick-${i}" x1="${cx}" y1="${KNOB_Y - KNOB_R + 3}" x2="${cx}" y2="${KNOB_Y - 4}" stroke="var(--text-dim)" />` +
+        `<circle cx="${cx}" cy="${KNOB_Y}" r="${KNOB_R + 5}" fill="transparent" />` +
+      '</g>'
+    );
+  }
+
+  // Pads
+  for (let i = 0; i < 16; i++) {
+    const c = PAD_CELLS[i];
+    parts.push(
+      `<g class="ctl" data-ctl="pad:${i}" tabindex="0" role="button" aria-label="pad:${i}">` +
+        `<rect class="etch hit-ring" x="${c.x}" y="${c.y}" width="${PAD_W}" height="${PAD_H}" rx="3" />` +
+        `<rect id="pad-fill-${i}" x="${c.x + 1}" y="${c.y + 1}" width="${PAD_W - 2}" height="${PAD_H - 2}" rx="2" fill="var(--accent)" opacity="0" />` +
+        `<path id="pad-tick-${i}" d="M ${c.x + PAD_W - 8} ${c.y + 2} h 6 v 6" fill="none" stroke="var(--accent)" opacity="0" />` +
+        `<text id="pad-label-${i}" x="${c.x + PAD_W / 2}" y="${c.y + PAD_H / 2 + 3}" text-anchor="middle"></text>` +
+      '</g>'
+    );
+  }
+
+  // Mappable buttons
+  for (let i = 0; i < 8; i++) {
+    const c = BTN_CELLS[i];
+    parts.push(
+      `<g class="ctl" data-ctl="button:${i}" tabindex="0" role="button" aria-label="button:${i}">` +
+        `<rect class="etch hit-ring" x="${c.x}" y="${c.y}" width="${BTN_W}" height="${BTN_H}" rx="2" />` +
+        `<rect id="btn-fill-${i}" x="${c.x + 2}" y="${c.y + 2}" width="${BTN_W - 4}" height="${BTN_H - 4}" fill="var(--accent)" opacity="0" />` +
+      '</g>'
+    );
+  }
+
+  // Center: preset row, display, wheel — device-local, display-only.
+  for (let i = 0; i < 6; i++) {
+    parts.push(`<rect class="etch" x="${571 + i * 22}" y="90" width="14" height="8" />`);
+  }
+  parts.push('<rect class="etch" x="543" y="106" width="180" height="44" rx="2" />');
+  parts.push('<text id="oled-line" x="633" y="126" text-anchor="middle" fill="var(--accent)" opacity="0.85"></text>');
+  parts.push('<text id="oled-sub" x="633" y="141" text-anchor="middle"></text>');
+  parts.push('<circle class="etch" cx="763" cy="128" r="22" />');
+  parts.push('<circle class="etch" cx="763" cy="128" r="9" />');
+  parts.push('<line class="etch" x1="763" y1="106" x2="763" y2="112" />');
+
+  // Selection reticle — corner brackets + pulsing diamond arms.
+  parts.push(
+    '<g id="reticle" visibility="hidden">' +
+      '<path id="ret-tl" class="arm" d="" /><path id="ret-tr" class="arm" d="" />' +
+      '<path id="ret-bl" class="arm" d="" /><path id="ret-br" class="arm" d="" />' +
+      '<rect id="ret-n" class="arm" width="6" height="6" /><rect id="ret-s" class="arm" width="6" height="6" />' +
+      '<rect id="ret-w" class="arm" width="6" height="6" /><rect id="ret-e" class="arm" width="6" height="6" />' +
+    '</g>'
+  );
+
+  parts.push('</svg>');
+  container.innerHTML = parts.join('');
+
+  const svg = container.querySelector('#sway-svg');
+  const $id = (id) => svg.querySelector(`#${CSS.escape(id)}`);
+
+  svg.addEventListener('click', (e) => {
+    const node = e.target.closest('[data-ctl]');
+    if (node && onSelect) onSelect(node.dataset.ctl);
+  });
+  svg.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    const node = e.target.closest('[data-ctl]');
+    if (node && onSelect) {
+      e.preventDefault();
+      onSelect(node.dataset.ctl);
+    }
+  });
+
+  const reticle = $id('reticle');
+  const knobArcs = Array.from({ length: 8 }, (_, i) => $id(`knob-arc-${i}`));
+  const knobTicks = Array.from({ length: 8 }, (_, i) => $id(`knob-tick-${i}`));
+  const padFills = Array.from({ length: 16 }, (_, i) => $id(`pad-fill-${i}`));
+  const padTicks = Array.from({ length: 16 }, (_, i) => $id(`pad-tick-${i}`));
+  const padLabels = Array.from({ length: 16 }, (_, i) => $id(`pad-label-${i}`));
+  const btnFills = Array.from({ length: 8 }, (_, i) => $id(`btn-fill-${i}`));
+  const leds = Array.from({ length: 16 }, (_, i) => $id(`led-${i}`));
+  const dims = CHIPS.map((c) => $id(`dim-${c.ctl.replace(':', '-')}`));
+  const xyDot = $id('xy-dot');
+  const sensorField = $id('sensor-field');
+  const oledLine = $id('oled-line');
+  const oledSub = $id('oled-sub');
+
+  const last = { knobs: new Array(8).fill(-1), pads: new Array(16).fill(-1), oled: '' };
+
+  function ledColor(palette, i, intensity) {
+    // 5 palette colors spread across 16 segments, linearly interpolated.
+    const f = (i / 15) * (palette.length - 1);
+    const a = palette[Math.floor(f)];
+    const b = palette[Math.min(palette.length - 1, Math.floor(f) + 1)];
+    const t = f - Math.floor(f);
+    const r = Math.round(((a.r + (b.r - a.r) * t) * intensity) * 255);
+    const g = Math.round(((a.g + (b.g - a.g) * t) * intensity) * 255);
+    const bl = Math.round(((a.b + (b.b - a.b) * t) * intensity) * 255);
+    return `rgb(${r},${g},${bl})`;
+  }
+
+  return {
+    el: svg,
+
+    update(io, monitor) {
+      const arcC = 2 * Math.PI * KNOB_R;
+      const sweep = arcC * 0.75; // 270° of travel
+      for (let i = 0; i < 8; i++) {
+        const v = io.knobs[i];
+        if (Math.abs(v - last.knobs[i]) > 0.002) {
+          last.knobs[i] = v;
+          knobArcs[i].setAttribute('stroke-dasharray', `${(v * sweep).toFixed(1)} ${arcC.toFixed(1)}`);
+          knobTicks[i].setAttribute('transform', `rotate(${(-135 + v * 270).toFixed(1)} ${KNOB_X[i]} ${KNOB_Y})`);
+        }
+      }
+      for (let i = 0; i < 16; i++) {
+        const v = io.pads[i];
+        if (Math.abs(v - last.pads[i]) > 0.005) {
+          last.pads[i] = v;
+          padFills[i].setAttribute('opacity', (v * 0.65).toFixed(2));
+        }
+      }
+      const level = 0.12 + io.intensity * io.level * 0.9;
+      for (let i = 0; i < 16; i++) {
+        leds[i].setAttribute('fill', ledColor(io.palette, i, Math.min(1, 0.25 + io.intensity * 0.75)));
+        leds[i].setAttribute('opacity', Math.min(1, level + io.beat * 0.5).toFixed(2));
+      }
+      xyDot.setAttribute('cx', (BEAM_X0 + io.xy.x * (BEAM_X1 - BEAM_X0)).toFixed(1));
+      xyDot.setAttribute('cy', (48 - io.xy.y * 22).toFixed(1));
+      xyDot.setAttribute('r', (3 + io.gestures.pulse * 4).toFixed(1));
+      sensorField.setAttribute('stroke-opacity', (0.4 + io.gestures.press * 0.6).toFixed(2));
+      const chipVals = [io.xy.x, io.xy.y, io.gestures.pulse, io.gestures.press, io.gestures.sway];
+      for (let i = 0; i < dims.length; i++) {
+        dims[i].setAttribute('width', (chipVals[i] * (CHIP_W - 6)).toFixed(1));
+      }
+      const line = monitor && monitor.length ? monitor[0] : '';
+      if (line !== last.oled) {
+        last.oled = line;
+        oledLine.textContent = line.slice(0, 30);
+      }
+    },
+
+    // Pad labels + assignment ticks; button lit state. Called on assignment
+    // or kit changes, not per frame.
+    refresh(labels, buttonLit) {
+      for (let i = 0; i < 16; i++) {
+        const text = labels[i] || '';
+        padLabels[i].textContent = text.length > 9 ? `${text.slice(0, 8)}…` : text;
+        padTicks[i].setAttribute('opacity', text ? '0.9' : '0');
+      }
+      for (let i = 0; i < 8; i++) {
+        btnFills[i].setAttribute('opacity', buttonLit && buttonLit[i] ? '0.5' : '0');
+      }
+    },
+
+    setStatus(text) {
+      oledSub.textContent = (text || '').slice(0, 34);
+    },
+
+    select(target) {
+      if (!target) {
+        reticle.setAttribute('visibility', 'hidden');
+        return;
+      }
+      const node = svg.querySelector(`[data-ctl="${CSS.escape(target)}"]`);
+      if (!node) {
+        reticle.setAttribute('visibility', 'hidden');
+        return;
+      }
+      const b = node.getBBox();
+      const pad = 5;
+      const x0 = b.x - pad;
+      const y0 = b.y - pad;
+      const x1 = b.x + b.width + pad;
+      const y1 = b.y + b.height + pad;
+      const arm = Math.min(10, Math.max(6, b.width / 5));
+      svg.querySelector('#ret-tl').setAttribute('d', `M ${x0} ${y0 + arm} V ${y0} H ${x0 + arm}`);
+      svg.querySelector('#ret-tr').setAttribute('d', `M ${x1 - arm} ${y0} H ${x1} V ${y0 + arm}`);
+      svg.querySelector('#ret-bl').setAttribute('d', `M ${x0} ${y1 - arm} V ${y1} H ${x0 + arm}`);
+      svg.querySelector('#ret-br').setAttribute('d', `M ${x1 - arm} ${y1} H ${x1} V ${y1 - arm}`);
+      const cx = (x0 + x1) / 2;
+      const cy = (y0 + y1) / 2;
+      const place = (id, x, y) => {
+        const el = svg.querySelector(id);
+        el.setAttribute('x', x - 3);
+        el.setAttribute('y', y - 3);
+        el.setAttribute('transform', `rotate(45 ${x} ${y})`);
+      };
+      place('#ret-n', cx, y0 - 6);
+      place('#ret-s', cx, y1 + 6);
+      place('#ret-w', x0 - 6, cy);
+      place('#ret-e', x1 + 6, cy);
+      reticle.setAttribute('visibility', 'visible');
+    },
+
+    setArmed(armed) {
+      reticle.classList.toggle('armed', !!armed);
+    },
+  };
+}

--- a/frontend/src/components/session/swaydeck/swaydeck.css
+++ b/frontend/src/components/session/swaydeck/swaydeck.css
@@ -1,0 +1,50 @@
+/* SwayCommand's surface styles, scoped under .sway-deck so the schematic in
+   PERFORM renders EXACTLY as the standalone cockpit draws it. Variable values
+   are SwayCommand's own (--accent #2de1fc, --accent2 #ff2d95). */
+.sway-deck {
+  --sd-accent: #2de1fc;
+  --sd-accent2: #ff2d95;
+  --sd-line: rgba(160, 190, 220, 0.5);
+  --sd-line-dim: rgba(120, 145, 175, 0.28);
+  --sd-text-dim: #7e8ba0;
+  --sd-display-font: 'Orbitron', 'Segoe UI', sans-serif;
+}
+
+.sway-deck #sway-svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.sway-deck #sway-svg .ctl { cursor: pointer; }
+.sway-deck #sway-svg .ctl:hover .hit-ring { stroke: var(--sd-accent); opacity: 1; }
+
+.sway-deck #sway-svg text {
+  font: 300 9px var(--sd-display-font);
+  letter-spacing: 0.08em;
+  fill: var(--sd-text-dim);
+  pointer-events: none;
+  user-select: none;
+}
+
+.sway-deck #sway-svg .etch { stroke: var(--sd-line-dim); fill: none; }
+.sway-deck #sway-svg .lit { stroke: var(--sd-line); fill: none; }
+
+/* The surface's own var names, mapped to the scoped ones. */
+.sway-deck #sway-svg {
+  --accent: var(--sd-accent);
+  --accent2: var(--sd-accent2);
+  --text-dim: var(--sd-text-dim);
+}
+
+.sway-deck #reticle .arm {
+  fill: none;
+  stroke: var(--sd-accent);
+  stroke-width: 1.2;
+  animation: sd-reticle-pulse 1.6s ease-in-out infinite;
+}
+.sway-deck #reticle.armed .arm { stroke: var(--sd-accent2); }
+@keyframes sd-reticle-pulse { 50% { opacity: 0.45; } }
+@media (prefers-reduced-motion: reduce) {
+  .sway-deck #reticle .arm { animation: none; }
+}

--- a/frontend/src/components/ui/PathInput.tsx
+++ b/frontend/src/components/ui/PathInput.tsx
@@ -15,6 +15,10 @@ interface PathInputProps {
   disabled?: boolean;
   onBlur?: () => void;
   onEnter?: () => void;
+  /** Fires after a successful native-picker choice (browse), AFTER onChange has
+   *  committed the path — so a call site can act on the pick immediately
+   *  (e.g. Perform's one-click Open imports the file on selection). */
+  onPicked?: (path: string) => void;
   onFocus?: () => void;
   onClick?: () => void;
   /** Runs before the built-in Enter handling; call e.preventDefault() to
@@ -54,6 +58,7 @@ export const PathInput: React.FC<PathInputProps> = ({
   disabled = false,
   onBlur,
   onEnter,
+  onPicked,
   onFocus,
   onClick,
   onKeyDown,
@@ -89,7 +94,10 @@ export const PathInput: React.FC<PathInputProps> = ({
                 initialDir: saveDir,
               })
             : await pickFile(fileFilter ? { filter: fileFilter } : undefined);
-      if (!result.cancelled && result.path) onChange(result.path);
+      if (!result.cancelled && result.path) {
+        onChange(result.path);
+        onPicked?.(result.path);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/frontend/src/orb-kit/react/GantasmoOrb.tsx
+++ b/frontend/src/orb-kit/react/GantasmoOrb.tsx
@@ -63,9 +63,23 @@ export interface GantasmoOrbProps {
     /**
      * Size of the orb's square hit/clamp box in px. Must match the CSS size
      * of .aether-orb-toggle for the host's skin (default 80; theDAW's 2x orb
-     * uses 160 via the orb-2x class).
+     * uses 112 via the orb-2x class).
      */
     bounds?: number;
+
+    /**
+     * Pin the orb to a viewport corner until the user drags it away.
+     *
+     * While stuck the orb re-solves its corner on every resize, so it cannot be
+     * left stranded mid-screen by a window change — which a saved absolute
+     * position otherwise does. The first drag past the threshold releases it
+     * permanently (persisted alongside the position), after which the orb is
+     * free and resizes only clamp it back into view.
+     */
+    stickCorner?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left' | false;
+
+    /** Gap in px between the orb box and the viewport edges while stuck. */
+    cornerMargin?: number;
 }
 
 // Small mouse movement should still count as a click.
@@ -91,9 +105,35 @@ export const GantasmoOrb: React.FC<GantasmoOrbProps> = ({
     coreOverlay,
     processing = false,
     bounds = ORB_BOUNDS,
+    stickCorner = false,
+    cornerMargin = 12,
 }) => {
+    // Where the orb sits while it is still stuck to its corner. Recomputed from
+    // the live viewport rather than stored, so a resize can never strand it.
+    const cornerPosition = useCallback(() => {
+        if (typeof window === 'undefined' || !stickCorner) return null;
+        const right = window.innerWidth - bounds - cornerMargin;
+        const bottom = window.innerHeight - bounds - cornerMargin;
+        switch (stickCorner) {
+            case 'bottom-right': return { x: Math.max(0, right), y: Math.max(0, bottom) };
+            case 'bottom-left': return { x: cornerMargin, y: Math.max(0, bottom) };
+            case 'top-right': return { x: Math.max(0, right), y: cornerMargin };
+            case 'top-left': return { x: cornerMargin, y: cornerMargin };
+            default: return null;
+        }
+    }, [bounds, cornerMargin, stickCorner]);
+
+    const unstuckKey = persistenceKey ? `${persistenceKey}-unstuck` : null;
+    // Read the release flag synchronously so the very first paint is already in
+    // the right place — deferring it to an effect makes the orb visibly jump.
+    const [unstuck, setUnstuck] = useState<boolean>(() => {
+        if (!stickCorner) return true;
+        if (!unstuckKey || typeof window === 'undefined') return false;
+        try { return window.localStorage.getItem(unstuckKey) === '1'; } catch { return false; }
+    });
+
     // Default visual placement mirrors the original app: lower-left-ish.
-    const initialPosition = defaultPosition ?? {
+    const initialPosition = (!unstuck && cornerPosition()) || defaultPosition || {
         x: 20,
         y: typeof window !== 'undefined' ? window.innerHeight - 140 : 500,
     };
@@ -133,6 +173,12 @@ export const GantasmoOrb: React.FC<GantasmoOrbProps> = ({
         if (!persistenceKey || typeof window === 'undefined') {
             return;
         }
+        // While the orb is still stuck to its corner the saved position is
+        // deliberately ignored — the corner is the source of truth until the
+        // user drags the orb out of it for the first time.
+        if (!unstuck) {
+            return;
+        }
 
         const savedPosition = window.localStorage.getItem(persistenceKey);
         if (!savedPosition) {
@@ -147,31 +193,35 @@ export const GantasmoOrb: React.FC<GantasmoOrbProps> = ({
         } catch {
             // Ignore invalid persisted state.
         }
-    }, [clampToViewport, persistenceKey]);
+    }, [clampToViewport, persistenceKey, unstuck]);
 
-    // Keep the orb visible after viewport resizes.
-    // Without this, a previously valid saved position could end up off-screen.
+    // Keep the orb visible after viewport resizes. A still-stuck orb re-solves
+    // its corner (so it stays welded to the edge no matter how the window is
+    // resized); a released orb is only clamped back into view.
     useEffect(() => {
         if (typeof window === 'undefined') {
             return;
         }
 
         const onResize = () => {
-            setPosition((current) => clampToViewport(current));
+            const corner = !unstuck && cornerPosition();
+            setPosition((current) => (corner ? corner : clampToViewport(current)));
         };
 
         window.addEventListener('resize', onResize);
         return () => window.removeEventListener('resize', onResize);
-    }, [clampToViewport]);
+    }, [clampToViewport, cornerPosition, unstuck]);
 
-    // Persist the latest settled position after drag completes.
+    // Persist the latest settled position after drag completes. Skipped while
+    // stuck: the corner is recomputed each load, so writing it back would only
+    // bake in one viewport's coordinates.
     useEffect(() => {
-        if (!persistenceKey || isDragging || typeof window === 'undefined') {
+        if (!persistenceKey || isDragging || !unstuck || typeof window === 'undefined') {
             return;
         }
 
         window.localStorage.setItem(persistenceKey, JSON.stringify(position));
-    }, [isDragging, persistenceKey, position]);
+    }, [isDragging, persistenceKey, position, unstuck]);
 
     // Emit position updates outward so the host can anchor a related surface.
     useEffect(() => {
@@ -211,11 +261,19 @@ export const GantasmoOrb: React.FC<GantasmoOrbProps> = ({
         }
 
         setHasDragged(true);
+        // The first drag past the threshold releases the orb from its corner
+        // for good. Persisted, so it stays free across reloads.
+        if (!unstuck) {
+            setUnstuck(true);
+            if (unstuckKey && typeof window !== 'undefined') {
+                try { window.localStorage.setItem(unstuckKey, '1'); } catch { /* non-fatal */ }
+            }
+        }
         setPosition(clampToViewport({
             x: dragRef.current.startPosX + deltaX,
             y: dragRef.current.startPosY + deltaY,
         }));
-    }, [clampToViewport, isDragging]);
+    }, [clampToViewport, isDragging, unstuck, unstuckKey]);
 
     // If the pointer never crossed the drag threshold, treat the interaction as a click.
     const handleMouseUp = useCallback(() => {

--- a/frontend/src/orb-kit/styles/gantasmo-orb.css
+++ b/frontend/src/orb-kit/styles/gantasmo-orb.css
@@ -154,44 +154,88 @@
    prop on GantasmoOrb must match the toggle size here (160). Only the FLUID is
    bigger: the core (the three.js canvas) fills the box edge to edge while the
    decorative glow/pulse chrome hugs it instead of framing a small ball. */
+/* Sized down 30% from the original 160 stack (160 -> 112, core 152 -> 106,
+   face inset 28 -> 20). The bounds prop on GantasmoOrb and OrbDripTrail's
+   orbBox must both match the toggle size here (112) or the viewport clamp and
+   the drip trail drift out of alignment with the visible orb. */
 .gantasmo-orb-theme.orb-2x .aether-orb-toggle {
-    width: 160px;
-    height: 160px;
+    width: 112px;
+    height: 112px;
+    /* Glide to a new position instead of snapping — this is what makes a resize
+       re-stick, or a release, read as movement. `.dragging` kills the transition
+       (transition: none !important) so dragging still tracks the cursor 1:1. */
+    transition: transform 900ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .gantasmo-orb-theme.orb-2x .aether-orb-main {
-    width: 160px;
-    height: 160px;
+    width: 112px;
+    height: 112px;
 }
 
 .gantasmo-orb-theme.orb-2x .orb-core-main {
-    width: 152px;
-    height: 152px;
-    /* No outer shadow rings: the glow lives in .orb-glow-main BEHIND the orb. */
+    width: 106px;
+    height: 106px;
+    /* No outer shadow rings — the fluid body is the whole visual. */
     box-shadow: none;
 }
 
 .gantasmo-orb-theme.orb-2x .gantasmo-face {
-    inset: 28px;
+    inset: 20px;
 }
 
-/* Backlight, not a ring: one soft blurred layer behind the opaque fluid so
-   only its spill past the rim is visible. The literal rings (rotating swirl,
-   expanding pulse) are disabled for this orb. Opacity runs 20% less
-   transparent than the stock glow (0.5/0.8 -> 0.6/0.96). */
-.gantasmo-orb-theme.orb-2x .orb-glow-main {
-    inset: -12px;
-    background: radial-gradient(circle,
-            var(--glow-primary) 0%,
-            var(--glow-secondary) 40%,
-            transparent 68%);
-    filter: blur(10px);
-    animation: gantasmo-glow-nestle-pulse 2s ease-in-out infinite;
-}
-
+/* No ring of any kind on this orb. The rotating swirl and the expanding pulse
+   border were already off; the soft radial backlight behind the rim read as a
+   ring too, so it goes as well. The ferrofluid body stands on its own. */
+.gantasmo-orb-theme.orb-2x .orb-glow-main,
 .gantasmo-orb-theme.orb-2x .orb-swirl-layer,
 .gantasmo-orb-theme.orb-2x .orb-pulse-main {
     display: none;
+}
+
+/* Slower idle motion. The stock 2-3s cycles read as jittery at this size; these
+   run roughly 2.4x longer so the orb drifts rather than twitches. The drag
+   transform itself is eased in GantasmoOrb (and disabled mid-drag). */
+.gantasmo-orb-theme.orb-2x .orb-core-main {
+    animation: gantasmo-orb-core-breathe 7.5s ease-in-out infinite;
+}
+
+.gantasmo-orb-theme.orb-2x .gantasmo-face {
+    animation: gantasmo-ghost-float 8s ease-in-out infinite;
+}
+
+.gantasmo-orb-theme.orb-2x .orb-cavity-eye {
+    animation: gantasmo-eye-blink 11s ease-in-out infinite;
+}
+
+.gantasmo-orb-theme.orb-2x .orb-cavity-mouth {
+    animation: gantasmo-mouth-move 7s ease-in-out infinite;
+}
+
+.gantasmo-orb-theme.orb-2x .aether-orb-toggle.active .orb-cavity-mouth {
+    animation: gantasmo-mouth-talk 1.6s ease-in-out infinite;
+}
+
+/* The ferrofluid canvas IS the body for this orb, so the stock purple gradient
+   core underneath it only ever showed as a rim around the canvas edge — another
+   ring by another name. Same for the face's white drop-shadow halo. */
+.gantasmo-orb-theme.orb-2x .orb-core-main {
+    background: #05040a;
+}
+
+.gantasmo-orb-theme.orb-2x .gantasmo-face svg {
+    filter: none;
+}
+
+.gantasmo-orb-theme.orb-2x .aether-orb-toggle:hover .gantasmo-face {
+    filter: none;
+}
+
+.gantasmo-orb-theme.orb-2x .floating-particles .particle {
+    animation-duration: 7s;
+}
+
+.gantasmo-orb-theme.orb-2x .aether-orb-toggle:hover .floating-particles .particle {
+    animation-duration: 4.5s;
 }
 
 @keyframes gantasmo-glow-nestle-pulse {

--- a/frontend/src/state/midiTriggerStore.ts
+++ b/frontend/src/state/midiTriggerStore.ts
@@ -19,11 +19,15 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 interface MidiTriggerState {
-  /** Master Web MIDI gate. Default OFF so the app never calls
-   *  navigator.requestMIDIAccess() at load — that call triggers Chrome's
-   *  Web MIDI permission prompt + a deprecation notice. We only request
-   *  access once the user explicitly turns MIDI on (the "MIDI" toggle, or
-   *  opening a MIDI mapper). */
+  /** Master Web MIDI gate. Default ON.
+   *
+   *  It used to default OFF to avoid Chrome's Web MIDI permission prompt and
+   *  deprecation notice at load. The cost of that was worse than the prompt:
+   *  theDAW owns the ONLY requestMIDIAccess() in the app and relays hardware to
+   *  the SwayCommand cockpit over postMessage, so with the gate off a connected
+   *  Sway was invisible to theDAW even while the standalone app saw it fine —
+   *  the controller simply did nothing until you found an unrelated toggle.
+   *  A hardware surface has to work when it is plugged in. */
   enabled: boolean;
   /** When true, MIDI note-on events do NOT fire the piano synth voice. */
   audioMuted: boolean;
@@ -36,14 +40,26 @@ interface MidiTriggerState {
 export const useMidiTriggerStore = create<MidiTriggerState>()(
   persist(
     (set) => ({
-      enabled: false,
+      enabled: true,
       audioMuted: false,
       setEnabled: (enabled) => set({ enabled }),
       toggleEnabled: () => set((s) => ({ enabled: !s.enabled })),
       setAudioMuted: (audioMuted) => set({ audioMuted }),
       toggleAudioMuted: () => set((s) => ({ audioMuted: !s.audioMuted })),
     }),
-    { name: 'thedaw.midiTrigger.v1' },
+    {
+      name: 'thedaw.midiTrigger.v1',
+      // v1 shipped with enabled:false persisted for everyone who ever loaded the
+      // app, so changing the default alone would leave every existing install
+      // still dark. Bumping the version re-runs migrate, which adopts the new
+      // default once; audioMuted (a real preference) is carried across.
+      version: 2,
+      migrate: (persisted, from) => {
+        const p = (persisted ?? {}) as Partial<MidiTriggerState>;
+        if (from < 2) return { ...p, enabled: true } as MidiTriggerState;
+        return p as MidiTriggerState;
+      },
+    },
   ),
 );
 

--- a/frontend/src/state/performRouting.ts
+++ b/frontend/src/state/performRouting.ts
@@ -22,7 +22,7 @@
  */
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { SwayDim } from './swayBus';
+import { SWAY_DIMS, seedSwayBinding, type SwayDim } from './swayBus';
 
 export type PerformFn = 'select' | 'launch' | 'stop' | 'next' | 'prev';
 
@@ -53,6 +53,35 @@ export interface TrackMod {
   target: ModTarget;
 }
 
+/**
+ * A DIRECT CC -> Perform-mix route, created automatically from an imported
+ * project's own MIDI-learn mappings (a set built FOR the Sway carries them in
+ * the .als/.swayproj/.tasmo). Unlike TrackMod this does not go through the
+ * dim layer at all: the project says "CC 21 ch1 moves track 3's volume", so
+ * that exact control moves that exact fader, faithful to the source DAW with
+ * zero setup. Session-scoped — derived from the loaded project, never
+ * persisted globally (it belongs to the project, not the machine).
+ */
+export interface CcMod {
+  id: string;
+  /** 0-indexed channel; -1 = omni. */
+  channel: number;
+  number: number;
+  isNote: boolean;
+  trackIndex: number;
+  target: 'volume' | 'mute' | 'fx';
+  /** fx only: index into the track's flattened (non-instrument, non-rack)
+   *  device list — the SAME indexing the Perform grid uses for its chain entry
+   *  ids (`perform-<mix>-<i>`), so the route reaches the running effect. */
+  deviceIndex?: number;
+  /** fx only: the rack-effect parameter this CC drives, plus its range. */
+  paramKey?: string;
+  min?: number;
+  max?: number;
+  /** Display label, e.g. "03 Bass · Volume". */
+  label: string;
+}
+
 /** What the panel has armed for learn; captured by the grid's MIDI listener. */
 export type LearnArm =
   | { kind: 'fn'; fn: PerformFn }
@@ -79,10 +108,14 @@ interface PerformRoutingState {
   sceneCtrls: Record<number, PerformCtrl>;
   /** Sway dim -> Perform-mix modulation targets. */
   trackMods: TrackMod[];
+  /** Project-derived direct CC routes (session only, replaced per project). */
+  ccMods: CcMod[];
   /** Armed learn (session only). */
   learn: LearnArm;
 
   arm: (a: LearnArm) => void;
+  setCcMods: (mods: CcMod[]) => void;
+  removeCcMod: (id: string) => void;
   bindFn: (fn: PerformFn, ctrl: PerformCtrl) => void;
   bindScene: (scene: number, ctrl: PerformCtrl) => void;
   clearFn: (fn: PerformFn) => void;
@@ -99,8 +132,11 @@ export const usePerformRoutingStore = create<PerformRoutingState>()(
       transport: {},
       sceneCtrls: {},
       trackMods: [],
+      ccMods: [],
       learn: null,
       arm: (a) => set({ learn: a }),
+      setCcMods: (ccMods) => set({ ccMods }),
+      removeCcMod: (id) => set((s) => ({ ccMods: s.ccMods.filter((m) => m.id !== id) })),
       bindFn: (fn, ctrl) => set((s) => ({ transport: { ...s.transport, [fn]: ctrl }, learn: null })),
       bindScene: (scene, ctrl) => set((s) => ({ sceneCtrls: { ...s.sceneCtrls, [scene]: ctrl }, learn: null })),
       clearFn: (fn) =>
@@ -155,4 +191,80 @@ export function ctrlMatches(c: PerformCtrl, isNote: boolean, channel: number, nu
   if (c.number !== number) return false;
   if (c.channel >= 0 && c.channel !== channel) return false;
   return true;
+}
+
+/**
+ * Build the automatic Perform routing for a freshly loaded project.
+ *
+ * A set designed for the Sway ships its MIDI-learn mappings inside the project
+ * file. Loading it should make the hardware work immediately — not present a
+ * blank routing panel. Two things happen here:
+ *
+ *  1. Every resolvable MIXER mapping becomes a direct CcMod on the Perform mix
+ *     (that exact channel+CC moves that exact track's live volume).
+ *  2. Any mapping whose names mention one of the Sway's six dimensions seeds
+ *     that dim's CC binding on swayBus — so the dim meters, the XR mirror and
+ *     dim-based modulation all light up with the project's own layout instead
+ *     of waiting for a learn (or for auto-bind order to happen to match).
+ *
+ * Non-mixer mappings (device/FX params) are NOT dropped — they are handled by
+ * the editor-side auto-attach (swayImportResolve) which owns FX faithfully.
+ */
+export function autoRoutePerformFromProject(project: {
+  controller_mappings?: {
+    is_note: boolean;
+    channel: number;
+    number: number;
+    target_kind: string;
+    track_name: string;
+    track_index: number;
+    device_name: string;
+    param_name: string;
+  }[] | null;
+  tracks: { name: string }[];
+}): { ccMods: CcMod[]; seededDims: number } {
+  const mods: CcMod[] = [];
+  const seen = new Set<string>();
+  let seededDims = 0;
+  const maps = project.controller_mappings ?? [];
+  for (const m of maps) {
+    // Dim seeding by name: "Strike", "SWAY Pulse Macro", etc.
+    const haystack = `${m.param_name} ${m.device_name} ${m.track_name}`.toLowerCase();
+    if (!m.is_note) {
+      if (trySeedSwayDim(haystack, m.channel, m.number)) seededDims += 1;
+    }
+    // What counts as "this CC is the track's loudness" in real Sway sets:
+    // a true mixer mapping, a Utility gain, OR a device/rack param literally
+    // named Volume/Level/Gain — the Ableton Sway templates put per-part volume
+    // on instrument-rack macros named "Volume", not on the track fader, and a
+    // mixer-only filter routed NOTHING from them.
+    const pn = m.param_name.toLowerCase();
+    const isMixer = m.target_kind === 'mixer' || m.device_name.toLowerCase().replace(/[^a-z]/g, '') === 'utility';
+    const isDeviceVolume = m.target_kind === 'device' && /(^|[^a-z])(volume|level|gain)([^a-z]|$)/.test(pn);
+    if ((!isMixer && !isDeviceVolume) || m.is_note || m.track_index < 0 || m.track_index >= project.tracks.length) continue;
+    if (pn.includes('pan')) continue; // perform mix has no pan lane
+    const id = `cc:${m.channel}:${m.number}:${m.track_index}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const trackName = project.tracks[m.track_index]?.name ?? m.track_name ?? `Track ${m.track_index + 1}`;
+    mods.push({
+      id,
+      channel: m.channel,
+      number: m.number,
+      isNote: false,
+      trackIndex: m.track_index,
+      target: 'volume',
+      label: `${String(m.track_index + 1).padStart(2, '0')} ${trackName} · Vol`,
+    });
+  }
+  return { ccMods: mods, seededDims };
+}
+
+function trySeedSwayDim(haystack: string, channel: number, cc: number): boolean {
+  for (const { id } of SWAY_DIMS) {
+    if (haystack.includes(id)) {
+      return seedSwayBinding(id, channel, cc);
+    }
+  }
+  return false;
 }

--- a/frontend/src/state/swayBus.ts
+++ b/frontend/src/state/swayBus.ts
@@ -30,10 +30,13 @@ export const SWAY_DIMS: { id: SwayDim; label: string }[] = [
   { id: 'sculpt', label: 'Sculpt' },
 ];
 
-/** A learned CC binding for one dimension (channel 0..15, cc 0..127). */
+/** A CC binding for one dimension. channel < 0 = omni. `source` records where
+ *  it came from, which sets its authority: a user-learned binding (no source)
+ *  beats a project seed beats the factory default. */
 export interface SwayBinding {
   channel: number;
   cc: number;
+  source?: 'factory' | 'project';
 }
 
 interface SwayState {
@@ -58,10 +61,36 @@ const ZERO_VALUES: Record<SwayDim, number> = {
   sculpt: 0,
 };
 
+/**
+ * The Sway's FACTORY layout, from SwayCommand's recovered map
+ * (SwayCommand/src/renderer/midi/swaymap.js — Base Project V2 + the official
+ * Ableton/Cubase remote scripts): gestures pulse=35 press=36 sway=37, hand
+ * tracking xy = 50/38, X-trigger/Y-mod = 73/74, knobs 20..27.
+ *
+ * theDAW's three dims without a dedicated gesture CC map onto the tracking
+ * surfaces: STRIKE is the X-trigger hit region, GLIDE is lateral hand travel
+ * (xy.x), SCULPT is vertical (xy.y). Channel is omni — pads/CCs have been
+ * observed on ch1 or ch16 depending on firmware/project, and a Sway is the
+ * only thing sending these CCs in practice.
+ *
+ * These are DEFAULTS, not law: a learned binding, a project seed, or auto-bind
+ * has already filled the slot and is never overwritten (see migrate below —
+ * factory values only ever fill EMPTY slots). A device with remapped firmware
+ * CCs still binds by moving its controls.
+ */
+export const FACTORY_BINDINGS: Record<SwayDim, SwayBinding> = {
+  strike: { channel: -1, cc: 73, source: 'factory' },
+  sway: { channel: -1, cc: 37, source: 'factory' },
+  pulse: { channel: -1, cc: 35, source: 'factory' },
+  glide: { channel: -1, cc: 50, source: 'factory' },
+  press: { channel: -1, cc: 36, source: 'factory' },
+  sculpt: { channel: -1, cc: 38, source: 'factory' },
+};
+
 export const useSwayStore = create<SwayState>()(
   persist(
     (set) => ({
-      bindings: {},
+      bindings: { ...FACTORY_BINDINGS },
       values: { ...ZERO_VALUES },
       learningDim: null,
       startLearn: (dim) => set({ learningDim: dim }),
@@ -76,6 +105,16 @@ export const useSwayStore = create<SwayState>()(
     {
       name: 'thedaw-sway-bindings-v1',
       partialize: (s) => ({ bindings: s.bindings }),
+      // v2: factory-layout defaults arrived. Fill only the slots the persisted
+      // state left EMPTY — anything the user learned stays exactly as learned.
+      version: 2,
+      migrate: (persisted, from) => {
+        const p = (persisted ?? {}) as { bindings?: Partial<Record<SwayDim, SwayBinding>> };
+        if (from < 2) {
+          return { ...p, bindings: { ...FACTORY_BINDINGS, ...(p.bindings ?? {}) } };
+        }
+        return p;
+      },
     },
   ),
 );
@@ -96,6 +135,53 @@ export function getSwayValue(dim: SwayDim): number {
   return useSwayStore.getState().values[dim] ?? 0;
 }
 
+/**
+ * Auto-binding.
+ *
+ * The Sway's CC numbers are user-configurable on the device, so nothing can be
+ * hardcoded — that is why this bus was learn-only. But the per-dimension Learn
+ * UI lived in the SWAY tab's rail, and that rail is gone (the tab is the
+ * SwayCommand cockpit now), which would leave a plugged-in Sway permanently
+ * unbound and PERFORM permanently dead.
+ *
+ * So: while any dimension is still unbound, the first time a NEW (channel, cc)
+ * pair moves it claims the next unbound dimension, in SWAY_DIMS order. Moving
+ * the six controls once binds all six, with no UI at all. A CC that is already
+ * bound never re-binds, and once all six are bound auto-binding stops
+ * completely — so ordinary playing can never silently re-map the surface.
+ *
+ * Explicit learn still wins when armed, and clearBinding re-opens a slot.
+ */
+function nextUnboundDim(bindings: Partial<Record<SwayDim, SwayBinding>>): SwayDim | null {
+  for (const { id } of SWAY_DIMS) if (!bindings[id]) return id;
+  return null;
+}
+
+/**
+ * Seed one dim's binding from an imported project's own mapping (channel may be
+ * -1 = omni, matched accordingly). Only fills an EMPTY slot — a binding the
+ * user learned, or one already seeded, is never overwritten by a file load.
+ * Returns true when the seed took.
+ */
+export function seedSwayBinding(dim: SwayDim, channel: number, cc: number): boolean {
+  const st = useSwayStore.getState();
+  const cur = st.bindings[dim];
+  // A project seed replaces the factory default (the project is more specific)
+  // but never a binding the user learned or auto-bound by moving the control.
+  if (cur && cur.source !== 'factory') return false;
+  useSwayStore.setState((s) => ({
+    bindings: { ...s.bindings, [dim]: { channel, cc, source: 'project' } },
+  }));
+  return true;
+}
+
+function isCcBound(bindings: Partial<Record<SwayDim, SwayBinding>>, channel: number, cc: number): boolean {
+  return SWAY_DIMS.some(({ id }) => {
+    const b = bindings[id];
+    return !!b && (b.channel < 0 || b.channel === channel) && b.cc === cc;
+  });
+}
+
 function ingestCc(channel: number, cc: number, value01: number): void {
   const st = useSwayStore.getState();
   // Learn: bind the armed dimension to the first CC it sees, then disarm.
@@ -107,13 +193,27 @@ function ingestCc(channel: number, cc: number, value01: number): void {
     }));
     return;
   }
+
+  // Auto-bind an unclaimed CC to the next unbound dimension.
+  if (!isCcBound(st.bindings, channel, cc)) {
+    const dim = nextUnboundDim(st.bindings);
+    if (dim) {
+      useSwayStore.setState((s) => ({ bindings: { ...s.bindings, [dim]: { channel, cc } } }));
+      // Fall through so this very first move also produces a value, rather than
+      // being swallowed as a binding-only event.
+    }
+  }
   // Route: update every dimension bound to this (channel, cc) and notify the raw
   // value subscribers (the XR mirror, future matrix consumers).
+  // Re-read: an auto-bind above wrote through setState, so the snapshot taken at
+  // the top of this function no longer has the binding we just created and the
+  // first movement would otherwise be dropped.
+  const cur = useSwayStore.getState();
   let changed = false;
-  const nextValues = { ...st.values };
+  const nextValues = { ...cur.values };
   for (const { id } of SWAY_DIMS) {
-    const b = st.bindings[id];
-    if (b && b.channel === channel && b.cc === cc) {
+    const b = cur.bindings[id];
+    if (b && (b.channel < 0 || b.channel === channel) && b.cc === cc) { // channel<0 = omni (project-seeded)
       nextValues[id] = value01;
       changed = true;
       for (const cb of valueListeners) {

--- a/frontend/src/views/SessionView.tsx
+++ b/frontend/src/views/SessionView.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { AlertCircle, AlertTriangle, FolderInput, Layers, Loader2, PackagePlus, Scissors, SlidersHorizontal } from 'lucide-react';
+import { AlertCircle, AlertTriangle, FolderInput, Info, Layers, Loader2, Save, Scissors, SlidersHorizontal } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDawImportStore } from '../state/dawImportStore';
 import { useProjectStore } from '../state/projectStore';
 import { DAW_LABELS } from '../lib/dawImportClient';
 import { dawProjectToTasmo, type RecentItem } from '../lib/projectClient';
-import { capturePerformRouting } from '../state/performRouting';
+import { capturePerformRouting, autoRoutePerformFromProject, usePerformRoutingStore } from '../state/performRouting';
 import { SESSION_IMPORT_FILTER } from '../lib/fileFilters';
 import { PathInput } from '../components/ui/PathInput';
 import { DawSessionGrid } from '../components/session/DawSessionGrid';
@@ -122,6 +122,24 @@ export const SessionView: React.FC = () => {
     }
   };
 
+  // Automatic routing. A set built FOR the Sway carries its MIDI-learn
+  // mappings in the project file; loading it should make the hardware work
+  // with zero setup. Mixer mappings become direct CC routes on the Perform
+  // mix, and dim-named mappings seed the Sway dimension bindings. Replaced
+  // wholesale per project; cleared on unload.
+  const setCcMods = usePerformRoutingStore((st) => st.setCcMods);
+  React.useEffect(() => {
+    if (!project) {
+      setCcMods([]);
+      return;
+    }
+    const { ccMods } = autoRoutePerformFromProject(project);
+    setCcMods(ccMods);
+    // Surface what just happened: a set with its own Sway mappings opens with
+    // the routing strip visible, so "it works" is also "you can see why".
+    if (ccMods.length > 0) setShowRouting(true);
+  }, [project, setCcMods]);
+
   return (
     <div className="h-full min-h-0 flex flex-col bg-[#0b0b10]">
       <div className="shrink-0 border-b border-white/10 bg-[#111118] px-3 py-2 flex items-center gap-3">
@@ -140,13 +158,18 @@ export const SessionView: React.FC = () => {
           <PathInput
             id="session-import-path"
             name="session_import_path"
-            label="Project"
+            label="Open"
             kind="file"
             inline
             fileFilter={SESSION_IMPORT_FILTER}
             value={sourcePath}
             onChange={setSourcePath}
             onEnter={importSource}
+            onPicked={(picked) => {
+              if (busy) return;
+              if (picked.trim().toLowerCase().endsWith('.tasmo')) void loadTasmoAsSession(picked);
+              else void detectAndImport();
+            }}
             onFocus={openRecent}
             onClick={openRecent}
             onBlur={scheduleCloseRecent}
@@ -156,18 +179,13 @@ export const SessionView: React.FC = () => {
             ariaControls={recentVisible ? 'session-recent-listbox' : undefined}
             ariaAutocomplete="list"
             ariaActiveDescendant={activeIdx >= 0 ? `session-recent-opt-${activeIdx}` : undefined}
-            placeholder=".als / .tasmo"
+            placeholder=".als / .swayproj / .tasmo / any project"
             className="flex-1 min-w-0"
           />
-          <button
-            type="button"
-            onClick={importSource}
-            disabled={busy || !sourcePath.trim()}
-            className="btn-primary h-7 px-2 inline-flex items-center justify-center gap-1.5 disabled:opacity-40"
-          >
-            {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <FolderInput className="w-3 h-3" />}
-            Import
-          </button>
+          {/* ONE Open control: the field's browse picker. A picked file imports
+              immediately (onPicked), typing + Enter imports, a recent row
+              imports — there is no separate Import button to click after. */}
+          {busy && <Loader2 className="w-3.5 h-3.5 shrink-0 animate-spin text-purple-300" aria-label="Importing…" />}
           {recentVisible && (
             <div
               id="session-recent-listbox"
@@ -195,98 +213,96 @@ export const SessionView: React.FC = () => {
             </div>
           )}
         </div>
-        {project && (
-          <div className="ml-auto flex items-center gap-2 text-[8px] font-mono text-zinc-500">
-            <span>{project.scenes.length} scenes</span>
-            <span>{project.tracks.length} tracks</span>
-            <button
-              type="button"
-              onClick={() => setShowRouting((v) => !v)}
-              aria-pressed={showRouting}
-              className={`h-7 px-2 inline-flex items-center gap-1 rounded border ${
-                showRouting
-                  ? 'border-fuchsia-400/40 text-fuchsia-100 bg-fuchsia-400/10'
-                  : 'border-white/10 text-zinc-300 hover:text-white hover:bg-white/5'
-              }`}
-              title="Assign the Sway (or any controller) to scene launch + mix modulation"
+        <div className="ml-auto flex items-center gap-1">
+          {/* Compact status badges — one icon each, detail on mouse-over. */}
+          {project && detected && (
+            <span
+              className="h-7 px-1.5 inline-flex items-center rounded border border-sky-400/25 bg-sky-400/5 text-[8px] font-black uppercase tracking-widest text-sky-200 cursor-help"
+              title={`Detected ${DAW_LABELS[detected.daw] ?? detected.daw}${hint ? ` — ${hint.limitation}` : ''}`}
             >
-              <SlidersHorizontal className="w-3 h-3" />
-              Routing
-            </button>
-            <button
-              type="button"
-              onClick={saveAsTasmo}
-              className="h-7 px-2 inline-flex items-center gap-1 rounded border border-white/10 text-zinc-300 hover:text-white hover:bg-white/5"
+              {(DAW_LABELS[detected.daw] ?? detected.daw).split(/\s+/).map((w) => w[0]).join('').slice(0, 2)}
+            </span>
+          )}
+          {project && (project.warnings.length > 0 || project.missing_files.length > 0) && (
+            <span
+              className="h-7 px-1.5 inline-flex items-center gap-1 rounded border border-amber-400/25 bg-amber-400/5 text-[9px] font-mono text-amber-200 cursor-help"
+              title={[
+                ...project.warnings,
+                ...(project.missing_files.length
+                  ? [`${project.missing_files.length} sample(s) missing — those clips will not play:`,
+                     ...project.missing_files.slice(0, 20),
+                     ...(project.missing_files.length > 20 ? [`…and ${project.missing_files.length - 20} more`] : [])]
+                  : []),
+              ].join('\n')}
             >
-              <PackagePlus className="w-3 h-3" />
-              .tasmo
-            </button>
-            <button
-              type="button"
-              onClick={() => void editInTimeline()}
-              disabled={timelineBusy}
-              className="h-7 px-2 inline-flex items-center gap-1 rounded border border-emerald-400/30 text-emerald-100 hover:text-white hover:bg-emerald-400/10 disabled:opacity-45"
-              title="Load this imported project into the editable timeline"
-            >
-              {timelineBusy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Scissors className="w-3 h-3" />}
-              Edit Timeline
-            </button>
-          </div>
-        )}
+              <AlertTriangle className="w-3 h-3" />
+              {project.warnings.length + (project.missing_files.length ? 1 : 0)}
+            </span>
+          )}
+          {project && (
+            <span className="h-7 px-1.5 inline-flex items-center text-[8px] font-mono text-zinc-500 cursor-help" title={`${project.scenes.length} scenes × ${project.tracks.length} tracks`}>
+              {project.scenes.length}×{project.tracks.length}
+            </span>
+          )}
+          {project && (
+            <>
+              <button
+                type="button"
+                onClick={() => setShowRouting((v) => !v)}
+                aria-pressed={showRouting}
+                aria-label="Sway routing"
+                className={`h-7 w-7 inline-flex items-center justify-center rounded border ${
+                  showRouting
+                    ? 'border-fuchsia-400/40 text-fuchsia-100 bg-fuchsia-400/10'
+                    : 'border-white/10 text-zinc-300 hover:text-white hover:bg-white/5'
+                }`}
+                title="Sway routing — auto-routed from the project; click to view or edit"
+              >
+                <SlidersHorizontal className="w-3.5 h-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={saveAsTasmo}
+                aria-label="Save as .tasmo"
+                className="h-7 w-7 inline-flex items-center justify-center rounded border border-white/10 text-zinc-300 hover:text-white hover:bg-white/5"
+                title="Save — writes this session (with its routing) as a .tasmo"
+              >
+                <Save className="w-3.5 h-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => void editInTimeline()}
+                disabled={timelineBusy}
+                aria-label="Edit in timeline"
+                className="h-7 w-7 inline-flex items-center justify-center rounded border border-emerald-400/30 text-emerald-100 hover:text-white hover:bg-emerald-400/10 disabled:opacity-45"
+                title="Edit — load this project into the editable timeline"
+              >
+                {timelineBusy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Scissors className="w-3.5 h-3.5" />}
+              </button>
+            </>
+          )}
+          {/* Credit, one icon: hover for the line, the links live in its popover. */}
+          <span className="relative group/credit h-7 w-7 inline-flex items-center justify-center rounded border border-white/10 text-zinc-500 hover:text-zinc-200">
+            <Info className="w-3.5 h-3.5" aria-label="Perform adapted from InfiNight's fork of theDAW" />
+            <span className="pointer-events-auto absolute right-0 top-full z-50 mt-1 hidden w-max max-w-xs rounded border border-white/10 bg-black/95 p-2 shadow-xl group-hover/credit:block">
+              <InfiNightCredit feature="Perform" />
+            </span>
+          </span>
+        </div>
       </div>
 
-      {(error || detected || hint || project?.warnings.length) && (
-        <div className="shrink-0 px-3 py-2 flex flex-col gap-1.5 bg-black/15 border-b border-white/5">
-          {error && (
-            <div className="flex items-center gap-2 text-[9px] font-mono text-red-200">
-              <AlertCircle className="w-3 h-3 text-red-300 shrink-0" />
-              {error}
-            </div>
-          )}
-          {detected && (
-            <div className="text-[9px] font-mono text-zinc-400">
-              Detected <span className="text-sky-200">{DAW_LABELS[detected.daw] ?? detected.daw}</span>
-            </div>
-          )}
-          {hint && (
-            <div className="text-[9px] font-mono text-amber-100">
-              {hint.limitation}
-            </div>
-          )}
-          {project?.warnings.map((warning, index) => (
-            <div key={index} className="flex items-start gap-1.5 text-[8px] font-mono text-amber-100">
-              <AlertTriangle className="w-3 h-3 text-amber-300 shrink-0 mt-px" />
-              {warning}
-            </div>
-          ))}
-          {/* Samples the importer could not resolve. The parser has always
-              collected these, and nothing rendered them — so a Library/Pack-heavy
-              set imported "successfully" with a full grid that played nothing and
-              named no file. Capped + scrollable: a relocated project can miss
-              hundreds, and this strip has no height limit of its own. */}
-          {project && project.missing_files.length > 0 && (
-            <div className="flex flex-col gap-0.5 max-h-24 overflow-y-auto">
-              <div className="flex items-start gap-1.5 text-[8px] font-mono text-amber-200">
-                <AlertTriangle className="w-3 h-3 text-amber-300 shrink-0 mt-px" />
-                {`${project.missing_files.length} sample${project.missing_files.length === 1 ? '' : 's'} could not be found — those clips will not play. Relink them in Live, or open the set from its Project folder.`}
-              </div>
-              {project.missing_files.slice(0, 40).map((file, index) => (
-                <div key={index} className="pl-4 text-[8px] font-mono text-amber-100/60 truncate" title={file}>
-                  {file}
-                </div>
-              ))}
-              {project.missing_files.length > 40 && (
-                <div className="pl-4 text-[8px] font-mono text-amber-100/40">
-                  {`…and ${project.missing_files.length - 40} more`}
-                </div>
-              )}
-            </div>
-          )}
+      {/* Errors only. Detection, format hints, warnings and missing samples all
+          moved into the header badges (mouse-over for detail) — an import that
+          WORKS no longer costs rows of chrome. */}
+      {error && (
+        <div className="shrink-0 px-3 py-1.5 flex items-center gap-2 text-[9px] font-mono text-red-200 bg-black/15 border-b border-white/5">
+          <AlertCircle className="w-3 h-3 text-red-300 shrink-0" />
+          {error}
         </div>
       )}
 
       {project && showRouting && (
-        <div className="shrink-0 max-h-72 overflow-hidden border-b border-white/5 bg-[#0d0d13]">
+        <div className="shrink-0 border-b border-white/5 bg-[#0d0d13]">
           <PerformRoutingPanel project={project} />
         </div>
       )}
@@ -313,9 +329,6 @@ export const SessionView: React.FC = () => {
         )}
       </div>
 
-      <div className="shrink-0 border-t border-white/5 px-3 py-1 flex items-center justify-end">
-        <InfiNightCredit feature="Perform" />
-      </div>
     </div>
   );
 };

--- a/frontend/src/views/SwayView.tsx
+++ b/frontend/src/views/SwayView.tsx
@@ -30,10 +30,11 @@
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertTriangle, RefreshCw, Waves } from 'lucide-react';
-import { SwayLinkPanel } from '../components/sway/SwayLinkPanel';
 import { subscribeToMidi } from '../state/midiBus';
 import { getAnalyser } from '../state/playerStore';
 import { logInfo, logWarn } from '../state/logStore';
+import { useMidiDevicesStore } from '../state/midiDevicesStore';
+import { useMidiTriggerStore } from '../state/midiTriggerStore';
 
 /** Where the cockpit is mounted. Must match backend/modules/sway/sidecar.py. */
 const SWAY_SRC = '/sway-app/';
@@ -66,7 +67,6 @@ export const SwayView: React.FC = () => {
   const [detail, setDetail] = useState<string | null>(null);
   const [build, setBuild] = useState<SwayUrlResponse['build']>(null);
   const [audioSource, setAudioSource] = useState<AudioSource>('thedaw');
-  const [railOpen, setRailOpen] = useState(true);
   const [childReady, setChildReady] = useState(false);
 
   // Readiness is a ref, not just state: the analysis and MIDI loops read it on
@@ -264,24 +264,36 @@ export const SwayView: React.FC = () => {
     return [build.version, sha].filter(Boolean).join(' @ ') || null;
   }, [build]);
 
+  // What is ACTUALLY hooked up, from the host's own MIDIAccess — the cockpit
+  // can only ever say "theDAW (relayed)" because raw bytes are relayed to it,
+  // so the real device names have to be surfaced on this side. midiEnabled
+  // matters too: with the master gate off there IS no relay, and saying
+  // "linked" while hardware is silently ignored is exactly the kind of lie
+  // this header used to tell.
+  const midiEnabled = useMidiTriggerStore((s) => s.enabled);
+  const midiInputs = useMidiDevicesStore((s) => s.inputs);
+  const hardwareLabel = useMemo(() => {
+    if (!midiEnabled) return 'MIDI off';
+    if (midiInputs.length === 0) return 'no MIDI device';
+    const sway = midiInputs.find((n) => /sway|audima/i.test(n));
+    if (sway) return `Sway: ${sway}`;
+    return midiInputs.join(', ');
+  }, [midiEnabled, midiInputs]);
+  const hardwareTone = !midiEnabled
+    ? 'text-amber-400'
+    : midiInputs.length === 0
+      ? 'text-zinc-500'
+      : 'text-emerald-400';
+
   return (
     <div ref={hostRef} className="absolute inset-0 flex bg-black">
-      {railOpen && (
-        <aside className="w-80 shrink-0 overflow-y-auto border-r border-white/10 bg-[#0a0910]">
-          <SwayLinkPanel />
-        </aside>
-      )}
-
+      {/* The SWAY tab is the SwayCommand cockpit, nothing else. theDAW's own
+          Sway rail (routing selects, per-dim learn rows, the MIDI enable
+          button) used to sit alongside it and duplicated what the cockpit
+          already does properly. Its plumbing is unchanged and still feeds
+          PERFORM — only the redundant UI is gone. */}
       <div className="relative min-w-0 grow">
         <div className="absolute inset-x-0 top-0 z-10 flex items-center gap-2 border-b border-white/10 bg-black/70 px-2 py-1 backdrop-blur">
-          <button
-            type="button"
-            onClick={() => setRailOpen((v) => !v)}
-            aria-expanded={railOpen}
-            className="rounded border border-white/15 px-1.5 py-0.5 text-[8px] font-mono uppercase tracking-widest text-zinc-400 hover:border-fuchsia-400/50 hover:text-fuchsia-200"
-          >
-            {railOpen ? 'Hide link' : 'Show link'}
-          </button>
           <Waves className="h-3 w-3 shrink-0 text-fuchsia-300" />
           <span className="text-[9px] font-black uppercase tracking-[0.2em] text-fuchsia-200">SwayCommand</span>
 
@@ -299,8 +311,9 @@ export const SwayView: React.FC = () => {
             <option value="input">Input device</option>
           </select>
 
-          <span className="ml-auto text-[8px] font-mono text-zinc-600">
-            {embedState === 'ready' ? (childReady ? 'linked' : 'loading…') : embedState}
+          <span className={`ml-auto text-[8px] font-mono ${hardwareTone}`}>{hardwareLabel}</span>
+          <span className="text-[8px] font-mono text-zinc-600">
+            · {embedState === 'ready' ? (childReady ? 'linked' : 'loading…') : embedState}
             {buildLabel ? ` · ${buildLabel}` : ''}
           </span>
         </div>
@@ -331,7 +344,7 @@ export const SwayView: React.FC = () => {
                 </p>
                 <p className="max-w-lg text-[10px] font-mono leading-relaxed text-zinc-500">
                   SwayCommand also runs as its own desktop application; this tab embeds the same
-                  cockpit inside theDAW. The controls on the left work either way.
+                  cockpit inside theDAW.
                 </p>
                 <button
                   type="button"

--- a/scripts/regenerate-docs.sh
+++ b/scripts/regenerate-docs.sh
@@ -68,7 +68,11 @@ log "Building frontend"
 
 # 4. Optional Playwright screenshots — only if all preconditions hold.
 screenshot_script="scripts/screenshots/capture.ts"
-if [[ -f "$screenshot_script" ]] && \
+# DISABLED by default (2026-08-26, user request): the 40-scene suite takes tens
+# of minutes and was blocking commits. Opt in per-run with DOCS_SCREENSHOTS=1.
+if [[ "${DOCS_SCREENSHOTS:-0}" != "1" ]]; then
+  warn "Screenshots disabled (set DOCS_SCREENSHOTS=1 to run them)."
+elif [[ -f "$screenshot_script" ]] && \
    ( cd frontend && [[ -d node_modules/playwright || -d node_modules/@playwright/test ]] ); then
   if curl -s -m 2 http://localhost:5173 >/dev/null 2>&1; then
     log "Dev server up — taking Playwright screenshots"


### PR DESCRIPTION
Sway works inside theDAW: the master MIDI gate now defaults ON (v2 migrate flips existing installs) so the relay to the embedded cockpit actually starts; the cockpit splash's available getter is patched to respect relay mode (staged bundle + re-applied on every fetch:sway).

PERFORM: imported Sway-designed .als sets auto-route their MIDI-learn mappings into the live mix and seed the six dim bindings; SwayCommand's factory CC map ships as overridable defaults (learned > project > factory). The SwayCommand deck schematic (surface.js, verbatim port) is
the collapsible assignment surface: pads->scenes, knobs/XY/gestures->
volume/mute/any live FX-chain param, buttons->transport by learn. Header reduced to one Open (imports on pick) + Save + hover badges.

Boot: full-window goo sheet sharing the orb's wet-obsidian material, wordmark sinks into and rises out of it, forward-hemisphere key lights, credits gated on formation (theDAW -> by -> GANTASMO).

Orb: 112px, rings/halos removed, ferrofluid from first frame, sticky bottom-left corner until first drag, slower idle, footer tip bubble replacing G-Search (Ctrl-K opens the library rail).

Capture harness: video/wall-ratio slicing, stamped per-run session files, bounded + concurrent stem loads, data-boot-splash wait, monitor pinning, six new tab scenes. Persistent CDP test window + probe. Docs-regen screenshots now opt-in (DOCS_SCREENSHOTS=1); pre-commit hook disabled locally for the time being at the user's request.