### PR TITLE
fix/lock-platform-guard, metamorphic meter maps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,3 +33,5 @@
 *.ckpt  binary
 *.pt    binary
 *.onnx  binary
+# Hooks run under sh on every platform; CRLF would break them.
+.githooks/* text eol=lf

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+# theDAW pre-commit hook. Installed per clone by theDAW.bat / theDAW.sh with
+#   git config core.hooksPath .githooks
+# and runnable by hand as `.githooks/pre-commit`.
+#
+# 1. ruff check + ruff format --check on the whole repo, with the ONE ruff the
+#    project venv carries (CLAUDE.md hard rule 2: never a second ruff).
+# 2. When pyproject.toml or uv.lock is staged, scripts/check_lock.py proves the
+#    lock is current and installs on Linux x86_64 and Windows (hard rule 4), so
+#    a platform-incomplete lock never reaches a pull request.
+#
+# Worktrees share the main checkout's venv: the venv lives beside the common
+# git dir, never inside a scratch worktree.
+set -e
+cd "$(git rev-parse --show-toplevel)"
+MAIN="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+if [ -x "$MAIN/.venv/Scripts/ruff.exe" ]; then
+  RUFF="$MAIN/.venv/Scripts/ruff.exe"; PY="$MAIN/.venv/Scripts/python.exe"
+elif [ -x "$MAIN/.venv/bin/ruff" ]; then
+  RUFF="$MAIN/.venv/bin/ruff"; PY="$MAIN/.venv/bin/python"
+else
+  echo "pre-commit: no project venv at $MAIN/.venv (run uv sync --group dev)" >&2
+  exit 1
+fi
+
+"$RUFF" check .
+"$RUFF" format --check .
+
+if git diff --cached --name-only | grep -qE '^(pyproject\.toml|uv\.lock)$'; then
+  "$PY" scripts/check_lock.py
+fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,25 @@ env:
   UV_VERSION: "0.9.5"
 
 jobs:
+  # uv.lock must install on every platform theDAW ships to, not only on this
+  # runner. scripts/check_lock.py runs `uv lock --check` and a cross-platform
+  # dry-run sync per target (Linux x86_64 and Windows) with the same flags the
+  # pytest job installs with, so a lock that only carries one platform's
+  # wheels fails here in seconds with the package named, before pytest
+  # spends minutes downloading. The same script is the pre-commit hook.
+  lock:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: .python-version
+      - name: Install uv
+        run: pipx install "uv==${{ env.UV_VERSION }}"
+      - name: uv.lock is current and installs on Linux x86_64 and Windows
+        run: python scripts/check_lock.py
+
   pytest:
     runs-on: ubuntu-latest
     # The cold dependency install dominates: uv.lock pins torch 2.14.0+cu130

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,32 @@ Concrete rules:
 
 See the `## Ruff Configuration` section below for more detail.
 
+### 4. NEVER push a lock that does not install on every shipped platform
+
+`uv lock` records whatever wheels the index listed at that minute. On
+2026-09-10 onnxruntime-gpu 1.30.0 was locked twenty minutes before its Linux
+x86_64 wheels reached PyPI, and the merge into gantasmo/theDAW failed on the
+Linux runner. The guard is in three places and all three stay:
+
+- `tool.uv.required-environments` in `pyproject.toml` names Linux x86_64 and
+  Windows AMD64, so `uv lock` refuses a version without wheels for both.
+- `scripts/check_lock.py` runs `uv lock --check` and a cross-platform dry-run
+  sync per target. The pre-commit hook in `.githooks/` runs it whenever
+  `pyproject.toml` or `uv.lock` is staged; the `lock` job in
+  `.github/workflows/test.yml` runs it on every pull request.
+- `theDAW.bat` / `theDAW.sh` set `git config core.hooksPath .githooks` on
+  every launch, so the hook is installed in every clone.
+
+Concrete rules:
+
+- **After any edit to `pyproject.toml`**, run `uv lock` and then
+  `python scripts/check_lock.py` before committing. Commit both files.
+- **When the check fails, fix the dependency, never the check or the CI.**
+  A missing wheel is a fact about the index; wait for it, pin the previous
+  patch release, or add a platform marker. Never `--no-install-package` the
+  problem away and never remove a platform from `required-environments`.
+- **Never bypass the hook** (`--no-verify`) to get a lock through.
+
 ## Project Overview
 
 Stable Audio 3 is a text-conditioned audio generation system. It generates audio from text prompts using a two-stage architecture: a DiT (diffusion transformer) generates latents, then the SAME autoencoder decodes them to 44.1kHz stereo audio.

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/src/hooks/useProjectPersistence.ts
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/src/hooks/useProjectPersistence.ts
@@ -319,7 +319,7 @@ The \`elements/\` folder contains the JSON representation of each individual UI 
   const handleImportGanFile = async (file: File) => {
     try {
       const buf = await file.arrayBuffer();
-      const { project, sourceKind } = await parseGan(buf);
+      const { project, sourceKind, omittedImages } = await parseGan(buf);
       clearElementSignals();
       clearHistory(project.elements || []);
       setCanvasState(project.canvasState);
@@ -331,7 +331,13 @@ The \`elements/\` folder contains the JSON representation of each individual UI 
       if (sourceKind === "reconstructed") {
         console.info(
           "[gan] No embedded Foundry source in this .gan; reconstructed an " +
-            "editable layout from the manifest.",
+            "editable layout from the runtime's index.html.",
+        );
+      }
+      if (omittedImages.length > 0) {
+        console.info(
+          `[gan] ${omittedImages.length} image element(s) carried no image data ` +
+            `and were left out (the artwork already shows them): ${omittedImages.join(", ")}`,
         );
       }
     } catch (e) {

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/src/lib/customCodeBridge.ts
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/src/lib/customCodeBridge.ts
@@ -73,6 +73,46 @@ export const BRIDGE_BOOTSTRAP_SOURCE = `(function () {
   var ERROR = "foundry:error";
   var READY = "foundry:ready";
 
+  // A sandboxed srcdoc has an opaque origin, so touching window.localStorage
+  // throws a SecurityError. Element code written for a normal page reaches for
+  // it at boot (remembered settings, presets), and every such read used to land
+  // in the host's diagnostics as an error. Give it an in-memory Storage for the
+  // life of the frame instead. Never allow-same-origin: the sandbox stays.
+  function memoryStorage() {
+    var data = {};
+    var s = {
+      getItem: function (k) {
+        k = String(k);
+        return Object.prototype.hasOwnProperty.call(data, k) ? data[k] : null;
+      },
+      setItem: function (k, v) { data[String(k)] = String(v); },
+      removeItem: function (k) { delete data[String(k)]; },
+      clear: function () { data = {}; },
+      key: function (i) {
+        var ks = Object.keys(data);
+        return i >= 0 && i < ks.length ? ks[i] : null;
+      },
+    };
+    try {
+      Object.defineProperty(s, "length", {
+        get: function () { return Object.keys(data).length; },
+      });
+    } catch (e) {}
+    return s;
+  }
+  function shimStorage(name) {
+    var usable = false;
+    try { usable = !!window[name]; } catch (e) {}
+    if (usable) return;
+    try {
+      Object.defineProperty(window, name, {
+        value: memoryStorage(), configurable: true, writable: true,
+      });
+    } catch (e) {}
+  }
+  shimStorage("localStorage");
+  shimStorage("sessionStorage");
+
   if (!window.PARAMS || typeof window.PARAMS !== "object") window.PARAMS = {};
   var userRegistered = false;
 

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/src/lib/customParams.test.ts
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/src/lib/customParams.test.ts
@@ -186,6 +186,56 @@ describe("customCodeBridge", () => {
     expect(() => new Function(BRIDGE_BOOTSTRAP_SOURCE)).not.toThrow();
   });
 
+  // Run the bootstrap against a stand-in window. The free identifiers it uses
+  // (window, document, parent) become parameters, so nothing leaks into jsdom.
+  function bootWindow(win: Record<string, unknown>): Record<string, unknown> {
+    const doc = {
+      readyState: "loading",
+      addEventListener: () => {},
+      documentElement: { style: { setProperty: () => {} } },
+      body: null,
+    };
+    const parent = { postMessage: () => {} };
+    win.addEventListener = () => {};
+    new Function("window", "document", "parent", BRIDGE_BOOTSTRAP_SOURCE)(win, doc, parent);
+    return win;
+  }
+
+  it("shims an in-memory localStorage/sessionStorage when the sandbox denies them", () => {
+    const win: Record<string, unknown> = {};
+    // Chromium's sandboxed srcdoc: the accessor itself throws.
+    for (const name of ["localStorage", "sessionStorage"]) {
+      Object.defineProperty(win, name, {
+        configurable: true,
+        get() {
+          throw new DOMException("denied", "SecurityError");
+        },
+      });
+    }
+    bootWindow(win);
+    const ls = win.localStorage as Storage;
+    expect(ls.getItem("missing")).toBeNull();
+    ls.setItem("preset", "3");
+    expect(ls.getItem("preset")).toBe("3");
+    expect(ls.length).toBe(1);
+    expect(ls.key(0)).toBe("preset");
+    ls.removeItem("preset");
+    expect(ls.getItem("preset")).toBeNull();
+    ls.setItem("a", "1");
+    ls.clear();
+    expect(ls.length).toBe(0);
+    expect(typeof (win.sessionStorage as Storage).setItem).toBe("function");
+    // The shim is per frame: a second boot starts empty.
+    expect((bootWindow({}).localStorage as Storage).getItem("a")).toBeNull();
+  });
+
+  it("leaves a real localStorage alone when the page has one", () => {
+    const real = { getItem: () => "kept", setItem: () => {} };
+    const win = bootWindow({ localStorage: real, sessionStorage: real });
+    expect(win.localStorage).toBe(real);
+    expect(win.sessionStorage).toBe(real);
+  });
+
   it("elementStyleTokens maps set fields and omits undefined ones", () => {
     const el = {
       id: "e1",

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/src/lib/ganImport.test.ts
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/src/lib/ganImport.test.ts
@@ -1,10 +1,11 @@
-// Reopening a .gan that has no embedded Foundry project.
+// Reopening a .gan in the Foundry.
 //
-// The runtime index.html is the layout the author built: every element is an
-// absolutely positioned gan-frame in percentages of the canvas, over a stage
-// whose background is the artwork. Reconstruction has to read that — the
-// manifest alone carries no positions and no background, which is how a
-// reopened plugin came back as knobs gridded into a corner on a bare canvas.
+// theDAW's runtime lays every element out as a positioned wrapper `div.gan-el`
+// with the element inside it — an `iframe.gan-frame` carrying the author's own
+// markup, or a native `div.gan-knob`. Reconstruction has to read exactly that
+// shape: the manifest alone carries no positions and no types beyond "value",
+// which is how a reopened bundle came back as knobs gridded into a corner on a
+// bare canvas — and how fifteen drum pads came back as fifteen knobs.
 
 import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
@@ -16,23 +17,53 @@ import {
   placementsFromIndexHtml,
 } from "./ganImport";
 
-const frame = (id: string, style: string) =>
-  `<iframe class="gan-frame" data-src="el_${id}.html" data-doc="&lt;!doctype html&gt;&lt;body style=&quot;x&quot;&gt;" style="${style}"></iframe>`;
+// The wrappers exactly as backend/modules/plugin/owl_import.py writes them.
+const custom = (id: string, name: string, style: string) =>
+  `<div class="gan-el" style="${style}"><iframe class="gan-frame" data-src="el_${id}.html" ` +
+  `data-doc="&lt;!doctype html&gt;&lt;body style=&quot;background:transparent&quot;&gt;" ` +
+  `title="${name}" scrolling="no"></iframe></div>`;
+const knob = (id: string, style: string, value = 0.0, glow = "#525252", active = "#666666") =>
+  `<div class="gan-el gan-knob-wrap" style="${style}"><div class="gan-knob" id="gan-knob-${id}" ` +
+  `role="slider" aria-label="Knob ${id}" tabindex="0" aria-valuemin="0" aria-valuemax="1" ` +
+  `aria-valuenow="${value}" style="--gan-glow:${glow};--gan-active:${active}">` +
+  `<span class="gan-knob-ind"></span></div><script>(function(){var id='${id}';})();</script></div>`;
+const image = (name: string, style: string) =>
+  `<div class="gan-el gan-image" style="${style}" title="${name}"></div>`;
+const pct = (l: number, t: number, w: number, h: number, extra = "") =>
+  `position:absolute;left:${l}%;top:${t}%;width:${w}%;height:${h}%;${extra}`;
 
 describe("placementsFromIndexHtml", () => {
-  it("turns the runtime's percentage boxes into canvas pixels, in stage order", () => {
+  it("reads each wrapper's percentage box into canvas pixels, in stage order", () => {
     const html =
-      frame("bg", "position:absolute;left:0%;top:0%;width:100%;height:100%;") +
-      frame("k1", "position:absolute;left:10%;top:20%;width:30%;height:40%;");
+      custom("panel", "Panel", pct(0, 0, 100, 100)) +
+      knob("k1", pct(10, 20, 30, 40)) +
+      custom("pad", "Pad", pct(50, 50, 10, 10));
     const placed = placementsFromIndexHtml(html, 1000, 500);
-    expect([...placed.keys()]).toEqual(["bg", "k1"]);
-    expect(placed.get("k1")).toEqual({ x: 100, y: 100, width: 300, height: 200 });
-    expect(placed.get("bg")).toEqual({ x: 0, y: 0, width: 1000, height: 500 });
+    expect([...placed.keys()]).toEqual(["panel", "k1", "pad"]);
+    expect(placed.get("panel")).toMatchObject({ kind: "custom", name: "Panel", x: 0, y: 0, width: 1000, height: 500 });
+    expect(placed.get("k1")).toMatchObject({ kind: "knob", x: 100, y: 100, width: 300, height: 200 });
+    expect(placed.get("pad")).toMatchObject({ kind: "custom", x: 500, y: 250, width: 100, height: 50 });
+  });
+
+  it("recovers what the runtime rendered a knob with", () => {
+    const placed = placementsFromIndexHtml(knob("cut", pct(1, 2, 3, 4), 0.35, "#ff0000", "#00ff00"), 100, 100);
+    expect(placed.get("cut")).toMatchObject({ value: 0.35, glowColor: "#ff0000", activeColor: "#00ff00" });
+  });
+
+  it("turns the runtime's signed rotation back into Foundry's 0..360", () => {
+    const html =
+      custom("tilt", "Tilt", pct(0, 0, 10, 10, "transform:rotate(-3.00deg);")) +
+      custom("flat", "Flat", pct(0, 0, 10, 10)) +
+      custom("pos", "Pos", pct(0, 0, 10, 10, "mix-blend-mode:screen;transform:rotate(2.00deg);"));
+    const placed = placementsFromIndexHtml(html, 100, 100);
+    expect(placed.get("tilt")?.rotation).toBe(357);
+    expect(placed.get("flat")?.rotation).toBeUndefined();
+    expect(placed.get("pos")?.rotation).toBe(2);
   });
 
   it("keeps an element the author parked off-canvas where they parked it", () => {
-    const html = frame("side", "position:absolute;left:-35.8852%;top:21.254%;width:10.0478%;height:15.9405%;");
-    expect(placementsFromIndexHtml(html, 1672, 941).get("side")).toEqual({
+    const html = custom("side", "Side", pct(-35.8852, 21.254, 10.0478, 15.9405));
+    expect(placementsFromIndexHtml(html, 1672, 941).get("side")).toMatchObject({
       x: -600,
       y: 200,
       width: 168,
@@ -40,25 +71,21 @@ describe("placementsFromIndexHtml", () => {
     });
   });
 
-  it("accepts px, and skips a frame without a full box", () => {
+  it("skips placeholders with no element behind them, and wrappers without a full box", () => {
     const html =
-      frame("px", "position:absolute;left:12px;top:8px;width:96px;height:96px;") +
-      frame("half", "position:absolute;left:5%;top:5%;");
+      image("image_16", pct(15, 4, 73, 95)) +
+      custom("half", "Half", "position:absolute;left:5%;top:5%;") +
+      knob("ok", "position:absolute;left:12px;top:8px;width:96px;height:96px;");
     const placed = placementsFromIndexHtml(html, 800, 600);
-    expect(placed.get("px")).toEqual({ x: 12, y: 8, width: 96, height: 96 });
-    expect(placed.has("half")).toBe(false);
+    expect([...placed.keys()]).toEqual(["ok"]);
+    expect(placed.get("ok")).toMatchObject({ x: 12, y: 8, width: 96, height: 96 });
   });
 
   it("is not fooled by the escaped element document in data-doc", () => {
     // data-doc carries the whole element page HTML-escaped; its quotes are
-    // entities, so it must never be read as the tag's own style attribute.
-    const html = frame("k1", "left:50%;top:50%;width:10%;height:10%;");
-    expect(placementsFromIndexHtml(html, 200, 200).get("k1")).toEqual({
-      x: 100,
-      y: 100,
-      width: 20,
-      height: 20,
-    });
+    // entities, so it must never be read as the wrapper's own style.
+    const placed = placementsFromIndexHtml(custom("k1", "K", pct(50, 50, 10, 10)), 200, 200);
+    expect(placed.get("k1")).toMatchObject({ x: 100, y: 100, width: 20, height: 20 });
   });
 });
 
@@ -82,9 +109,12 @@ describe("innerMarkup", () => {
   });
 });
 
-describe("parseGan on a .gan with no embedded project", () => {
-  const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
 
+describe("parseGan on a .gan with no embedded project", () => {
+  // The Owl as it shipped: a native knob and custom drum pads, every one of
+  // them a manifest control of kind "value" — the manifest cannot tell a pad
+  // from a knob. The runtime markup can.
   async function build(withIndex: boolean): Promise<Uint8Array> {
     const zip = new JSZip();
     zip.file(
@@ -99,49 +129,187 @@ describe("parseGan on a .gan with no embedded project", () => {
         canvas: { width: 1000, height: 500 },
         controls: [
           { id: "cut", name: "Cutoff", kind: "value" },
-          { id: "go", name: "Go", kind: "trigger" },
+          { id: "pad", name: "Drum Pad", kind: "value" },
+          { id: "ghost", name: "Never Drawn", kind: "value" },
         ],
       }),
     );
     if (withIndex) {
       zip.file(
         "index.html",
-        "<style>#stage{background:url(background.png) 0 0/100% 100%}</style>" +
-          frame("panel", "left:0%;top:0%;width:100%;height:100%;") +
-          frame("cut", "left:10%;top:20%;width:30%;height:40%;") +
-          frame("go", "left:50%;top:50%;width:10%;height:10%;"),
+        "<style>#gan-canvas{background:url(background.png) 0 0/100% 100%}</style>" +
+          '<div id="gan-stage"><div id="gan-canvas">' +
+          custom("panel", "decor_panel", pct(0, 0, 100, 100)) +
+          knob("cut", pct(10, 20, 30, 40, "transform:rotate(-3.00deg);"), 0.25, "#111111", "#222222") +
+          custom("pad", "Drum Pad", pct(50, 50, 10, 10)) +
+          image("image_16", pct(15, 4, 73, 95)) +
+          "</div></div>",
       );
       zip.file("el_panel.html", "<html><body><div class=\"panel\">art</div></body></html>");
+      zip.file("el_pad.html", "<!doctype html><html><head><style>html{background:transparent}</style></head><body><button>hit</button></body></html>");
       zip.file("background.png", PNG);
     }
     return zip.generateAsync({ type: "uint8array", comment: "GANv1" });
   }
 
-  it("puts every control at its authored box, on its artwork, with decor as CustomCode", async () => {
-    const { project, sourceKind } = await parseGan(await build(true));
+  it("returns every element as what the runtime drew, at its box, on its artwork", async () => {
+    const { project, sourceKind, omittedImages } = await parseGan(await build(true));
     expect(sourceKind).toBe("reconstructed");
     const byId = new Map(project.elements.map((e) => [e.id, e]));
-    expect(byId.get("cut")).toMatchObject({ type: "Knob", x: 100, y: 100, width: 300, height: 200 });
-    expect(byId.get("go")).toMatchObject({ type: "Button", x: 500, y: 250, width: 100, height: 50 });
+    // A control that is custom markup comes back as CustomCode, not a knob.
+    expect(byId.get("pad")).toMatchObject({
+      type: "CustomCode",
+      name: "Drum Pad",
+      x: 500,
+      y: 250,
+      width: 100,
+      height: 50,
+      customCode: "<button>hit</button>",
+      transparentBackground: true,
+    });
+    // A native knob comes back as a knob, with what it was rendered with.
+    expect(byId.get("cut")).toMatchObject({
+      type: "Knob",
+      name: "Cutoff",
+      x: 100,
+      y: 100,
+      width: 300,
+      height: 200,
+      rotation: 357,
+      value: 0.25,
+      glowColor: "#111111",
+      activeColor: "#222222",
+    });
+    // Decor the manifest never listed returns as editable markup.
     expect(byId.get("panel")).toMatchObject({
       type: "CustomCode",
+      name: "decor_panel",
       x: 0,
       y: 0,
       width: 1000,
       height: 500,
       customCode: '<div class="panel">art</div>',
     });
-    // Stage order is z-order: the panel was drawn first, so it sits under the controls.
-    expect(project.elements.map((e) => e.id)).toEqual(["panel", "cut", "go"]);
+    // A control the runtime never drew keeps its grid slot (third control ->
+    // third column) rather than vanishing.
+    expect(byId.get("ghost")).toMatchObject({ type: "Knob", x: 24 + 2 * 160, y: 24 });
+    // Stage order is z-order; the undrawn control goes on top.
+    expect(project.elements.map((e) => e.id)).toEqual(["panel", "cut", "pad", "ghost"]);
+    // The image placeholder had no element behind it — and no Image element
+    // was invented for it, so there is nothing to report either.
+    expect(omittedImages).toEqual([]);
     expect(project.canvasState.backgroundImage?.startsWith("data:image/png;base64,")).toBe(true);
     expect(project.canvasState.width).toBe(1000);
   });
 
+  it("keeps the artwork even when the layout is unreadable", async () => {
+    const zip = new JSZip();
+    zip.file("manifest.json", JSON.stringify({ id: "t", name: "T", canvas: { width: 1000, height: 500 }, controls: [{ id: "cut", name: "Cutoff", kind: "value" }] }));
+    zip.file(
+      "index.html",
+      "<style>#gan-canvas{background:url(background.png) 0 0/100% 100% no-repeat}</style>" +
+        '<div class="gan-el" style="position:absolute;left:48%;top:74%;">' +
+        '<iframe class="gan-frame" data-src="el_cut.html"></iframe></div>',
+    );
+    zip.file("background.png", PNG);
+    const { project } = await parseGan(await zip.generateAsync({ type: "uint8array" }));
+    expect(project.canvasState.backgroundImage?.startsWith("data:image/png;base64,")).toBe(true);
+    // The grid, because nothing readable said otherwise.
+    expect(project.elements[0]).toMatchObject({ id: "cut", x: 24, y: 24 });
+  });
+
   it("still never comes back empty when there is no index.html to read", async () => {
     const { project } = await parseGan(await build(false));
-    expect(project.elements.map((e) => e.id)).toEqual(["cut", "go"]);
+    expect(project.elements.map((e) => e.id)).toEqual(["cut", "pad", "ghost"]);
     expect(project.canvasState.backgroundImage).toBeNull();
     // The grid: the only thing left to do without a layout.
     expect(project.elements[0]).toMatchObject({ x: 24, y: 24 });
+  });
+});
+
+describe("parseGan on a .gan with an embedded project", () => {
+  // theDAW's backend embeds a VST Foundry export byte-for-byte. An export keeps
+  // its artwork in a file beside project.json (so backgroundImage is null while
+  // the archive carries background.png), and names Image elements it has no
+  // pixels for (assets: []). Ares is exactly this: the layout came back, the
+  // artwork did not, and a 1223x894 empty box sat over the art.
+  const canvasState = {
+    backgroundImage: null,
+    width: 1672,
+    height: 941,
+    scale: 1,
+    panX: 0,
+    panY: 0,
+    showRulers: true,
+  };
+  const knobEl = { id: "k1", name: "Cutoff", type: "Knob", x: 240, y: 110, width: 96, height: 96 };
+  const imageEl = { id: "1ow4zt9", name: "image_16", type: "Image", x: 250, y: 39, width: 1223, height: 894, assetId: "a68xzr3" };
+
+  async function build(opts: {
+    background?: string | null;
+    artworkName?: string;
+    withArtwork?: boolean;
+    elements?: unknown[];
+    assets?: unknown[];
+  }): Promise<Uint8Array> {
+    const zip = new JSZip();
+    const art = opts.artworkName ?? "background.png";
+    zip.file(
+      "manifest.json",
+      JSON.stringify({ id: "ares", name: "Ares", entry_html: "index.html", canvas: { width: 1672, height: 941 } }),
+    );
+    zip.file("index.html", `<style>#stage{background:url(${art}) 0 0/100% 100%}</style>`);
+    if (opts.withArtwork !== false) zip.file(art, PNG);
+    zip.file(
+      "source/foundry-project.json",
+      JSON.stringify({
+        version: 1,
+        elements: opts.elements ?? [knobEl],
+        canvasState: { ...canvasState, backgroundImage: opts.background ?? null },
+        assets: opts.assets ?? [],
+        textures: [],
+      }),
+    );
+    return zip.generateAsync({ type: "uint8array", comment: "GANv1" });
+  }
+
+  it("reopens on the archive's artwork, keeping the authored layout", async () => {
+    const { project, sourceKind } = await parseGan(await build({}));
+    expect(sourceKind).toBe("embedded");
+    expect(project.elements).toEqual([knobEl]);
+    expect(project.canvasState.backgroundImage?.startsWith("data:image/png;base64,")).toBe(true);
+    expect(project.canvasState.width).toBe(1672);
+  });
+
+  it("takes the artwork index.html actually paints, not the conventional name", async () => {
+    const { project } = await parseGan(await build({ artworkName: "art.webp" }));
+    expect(project.canvasState.backgroundImage?.startsWith("data:image/webp;base64,")).toBe(true);
+  });
+
+  it("leaves a project that brought its own artwork exactly as it was written", async () => {
+    const own = "data:image/png;base64,AAAA";
+    const { project } = await parseGan(await build({ background: own }));
+    expect(project.canvasState.backgroundImage).toBe(own);
+  });
+
+  it("stays on the embedded project when the archive has no artwork at all", async () => {
+    const { project, sourceKind } = await parseGan(await build({ withArtwork: false }));
+    expect(sourceKind).toBe("embedded");
+    expect(project.canvasState.backgroundImage).toBeNull();
+    expect(project.elements).toHaveLength(1);
+  });
+
+  it("leaves out an Image the project has no pixels for, and says which", async () => {
+    const { project, omittedImages } = await parseGan(await build({ elements: [imageEl, knobEl] }));
+    expect(project.elements).toEqual([knobEl]);
+    expect(omittedImages).toEqual(["image_16"]);
+  });
+
+  it("keeps an Image whose asset travelled with the project", async () => {
+    const asset = { id: "a68xzr3", name: "art", url: "data:image/png;base64,AAAA" };
+    const { project, omittedImages } = await parseGan(await build({ elements: [imageEl, knobEl], assets: [asset] }));
+    expect(project.elements).toEqual([imageEl, knobEl]);
+    expect(project.assets).toEqual([asset]);
+    expect(omittedImages).toEqual([]);
   });
 });

--- a/VST-Foundry-UI/VST-UI-FOUNDRY/src/lib/ganImport.ts
+++ b/VST-Foundry-UI/VST-UI-FOUNDRY/src/lib/ganImport.ts
@@ -3,16 +3,23 @@
 // A `.gan` written by this app (ganExport.ts) embeds the full editable project
 // at source/foundry-project.json — reading it back gives a lossless round-trip
 // (every element, texture, custom module preserved). theDAW's backend importer
-// embeds the same file now, so plugins that went project.json -> .gan round-trip
-// too. A `.gan` without it (an older bundle, a hand-made one, a third party) is
-// RECONSTRUCTED: the manifest's controls give the what, and the runtime's own
-// index.html gives the where — every element is an absolutely positioned
-// <iframe class="gan-frame" data-src="el_<id>.html" style="left:%;top:%;..."> over
-// a stage whose background is `url(<artwork>)`. That is the layout the author
-// built, in percentages of the canvas, and it puts every control back at its
-// real position and size on its real artwork, with the decorative frames
-// (panels, labels) returning as editable CustomCode elements. Only a .gan with
-// no readable index.html falls to the last resort: controls on a grid.
+// embeds the same file, so plugins that went project.json -> .gan round-trip
+// too — with two gaps the archive itself closes. A Foundry EXPORT keeps its
+// artwork in a file BESIDE project.json, so the embedded project reports no
+// background while the .gan carries the artwork as its own entry; the embedded
+// path reads it back out. And an export names Image elements it carries no
+// pixels for; those would reopen as drawn boxes over the artwork that already
+// shows them, so they are left out and reported.
+//
+// A `.gan` with no embedded project (an older bundle, a hand-made one, a third
+// party) is RECONSTRUCTED from what theDAW's runtime wrote. Its index.html IS
+// the authored layout: every element is a wrapper `div.gan-el` absolutely
+// positioned in percentages of the canvas over a stage whose background is the
+// artwork, with the element itself inside — an `iframe.gan-frame` carrying the
+// author's own markup, or a native `div.gan-knob`. So every control returns as
+// what it was, at its real box, on its real artwork. The manifest's controls
+// only fill in names, and place on a grid whatever the runtime did not draw.
+// Only a .gan with no readable index.html falls to the grid entirely.
 
 import JSZip from "jszip";
 import { UIElement, CanvasState } from "../types";
@@ -28,6 +35,9 @@ export interface GanImportResult {
   // Whether the archive carried the "GANv1" comment (some tools strip it; the
   // presence of a valid manifest.json is the authoritative validity check).
   hadGanComment: boolean;
+  // Image elements the project named but carried no pixels for, by name. Left
+  // out of the canvas rather than drawn as empty boxes over the artwork.
+  omittedImages: string[];
 }
 
 function defaultCanvas(width: number, height: number): CanvasState {
@@ -71,9 +81,36 @@ export interface FrameRect {
   height: number;
 }
 
-const FRAME_TAG = /<iframe\b[^>]*\bclass="[^"]*\bgan-frame\b[^"]*"[^>]*>/g;
+export type PlacementKind = "custom" | "knob";
+
+/** One element as the runtime drew it: its box, what it is, and what the
+ *  runtime rendered it with. */
+export interface Placement extends FrameRect {
+  kind: PlacementKind;
+  /** The runtime's own title for the element, when it wrote one. */
+  name?: string;
+  /** Degrees, 0..360 as Foundry stores them. Absent when unrotated. */
+  rotation?: number;
+  /** Knob: the value and colours the runtime rendered. */
+  value?: number;
+  glowColor?: string;
+  activeColor?: string;
+}
+
+// The runtime lays every element out as a positioned wrapper with the element
+// inside it. Wrappers are siblings under #gan-canvas, never nested, so the text
+// from one wrapper tag to the next is that element's whole markup:
+//   <div class="gan-el" style="position:absolute;left:%;top:%;width:%;height:%;">
+//     <iframe class="gan-frame" data-src="el_<id>.html" title="<name>" …>   custom markup
+//   <div class="gan-el gan-knob-wrap" style="…">
+//     <div class="gan-knob" id="gan-knob-<id>" aria-valuenow="…" style="--gan-glow:…;--gan-active:…">
+//   <div class="gan-el gan-image" style="…" title="…"></div>                   no element behind it
+const WRAPPER_TAG = /<div\b[^>]*\sclass="gan-el(?:\s[^"]*)?"[^>]*>/g;
+const FRAME_TAG = /<iframe\b[^>]*\sclass="[^"]*\bgan-frame\b[^"]*"[^>]*>/;
+const KNOB_TAG = /<div\b[^>]*\sclass="gan-knob"[^>]*>/;
+
 const attr = (tag: string, name: string): string | null =>
-  new RegExp(`\\b${name}="([^"]*)"`).exec(tag)?.[1] ?? null;
+  new RegExp(`(?:^|\\s)${name}="([^"]*)"`).exec(tag)?.[1] ?? null;
 
 // One CSS length out of a style declaration, in canvas pixels. The runtime
 // writes percentages so the layout survives resizing; px is accepted too.
@@ -85,30 +122,73 @@ function lengthPx(decl: string, prop: string, span: number): number | null {
   return m[2] === "%" ? (v / 100) * span : v;
 }
 
-/** Element id -> pixel rect for every gan-frame the runtime index.html places,
- *  in stage order (which is z-order). Frames without a full box are skipped. */
+function boxFromStyle(decl: string, canvasW: number, canvasH: number): FrameRect | null {
+  const x = lengthPx(decl, "left", canvasW);
+  const y = lengthPx(decl, "top", canvasH);
+  const width = lengthPx(decl, "width", canvasW);
+  const height = lengthPx(decl, "height", canvasH);
+  if (x === null || y === null || width === null || height === null) return null;
+  return {
+    x: Math.round(x),
+    y: Math.round(y),
+    width: Math.max(1, Math.round(width)),
+    height: Math.max(1, Math.round(height)),
+  };
+}
+
+// The runtime writes rotation as a signed transform (357 -> -3deg); Foundry
+// stores 0..360.
+function rotationFromStyle(decl: string): number | undefined {
+  const m = /(?:^|;)\s*transform\s*:\s*rotate\((-?[\d.]+)deg\)/.exec(decl);
+  if (!m) return undefined;
+  const deg = ((parseFloat(m[1]) % 360) + 360) % 360;
+  return Math.abs(deg) < 0.005 ? undefined : Math.round(deg * 100) / 100;
+}
+
+const cssVar = (decl: string, name: string): string | undefined =>
+  new RegExp(`${name}\\s*:\\s*([^;"]+)`).exec(decl)?.[1]?.trim() || undefined;
+
+/** Element id -> placement for every element the runtime index.html draws, in
+ *  stage order (which is z-order). Placeholders with no element behind them and
+ *  wrappers without a full box are skipped. */
 export function placementsFromIndexHtml(
   html: string,
   canvasW: number,
   canvasH: number,
-): Map<string, FrameRect> {
-  const out = new Map<string, FrameRect>();
-  for (const tag of html.match(FRAME_TAG) ?? []) {
-    const id = /^el_(.+)\.html$/.exec(attr(tag, "data-src") ?? "")?.[1];
+): Map<string, Placement> {
+  const out = new Map<string, Placement>();
+  const wrappers = [...html.matchAll(WRAPPER_TAG)];
+  wrappers.forEach((m, i) => {
+    const tag = m[0];
+    const start = (m.index ?? 0) + tag.length;
+    const end = i + 1 < wrappers.length ? (wrappers[i + 1].index ?? html.length) : html.length;
+    const inner = html.slice(start, end);
     const style = attr(tag, "style") ?? "";
-    if (!id) continue;
-    const x = lengthPx(style, "left", canvasW);
-    const y = lengthPx(style, "top", canvasH);
-    const width = lengthPx(style, "width", canvasW);
-    const height = lengthPx(style, "height", canvasH);
-    if (x === null || y === null || width === null || height === null) continue;
-    out.set(id, {
-      x: Math.round(x),
-      y: Math.round(y),
-      width: Math.max(1, Math.round(width)),
-      height: Math.max(1, Math.round(height)),
-    });
-  }
+    const box = boxFromStyle(style, canvasW, canvasH);
+    if (!box) return;
+    const rotation = rotationFromStyle(style);
+
+    const frame = FRAME_TAG.exec(inner)?.[0];
+    const customId = frame ? /^el_(.+)\.html$/.exec(attr(frame, "data-src") ?? "")?.[1] : undefined;
+    if (frame && customId) {
+      out.set(customId, { ...box, kind: "custom", name: attr(frame, "title") ?? undefined, rotation });
+      return;
+    }
+    const knob = KNOB_TAG.exec(inner)?.[0];
+    const knobId = knob ? /^gan-knob-(.+)$/.exec(attr(knob, "id") ?? "")?.[1] : undefined;
+    if (knob && knobId) {
+      const knobStyle = attr(knob, "style") ?? "";
+      const value = parseFloat(attr(knob, "aria-valuenow") ?? "");
+      out.set(knobId, {
+        ...box,
+        kind: "knob",
+        rotation,
+        value: Number.isFinite(value) ? value : undefined,
+        glowColor: cssVar(knobStyle, "--gan-glow"),
+        activeColor: cssVar(knobStyle, "--gan-active"),
+      });
+    }
+  });
   return out;
 }
 
@@ -133,51 +213,110 @@ const MIME: Record<string, string> = {
   svg: "image/svg+xml",
 };
 
-// The full reconstruction: controls at their authored boxes, decor as
-// CustomCode, artwork on the canvas. Falls back to the grid when index.html is
+/** The in-archive name of the runtime's entry document. */
+function entryName(manifest: GanManifest): string {
+  return String((manifest as { entry_html?: string })?.entry_html || "index.html");
+}
+
+/** The stage artwork as a data URI, read out of the archive itself: the file the
+ *  runtime index.html paints on the stage, else the conventional background.png.
+ *  Null when the archive carries no artwork. */
+async function artworkFromArchive(
+  zip: JSZip,
+  html: string | null,
+): Promise<string | null> {
+  const name = (html ? backgroundNameFromIndexHtml(html) : null) ?? "background.png";
+  const file = zip.file(name);
+  if (!file) return null;
+  const ext = name.split(".").pop()?.toLowerCase() ?? "png";
+  return `data:${MIME[ext] ?? "image/png"};base64,${await file.async("base64")}`;
+}
+
+// An Image element whose asset is not in the project has nothing to show. The
+// canvas would draw it as a control-shaped box — for a backend-built bundle a
+// box over most of the artwork, which already shows what the image showed. Leave
+// it out and say so, rather than hide it where it would still catch clicks.
+function withoutGhostImages(
+  project: GanProjectSource,
+): { project: GanProjectSource; omitted: string[] } {
+  const assetIds = new Set(project.assets.map((a) => a.id));
+  const ghosts = project.elements.filter(
+    (e) => e.type === "Image" && !assetIds.has(e.assetId ?? ""),
+  );
+  if (ghosts.length === 0) return { project, omitted: [] };
+  const drop = new Set(ghosts.map((e) => e.id));
+  return {
+    project: { ...project, elements: project.elements.filter((e) => !drop.has(e.id)) },
+    omitted: ghosts.map((e) => e.name || e.id),
+  };
+}
+
+// The full reconstruction: every element the runtime drew, as what it drew, at
+// its authored box, on the artwork. Falls back to the grid when index.html is
 // missing, so the result is never empty.
 async function reconstructFromArchive(
   zip: JSZip,
   manifest: GanManifest,
 ): Promise<GanProjectSource> {
   const base = reconstructFromManifest(manifest);
-  const entry = String((manifest as { entry_html?: string })?.entry_html || "index.html");
-  const indexFile = zip.file(entry);
+  const indexFile = zip.file(entryName(manifest));
   if (!indexFile) return base;
   const html = await indexFile.async("string");
+  // Artwork first: whatever else this index.html yields, a .gan that carries a
+  // stage image must never reopen on a bare canvas.
+  const withArt = {
+    ...base,
+    canvasState: {
+      ...base.canvasState,
+      backgroundImage: await artworkFromArchive(zip, html),
+    },
+  };
   const { width: w, height: h } = base.canvasState;
   const placed = placementsFromIndexHtml(html, w, h);
-  if (placed.size === 0) return base;
+  if (placed.size === 0) return withArt;
 
-  const controlIds = new Set(base.elements.map((e) => e.id));
-  const elements: UIElement[] = base.elements.map((el) => {
-    const r = placed.get(el.id);
-    return r ? { ...el, ...r } : el;
-  });
-  for (const [id, r] of placed) {
-    if (controlIds.has(id)) continue;
-    const file = zip.file(`el_${id}.html`);
-    const doc = file ? await file.async("string") : "";
-    elements.push({
-      id,
-      name: id,
-      type: "CustomCode",
-      ...r,
-      customCode: innerMarkup(doc),
-      customCodeFit: "stretch",
-    });
+  const controls = new Map(
+    (Array.isArray(manifest?.controls) ? manifest.controls : []).map((c) => [c.id, c] as const),
+  );
+  const unplaced = new Map(base.elements.map((e) => [e.id, e] as const));
+  const elements: UIElement[] = [];
+  // Stage order is z-order; the Map keeps it.
+  for (const [id, p] of placed) {
+    const name = controls.get(id)?.name || p.name || id;
+    const box = { x: p.x, y: p.y, width: p.width, height: p.height };
+    const rotation = p.rotation === undefined ? {} : { rotation: p.rotation };
+    if (p.kind === "custom") {
+      const file = zip.file(`el_${id}.html`);
+      elements.push({
+        id,
+        name,
+        type: "CustomCode",
+        ...box,
+        ...rotation,
+        customCode: innerMarkup(file ? await file.async("string") : ""),
+        customCodeFit: "stretch",
+        // The runtime renders every custom document on a transparent body.
+        transparentBackground: true,
+      });
+    } else {
+      elements.push({
+        id,
+        name,
+        type: "Knob",
+        ...box,
+        ...rotation,
+        value: p.value ?? 0,
+        min: 0,
+        max: 1,
+        ...(p.glowColor ? { glowColor: p.glowColor } : {}),
+        ...(p.activeColor ? { activeColor: p.activeColor } : {}),
+      });
+    }
+    unplaced.delete(id);
   }
-  // Stage order is z-order; keep it for controls and decor alike.
-  const order = new Map([...placed.keys()].map((id, i) => [id, i] as const));
-  elements.sort((a, b) => (order.get(a.id) ?? Infinity) - (order.get(b.id) ?? Infinity));
-
-  const bgName = backgroundNameFromIndexHtml(html) ?? "background.png";
-  const bgFile = zip.file(bgName);
-  const ext = bgName.split(".").pop()?.toLowerCase() ?? "png";
-  const backgroundImage = bgFile
-    ? `data:${MIME[ext] ?? "image/png"};base64,${await bgFile.async("base64")}`
-    : null;
-  return { ...base, elements, canvasState: { ...base.canvasState, backgroundImage } };
+  // A control the runtime did not draw keeps its grid slot; nothing is lost.
+  elements.push(...unplaced.values());
+  return { ...withArt, elements };
 }
 
 // Last resort for a .gan with no readable index.html: one native control per
@@ -251,23 +390,36 @@ export async function parseGan(
 
   const sourceFile = zip.file("source/foundry-project.json");
   if (sourceFile) {
+    const text = await sourceFile.async("string");
+    let embedded: GanProjectSource | null = null;
     try {
-      const parsed = JSON.parse(await sourceFile.async("string"));
-      return {
-        manifest,
-        project: normalizeProject(parsed, manifest),
-        sourceKind: "embedded",
-        hadGanComment,
-      };
+      embedded = normalizeProject(JSON.parse(text), manifest);
     } catch {
       // Corrupt embedded source — fall through to reconstruction.
     }
+    if (embedded) {
+      // A VST Foundry EXPORT keeps its artwork beside project.json as a separate
+      // background.png, so its canvasState.backgroundImage is null. theDAW's
+      // backend embeds that export byte-for-byte and bundles the artwork as its
+      // own archive entry — so the project says "no background" while the .gan
+      // plainly has one, and Ares reopened on a bare canvas. Take the artwork
+      // from the archive. A Foundry-authored .gan already carries its own data
+      // URI here and is left exactly as it was written.
+      if (!embedded.canvasState.backgroundImage) {
+        const html = (await zip.file(entryName(manifest))?.async("string")) ?? null;
+        const artwork = await artworkFromArchive(zip, html);
+        if (artwork) {
+          embedded = {
+            ...embedded,
+            canvasState: { ...embedded.canvasState, backgroundImage: artwork },
+          };
+        }
+      }
+      const { project, omitted } = withoutGhostImages(embedded);
+      return { manifest, project, sourceKind: "embedded", hadGanComment, omittedImages: omitted };
+    }
   }
 
-  return {
-    manifest,
-    project: await reconstructFromArchive(zip, manifest),
-    sourceKind: "reconstructed",
-    hadGanComment,
-  };
+  const { project, omitted } = withoutGhostImages(await reconstructFromArchive(zip, manifest));
+  return { manifest, project, sourceKind: "reconstructed", hadGanComment, omittedImages: omitted };
 }

--- a/backend/modules/plugin/gan_file.py
+++ b/backend/modules/plugin/gan_file.py
@@ -3,16 +3,23 @@
 Mirrors the container approach of .tasmo (manifest.json + payload in a ZIP,
 version-checked on load), but the payload is a bundled web app (index.html +
 assets) instead of a serialized music project.
+
+Every write lands through a temp file + rename. A .gan and its extracted runtime
+are read while they are rewritten — the /list sweep walks the library, the stage
+iframe fetches the runtime — and a reader that opened a half-deflated archive got
+BadZipFile, which 500'd the whole plugin list.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import shutil
 import zipfile
 from pathlib import Path
 from datetime import datetime, timezone
 
+from backend.lib.atomic import atomic_replace, atomic_write, temp_sibling
 from backend.modules.plugin.gan_manifest import GanManifest
 
 log = logging.getLogger(__name__)
@@ -23,6 +30,19 @@ SOFT_SIZE_WARN_BYTES = 200 * 1024 * 1024  # 200 MB
 
 # Assets carrying these names are reserved/handled separately.
 _MANIFEST_NAME = "manifest.json"
+
+
+def _open_zip(path: str) -> zipfile.ZipFile:
+    """Open a .gan for reading, reporting an unreadable archive as a ValueError.
+
+    ``zipfile.BadZipFile`` derives straight from ``Exception``, not ``OSError``,
+    so every ``except (ValueError, OSError)`` guard around a .gan used to miss it
+    and one unreadable file took out the endpoint that touched it.
+    """
+    try:
+        return zipfile.ZipFile(path, "r")
+    except zipfile.BadZipFile as e:
+        raise ValueError(f"Invalid .gan: not a readable ZIP archive ({e})") from e
 
 
 class GanFile:
@@ -40,15 +60,25 @@ class GanFile:
         manifest.format_version = CURRENT_FORMAT_VERSION
         manifest_dict = manifest.model_dump()
 
+        # Deflate beside the destination and swap it in with one rename, so a
+        # reader mid-write opens the whole old archive or the whole new one.
+        dest = Path(path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        tmp = temp_sibling(dest)
         total_size = 0
-        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
-            zf.comment = GAN_COMMENT
-            zf.writestr(_MANIFEST_NAME, json.dumps(manifest_dict, indent=2))
-            for name, data in assets.items():
-                if name == _MANIFEST_NAME:
-                    continue
-                zf.writestr(name, data)
-                total_size += len(data)
+        try:
+            with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zf:
+                zf.comment = GAN_COMMENT
+                zf.writestr(_MANIFEST_NAME, json.dumps(manifest_dict, indent=2))
+                for name, data in assets.items():
+                    if name == _MANIFEST_NAME:
+                        continue
+                    zf.writestr(name, data)
+                    total_size += len(data)
+            atomic_replace(tmp, dest)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
 
         if total_size > SOFT_SIZE_WARN_BYTES:
             log.warning(
@@ -59,11 +89,25 @@ class GanFile:
         return manifest_dict
 
     @staticmethod
+    def install(src: str, dest: str) -> None:
+        """Copy a .gan into the library so a concurrent /list sweep never reads
+        the destination mid-copy. Streamed — a bundle may be hundreds of MB."""
+        target = Path(dest)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = temp_sibling(target)
+        try:
+            shutil.copyfile(src, tmp)
+            atomic_replace(tmp, target)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+
+    @staticmethod
     def info(path: str) -> dict:
         """Read only the manifest from a .gan (no asset extraction)."""
         if not Path(path).is_file():
             raise FileNotFoundError(f".gan file not found: {path}")
-        with zipfile.ZipFile(path, "r") as zf:
+        with _open_zip(path) as zf:
             try:
                 manifest = json.loads(zf.read(_MANIFEST_NAME))
             except KeyError:
@@ -82,7 +126,7 @@ class GanFile:
         in-zip path -> bytes (excluding manifest.json)."""
         manifest = GanFile.info(path)
         assets: dict[str, bytes] = {}
-        with zipfile.ZipFile(path, "r") as zf:
+        with _open_zip(path) as zf:
             for name in zf.namelist():
                 if name == _MANIFEST_NAME or name.endswith("/"):
                     continue
@@ -96,7 +140,7 @@ class GanFile:
         manifest = GanFile.info(path)
         out = Path(out_dir).resolve()
         out.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(path, "r") as zf:
+        with _open_zip(path) as zf:
             for name in zf.namelist():
                 if name == _MANIFEST_NAME or name.endswith("/"):
                     continue
@@ -105,6 +149,10 @@ class GanFile:
                     log.warning("Skipping unsafe .gan entry: %s", name)
                     continue
                 dest.parent.mkdir(parents=True, exist_ok=True)
-                dest.write_bytes(zf.read(name))
-        (out / _MANIFEST_NAME).write_text(json.dumps(manifest, indent=2))
+                # Atomic per file: the iframe re-fetching the runtime during a
+                # rebuild gets the whole old asset or the whole new one, never a
+                # truncated one (a half-written background.png renders as no
+                # artwork at all).
+                atomic_write(dest, zf.read(name))
+        atomic_write(out / _MANIFEST_NAME, json.dumps(manifest, indent=2))
         return manifest

--- a/backend/modules/plugin/router.py
+++ b/backend/modules/plugin/router.py
@@ -189,7 +189,7 @@ def open_plugin(req: OpenRequest) -> dict:
         GAN_DIR.mkdir(parents=True, exist_ok=True)
         dest = _gan_path(pid)
         if src.resolve() != dest.resolve():
-            shutil.copyfile(src, dest)
+            GanFile.install(str(src), str(dest))
         GanFile.extract(str(dest), str(_runtime_dir(pid)))
         return {"manifest": manifest, "entry_url": _entry_url(pid, manifest)}
 

--- a/backend/modules/rhythm/__init__.py
+++ b/backend/modules/rhythm/__init__.py
@@ -1,0 +1,1 @@
+"""Rhythm analysis: tempo curve, meter map, downbeats, syncopation, polymeter."""

--- a/backend/modules/rhythm/engine.py
+++ b/backend/modules/rhythm/engine.py
@@ -1,0 +1,2120 @@
+"""Rhythm analysis for music whose meter does not sit still.
+
+A tempo curve, beats that follow it, a METER MAP — the time signature per
+segment, with the grouping of an additive meter (7 as 2+2+3) — downbeats and
+bars, per-bar syncopation (Longuet-Higgins & Lee, WNBD, off-beat ratio, swing),
+and polymeter: layers that keep their own bar length, plus cross-rhythms
+(3:2, 4:3 …) read off the tempogram.
+
+Everything is numpy + librosa on a mono 22.05 kHz signal, so it runs wherever
+the library analysis runs. No model, no network.
+
+The shape of the problem: ``chimera.detect`` and ``chimera.structure`` assume
+ONE tempo and ONE fixed ``beats_per_bar``. Metamorphic music breaks both. So:
+
+  1. multi-band onset strength (low / mid / high / broad) from one STFT
+  2. a local tempo curve from the tempogram, octave-folded and smoothed, cut
+     into tempo runs where it steps (runs under 8 s fold into their
+     neighbours — a drumless intro is not a tempo change); beats are tracked
+     AGAINST that curve, so they follow a change instead of averaging it away
+  3. per-beat evidence: an ACCENT score (peak low-band level, broad level,
+     chroma novelty, low-band onset — where bars start) and a FEATURE matrix
+     (band onsets, levels, rms, mfcc, chroma — what each beat sounds like)
+  4. meter per sliding window: for every bar length L in 2..12 and every
+     grouping of L into 2s and 3s, how well does an L-periodic bar explain
+     the window? Four readings agree or not: the accent variance an L-phase
+     grouping explains, the accent autocorrelation at lag L, the correlation
+     with the grouping's accent template, and — the strongest cue on a real
+     mix — how similar each beat is to the beat one bar later (the drum
+     pattern repeats every bar; at lag 2 a kick beat meets a snare beat).
+     A prior over common meters breaks ties, and a phrase guard keeps a
+     two-bar pattern from being called 8/4
+  5. windows -> runs with hysteresis -> the meter map; downbeats from each
+     segment's phase; bars from downbeats. If nothing fits at the tracked beat
+     level, the same is tried at double tempo — a fast 7/8 is often tracked
+     at the quarter, where its bar is 3.5 beats long and no meter fits
+  6. subdivision per segment (simple vs compound, sixteenths present) from
+     where onsets fall inside beats -> denominator and beat unit
+  7. syncopation per bar on the metrical grid the segment implies
+  8. polymeter per layer (stems when given, else low/mid/high bands) and
+     cross-rhythm ratios from the tempogram
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+RHYTHM_VERSION = 2
+
+SR = 22050
+_HOP = 512
+_N_FFT = 2048
+_N_MELS = 64
+_BAND_EDGES = (0, 8, 24, 64)  # mel bins: low ~<260 Hz, mid ~260-1100, high
+_MIN_DURATION_SEC = 4.0
+_TG_WIN = 384  # tempogram window in frames: ~8.9 s at hop 512 / 22.05 kHz
+_TEMPO_SMOOTH_SEC = 2.0
+_TEMPO_STEP = 0.04  # a sustained local-tempo step this large starts a run
+_TEMPO_STEP_MIN_SEC = 3.0
+_TEMPO_RUN_MIN_SEC = 8.0  # shorter runs fold into a neighbour
+L_MIN, L_MAX = 2, 16  # at the tracked beat; finer levels go to 32
+METER_WINDOW_BEATS = 48
+_METER_STRIDE_BEATS = 4
+_MIN_RUN_WINDOWS = 4
+_UNDECIDED_CONF = 0.08  # a window this unsure inherits the running meter
+_PHRASE_GUARD_RATIO = 0.85  # a divisor keeping this much evidence is the bar
+_LEVEL_RETRY_BELOW = 0.2  # mean window confidence below which 2x tempo is tried
+_LEVEL_RETRY_GAIN = 0.2  # ... and how much better a finer level must read
+_LEVEL_GOOD = 0.35  # a level reading this well needs no finer level
+_PRIOR_WEIGHT = 0.15  # the prior is a tie-breaker, added to the evidence
+_UNSURE_CONF = 0.12  # a composite reading this unsure yields to the low band
+_TATUM_MIN_REL = 0.5  # of the band's strongest tempogram peak
+_TATUM_MAX_BPM = 640.0
+_TATUM_MIN_PROM = 0.1  # of the band's maximum: a pulse, not the envelope's own width
+_EQUAL_DOWNBEAT_TOL = 0.3  # of the profile's span: downbeats this alike are one bar
+_HOP_FINE = 128  # for grids over _FINE_GRID_FROM_BPM: a sixteenth at 120 is 5.38
+_N_FFT_FINE = 512  # a 23 ms window, so a hat's flux lands in a frame or two
+# frames at hop 512 and the DP rounds it to 5 — a grid 7 % fast that never locks
+_FINE_GRID_FROM_BPM = 200.0
+_MIN_OCCUPANCY = 0.6  # of a grid's positions must carry an onset, or it is too fine
+_POLY_MIN_BARS = 4  # a polymeter is claimed against a bar that has settled
+_TOP_K_GROUPING = 12  # bar lengths that get the grouping search per window
+_SCALE_FLOOR = 0.25  # of the median row spread: a flatter row barely counts
+_PHASE_FLIP_RATIO = 1.15  # low-band mass the half-beat grid needs to take the beat
+_SPAN_SHIFT = 0.25  # of a beat: feature spans start this early, so a kick
+# a frame either side of its beat still lands in that beat's span
+_BOUNDARY_SEARCH_BEATS = 24  # either side of a meter change, for the refinement
+# Similarity rows after per-window scaling: low and broad energy carry the
+# bar (kick, bass, the whole kit), mid/high and timbre support it — a melody
+# cycling in 3 over 4/4 drums is louder than the kick in its own band and
+# must not move the bar.
+_ROW_WEIGHTS = np.asarray([2.0, 0.7, 0.7, 1.5] + [0.5] * 13, dtype=np.float64)
+_LOW_ROW_WEIGHTS = np.asarray([2.0, 1.5], dtype=np.float64)  # low, broad
+_LOW_LEAD_CONF = 0.3  # the low band's own bar overrides a multiple of it from here
+_SEGMENT_MIN_CONF = 0.15  # below this, no polymeter / cross-rhythm claims
+_UNCERTAIN_CONF = 0.1  # a segment under this is a guess, and says so
+_POLY_MIN_CONF = 0.4
+_CROSS_MIN_REL = 0.6  # of the tempogram profile's peak
+_CROSS_PEAK_TOL = 0.06
+_EPS = 1e-9
+
+# How common a bar length is; multiplies the data score. Keeps 4 ahead of 2 and
+# 8 when the evidence alone cannot tell them apart, without ever overriding a
+# clear 7 or 5. 2 sits low on purpose: on four-on-the-floor nothing separates
+# beats 1 and 3, the bias-corrected 2-phase reading then edges the 4-phase one,
+# and the bar is still 4/4 by every convention — 2/4 has to be unmistakable.
+_METER_PRIOR: dict[int, float] = {
+    2: 0.6,
+    3: 0.9,
+    4: 1.0,
+    5: 0.8,
+    6: 0.85,
+    7: 0.8,
+    8: 0.7,
+    9: 0.7,
+    10: 0.6,
+    11: 0.6,
+    12: 0.7,
+}
+
+# The same, when the tracked beat is a dotted quarter (each beat splits in
+# three): a 2-beat bar is 6/8 and common, 4 is 12/8, 3 is 9/8.
+_METER_PRIOR_COMPOUND: dict[int, float] = {
+    2: 1.0,
+    3: 0.9,
+    4: 0.95,
+    5: 0.7,
+    6: 0.65,
+    7: 0.6,
+    8: 0.55,
+    9: 0.5,
+    10: 0.5,
+    11: 0.5,
+    12: 0.5,
+}
+
+
+def _prior(length: int, compound: bool) -> float:
+    """How common a bar length is. Past the tables an odd length is a real
+    possibility (13, 19, 23 …) and an even one is usually two bars of half its
+    length — the phrase guard reduces it, the prior keeps it from winning."""
+    table = _METER_PRIOR_COMPOUND if compound else _METER_PRIOR
+    if length in table:
+        return table[length]
+    return 0.55 if length % 2 else 0.4
+
+
+def _l_max_for(mult: int) -> int:
+    """Longest bar tried at a level: 16 tracked beats, 24 eighths, 32 sixteenths."""
+    return min(32, 8 * int(mult) + 8)
+
+
+_CROSS_RATIOS: tuple[tuple[str, float], ...] = (
+    ("3:2", 1.5),
+    ("2:3", 2.0 / 3.0),
+    ("4:3", 4.0 / 3.0),
+    ("3:4", 0.75),
+    ("5:4", 1.25),
+    ("4:5", 0.8),
+    ("5:3", 5.0 / 3.0),
+    ("3:5", 0.6),
+)
+
+
+# --------------------------------------------------------------------------
+# small numerics
+# --------------------------------------------------------------------------
+
+
+def _zscore(x: np.ndarray) -> np.ndarray:
+    x = np.asarray(x, dtype=np.float64)
+    sd = float(x.std())
+    return (x - x.mean()) / sd if sd > _EPS else np.zeros_like(x)
+
+
+def _robust(x: np.ndarray, floor: float) -> np.ndarray:
+    """Centre and scale, with the spread floored: ``(x - mean) / (std + floor)``.
+    A plain z-score blows a nearly flat row up to unit variance, and on a beat
+    grid the only variation left in a flat row is the ±1-frame quantization of
+    the beat window — a periodic artefact that then reads as meter."""
+    x = np.asarray(x, dtype=np.float64)
+    return (x - x.mean()) / (float(x.std()) + floor)
+
+
+def _scale_rows(m: np.ndarray, rel_floor: float = _SCALE_FLOOR) -> np.ndarray:
+    """Rows centred and scaled by ``std + floor``, the floor a fraction of the
+    median row spread, so rows with real beat-to-beat structure carry the
+    cosine and flat ones barely register."""
+    m = np.asarray(m, dtype=np.float64)
+    sd = m.std(axis=1, keepdims=True)
+    live = sd[sd > _EPS]
+    floor = rel_floor * float(np.median(live)) if live.size else 1.0
+    return (m - m.mean(axis=1, keepdims=True)) / (sd + floor + _EPS)
+
+
+def _clamp(x: float) -> float:
+    return float(max(0.0, min(1.0, x)))
+
+
+def _corr(a: np.ndarray, b: np.ndarray) -> float:
+    a = a - a.mean()
+    b = b - b.mean()
+    d = math.sqrt(float((a * a).sum()) * float((b * b).sum()))
+    return float((a * b).sum() / d) if d > _EPS else 0.0
+
+
+def _autocorr(s: np.ndarray, lag: int) -> float:
+    if lag <= 0 or lag >= s.size:
+        return 0.0
+    a, b = s[:-lag], s[lag:]
+    d = math.sqrt(float((a * a).sum()) * float((b * b).sum()))
+    return float((a * b).sum() / d) if d > _EPS else 0.0
+
+
+def _effect_size(score: np.ndarray, k: int) -> float:
+    """Bias-corrected fraction of the per-beat score variance explained by
+    grouping beats into ``k`` phases (epsilon-squared, clamped to [0, 1]).
+    ~1 when the k-periodic structure is real, ~0 for noise — where the raw
+    eta-squared would still read ``(k-1)/(n-1)``."""
+    n = score.size
+    if n < 2 * k:
+        return 0.0
+    mean = score.mean()
+    total = float(np.sum((score - mean) ** 2))
+    if total <= 1e-12:
+        return 0.0
+    between = 0.0
+    for p in range(k):
+        grp = score[p::k]
+        if grp.size:
+            between += grp.size * float((grp.mean() - mean) ** 2)
+    within = max(0.0, total - between)
+    eps_sq = (between - (k - 1) * within / float(n - k)) / total
+    return float(max(0.0, min(1.0, eps_sq)))
+
+
+def _cos_dist(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    num = np.sum(a * b, axis=0)
+    den = np.linalg.norm(a, axis=0) * np.linalg.norm(b, axis=0) + _EPS
+    return 1.0 - num / den
+
+
+def _lag_similarity(features: np.ndarray, lag: int) -> float:
+    """How alike each beat is to the beat ``lag`` beats later: minus the mean
+    squared distance between their (scaled) feature vectors. Distance, not
+    cosine — a plain beat's centred vector is nearly zero and its DIRECTION is
+    frame jitter, which cosine reads as a periodicity of its own; two plain
+    beats are simply close, at any lag."""
+    b = features.shape[1]
+    if lag <= 0 or lag >= b:
+        return -np.inf
+    d = features[:, :-lag] - features[:, lag:]
+    return -float(np.mean(np.sum(d * d, axis=0)))
+
+
+# --------------------------------------------------------------------------
+# meter templates
+# --------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=None)
+def groupings(beats_per_bar: int) -> tuple[tuple[int, ...], ...]:
+    """Every composition of ``beats_per_bar`` into 2s and 3s, in order — the
+    additive groupings a bar of that length can have (7 -> 2+2+3, 2+3+2,
+    3+2+2). 4 is 2+2; 2 and 3 are themselves."""
+    out: list[tuple[int, ...]] = []
+
+    def rec(rem: int, acc: list[int]) -> None:
+        if rem == 0:
+            out.append(tuple(acc))
+            return
+        for part in (2, 3):
+            if part <= rem:
+                rec(rem - part, acc + [part])
+
+    rec(int(beats_per_bar), [])
+    return tuple(out) or ((int(beats_per_bar),),)
+
+
+def _template(grouping: tuple[int, ...]) -> np.ndarray:
+    """Accent hierarchy of a grouping: 1.0 on the downbeat, 0.6 on every other
+    group start, 0.25 elsewhere."""
+    t = np.full(sum(grouping), 0.25, dtype=np.float64)
+    pos = 0
+    for i, part in enumerate(grouping):
+        t[pos] = 1.0 if i == 0 else 0.6
+        pos += part
+    return t
+
+
+def best_grouping(prof: np.ndarray) -> tuple[tuple[int, ...], int, float]:
+    """``(grouping, phase, template_corr)`` for a bar whose per-beat accent
+    profile is ``prof``: the downbeat phase and the tiling of the bar into 2s
+    and 3s whose group starts sit on the strongest accents (the downbeat
+    weighted 1.0, other group starts 0.6). Dynamic programming over the bar,
+    so 23 costs a few hundred operations, not the 265 compositions of 23."""
+    length = int(prof.size)
+    best_v, best_phase, best_g = -np.inf, 0, (length,)
+    for phase in range(length):
+        r = np.roll(prof, -phase)
+        value = [-np.inf] * (length + 1)
+        choice = [0] * (length + 1)
+        value[length] = 0.0
+        for i in range(length - 1, -1, -1):
+            w = 1.0 if i == 0 else 0.6
+            for part in (2, 3):
+                j = i + part
+                if j <= length and value[j] > -np.inf:
+                    v = w * float(r[i]) + value[j]
+                    if v > value[i]:
+                        value[i], choice[i] = v, part
+        if value[0] > best_v:
+            g: list[int] = []
+            i = 0
+            while i < length and choice[i]:
+                g.append(choice[i])
+                i += choice[i]
+            if sum(g) == length:
+                best_v, best_phase, best_g = value[0], phase, tuple(g)
+    tc = max(0.0, _corr(np.roll(prof, -best_phase), _template(best_g)))
+    return best_g, best_phase, tc
+
+
+@dataclass(frozen=True)
+class MeterFit:
+    beats_per_bar: int
+    grouping: tuple[int, ...]
+    phase: int  # beat index within the window (mod beats_per_bar) of the downbeat
+    score: float  # prior-weighted
+    data: float  # the evidence alone, in [0, 1]
+    effect: float
+    autocorr: float
+    template_corr: float
+    similarity: float
+    profile: tuple[float, ...] = ()  # mean accent per phase, downbeat at ``phase``
+
+
+def fit_meter(
+    accents: np.ndarray,
+    features: Optional[np.ndarray] = None,
+    l_min: int = L_MIN,
+    l_max: int = L_MAX,
+    *,
+    compound: bool = False,
+    row_weights: Optional[np.ndarray] = None,
+) -> list[MeterFit]:
+    """Score every bar length in ``[l_min, l_max]`` against a window.
+
+    ``accents`` is the per-beat accent score; ``features`` (optional, [D, B])
+    the per-beat feature matrix whose lag-L self-similarity is the fourth
+    reading. ``data`` weighs the readings (0.30 effect, 0.25 autocorr, 0.15
+    template, 0.30 similarity — or 0.45 / 0.35 / 0.20 without features);
+    ``score`` multiplies in the prior — the compound one when each tracked
+    beat splits in three, where a 2-beat bar is 6/8. The grouping search
+    (``best_grouping``) runs for the ``_TOP_K_GROUPING`` best lengths by the
+    cheaper readings; the rest keep a plain 2s-then-3 grouping and no template
+    credit.
+    """
+    s = np.asarray(accents, dtype=np.float64)
+    lengths = [
+        length for length in range(int(l_min), int(l_max) + 1) if s.size >= 2 * length
+    ]
+    if not lengths:
+        return []
+    sims: dict[int, float] = {}
+    if features is not None and features.ndim == 2 and features.shape[1] == s.size:
+        feats = _scale_rows(features)
+        if row_weights is not None and row_weights.size == feats.shape[0]:
+            feats = feats * row_weights[:, None]
+        sims = {length: _lag_similarity(feats, length) for length in lengths}
+        sims = {k: v for k, v in sims.items() if np.isfinite(v)}
+        lo, hi = (min(sims.values()), max(sims.values())) if sims else (0.0, 0.0)
+        span = hi - lo
+        sims = {k: (v - lo) / span if span > _EPS else 0.0 for k, v in sims.items()}
+
+    cheap: list[tuple[int, np.ndarray, float, float, float]] = []
+    for length in lengths:
+        prof = np.asarray([s[p::length].mean() for p in range(length)])
+        eff = _effect_size(s, length)
+        ac = max(0.0, _autocorr(s, length))
+        sim = sims.get(length, 0.0) if sims else 0.0
+        cheap.append((length, prof, eff, ac, sim))
+    rank = sorted(
+        cheap,
+        key=lambda c: (
+            -(
+                0.30 * c[2] + 0.25 * c[3] + 0.30 * c[4]
+                if sims
+                else 0.45 * c[2] + 0.35 * c[3]
+            )
+        ),
+    )
+    searched = {c[0] for c in rank[:_TOP_K_GROUPING]}
+
+    fits: list[MeterFit] = []
+    for length, prof, eff, ac, sim in cheap:
+        if length in searched:
+            grouping, phase, tc = best_grouping(prof)
+        else:
+            grouping, phase, tc = groupings(length)[0], int(np.argmax(prof)), 0.0
+        if sims:
+            data = 0.30 * eff + 0.25 * ac + 0.15 * tc + 0.30 * sim
+        else:
+            data = 0.45 * eff + 0.35 * ac + 0.20 * tc
+        fits.append(
+            MeterFit(
+                length,
+                grouping,
+                phase,
+                data + _PRIOR_WEIGHT * _prior(length, compound),
+                data,
+                eff,
+                ac,
+                tc,
+                sim,
+                tuple(float(v) for v in prof),
+            )
+        )
+    return fits
+
+
+def _one_downbeat(best: MeterFit, fits: list[MeterFit]) -> MeterFit:
+    """One bar, one downbeat. A 4/4 whose melody cycles in 3 is 12-periodic —
+    the melody's onsets even leak into the low band — and 12 explains more
+    variance than 4. But its profile has downbeats of equal strength at 0, 4
+    and 8, and a bar with three equal downbeats is three bars. For each divisor
+    of the winning length: if the profile's values at that spacing from the
+    downbeat are all accents (above the mean) and alike (spread within
+    ``_EQUAL_DOWNBEAT_TOL`` of the profile's span), the bar is the divisor. A
+    real 12/8 keeps its 12: the downbeat at +6 dB stands over group starts at
+    +3, half the span apart."""
+    length = best.beats_per_bar
+    prof = np.asarray(best.profile, dtype=np.float64)
+    if prof.size != length or length < 4:
+        return best
+    span = float(prof.max() - prof.min())
+    if span <= _EPS:
+        return best
+    by_len = {f.beats_per_bar: f for f in fits}
+    mean = float(prof.mean())
+    for d in range(2, length):
+        if length % d or d not in by_len:
+            continue
+        downbeats = prof[[(best.phase + k * d) % length for k in range(length // d)]]
+        if (
+            float(downbeats.min()) >= mean
+            and float(downbeats.max() - downbeats.min()) <= _EQUAL_DOWNBEAT_TOL * span
+        ):
+            return by_len[d]
+    return best
+
+
+def pick_meter(
+    fits: list[MeterFit], *, tie_penalty: bool = True
+) -> tuple[Optional[MeterFit], float]:
+    """The winning fit and a confidence in [0, 1].
+
+    The score — evidence plus a small prior, so the prior breaks ties and never
+    outvotes a bar that explains the accents completely — picks a candidate. Every divisor of it that keeps
+    ``_PHRASE_GUARD_RATIO`` of its evidence is the same pattern read with a
+    shorter bar, and the bar is the shortest cycle that explains the accents:
+    among the candidate and those divisors the best SCORE wins — so 8 becomes
+    4 (a two-bar fill is 8-periodic, the bar is still 4), 6 becomes 2 in 6/8,
+    and 4 stays 4 over a 2 that explains as much, because 4/4 is the
+    convention when nothing separates them.
+
+    Confidence is the top-two margin against bar lengths COPRIME to the winner.
+    A length sharing a factor with the true bar (6 against 4, 9 against 6)
+    explains part of the pattern by construction — the duple alternation, the
+    triple — so it always scores well and says nothing about whether the bar
+    is right; multiples and divisors are the same reading at another level.
+    When such a related length all but ties the winner the reading IS
+    ambiguous (4 against 6 in a hemiola) and the confidence is halved. The
+    whole thing is then scaled by how much evidence the winner has at all.
+    """
+    if not fits:
+        return None, 0.0
+    top = max(fits, key=lambda f: f.score)
+    family = [top] + [
+        f
+        for f in fits
+        if 1 < f.beats_per_bar < top.beats_per_bar
+        and top.beats_per_bar % f.beats_per_bar == 0
+        and f.data >= top.data * _PHRASE_GUARD_RATIO
+    ]
+    best = max(family, key=lambda f: (f.score, -f.beats_per_bar))
+    best = _one_downbeat(best, fits)
+    length = best.beats_per_bar
+    unrelated = [f.data for f in fits if math.gcd(f.beats_per_bar, length) == 1]
+    related = [
+        f.score
+        for f in fits
+        if f.beats_per_bar != length
+        and math.gcd(f.beats_per_bar, length) > 1
+        and length % f.beats_per_bar != 0
+        and f.beats_per_bar % length != 0
+    ]
+    second = max(unrelated, default=0.0)
+    margin = (best.data - second) / (abs(best.data) + abs(second) + _EPS)
+    # A related length that all but ties (4 against 6 in a hemiola) halves the
+    # confidence — unless the caller reads the rhythm section alone, whose job
+    # is the bar: a melody cycling in 3 over 4/4 drums makes 6 tie 4 in the
+    # mix, and that ambiguity is the polymeter to report, not a reason to
+    # doubt the drums.
+    penalty = (
+        0.5 if tie_penalty and any(r >= 0.9 * best.score for r in related) else 1.0
+    )
+    conf = _clamp(margin) * _clamp(best.data / 0.6) * penalty
+    return best, float(conf)
+
+
+# --------------------------------------------------------------------------
+# front end: onsets, tempo curve, beats
+# --------------------------------------------------------------------------
+
+
+def _onset_envelopes(y: np.ndarray, sr: int) -> tuple[np.ndarray, np.ndarray]:
+    """``(env [4, T], band_power [3, T])``: low / mid / high / broad onset
+    strength from one STFT, and the linear power per frame of the low, mid and
+    high bands — what a beat's ENERGY is read from, alignment be damned."""
+    import librosa
+
+    S = np.abs(librosa.stft(y, n_fft=_N_FFT, hop_length=_HOP))
+    mel = librosa.feature.melspectrogram(S=S**2, sr=sr, n_mels=_N_MELS)
+    channels = [
+        slice(_BAND_EDGES[0], _BAND_EDGES[1]),
+        slice(_BAND_EDGES[1], _BAND_EDGES[2]),
+        slice(_BAND_EDGES[2], _BAND_EDGES[3]),
+        slice(_BAND_EDGES[0], _BAND_EDGES[3]),
+    ]
+    env = librosa.onset.onset_strength_multi(
+        S=librosa.power_to_db(mel), sr=sr, hop_length=_HOP, channels=channels
+    )
+    band_power = np.stack(
+        [
+            mel[channels[0]].sum(axis=0),
+            mel[channels[1]].sum(axis=0),
+            mel[channels[2]].sum(axis=0),
+        ]
+    )
+    return np.asarray(env, dtype=np.float64), np.asarray(band_power, dtype=np.float64)
+
+
+def _fold_octaves(local: np.ndarray, reference: float) -> np.ndarray:
+    """Pull per-frame tempo estimates that sit an octave off ``reference`` back
+    to it. The tempogram peaks at 2x and 1/2x too, and a frame-wise argmax
+    hops between them."""
+    out = local.astype(np.float64).copy()
+    for _ in range(3):
+        out = np.where(out > 1.55 * reference, out / 2.0, out)
+        out = np.where(out < 0.65 * reference, out * 2.0, out)
+    return out
+
+
+def _tempo_runs(curve: np.ndarray, frame_sec: float) -> list[tuple[int, int, float]]:
+    """``(start_frame, end_frame, bpm)`` runs of the smoothed local tempo. A new
+    run starts where the curve leaves the current run's tempo by more than
+    ``_TEMPO_STEP`` for at least ``_TEMPO_STEP_MIN_SEC``; runs shorter than
+    ``_TEMPO_RUN_MIN_SEC`` then fold into the neighbour they are closer to."""
+    n = int(curve.size)
+    if n == 0:
+        return []
+    min_frames = max(1, int(round(_TEMPO_STEP_MIN_SEC / frame_sec)))
+    step = math.log(1.0 + _TEMPO_STEP)
+    runs: list[tuple[int, int, float]] = []
+    start = 0
+    ref = float(np.median(curve[: min(n, min_frames)]))
+    i = 0
+    while i < n:
+        if abs(math.log(max(curve[i], _EPS) / ref)) > step:
+            j = i
+            while j < n and abs(math.log(max(curve[j], _EPS) / ref)) > step:
+                j += 1
+            if j - i >= min_frames:
+                runs.append((start, i, float(np.median(curve[start:i]))))
+                start = i
+                ref = float(np.median(curve[i:j]))
+            i = j
+            continue
+        i += 1
+    runs.append((start, n, float(np.median(curve[start:n]))))
+
+    min_run = int(round(_TEMPO_RUN_MIN_SEC / frame_sec))
+    changed = True
+    while changed and len(runs) > 1:
+        changed = False
+        for k, (a, b, bpm) in enumerate(runs):
+            if b - a >= min_run:
+                continue
+            # Fold into the neighbour whose tempo is closer; the neighbour's
+            # tempo stands (it is the one with enough music behind it).
+            cands = []
+            if k > 0:
+                cands.append((abs(math.log(bpm / runs[k - 1][2])), k - 1))
+            if k + 1 < len(runs):
+                cands.append((abs(math.log(bpm / runs[k + 1][2])), k + 1))
+            _, into = min(cands)
+            lo, hi = min(k, into), max(k, into)
+            merged = (runs[lo][0], runs[hi][1], runs[into][2])
+            runs = runs[:lo] + [merged] + runs[hi + 1 :]
+            changed = True
+            break
+    return runs
+
+
+def _track_beats(
+    oenv: np.ndarray,
+    sr: int,
+    bpm_curve: np.ndarray,
+    fallback_bpm: float,
+    hop: int = _HOP,
+) -> np.ndarray:
+    """Beat frames from the DP tracker, following a per-frame tempo curve.
+    Falls back to one tempo if this librosa cannot take an array."""
+    import librosa
+
+    try:
+        _, frames = librosa.beat.beat_track(
+            onset_envelope=oenv,
+            sr=sr,
+            hop_length=hop,
+            bpm=bpm_curve,
+            trim=False,
+            units="frames",
+        )
+    except Exception as e:  # pragma: no cover - depends on the librosa build
+        log.info("rhythm: per-frame tempo not accepted by beat_track (%s)", e)
+        _, frames = librosa.beat.beat_track(
+            onset_envelope=oenv,
+            sr=sr,
+            hop_length=hop,
+            bpm=float(fallback_bpm),
+            trim=False,
+            units="frames",
+        )
+    return np.asarray(frames, dtype=np.int64)
+
+
+def _unit(x: np.ndarray) -> np.ndarray:
+    m = float(np.max(x)) if x.size else 0.0
+    return x / m if m > _EPS else x
+
+
+def _mass_at(env: np.ndarray, frames: np.ndarray) -> float:
+    """Onset mass at ``frames``, a frame either side allowed."""
+    n = env.size
+    f = frames[(frames >= 0) & (frames < n)]
+    if f.size == 0:
+        return 0.0
+    lo = np.clip(f - 1, 0, n - 1)
+    hi = np.clip(f + 1, 0, n - 1)
+    return float(np.sum(np.maximum(np.maximum(env[lo], env[f]), env[hi])))
+
+
+def _snap_to_peaks(
+    beat_frames: np.ndarray, env: np.ndarray, radius: int = 2
+) -> np.ndarray:
+    """Move each beat to the strongest frame of ``env`` within ``radius`` frames.
+    The tracker and the phase shift place beats to the frame, and onsets are
+    detected at envelope peaks; a one-frame gap between the two grids is a 0.05
+    error in every sub-beat phase — enough to read a triplet swing (2.0) as
+    2.5. On one grid the phases are exact to the hop."""
+    n = env.size
+    out = beat_frames.astype(np.int64).copy()
+    for i, f in enumerate(out):
+        lo, hi = max(0, f - radius), min(n, f + radius + 1)
+        if hi > lo:
+            out[i] = lo + int(np.argmax(env[lo:hi]))
+    return np.unique(out)
+
+
+def _occupancy(frames: np.ndarray, env: np.ndarray) -> float:
+    """The share of a grid's positions that carry an onset of their own: mass
+    within a frame of the position at least 1.5x the mass at the midpoints on
+    either side, and not noise. A contrast, not a level — kicks on the group
+    starts are several times a hat, and a level threshold reads only them. A
+    grid twice as fine as the music (sixteenths over eighth-note hats) leaves
+    every other position no louder than the gaps around it, and reads 0.5."""
+    n = env.size
+    f = np.sort(frames[(frames >= 0) & (frames < n)])
+    if f.size < 6:
+        return 0.0
+
+    def mass(idx: np.ndarray) -> np.ndarray:
+        lo = np.clip(idx - 1, 0, n - 1)
+        hi = np.clip(idx + 1, 0, n - 1)
+        return np.maximum(np.maximum(env[lo], env[np.clip(idx, 0, n - 1)]), env[hi])
+
+    at = mass(f)
+    mids = mass((f[:-1] + f[1:]) // 2)
+    floor = 0.05 * float(at.max()) if at.size else 0.0
+    inner = at[1:-1]
+    gaps = np.maximum(mids[:-1], mids[1:])
+    occupied = (inner >= 1.5 * gaps) & (inner > floor)
+    return float(np.mean(occupied)) if inner.size else 0.0
+
+
+def _align_phase(beat_frames: np.ndarray, low_power: np.ndarray) -> np.ndarray:
+    """Put the beats where the low end hits. Spectral flux makes a broadband
+    hat outweigh a kick, so the tracker readily locks onto hats — on the
+    off-beat, or on the swung eighth two thirds through — and the period is
+    right while the phase is not. Of the grid's fractional offsets (twelfths of
+    a beat), the one sitting on clearly the most low-band POWER is the beat.
+    Power, not flux: a hat out of silence is a large dB step in the low bands
+    too, but it has no low-band energy to speak of."""
+    if beat_frames.size < 3:
+        return beat_frames
+    period = float(np.median(np.diff(beat_frames)))
+    if period < 2:
+        return beat_frames
+    n = low_power.size
+    base = _mass_at(low_power, beat_frames)
+    best_shift, best_mass = 0, base
+    for k in range(1, 12):
+        shift = int(round(k * period / 12.0))
+        if shift <= 0 or shift >= period:
+            continue
+        cand = beat_frames + shift
+        mass = _mass_at(low_power, cand[cand < n])
+        if mass > best_mass:
+            best_shift, best_mass = shift, mass
+    if best_shift == 0 or best_mass <= _PHASE_FLIP_RATIO * base:
+        return beat_frames
+    shifted = beat_frames + best_shift
+    lead = beat_frames[0] + best_shift - int(round(period))
+    if lead >= 0:
+        shifted = np.concatenate([[lead], shifted])
+    log.debug("rhythm: beats moved by %d frames onto the low-band grid", best_shift)
+    return shifted[shifted < n].astype(np.int64)
+
+
+def _beat_energies(band_power: np.ndarray, spans: np.ndarray) -> np.ndarray:
+    """[4, B] dB: low / mid / high / broad energy of each beat, the band power
+    summed over the beat's span. A sum over the span does not care where the
+    frames fall against the transient; a peak level does — a kick's sampled
+    peak swings several dB with sub-frame alignment, and since the beat period
+    is not a whole number of frames that swing is periodic, and reads as
+    meter (a 6-beat cycle at 100 bpm, 5.5 at 128)."""
+    n = band_power.shape[1]
+    spans = np.clip(np.asarray(spans, dtype=np.int64), 0, n)
+    period = int(round(float(np.median(np.diff(spans))))) if spans.size > 1 else 1
+    ends = np.append(spans[1:], min(n, spans[-1] + max(1, period)))
+    cs = np.concatenate([np.zeros((3, 1)), np.cumsum(band_power, axis=1)], axis=1)
+    e = cs[:, ends] - cs[:, spans]  # [3, B]
+    # The SUM, not the mean: a hit's energy is the same whether its span is 5
+    # or 6 frames, and dividing by the span would manufacture a 2-cycle on a
+    # fine grid rounded to whole frames. (A sustained pad does the opposite,
+    # by 0.8 dB; the accents this feeds are about hits.)
+    e = np.concatenate([e, e.sum(axis=0, keepdims=True)], axis=0)
+    db = 10.0 * np.log10(np.maximum(e, 1e-12))
+    # A beat in digital silence (a trailing beat past the last hit, a gap) is
+    # -120 dB — one such outlier owns the variance of the whole row and
+    # flattens every real contrast in it. 60 dB under the row's loudest beat is
+    # as quiet as a beat needs to be.
+    return np.maximum(db, db.max(axis=1, keepdims=True) - 60.0)
+
+
+def _accents(f: dict[str, np.ndarray], energies: np.ndarray) -> np.ndarray:
+    """Per-beat accent score: where bars start. Low-band energy first (the kick,
+    the bass), broad energy next, chroma novelty last — a melody cycling in 3
+    over 4/4 drums does not move the bar. Each term is floored (1 dB, 0.05 of
+    cosine distance) so a flat one cannot be inflated into evidence."""
+    low_db, broad_db = energies[0], energies[3]
+    b = low_db.size
+    chroma = np.asarray(f["chroma"], dtype=np.float64)
+    c = np.zeros(b, dtype=np.float64)
+    if chroma.ndim == 2 and chroma.shape[1] == b and b > 1:
+        c[1:] = _cos_dist(chroma[:, 1:], chroma[:, :-1])
+    return (
+        1.0 * _robust(low_db, 1.0)
+        + 0.5 * _robust(broad_db, 1.0)
+        + 0.35 * _robust(c, 0.05)
+    )
+
+
+def _feature_matrix(f: dict[str, np.ndarray], energies: np.ndarray) -> np.ndarray:
+    """[17, B]: what each beat sounds like, for the lag similarity — the four
+    band energies and the 13 MFCCs, weighted by ``_ROW_WEIGHTS`` after the fit
+    scales each row per window. Chroma is left out: on percussive music it is
+    noise, and harmonic rhythm repeats at the phrase more than the bar."""
+    return np.concatenate([energies, np.asarray(f["mfcc"], dtype=np.float64)], axis=0)
+
+
+# --------------------------------------------------------------------------
+# meter map
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class _Window:
+    start: int
+    center: int
+    fit: Optional[MeterFit]
+    conf: float
+
+
+def _pick_window(
+    accents: np.ndarray,
+    features: np.ndarray,
+    low_accents: np.ndarray,
+    low_features: np.ndarray,
+    compound: bool,
+    l_max: int = L_MAX,
+) -> tuple[Optional[MeterFit], float]:
+    """One window's bar, read twice. The composite hears everything — and a
+    melody cycling in 3 over 4/4 drums makes it 12-periodic, so 12 (or 6) wins
+    on the evidence. The rhythm section sets the bar: when the low band alone
+    reads a bar that divides the composite's, with some confidence, the low
+    band's bar stands and the melody's cycle is a polymeter to report."""
+    fit, conf = pick_meter(
+        fit_meter(
+            accents, features, l_max=l_max, compound=compound, row_weights=_ROW_WEIGHTS
+        )
+    )
+    low_fit, low_conf = pick_meter(
+        fit_meter(
+            low_accents,
+            low_features,
+            l_max=l_max,
+            compound=compound,
+            row_weights=_LOW_ROW_WEIGHTS,
+        ),
+        tie_penalty=False,
+    )
+    if low_fit is not None and low_conf >= _LOW_LEAD_CONF:
+        # The composite cannot decide (a melody's cycle and the drums' bar
+        # share no small multiple): the rhythm section's reading stands.
+        if fit is None or conf < _UNSURE_CONF:
+            return low_fit, low_conf
+        if low_fit.beats_per_bar == fit.beats_per_bar:
+            # Two independent readings agree: the confidence is the stronger.
+            return fit, max(conf, low_conf)
+        if (
+            low_fit.beats_per_bar < fit.beats_per_bar
+            and fit.beats_per_bar % low_fit.beats_per_bar == 0
+        ):
+            return low_fit, max(low_conf, conf)
+    return fit, conf
+
+
+def _fit_windows(
+    accents: np.ndarray,
+    features: np.ndarray,
+    low_accents: np.ndarray,
+    low_features: np.ndarray,
+    window: int,
+    stride: int,
+    *,
+    compound: bool = False,
+    l_max: int = L_MAX,
+) -> list[_Window]:
+    b = accents.size
+    out: list[_Window] = []
+    if b <= window:
+        fit, conf = _pick_window(
+            accents, features, low_accents, low_features, compound, l_max
+        )
+        return [_Window(0, b // 2, fit, conf)]
+    starts = list(range(0, b - window + 1, stride))
+    if starts[-1] != b - window:
+        starts.append(b - window)
+    for st in starts:
+        sl = slice(st, st + window)
+        fit, conf = _pick_window(
+            accents[sl],
+            features[:, sl],
+            low_accents[sl],
+            low_features[:, sl],
+            compound,
+            l_max,
+        )
+        out.append(_Window(st, st + window // 2, fit, conf))
+    return out
+
+
+@dataclass
+class _Segment:
+    start_beat: int
+    end_beat: int
+    beats_per_bar: int
+    grouping: tuple[int, ...]
+    phase: int  # absolute beat index class (mod beats_per_bar) of the downbeats
+    confidence: float
+
+
+def _labels(windows: list[_Window]) -> list[int]:
+    """One bar length per window. A window too unsure to say inherits the
+    running label — it may not open a segment of its own."""
+    labels: list[int] = []
+    current: Optional[int] = None
+    for w in windows:
+        if w.fit is not None and (w.conf >= _UNDECIDED_CONF or current is None):
+            current = w.fit.beats_per_bar
+        labels.append(current if current is not None else 0)
+    # Leading undecided windows take the first decided label.
+    first = next((label for label in labels if label), 0)
+    return [label or first for label in labels]
+
+
+def _runs(windows: list[_Window]) -> list[tuple[int, list[_Window]]]:
+    """``(bar length, windows)`` runs of consecutive windows with the same label;
+    runs shorter than ``_MIN_RUN_WINDOWS`` are absorbed by their predecessor
+    (or successor, at the start)."""
+    labels = _labels(windows)
+    if not windows or not any(labels):
+        return []
+    runs: list[tuple[int, list[_Window]]] = [(labels[0], [windows[0]])]
+    for w, label in zip(windows[1:], labels[1:]):
+        if label == runs[-1][0]:
+            runs[-1][1].append(w)
+        else:
+            runs.append((label, [w]))
+    changed = True
+    while changed and len(runs) > 1:
+        changed = False
+        for k, (label, ws) in enumerate(runs):
+            if len(ws) >= _MIN_RUN_WINDOWS:
+                continue
+            into = k - 1 if k > 0 else k + 1
+            lo, hi = min(k, into), max(k, into)
+            merged = (runs[into][0], runs[lo][1] + runs[hi][1])
+            runs = runs[:lo] + [merged] + runs[hi + 1 :]
+            changed = True
+            break
+    return runs
+
+
+def _phase_vote(run: list[_Window], length: int) -> tuple[int, tuple[int, ...]]:
+    votes: dict[int, float] = {}
+    group_votes: dict[tuple[int, ...], float] = {}
+    for w in run:
+        if w.fit is None or w.fit.beats_per_bar != length:
+            continue
+        cls = (w.start + w.fit.phase) % length
+        votes[cls] = votes.get(cls, 0.0) + max(w.conf, 1e-3)
+        group_votes[w.fit.grouping] = group_votes.get(w.fit.grouping, 0.0) + max(
+            w.conf, 1e-3
+        )
+    phase = max(votes.items(), key=lambda kv: kv[1])[0] if votes else 0
+    grouping = (
+        max(group_votes.items(), key=lambda kv: kv[1])[0]
+        if group_votes
+        else groupings(length)[0]
+    )
+    return phase, grouping
+
+
+def _snap_to_class(beat: int, cls: int, length: int, lo: int, hi: int) -> int:
+    """The beat nearest ``beat`` that is ≡ cls (mod length), clamped to
+    [lo, hi]."""
+    base = beat - ((beat - cls) % length)
+    cands = [c for c in (base, base + length) if lo <= c <= hi]
+    if not cands:
+        return max(lo, min(hi, beat))
+    return min(cands, key=lambda c: abs(c - beat))
+
+
+def _refine_boundary(
+    accents: np.ndarray,
+    start: int,
+    end: int,
+    guess: int,
+    old_len: int,
+    new_len: int,
+    new_cls: int,
+) -> int:
+    """The beat where the old meter stops explaining the accents and the new
+    one starts: among candidates on the new meter's downbeat class within
+    ``_BOUNDARY_SEARCH_BEATS`` of ``guess``, the split whose two halves are best
+    explained by their own bar lengths (variance explained, length-weighted).
+    A window that straddles a change keeps reading the old meter until most of
+    it is new, so the guess from window centres runs late by up to half a
+    window; this puts the change back where the accents change."""
+    lo = max(start + old_len, guess - _BOUNDARY_SEARCH_BEATS)
+    hi = min(end - new_len, guess + _BOUNDARY_SEARCH_BEATS)
+    first = lo + ((new_cls - lo) % new_len)
+    cands = list(range(first, hi + 1, new_len))
+    if not cands:
+        return _snap_to_class(guess, new_cls, new_len, start + 1, end)
+    best, best_score = cands[0], -1.0
+    for b in cands:
+        before = _effect_size(accents[start:b], old_len) * (b - start)
+        after = _effect_size(accents[b:end], new_len) * (end - b)
+        score = before + after
+        if score > best_score:
+            best, best_score = b, score
+    return best
+
+
+def _segments(
+    windows: list[_Window], n_beats: int, accents: Optional[np.ndarray] = None
+) -> list[_Segment]:
+    runs = _runs(windows)
+    if not runs:
+        return []
+    segs: list[_Segment] = []
+    start = 0
+    for i, (length, run) in enumerate(runs):
+        phase, grouping = _phase_vote(run, length)
+        if i + 1 < len(runs):
+            nxt_len, nxt_run = runs[i + 1]
+            mid = (run[-1].center + nxt_run[0].center) // 2
+            nxt_phase, _ = _phase_vote(nxt_run, nxt_len)
+            # The next run's own far edge bounds the search for this boundary.
+            far = (
+                (nxt_run[-1].center + runs[i + 2][1][0].center) // 2
+                if i + 2 < len(runs)
+                else n_beats
+            )
+            if accents is not None:
+                end = _refine_boundary(
+                    accents, start, min(far, n_beats), mid, length, nxt_len, nxt_phase
+                )
+            else:
+                end = _snap_to_class(mid, nxt_phase, nxt_len, start + 1, n_beats)
+        else:
+            end = n_beats
+        conf = float(
+            np.mean(
+                [w.conf for w in run if w.fit and w.fit.beats_per_bar == length]
+                or [0.0]
+            )
+        )
+        segs.append(_Segment(start, end, length, grouping, phase, conf))
+        start = end
+    # A segment shorter than two of its own bars is a boundary artefact; it
+    # joins the more confident neighbour, which keeps its meter.
+    changed = True
+    while changed and len(segs) > 1:
+        changed = False
+        for k, seg in enumerate(segs):
+            if seg.end_beat - seg.start_beat >= max(2 * seg.beats_per_bar, 8):
+                continue
+            cands = [j for j in (k - 1, k + 1) if 0 <= j < len(segs)]
+            into = max(cands, key=lambda j: segs[j].confidence)
+            host = segs[into]
+            lo, hi = min(k, into), max(k, into)
+            merged = _Segment(
+                segs[lo].start_beat,
+                segs[hi].end_beat,
+                host.beats_per_bar,
+                host.grouping,
+                host.phase,
+                host.confidence,
+            )
+            segs = segs[:lo] + [merged] + segs[hi + 1 :]
+            changed = True
+            break
+    return segs
+
+
+# --------------------------------------------------------------------------
+# subdivision, syncopation
+# --------------------------------------------------------------------------
+
+
+def _beat_phases(
+    onsets: np.ndarray, strengths: np.ndarray, beats: np.ndarray, lo: int, hi: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """For onsets inside beats ``lo..hi-1``: ``(phase in [0,1), strength, beat
+    index)``."""
+    if hi - lo < 1 or onsets.size == 0:
+        return np.zeros(0), np.zeros(0), np.zeros(0, dtype=np.int64)
+    last = beats[-1] - beats[-2] if beats.size > 1 else 0.5
+    ends = np.append(beats[1:], beats[-1] + last)
+    idx = np.searchsorted(beats, onsets, side="right") - 1
+    keep = (idx >= lo) & (idx < hi)
+    idx = idx[keep]
+    o = onsets[keep]
+    dur = np.maximum(ends[idx] - beats[idx], _EPS)
+    return (o - beats[idx]) / dur, strengths[keep], idx
+
+
+def _subdivision(phases: np.ndarray, strengths: np.ndarray) -> dict[str, Any]:
+    """Simple vs compound from where off-beat onsets fall inside the beat, and
+    whether sixteenths are in play. Compound needs BOTH thirds to carry the
+    off-beat mass outright, not merely to edge out the half."""
+    off = (phases > 0.1) & (phases < 0.9)
+    p, s = phases[off], strengths[off]
+    total = float(s.sum())
+    if total <= _EPS:
+        return {"kind": "simple", "confidence": 0.0, "sixteenths": False}
+    m_half = float(s[np.abs(p - 0.5) < 0.07].sum())
+    m_first = float(s[np.abs(p - 1 / 3) < 0.07].sum())
+    m_second = float(s[np.abs(p - 2 / 3) < 0.07].sum())
+    m_third = m_first + m_second
+    m_quarter = float(s[(np.abs(p - 0.25) < 0.06) | (np.abs(p - 0.75) < 0.06)].sum())
+    # Both thirds have to be there: swung eighths sit on the second third
+    # alone, and that is 4/4 with swing, not 12/8.
+    compound = (
+        m_third >= 0.4 * total
+        and m_half < 0.5 * m_third
+        and min(m_first, m_second) >= 0.2 * m_third
+    )
+    conf = abs(m_third - m_half) / (m_third + m_half + _EPS)
+    return {
+        "kind": "compound" if compound else "simple",
+        "confidence": float(min(1.0, conf)),
+        "sixteenths": bool(not compound and m_quarter >= 0.3 * total),
+    }
+
+
+def _swing(phases: np.ndarray, beat_idx: np.ndarray) -> tuple[Optional[float], float]:
+    """Swing ratio (long eighth / short eighth; 1 straight, 2 triplet) from beats
+    with exactly one off-beat onset in the swing range."""
+    if phases.size == 0:
+        return None, 0.0
+    ratios: list[float] = []
+    for b in np.unique(beat_idx):
+        ph = phases[(beat_idx == b) & (phases > 0.1) & (phases < 0.9)]
+        if ph.size == 1 and 0.4 <= ph[0] <= 0.8:
+            ratios.append(float(ph[0] / (1.0 - ph[0])))
+    if len(ratios) < 4:
+        return None, 0.0
+    return float(np.median(ratios)), float(min(1.0, len(ratios) / 16.0))
+
+
+def _metrical_weights(grouping: tuple[int, ...], q: int) -> np.ndarray:
+    """Weights per grid position of one bar: 4 bar start, 3 group start, 2 beat,
+    1 the beat's main subdivision, 0 the rest."""
+    length = sum(grouping)
+    w = np.zeros(length * q, dtype=np.float64)
+    if q == 2:
+        w[1::2] = 1
+    elif q == 4:
+        w[2::4] = 1
+    elif q == 3:
+        w[1::3] = 1
+        w[2::3] = 1
+    w[0::q] = 2
+    pos = 0
+    for part in grouping:
+        w[pos * q] = 3
+        pos += part
+    w[0] = 4
+    return w
+
+
+def _bar_syncopation(
+    positions: np.ndarray, saliences: np.ndarray, weights: np.ndarray, q: int
+) -> dict[str, float]:
+    """LHL (a note on a weak position followed by silence on a stronger one,
+    weighted by salience, per note, /4), WNBD on onsets (1 / distance to the
+    nearest beat, per note, /4), and the share of onset salience off the beat."""
+    n = weights.size
+    if positions.size == 0:
+        return {"lhl": 0.0, "wnbd": 0.0, "offbeat_ratio": 0.0, "onsets": 0}
+    occupied: dict[int, float] = {}
+    for p, s in zip(positions.tolist(), saliences.tolist()):
+        p = int(max(0, min(n - 1, p)))
+        occupied[p] = max(occupied.get(p, 0.0), float(s))
+    ps = sorted(occupied)
+    lhl = 0.0
+    for i, p in enumerate(ps):
+        nxt = ps[i + 1] if i + 1 < len(ps) else n
+        if nxt - p <= 1:
+            continue
+        rest = float(weights[p + 1 : nxt].max())
+        if rest > weights[p]:
+            lhl += occupied[p] * (rest - weights[p])
+    wnbd = 0.0
+    for p in ps:
+        d = min(p % q, q - (p % q)) / q
+        wnbd += 0.0 if d == 0 else 1.0 / d
+    total = sum(occupied.values())
+    off = sum(v for p, v in occupied.items() if weights[p] < 2)
+    return {
+        "lhl": float(lhl / len(ps) / 4.0),
+        "wnbd": float(wnbd / len(ps) / 4.0),
+        "offbeat_ratio": float(off / total) if total > _EPS else 0.0,
+        "onsets": len(ps),
+    }
+
+
+# --------------------------------------------------------------------------
+# polymeter, cross-rhythms
+# --------------------------------------------------------------------------
+
+
+def _poly_relation(length: int, seg_len: int, den: int) -> Optional[tuple[str, str]]:
+    """``(relation, label)`` for a layer bar of ``length`` positions against a
+    segment bar of ``seg_len`` positions on one grid whose note value is
+    ``den``, or None when it is the same meter at another level."""
+    if length == seg_len or seg_len % length == 0 or length % seg_len == 0:
+        return None
+    return f"{length}:{seg_len}", f"{length}/{den} against {seg_len}/{den}"
+
+
+def _polymeter(
+    layers: dict[str, np.ndarray],
+    segs: list[_Segment],
+    *,
+    den: int = 4,
+    l_max: int = L_MAX,
+) -> list[dict[str, Any]]:
+    """Per segment and layer: a bar length of its own that is neither the
+    segment's nor the same meter at another level. Only claimed against a
+    segment whose own meter is trusted. ``den`` is the level's note value."""
+    out: list[dict[str, Any]] = []
+    for si, seg in enumerate(segs):
+        # Gated on length, not on the segment's confidence: a layer cycling in
+        # 3 over 4/4 drums is exactly what lowers the bar's confidence, and
+        # that ambiguity is the finding.
+        if seg.end_beat - seg.start_beat < _POLY_MIN_BARS * seg.beats_per_bar:
+            continue
+        for name, acc in layers.items():
+            chunk = acc[seg.start_beat : seg.end_beat]
+            if chunk.size < 2 * L_MIN:
+                continue
+            fit, conf = pick_meter(fit_meter(_zscore(chunk), l_max=l_max))
+            if fit is None or conf < _POLY_MIN_CONF:
+                continue
+            length = fit.beats_per_bar
+            if length == seg.beats_per_bar:
+                cls = (seg.start_beat + fit.phase) % length
+                offset = (cls - seg.phase) % length
+                if offset == 0:
+                    continue
+                relation, label = f"displaced:+{offset}", f"the same bar, {offset} late"
+            else:
+                rel = _poly_relation(length, seg.beats_per_bar, den)
+                if rel is None:
+                    continue
+                relation, label = rel
+            out.append(
+                {
+                    "segment": si,
+                    "layer": name,
+                    "beats_per_bar": length,
+                    "grouping": list(fit.grouping),
+                    "relation": relation,
+                    "label": label,
+                    "level": f"x{den // 4}" if den > 4 else "tracked",
+                    "confidence": round(conf, 3),
+                    "segment_confidence": round(seg.confidence, 3),
+                }
+            )
+    return out
+
+
+def _polymeter_finer(
+    layers: dict[str, np.ndarray],
+    times: np.ndarray,
+    segs: list[_Segment],
+    seg_times: list[tuple[float, float]],
+    *,
+    ratio: int,
+    den_seg: int,
+) -> list[dict[str, Any]]:
+    """The same, on a grid ``ratio`` times finer than the segments' — where a
+    layer's bar that is not a whole number of the segment's beats (7/8 against
+    5/4: 3.5 quarters) becomes one (7 against 10 eighths)."""
+    out: list[dict[str, Any]] = []
+    den = den_seg * ratio
+    for si, seg in enumerate(segs):
+        if seg.end_beat - seg.start_beat < _POLY_MIN_BARS * seg.beats_per_bar:
+            continue
+        t0, t1 = seg_times[si]
+        lo = int(np.searchsorted(times, t0))
+        hi = int(np.searchsorted(times, t1))
+        seg_len = seg.beats_per_bar * ratio
+        for name, acc in layers.items():
+            chunk = acc[lo:hi]
+            if chunk.size < 2 * L_MIN:
+                continue
+            fit, conf = pick_meter(fit_meter(_zscore(chunk), l_max=_l_max_for(ratio)))
+            if fit is None or conf < _POLY_MIN_CONF:
+                continue
+            length = fit.beats_per_bar
+            if length % ratio == 0:
+                continue  # a whole number of the segment's beats: read at the level above
+            rel = _poly_relation(length, seg_len, den)
+            if rel is None:
+                continue
+            relation, _ = rel
+            out.append(
+                {
+                    "segment": si,
+                    "layer": name,
+                    "beats_per_bar": length,
+                    "grouping": list(fit.grouping),
+                    "relation": relation,
+                    "label": f"{length}/{den} against {seg.beats_per_bar}/{den_seg}",
+                    "level": f"x{ratio}",
+                    "confidence": round(conf, 3),
+                    "segment_confidence": round(seg.confidence, 3),
+                }
+            )
+    return out
+
+
+def _cross_rhythms(
+    tg: np.ndarray, sr: int, frames: tuple[int, int], bpm: float
+) -> list[dict[str, Any]]:
+    """Tempogram peaks at non-octave ratios of the tracked tempo. A ratio counts
+    when the profile there is a local peak and carries ``_CROSS_MIN_REL`` of the
+    profile's own maximum; strengths are relative to that maximum, so they are
+    comparable across segments and never above 1."""
+    import librosa
+
+    lo, hi = frames
+    if hi <= lo or bpm <= 0:
+        return []
+    strength = tg[:, lo:hi].mean(axis=1)
+    freqs = librosa.tempo_frequencies(tg.shape[0], sr=sr, hop_length=_HOP)
+    ok = np.isfinite(freqs) & (freqs > 0)
+    f, s = freqs[ok], strength[ok]
+    order = np.argsort(f)
+    f, s = f[order], s[order]
+    peak = float(s.max()) if s.size else 0.0
+    if peak <= _EPS:
+        return []
+
+    def at(b: float) -> float:
+        if b < f[0] or b > f[-1]:
+            return 0.0
+        return float(np.interp(b, f, s))
+
+    out = []
+    for label, ratio in _CROSS_RATIOS:
+        b = bpm * ratio
+        here = at(b)
+        rel = here / peak
+        is_peak = here >= at(b * (1 - _CROSS_PEAK_TOL)) and here >= at(
+            b * (1 + _CROSS_PEAK_TOL)
+        )
+        if rel >= _CROSS_MIN_REL and is_peak:
+            out.append({"ratio": label, "bpm": round(b, 2), "strength": round(rel, 3)})
+    out.sort(key=lambda c: -c["strength"])
+    return out[:2]
+
+
+# --------------------------------------------------------------------------
+# the analysis
+# --------------------------------------------------------------------------
+
+
+def _base_den(tracked_bpm: float) -> int:
+    """The note value of the tracked beat: a pulse over 160 a minute is read
+    as eighths, otherwise quarters."""
+    return 8 if tracked_bpm > 160 else 4
+
+
+def _den_for_rate(grid_bpm: float) -> int:
+    """The note value of a grid from its own rate: sixteenths past 320 a
+    minute, eighths past 160, quarters below."""
+    return 16 if grid_bpm > 320 else 8 if grid_bpm > 160 else 4
+
+
+def _time_signature(
+    length: int,
+    grouping: tuple[int, ...],
+    subdivision: str,
+    bpm: float,
+    den: Optional[int] = None,
+) -> dict[str, Any]:
+    """Numerator / denominator / beat unit. Read on a tatum grid (``den``
+    given: 8 for eighths, 16 for sixteenths) the positions ARE the unit and 19
+    sixteenths is 19/16. At the tracked beat a compound beat is a dotted
+    quarter (2 beats of triplets -> 6/8); a fast pulse of five or more is
+    eighths (7 at 190 -> 7/8, 13 at 240 -> 13/8); otherwise the tracked beat is
+    the quarter."""
+    units = {4: "quarter", 8: "eighth", 16: "sixteenth", 32: "thirty-second"}
+    if den is not None:
+        num, unit = length, units.get(den, f"1/{den}")
+    elif subdivision == "compound":
+        num, den, unit = 3 * length, 8, "dotted-quarter"
+    elif bpm > 160 and length >= 5:
+        num, den, unit = length, 8, "eighth"
+    else:
+        num, den, unit = length, 4, "quarter"
+    label = f"{num}/{den}"
+    if len(grouping) > 1 and grouping != (2, 2):
+        label += " (" + "+".join(str(g) for g in grouping) + ")"
+    return {"numerator": num, "denominator": den, "beat_unit": unit, "label": label}
+
+
+def _tatum_curve(
+    tg: np.ndarray, sr: int, runs: list[tuple[int, int, float]], n_frames: int
+) -> tuple[Optional[np.ndarray], Optional[float]]:
+    """The tatum — the fastest strong pulse above the beat, hats on eighths or
+    sixteenths — per tempo run, as a per-frame tempo curve and its median.
+
+    An additive meter's felt beats are uneven (3+3+3+2 eighths), and a beat
+    tracker averages them into a pulse that is not there (87 bpm for 11/8 at
+    240); the tatum is the only regular grid, and the bar is a whole number of
+    tatums. In the autocorrelation tempogram a pulse train peaks at its own
+    period and every multiple (its tempo and every sub-tempo), so the fastest
+    peak that carries ``_TATUM_MIN_REL`` of the band's maximum is the tatum.
+    The peak's lag is refined by parabolic interpolation: at 480 a minute a
+    lag is five frames and a whole frame is a 20 % error."""
+    import librosa
+    from scipy.signal import find_peaks
+
+    freqs = librosa.tempo_frequencies(tg.shape[0], sr=sr, hop_length=_HOP)
+    curve = np.zeros(n_frames, dtype=np.float64)
+    found: list[float] = []
+    for a, b, run_bpm in runs:
+        if b <= a:
+            continue
+        prof = tg[:, a:b].mean(axis=1)
+        lo, hi = 1.5 * run_bpm, min(_TATUM_MAX_BPM, 6.0 * run_bpm)
+        band = np.where(np.isfinite(freqs) & (freqs > lo) & (freqs <= hi))[0]
+        if band.size < 3:
+            continue
+        top = float(prof[band].max())
+        floor = _TATUM_MIN_REL * top
+        # Peaks with prominence: the autocorrelation is high at every lag
+        # inside the onset envelope's own width (a few frames), and that
+        # bump at the fast edge of the band is not a pulse.
+        lo_i, hi_i = int(band.min()), int(band.max())
+        a0 = max(0, lo_i - 3)
+        pk, _props = find_peaks(prof[a0 : hi_i + 4], prominence=_TATUM_MIN_PROM * top)
+        peaks = [
+            int(q + a0) for q in pk if lo_i <= q + a0 <= hi_i and prof[q + a0] >= floor
+        ]
+        if not peaks:
+            continue
+        i = min(peaks)  # smallest lag: the fastest tempo
+        # parabolic refinement of the lag
+        y0, y1, y2 = float(prof[i - 1]), float(prof[i]), float(prof[i + 1])
+        denom = y0 - 2.0 * y1 + y2
+        lag = i + (0.5 * (y0 - y2) / denom if abs(denom) > _EPS else 0.0)
+        tatum = 60.0 * sr / (_HOP * max(lag, 1.0))
+        # Snap to a whole multiple of the run's beat when it is within 6 %;
+        # the grid then stays a subdivision of the beat, not a rival to it.
+        for k in (2, 3, 4, 5, 6):
+            if abs(tatum / run_bpm - k) <= 0.06 * k:
+                tatum = k * run_bpm
+                break
+        curve[a:b] = tatum
+        found.append(tatum)
+    if not found:
+        return None, None
+    med = float(np.median(found))
+    curve[curve <= 0] = med
+    return curve, med
+
+
+def _slope_bpm(times: np.ndarray, fallback: float) -> float:
+    """Tempo from the span of the beats, not from a median of frame-quantized
+    intervals (which lands on 18, 19 or 20 frames and reads 143, 136 or 129)."""
+    if times.size < 2 or times[-1] <= times[0]:
+        return fallback
+    return 60.0 * (times.size - 1) / float(times[-1] - times[0])
+
+
+def _meter_quality(
+    accents: np.ndarray,
+    features: np.ndarray,
+    low_accents: np.ndarray,
+    low_features: np.ndarray,
+    *,
+    compound: bool = False,
+    mult: int = 1,
+) -> tuple[list[_Window], float]:
+    """Windows scale with the level: the same span of music holds twice the
+    eighths, so the window holds twice the positions — and a longer bar fits."""
+    windows = _fit_windows(
+        accents,
+        features,
+        low_accents,
+        low_features,
+        METER_WINDOW_BEATS * mult,
+        _METER_STRIDE_BEATS * mult,
+        compound=compound,
+        l_max=_l_max_for(mult),
+    )
+    confs = [w.conf for w in windows if w.fit is not None]
+    return windows, float(np.mean(confs)) if confs else 0.0
+
+
+def _dominant_length(windows: list[_Window]) -> int:
+    """The bar length most of the windows' confidence sits on; 0 when none."""
+    votes: dict[int, float] = {}
+    for w in windows:
+        if w.fit is not None:
+            votes[w.fit.beats_per_bar] = votes.get(w.fit.beats_per_bar, 0.0) + w.conf
+    return max(votes.items(), key=lambda kv: kv[1])[0] if votes else 0
+
+
+def analyze_rhythm(
+    y: np.ndarray,
+    sr: int,
+    *,
+    stems: Optional[dict[str, np.ndarray]] = None,
+) -> dict[str, Any]:
+    """The full analysis of a mono signal. ``stems`` (name -> mono at ``sr``)
+    give the polymeter pass real layers; without them it reads the low / mid /
+    high bands."""
+    import librosa
+    from scipy.signal import medfilt
+
+    from backend.modules.chimera.structure import beat_features
+
+    y = np.asarray(y, dtype=np.float32)
+    if y.ndim == 2:
+        y = y.mean(axis=1)
+    duration = float(y.size) / float(sr) if sr else 0.0
+    if y.size == 0 or duration < _MIN_DURATION_SEC:
+        return _empty(sr, duration, "too short")
+
+    env, band_power = _onset_envelopes(y, sr)
+    low_power = band_power[0]
+    oenv = env[3]  # the broad stream: onsets for subdivision and syncopation
+    # Low-band onsets from the low band's POWER rising, not its dB flux: a
+    # broadband hat out of silence is a huge dB step in every band, the low
+    # ones included, and out-shouts the kick in flux terms. In power the
+    # kick has no rival.
+    low_env = _unit(np.maximum(0.0, np.diff(low_power, prepend=low_power[:1])))
+    # The pulse is tracked on broad flux + low-band onsets, so a kick counts
+    # as much as a hat.
+    track_env = _unit(env[3]) + low_env
+    n_frames = int(oenv.size)
+    frame_sec = _HOP / float(sr)
+
+    # --- tempo curve ------------------------------------------------------
+    tg = librosa.feature.tempogram(
+        onset_envelope=track_env, sr=sr, hop_length=_HOP, win_length=_TG_WIN
+    )
+    global_bpm = float(
+        np.atleast_1d(
+            librosa.feature.tempo(
+                onset_envelope=track_env, sr=sr, hop_length=_HOP, tg=tg
+            )
+        )[0]
+    )
+    if not np.isfinite(global_bpm) or global_bpm <= 0:
+        return _empty(sr, duration, "no tempo")
+    local = np.atleast_1d(
+        librosa.feature.tempo(
+            onset_envelope=track_env, sr=sr, hop_length=_HOP, tg=tg, aggregate=None
+        )
+    ).astype(np.float64)
+    if local.size != n_frames:
+        local = np.full(n_frames, global_bpm)
+    local = _fold_octaves(local, global_bpm)
+    k = int(round(_TEMPO_SMOOTH_SEC / frame_sec)) | 1
+    smooth = (
+        medfilt(local, kernel_size=min(k, (n_frames - 1) | 1))
+        if n_frames > 3
+        else local
+    )
+    tempo_runs = _tempo_runs(smooth, frame_sec)
+    # Beats follow the piecewise tempo the runs describe: steady inside a run,
+    # stepping at a change, never smeared across it.
+    bpm_curve = np.empty(n_frames, dtype=np.float64)
+    for a, b, bpm in tempo_runs:
+        bpm_curve[a:b] = bpm
+    beat_frames = _snap_to_peaks(
+        _align_phase(_track_beats(track_env, sr, bpm_curve, global_bpm), low_power),
+        track_env,
+    )
+    if beat_frames.size < 2 * L_MIN:
+        return _empty(sr, duration, "too few beats")
+
+    # --- onsets: subdivision reads them, and it is read before the fit ------
+    onset_frames = np.asarray(
+        librosa.onset.onset_detect(
+            onset_envelope=oenv, sr=sr, hop_length=_HOP, units="frames", backtrack=False
+        ),
+        dtype=np.int64,
+    )
+    onset_times = librosa.frames_to_time(onset_frames, sr=sr, hop_length=_HOP)
+    onset_strength = oenv[np.clip(onset_frames, 0, n_frames - 1)]
+    # The low band on its own: syncopation is the low end pushing against
+    # the pulse, and a hat on every beat would fill every rest in the mix.
+    low_frames = np.asarray(
+        librosa.onset.onset_detect(
+            onset_envelope=low_env,
+            sr=sr,
+            hop_length=_HOP,
+            units="frames",
+            backtrack=False,
+        ),
+        dtype=np.int64,
+    )
+    low_times = librosa.frames_to_time(low_frames, sr=sr, hop_length=_HOP)
+    low_strength = low_env[np.clip(low_frames, 0, n_frames - 1)]
+
+    # --- evidence, meter — at the tracked level, then at 2x if nothing fits ---
+    hires: dict[str, np.ndarray] = {}
+
+    def fine_envelopes() -> dict[str, np.ndarray]:
+        """Onset envelopes at hop 128 with a 23 ms window, for the fast grids,
+        computed once when first needed: at hop 512 a sixteenth at 120 bpm is
+        5.38 frames, the DP rounds the period to 5, and the grid runs 7 % fast
+        and never locks; and with a 93 ms window a hat's flux smears over
+        sixteen hop-128 frames, so no position stands out from the gaps.
+        ``onset_strength`` is told the window: librosa pads the envelope by
+        ``n_fft // (2 * hop)`` frames to undo the STFT's centering and assumes
+        2048 unless told, which put the flux 35 ms behind the band power."""
+        if not hires:
+            spec = np.abs(librosa.stft(y, n_fft=_N_FFT_FINE, hop_length=_HOP_FINE))
+            mel = librosa.feature.melspectrogram(S=spec**2, sr=sr, n_mels=_N_MELS)
+            env_hi = librosa.onset.onset_strength(
+                S=librosa.power_to_db(mel),
+                sr=sr,
+                hop_length=_HOP_FINE,
+                n_fft=_N_FFT_FINE,
+            )
+            low_hi = mel[_BAND_EDGES[0] : _BAND_EDGES[1]].sum(axis=0)
+            hires["track"] = _unit(np.asarray(env_hi, dtype=np.float64)) + _unit(
+                np.maximum(0.0, np.diff(low_hi, prepend=low_hi[:1]))
+            )
+            hires["low_power"] = np.asarray(low_hi, dtype=np.float64)
+        return hires
+
+    def grid_for(curve: np.ndarray, grid_bpm: float) -> tuple[np.ndarray, float]:
+        """A beat grid tracked by the same DP against ``curve``, phase-aligned
+        to the low band and snapped to onset peaks — at hop 128 when the grid
+        is fast enough for hop 512 to misround its period."""
+        if grid_bpm <= _FINE_GRID_FROM_BPM:
+            grid = _snap_to_peaks(
+                _align_phase(_track_beats(track_env, sr, curve, grid_bpm), low_power),
+                track_env,
+            )
+            return grid, _occupancy(grid, track_env)
+        h = fine_envelopes()
+        n_hi = h["track"].size
+        k = _HOP // _HOP_FINE
+        curve_hi = np.repeat(curve, k)[:n_hi]
+        if curve_hi.size < n_hi:
+            tail = curve_hi[-1] if curve_hi.size else grid_bpm
+            curve_hi = np.concatenate([curve_hi, np.full(n_hi - curve_hi.size, tail)])
+        frames_hi = _track_beats(h["track"], sr, curve_hi, grid_bpm, hop=_HOP_FINE)
+        frames_hi = _snap_to_peaks(_align_phase(frames_hi, h["low_power"]), h["track"])
+        # Occupancy on the envelope the grid was tracked against: at hop 512 a
+        # frame either side of a sixteenth already reaches the next hat.
+        occ = _occupancy(frames_hi, h["track"])
+        return np.unique(np.round(frames_hi * _HOP_FINE / _HOP).astype(np.int64)), occ
+
+    def level_of(
+        frames: np.ndarray, name: str, ratio: int, den: Optional[int]
+    ) -> dict[str, Any]:
+        # Feature spans start a quarter beat early: a kick a frame either
+        # side of its beat then lands in that beat's span, not the one
+        # before, and the per-beat features stop depending on jitter.
+        shift = max(1, int(round(_SPAN_SHIFT * float(np.median(np.diff(frames))))))
+        spans = np.maximum(0, frames - shift)
+        f = beat_features(y, sr, spans)
+        en = _beat_energies(band_power, spans)
+        t = librosa.frames_to_time(frames, sr=sr, hop_length=_HOP).astype(np.float64)
+        compound = False
+        if den is None:
+            ph, st, _ = _beat_phases(onset_times, onset_strength, t, 0, t.size)
+            compound = _subdivision(ph, st)["kind"] == "compound"
+        acc = _accents(f, en)
+        mat = _feature_matrix(f, en)
+        # The low band on its own: the rhythm section's bar (see _pick_window).
+        low_acc = _robust(en[0], 1.0)
+        low_mat = en[[0, 3]]
+        win, q = _meter_quality(
+            acc, mat, low_acc, low_mat, compound=compound, mult=ratio
+        )
+        period = (
+            float(np.median(np.diff(frames))) * frame_sec if frames.size > 1 else 0.0
+        )
+        return {
+            "name": name,
+            "ratio": ratio,
+            "den": den,
+            "frames": frames,
+            "spans": spans,
+            "energies": en,
+            "feats": f,
+            "accents": acc,
+            "matrix": mat,
+            "windows": win,
+            "quality": q,
+            "period_sec": period,
+        }
+
+    def bar_seconds(lv: dict[str, Any]) -> float:
+        dom = _dominant_length(lv["windows"])
+        return dom * lv["period_sec"] if dom else float("inf")
+
+    base_bpm = _slope_bpm(
+        librosa.frames_to_time(beat_frames, sr=sr, hop_length=_HOP), global_bpm
+    )
+    chosen = level_of(beat_frames, "tracked", 1, None)
+    level_log: list[dict[str, Any]] = [
+        {
+            "level": "tracked",
+            "grid_bpm": round(base_bpm, 2),
+            "positions": int(beat_frames.size),
+            "quality": round(chosen["quality"], 3),
+            "dominant": _dominant_length(chosen["windows"]),
+            "bar_sec": round(bar_seconds(chosen), 3),
+            "accepted": True,
+        }
+    ]
+
+    # The tracked beat first. Then the tatum grids — the fastest strong pulse in
+    # the tempogram, and half of it when that is four to a beat — tried while
+    # the reading is poor. A finer level is taken only when it reads an ODD bar
+    # (an even one is the coarser bar in more positions) and either reads
+    # clearly better, or reads a SHORTER bar about as well: 13/8 at the quarter
+    # is a two-bar 13/4, and the bar is the shortest cycle that explains the
+    # accents.
+    tatum_curve, tatum_bpm = _tatum_curve(tg, sr, tempo_runs, n_frames)
+    candidates: list[tuple[str, np.ndarray, float, int]] = []
+    if tatum_curve is not None and tatum_bpm is not None and tatum_bpm > 1.5 * base_bpm:
+        ratio = max(2, int(round(tatum_bpm / max(base_bpm, _EPS))))
+        if ratio >= 4:
+            candidates.append(
+                ("tatum/2", tatum_curve / 2.0, tatum_bpm / 2.0, ratio // 2)
+            )
+        candidates.append(("tatum", tatum_curve, tatum_bpm, ratio))
+    for name, curve, grid_bpm, ratio in candidates:
+        if chosen["quality"] >= _LEVEL_GOOD:
+            break
+        grid, occ = grid_for(curve, grid_bpm)
+        entry: dict[str, Any] = {
+            "level": name,
+            "grid_bpm": round(grid_bpm, 2),
+            "positions": int(grid.size),
+            "occupancy": round(occ, 3),
+            "accepted": False,
+        }
+        level_log.append(entry)
+        if grid.size < 4 * L_MIN or occ < _MIN_OCCUPANCY:
+            entry["rejected"] = "too fine: empty positions"
+            continue  # nothing there on half the positions: finer than the music
+        finer = level_of(grid, name, ratio, _den_for_rate(grid_bpm))
+        dominant = _dominant_length(finer["windows"])
+        # A level that is itself a guess (under 0.15) is easy to beat; a reading
+        # that replaces one has to be a reading — a shorter bar at a lower
+        # quality than that is noise finding noise.
+        gain = _LEVEL_RETRY_GAIN if chosen["quality"] >= 0.15 else 0.1
+        better = finer["quality"] > chosen["quality"] + gain
+        shorter = bar_seconds(finer) < 0.9 * bar_seconds(chosen) and finer[
+            "quality"
+        ] >= max(0.15, 0.6 * chosen["quality"])
+        entry.update(
+            quality=round(finer["quality"], 3),
+            dominant=dominant,
+            bar_sec=round(bar_seconds(finer), 3),
+            better=bool(better),
+            shorter=bool(shorter),
+        )
+        if dominant % 2 == 1 and (better or shorter):
+            chosen = finer
+            entry["accepted"] = True
+    level = str(chosen["name"])
+    finer_den: Optional[int] = chosen["den"]
+    ratio = int(chosen["ratio"])
+    beat_frames = chosen["frames"]
+    accents = chosen["accents"]
+    energies = chosen["energies"]
+    spans = chosen["spans"]
+    windows, quality = chosen["windows"], chosen["quality"]
+    beats = librosa.frames_to_time(beat_frames, sr=sr, hop_length=_HOP).astype(
+        np.float64
+    )
+    n_beats = int(beats.size)
+    period = float(np.median(np.diff(beats))) if n_beats > 1 else 0.5
+    beat_ends = np.append(beats[1:], beats[-1] + period)
+    tracked_bpm = base_bpm
+
+    segs = _segments(windows, n_beats, accents)
+    if not segs:
+        return _empty(sr, duration, "no meter")
+
+    # --- per segment: downbeats, bars, subdivision, signature, syncopation ---
+    downbeats: list[float] = []
+    bars: list[dict[str, Any]] = []
+    meter_map: list[dict[str, Any]] = []
+    lhl_curve: list[float] = []
+    swing_ratios: list[tuple[float, float]] = []
+    for si, seg in enumerate(segs):
+        length = seg.beats_per_bar
+        grid_rate = _slope_bpm(
+            beats[seg.start_beat : seg.end_beat], tracked_bpm * ratio
+        )
+        # The musical tempo: a grid of sixteenths at 480 is 120 to the quarter.
+        seg_bpm = grid_rate * 4.0 / finer_den if finer_den else grid_rate
+        phases, strengths, bidx = _beat_phases(
+            onset_times, onset_strength, beats, seg.start_beat, seg.end_beat
+        )
+        if finer_den is not None:
+            # At eighths or sixteenths the positions are the smallest unit:
+            # no subdivision to read, no swing to measure, the grid is 1:1.
+            sub = {"kind": "simple", "confidence": 0.0, "sixteenths": False}
+            q = 1
+        else:
+            sub = _subdivision(phases, strengths)
+            q = 3 if sub["kind"] == "compound" else (4 if sub["sixteenths"] else 2)
+            if sub["kind"] == "simple":
+                sw, sw_conf = _swing(phases, bidx)
+                if sw is not None:
+                    swing_ratios.append((sw, sw_conf))
+        sig = _time_signature(length, seg.grouping, sub["kind"], seg_bpm, finer_den)
+        weights = _metrical_weights(seg.grouping, q)
+        first_db = seg.start_beat + ((seg.phase - seg.start_beat) % length)
+        db_idx = list(range(first_db, seg.end_beat, length))
+        downbeats.extend(float(beats[i]) for i in db_idx)
+        first_bar_index = len(bars)
+        for j, b0 in enumerate(db_idx):
+            b1 = min(db_idx[j + 1] if j + 1 < len(db_idx) else seg.end_beat, n_beats)
+            t0 = float(beats[b0])
+            t1 = float(beat_ends[b1 - 1]) if b1 - 1 < n_beats else t0 + period * length
+
+            def grid(times: np.ndarray, strength: np.ndarray):
+                in_bar = (times >= t0) & (times < t1)
+                o = times[in_bar]
+                st = strength[in_bar]
+                if not o.size:
+                    return np.zeros(0, dtype=int), np.zeros(0)
+                bi = np.clip(np.searchsorted(beats, o, side="right") - 1, b0, b1 - 1)
+                frac = (o - beats[bi]) / np.maximum(beat_ends[bi] - beats[bi], _EPS)
+                pos = (bi - b0) * q + np.round(frac * q).astype(int)
+                return np.clip(pos, 0, weights.size - 1), st / (st.max() + _EPS)
+
+            broad_sync = _bar_syncopation(
+                *grid(onset_times, onset_strength), weights, q
+            )
+            low_sync = _bar_syncopation(*grid(low_times, low_strength), weights, q)
+            sync = {
+                "lhl": low_sync["lhl"],
+                "wnbd": broad_sync["wnbd"],
+                "offbeat_ratio": broad_sync["offbeat_ratio"],
+                "onsets": broad_sync["onsets"],
+                "low_onsets": low_sync["onsets"],
+            }
+            lhl_curve.append(sync["lhl"])
+            bars.append(
+                {
+                    "index": len(bars),
+                    "segment": si,
+                    "start_sec": round(t0, 4),
+                    "end_sec": round(t1, 4),
+                    "beats": int(b1 - b0),
+                    "time_signature": sig["label"],
+                    "syncopation": {
+                        k: (round(v, 4) if isinstance(v, float) else v)
+                        for k, v in sync.items()
+                    },
+                }
+            )
+        meter_map.append(
+            {
+                "segment": si,
+                "start_sec": round(float(beats[seg.start_beat]), 4),
+                "end_sec": round(float(beat_ends[min(seg.end_beat, n_beats) - 1]), 4),
+                "start_beat": seg.start_beat,
+                "end_beat": seg.end_beat,
+                "start_bar": first_bar_index,
+                "bars": len(db_idx),
+                "beats_per_bar": length,
+                "grouping": list(seg.grouping),
+                "time_signature": sig["label"],
+                "numerator": sig["numerator"],
+                "denominator": sig["denominator"],
+                "beat_unit": sig["beat_unit"],
+                "level": level,
+                "subdivision": sub["kind"],
+                "subdivision_confidence": round(sub["confidence"], 3),
+                "sixteenths": sub["sixteenths"],
+                "bpm": round(seg_bpm, 2),
+                "confidence": round(seg.confidence, 3),
+                "uncertain": bool(seg.confidence < _UNCERTAIN_CONF),
+            }
+        )
+
+    # --- polymeter: per band (and per stem, when given) ----------------------
+    layers: dict[str, np.ndarray] = {
+        "low": energies[0],
+        "mid": energies[1],
+        "high": energies[2],
+    }
+    if stems:
+        for name, stem in stems.items():
+            stem = np.asarray(stem, dtype=np.float32)
+            if stem.ndim == 2:
+                stem = stem.mean(axis=1)
+            if stem.size < y.size // 2:
+                continue
+            _, stem_power = _onset_envelopes(stem[: y.size], sr)
+            sf = beat_features(stem[: y.size], sr, spans)
+            layers[f"stem:{name}"] = _accents(sf, _beat_energies(stem_power, spans))
+    den_base = finer_den or _base_den(base_bpm)
+    # The finer grid first: a layer whose bar is not a whole number of the
+    # segment's beats (7/8 against 5/4: 3.5 quarters) becomes one there (7
+    # against 10 eighths). The tatum grid when there is one, else twice the
+    # beat. Energies only — no beat_features — so it costs one DP pass.
+    finer_entries: list[dict[str, Any]] = []
+    fine_curve: Optional[np.ndarray] = None
+    fine_ratio = 2
+    if tatum_curve is not None and tatum_bpm is not None and level != "tatum":
+        chosen_rate = base_bpm * ratio
+        fine_ratio = max(2, int(round(tatum_bpm / max(chosen_rate, _EPS))))
+        fine_curve = tatum_curve
+    elif level == "tracked":
+        fine_curve = bpm_curve * 2.0
+    if fine_curve is not None:
+        fine, fine_occ = grid_for(fine_curve, float(np.median(fine_curve)))
+        # A tatum grid with empty positions is finer than the music: halve it
+        # (sixteenths found where the hats play eighths).
+        while fine.size >= 4 * L_MIN and fine_occ < _MIN_OCCUPANCY and fine_ratio >= 4:
+            fine_ratio //= 2
+            fine_curve = fine_curve / 2.0
+            fine, fine_occ = grid_for(fine_curve, float(np.median(fine_curve)))
+        if fine.size >= 4 * L_MIN and fine_occ >= _MIN_OCCUPANCY:
+            fine_shift = max(
+                1, int(round(_SPAN_SHIFT * float(np.median(np.diff(fine)))))
+            )
+            fine_en = _beat_energies(band_power, np.maximum(0, fine - fine_shift))
+            fine_layers = {"low": fine_en[0], "mid": fine_en[1], "high": fine_en[2]}
+            fine_times = librosa.frames_to_time(fine, sr=sr, hop_length=_HOP)
+            seg_times = [(m["start_sec"], m["end_sec"]) for m in meter_map]
+            finer_entries = _polymeter_finer(
+                fine_layers,
+                fine_times,
+                segs,
+                seg_times,
+                ratio=fine_ratio,
+                den_seg=den_base,
+            )
+    covered = {(e["segment"], e["layer"]) for e in finer_entries}
+    polymeter = finer_entries + [
+        e
+        for e in _polymeter(layers, segs, den=den_base, l_max=_l_max_for(ratio))
+        if (e["segment"], e["layer"]) not in covered
+    ]
+    cross: list[dict[str, Any]] = []
+    for si, seg in enumerate(segs):
+        if seg.confidence < _SEGMENT_MIN_CONF:
+            continue
+        f0 = int(beat_frames[seg.start_beat])
+        f1 = int(beat_frames[min(seg.end_beat, n_beats) - 1])
+        for c in _cross_rhythms(tg, sr, (f0, f1), meter_map[si]["bpm"]):
+            cross.append({"segment": si, **c})
+
+    # --- tempo report --------------------------------------------------------
+    times = librosa.frames_to_time(np.arange(n_frames), sr=sr, hop_length=_HOP)
+    step = max(1, int(round(1.0 / frame_sec)))
+    curve = [
+        [round(float(times[i]), 3), round(float(smooth[i]), 2)]
+        for i in range(0, n_frames, step)
+    ]
+    tempo_segments = [
+        {
+            "start_sec": round(float(times[a]), 3),
+            "end_sec": round(float(times[min(b, n_frames) - 1]), 3),
+            "bpm": round(bpm, 2),
+        }
+        for a, b, bpm in tempo_runs
+    ]
+    bpm_min, bpm_max = float(smooth.min()), float(smooth.max())
+
+    lhl_arr = np.asarray(lhl_curve, dtype=np.float64)
+    peak_bars = (
+        [int(i) for i in np.argsort(-lhl_arr)[:4] if lhl_arr[i] > 0]
+        if lhl_arr.size
+        else []
+    )
+    swing = None
+    swing_conf = 0.0
+    if swing_ratios:
+        swing = float(np.median([r for r, _ in swing_ratios]))
+        swing_conf = float(max(c for _, c in swing_ratios))
+
+    result: dict[str, Any] = {
+        "version": RHYTHM_VERSION,
+        "sr": int(sr),
+        "duration_sec": round(duration, 3),
+        "tempo": {
+            "bpm": round(tracked_bpm, 2),
+            "global_bpm": round(global_bpm, 2),
+            "range_bpm": [round(bpm_min, 2), round(bpm_max, 2)],
+            "stable": bool(
+                len(tempo_runs) == 1 and (bpm_max - bpm_min) / max(bpm_min, _EPS) < 0.05
+            ),
+            "segments": tempo_segments,
+            "curve": curve,
+            "level": level,
+            "tatum_bpm": round(tatum_bpm, 2) if tatum_bpm else None,
+        },
+        "beats": [round(float(t), 4) for t in beats],
+        "downbeats": [round(t, 4) for t in downbeats],
+        "meter_map": meter_map,
+        "bars": bars,
+        "syncopation": {
+            "mean_lhl": round(float(lhl_arr.mean()), 4) if lhl_arr.size else 0.0,
+            "max_lhl": round(float(lhl_arr.max()), 4) if lhl_arr.size else 0.0,
+            "mean_offbeat_ratio": (
+                round(
+                    float(np.mean([b["syncopation"]["offbeat_ratio"] for b in bars])),
+                    4,
+                )
+                if bars
+                else 0.0
+            ),
+            "peak_bars": peak_bars,
+            "curve": [round(v, 4) for v in lhl_curve],
+            "swing_ratio": round(swing, 3) if swing is not None else None,
+            "swing_confidence": round(swing_conf, 3),
+        },
+        "polymeter": polymeter,
+        "cross_rhythms": cross,
+        "diagnostics": {
+            "n_beats": n_beats,
+            "n_onsets": int(onset_times.size),
+            "meter_window_beats": METER_WINDOW_BEATS,
+            "meter_quality": round(quality, 3),
+            "windows": len(windows),
+            "levels": level_log,
+        },
+    }
+    result["summary"] = summarize(result)
+    return result
+
+
+def _empty(sr: int, duration: float, reason: str) -> dict[str, Any]:
+    return {
+        "version": RHYTHM_VERSION,
+        "sr": int(sr),
+        "duration_sec": round(duration, 3),
+        "tempo": {
+            "bpm": None,
+            "global_bpm": None,
+            "range_bpm": None,
+            "stable": False,
+            "segments": [],
+            "curve": [],
+            "level": "none",
+        },
+        "beats": [],
+        "downbeats": [],
+        "meter_map": [],
+        "bars": [],
+        "syncopation": {
+            "mean_lhl": 0.0,
+            "max_lhl": 0.0,
+            "mean_offbeat_ratio": 0.0,
+            "peak_bars": [],
+            "curve": [],
+            "swing_ratio": None,
+            "swing_confidence": 0.0,
+        },
+        "polymeter": [],
+        "cross_rhythms": [],
+        "diagnostics": {"reason": reason},
+        "summary": f"No rhythm analysis: {reason}.",
+    }
+
+
+def summarize(r: dict[str, Any]) -> str:
+    """One paragraph a person (or the assistant) can read."""
+    mm = r.get("meter_map") or []
+    if not mm:
+        return "No meter could be read."
+    parts = []
+    for seg in mm:
+        span = f"{seg['start_sec']:.1f}-{seg['end_sec']:.1f}s"
+        mark = "?" if seg.get("uncertain") else ""
+        parts.append(
+            f"{mark}{seg['time_signature']} at {seg['bpm']:.0f} bpm "
+            f"({seg['bars']} bars, {span}, conf {seg['confidence']:.2f})"
+        )
+    text = "Meter: " + " -> ".join(parts) + "."
+    if any(seg.get("uncertain") for seg in mm):
+        text += " (? = a guess: the accents there fit no bar length well.)"
+    t = r.get("tempo") or {}
+    if t.get("segments") and len(t["segments"]) > 1:
+        text += " Tempo changes: " + ", ".join(
+            f"{s['bpm']:.0f} from {s['start_sec']:.1f}s" for s in t["segments"]
+        )
+        text += "."
+    s = r.get("syncopation") or {}
+    if s.get("mean_lhl") is not None:
+        text += f" Syncopation (LHL) mean {s['mean_lhl']:.2f}, max {s['max_lhl']:.2f}"
+        if s.get("peak_bars"):
+            text += " at bars " + ", ".join(str(b) for b in s["peak_bars"])
+        text += "."
+    if s.get("swing_ratio"):
+        text += f" Swing ratio {s['swing_ratio']:.2f}."
+    poly = sorted(r.get("polymeter") or [], key=lambda p: -p["confidence"])[:3]
+    if poly:
+        text += " Polymeter: " + "; ".join(
+            f"{p['layer']} keeps {p.get('label') or str(p['beats_per_bar']) + ' (' + p['relation'] + ')'}"
+            for p in poly
+        )
+        text += "."
+    cross = sorted(r.get("cross_rhythms") or [], key=lambda c: -c["strength"])[:3]
+    if cross:
+        text += " Cross-rhythms: " + ", ".join(
+            f"{c['ratio']} ({c['strength']:.2f})" for c in cross
+        )
+        text += "."
+    return text
+
+
+def analyze_file(
+    path: str | Path, *, stems: Optional[dict[str, str | Path]] = None
+) -> dict[str, Any]:
+    """Decode ``path`` (any format librosa/soundfile reads, Opus included) to
+    mono 22.05 kHz and analyze it. ``stems`` maps layer names to files."""
+    import librosa
+
+    y, sr = librosa.load(str(path), sr=SR, mono=True)
+    stem_arrays: Optional[dict[str, np.ndarray]] = None
+    if stems:
+        stem_arrays = {}
+        for name, p in stems.items():
+            try:
+                s, _ = librosa.load(str(p), sr=SR, mono=True)
+                stem_arrays[str(name)] = s
+            except Exception as e:  # noqa: BLE001 — one bad stem must not sink the run
+                log.info("rhythm: stem %s unreadable (%s)", name, e)
+    return analyze_rhythm(y, int(sr), stems=stem_arrays)

--- a/backend/modules/rhythm/module.json
+++ b/backend/modules/rhythm/module.json
@@ -1,0 +1,10 @@
+{
+  "name": "rhythm",
+  "label": "Rhythm",
+  "enabled": true,
+  "icon": "Waves",
+  "sidebar": false,
+  "api_prefix": "/api/rhythm",
+  "backend": true,
+  "description": "Deep rhythm analysis for music whose meter does not sit still: a tempo curve with change points, beats that follow it, a meter map (time signature per segment with additive groupings like 7/8 as 2+2+3), downbeats and bars, per-bar syncopation (Longuet-Higgins & Lee, WNBD, off-beat ratio, swing), polymeter per layer and cross-rhythms from the tempogram. numpy + librosa, no model."
+}

--- a/backend/modules/rhythm/report.py
+++ b/backend/modules/rhythm/report.py
@@ -1,0 +1,103 @@
+"""Print a rhythm report for audio files — the whole meter map, bar by bar
+if asked, so a musician can check the engine against music they know.
+
+    uv run python -m backend.modules.rhythm.report "data/uncanny/master/*.opus"
+    uv run python -m backend.modules.rhythm.report song.wav --bars --json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+import time
+from pathlib import Path
+
+from .engine import analyze_file
+
+
+def _fmt_segment(m: dict) -> str:
+    mark = "?" if m.get("uncertain") else " "
+    return (
+        f" {mark}{m['start_sec']:7.1f}-{m['end_sec']:7.1f}s  {m['time_signature']:<16} "
+        f"L={m['beats_per_bar']:<2} bars={m['bars']:<3} bpm={m['bpm']:<7} "
+        f"sub={m['subdivision']:<8} conf={m['confidence']:.2f}"
+    )
+
+
+def report(path: Path, *, bars: bool = False) -> dict:
+    t0 = time.time()
+    r = analyze_file(path)
+    took = time.time() - t0
+    print(f"\n=== {path.name}  ({r['duration_sec']:.0f}s, analyzed in {took:.1f}s) ===")
+    t = r["tempo"]
+    if t["bpm"] is None:
+        print("  " + r["summary"])
+        return r
+    print(
+        f"tempo {t['bpm']} bpm (global {t['global_bpm']}, range "
+        f"{t['range_bpm'][0]}-{t['range_bpm'][1]}, level {t['level']}, "
+        f"{'stable' if t['stable'] else 'changes: ' + ', '.join(f'{s["bpm"]}@{s["start_sec"]}s' for s in t['segments'])})"
+    )
+    print(
+        f"beats {len(r['beats'])}  downbeats {len(r['downbeats'])}  bars {len(r['bars'])}"
+    )
+    print("meter map:")
+    for m in r["meter_map"]:
+        print(_fmt_segment(m))
+    s = r["syncopation"]
+    print(
+        f"syncopation: LHL mean {s['mean_lhl']:.3f} max {s['max_lhl']:.3f} "
+        f"off-beat {s['mean_offbeat_ratio']:.2f} swing {s['swing_ratio']} "
+        f"(conf {s['swing_confidence']:.2f}) peak bars {s['peak_bars']}"
+    )
+    if r["polymeter"]:
+        print("polymeter:")
+        for p in sorted(r["polymeter"], key=lambda p: -p["confidence"])[:6]:
+            print(
+                f"  seg {p['segment']:<3} {p['layer']:<10} keeps {p['beats_per_bar']} "
+                f"{'+'.join(map(str, p['grouping']))}  {p['relation']}  conf {p['confidence']:.2f}"
+            )
+    if r["cross_rhythms"]:
+        print("cross-rhythms:")
+        for c in sorted(r["cross_rhythms"], key=lambda c: -c["strength"])[:6]:
+            print(
+                f"  seg {c['segment']:<3} {c['ratio']}  {c['bpm']} bpm  strength {c['strength']:.2f}"
+            )
+    if bars:
+        print("bars:")
+        for b in r["bars"]:
+            sy = b["syncopation"]
+            print(
+                f"  {b['index']:4d} {b['start_sec']:8.2f}s {b['time_signature']:<12} "
+                f"lhl={sy['lhl']:.3f} wnbd={sy['wnbd']:.3f} off={sy['offbeat_ratio']:.2f} n={sy['onsets']}"
+            )
+    print("summary: " + r["summary"])
+    return r
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("paths", nargs="+", help="audio files or globs")
+    ap.add_argument("--bars", action="store_true", help="print every bar")
+    ap.add_argument("--json", help="write all results to this JSON file")
+    args = ap.parse_args(argv)
+    files: list[Path] = []
+    for p in args.paths:
+        hits = glob.glob(p)
+        files.extend(Path(h) for h in (hits or [p]))
+    results = {}
+    for f in files:
+        if not f.is_file():
+            print(f"skip (not a file): {f}", file=sys.stderr)
+            continue
+        results[str(f)] = report(f, bars=args.bars)
+    if args.json:
+        Path(args.json).write_text(json.dumps(results, indent=1), encoding="utf-8")
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/modules/rhythm/router.py
+++ b/backend/modules/rhythm/router.py
@@ -1,0 +1,155 @@
+"""FastAPI router for the rhythm module (prefix from module.json: ``/api/rhythm``).
+
+    GET  /                capability report
+    GET  /{entry_id}      the cached analysis for a library entry — 200 with
+                          ``status: pending`` when there is none yet (the
+                          Details panel polls this; a 404 would paint the
+                          Network tab red for a normal state)
+    POST /{entry_id}/run  analyze the entry's audio now, cache it, return it
+    POST /file            analyze an arbitrary audio path (tools, tests,
+                          the UNCANNY report), optional stems by name
+
+Results are cached as JSON under ``data/rhythm/<entry_id>.json`` — written
+atomically, versioned by ``RHYTHM_VERSION`` so a cache from an older engine
+reads as pending and re-runs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.lib.atomic import atomic_write
+
+from .engine import RHYTHM_VERSION, analyze_file
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Repo-root anchored, so it resolves regardless of the process CWD.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+CACHE_DIR = _REPO_ROOT / "data" / "rhythm"
+
+
+def _cache_path(entry_id: str) -> Path:
+    safe = "".join(c for c in entry_id if c.isalnum() or c in "-_") or "entry"
+    return CACHE_DIR / f"{safe}.json"
+
+
+def _read_cache(entry_id: str) -> Optional[dict[str, Any]]:
+    p = _cache_path(entry_id)
+    if not p.is_file():
+        return None
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        log.info("rhythm: unreadable cache %s (%s)", p.name, e)
+        return None
+    if int(data.get("version") or 0) < RHYTHM_VERSION:
+        return None
+    return data
+
+
+def _write_cache(entry_id: str, data: dict[str, Any]) -> None:
+    atomic_write(_cache_path(entry_id), json.dumps(data))
+
+
+def _entry_audio(entry_id: str) -> Path:
+    from backend.modules.library.router import get_store as get_library_store
+
+    store = get_library_store()
+    if store.get_entry(entry_id) is None:
+        raise HTTPException(404, f"entry {entry_id!r} not found")
+    audio_path = store.get_audio_path(entry_id)
+    if audio_path is None or not Path(audio_path).is_file():
+        raise HTTPException(404, f"audio for entry {entry_id!r} not on disk")
+    return Path(audio_path)
+
+
+def _bump_idle(tag: str) -> None:
+    # A manual run is foreground activity; keep the background workers off it.
+    try:
+        from backend.core.idle import get_idle_manager
+
+        get_idle_manager().bump_activity(tag=tag)
+    except Exception:  # noqa: BLE001 — the idle manager is optional here
+        pass
+
+
+@router.get("")
+@router.get("/")
+def health() -> dict[str, Any]:
+    return {
+        "module": "rhythm",
+        "version": RHYTHM_VERSION,
+        "cache_dir": str(CACHE_DIR),
+        "features": [
+            "tempo_curve",
+            "tempo_segments",
+            "beats",
+            "downbeats",
+            "meter_map",
+            "additive_groupings",
+            "subdivision",
+            "syncopation_lhl",
+            "syncopation_wnbd",
+            "offbeat_ratio",
+            "swing_ratio",
+            "polymeter",
+            "cross_rhythms",
+        ],
+    }
+
+
+@router.get("/{entry_id}")
+def get_rhythm(entry_id: str) -> dict[str, Any]:
+    cached = _read_cache(entry_id)
+    if cached is None:
+        return {"entry_id": entry_id, "status": "pending"}
+    return {"entry_id": entry_id, "status": "ready", **cached}
+
+
+@router.post("/{entry_id}/run")
+def run_rhythm(entry_id: str) -> dict[str, Any]:
+    audio = _entry_audio(entry_id)
+    _bump_idle("rhythm-manual")
+    t0 = time.time()
+    try:
+        result = analyze_file(audio)
+    except Exception as e:  # noqa: BLE001 — surfaced to the caller as a 500 with the cause
+        log.exception("rhythm: analysis failed for %s", audio.name)
+        raise HTTPException(500, f"rhythm analysis failed: {e}") from e
+    result["analyzed_at"] = time.time()
+    result["elapsed_sec"] = round(time.time() - t0, 2)
+    result["source"] = audio.name
+    _write_cache(entry_id, result)
+    return {"entry_id": entry_id, "status": "ready", **result}
+
+
+class FileRequest(BaseModel):
+    path: str
+    stems: Optional[dict[str, str]] = None
+
+
+@router.post("/file")
+def run_rhythm_file(req: FileRequest) -> dict[str, Any]:
+    p = Path(req.path)
+    if not p.is_file():
+        raise HTTPException(404, f"audio not found: {req.path}")
+    _bump_idle("rhythm-file")
+    t0 = time.time()
+    try:
+        result = analyze_file(p, stems=req.stems)
+    except Exception as e:  # noqa: BLE001
+        log.exception("rhythm: analysis failed for %s", p.name)
+        raise HTTPException(500, f"rhythm analysis failed: {e}") from e
+    result["elapsed_sec"] = round(time.time() - t0, 2)
+    result["source"] = p.name
+    return result

--- a/backend/rag.py
+++ b/backend/rag.py
@@ -44,6 +44,10 @@ DOC_PATHS = [
     # opt-in interpretive LLM pass. Its companion is the LYRIC tab's notebook.
     PROJECT_ROOT / "docs" / "guides" / "lyric-analysis.md",
     PROJECT_ROOT / "docs" / "guides" / "lyric-notebook.md",
+    # The rhythm module (backend/modules/rhythm): the meter map and how to read
+    # its confidence and `?` marks, syncopation, swing, polymeter, cross-rhythms
+    # — and the six things that silently break any beat-synchronous analysis.
+    PROJECT_ROOT / "docs" / "guides" / "rhythm-analysis.md",
     # Onboarding: the pinned labels on the library rail, LOG and PANELS, why
     # they retire themselves, and the menu entry that brings them back. Indexed
     # because "where is the library?" is exactly what gets asked here.

--- a/docs/IN-THE-WORKS.md
+++ b/docs/IN-THE-WORKS.md
@@ -231,6 +231,25 @@ driven in the live app yet; items stay here until that happens.
 
 ---
 
+## P1 — from the user, 2026-09-11 (marked done only when the user says so)
+
+- [ ] **LOG strip: the gradient runs far past the readouts.** Only the things
+  that float over the strip (the system stats, the library-rail handle) get the
+  dark gradient, and only behind themselves. The log readouts extend to the edge
+  of the panel / window unless a floating element sits over them. The LOG body
+  is exactly as wide as the tab that opens and closes it. — S —
+  `frontend/src/components/layout/Shell.tsx:825-860` (LOG strip section,
+  `logWidth`), `frontend/src/components/layout/ProcessingLog.tsx:296` (the
+  `linear-gradient(to left, rgba(0,0,0,0.85) 60%, transparent)` backdrop),
+  `frontend/src/state/bottomPanelStore.ts` (`logWidth`)
+- [ ] **CHORDS: bring the chord visual to the NOW line.** The section reads as
+  crowded at the top and the current chord sits at the far left. The sounding
+  chord belongs on the NOW line with the next chord to its right and the
+  previous to its left, and the section gets a nicer layout. — S —
+  `frontend/src/components/layout/score/chords/ChordPlayAlong.tsx`,
+  `frontend/src/components/layout/score/chords/ChordStripCanvas.tsx`,
+  `frontend/src/components/layout/score/chords/ChordDiagram.tsx`
+
 ## P0 — breaks the app's primary action
 
 - [ ] **ABORT is client-side only.** No cancel route exists; the job finishes on the GPU, writes artifacts to the library, and holds `_generation_job_lock` so the next CREATE queues behind it. — M — `backend/server.py:105,1351`, `frontend/src/state/generateStore.ts:759`

--- a/docs/guides/rhythm-analysis.md
+++ b/docs/guides/rhythm-analysis.md
@@ -1,0 +1,127 @@
+# Rhythm analysis — meter maps for music whose meter does not sit still
+
+theDAW's rhythm module reads a track's **tempo curve**, its **beats**, and a
+**meter map**: the time signature of every stretch of the song, with the
+grouping of an additive meter (7/8 as 2+2+3, 19/16 as 3+3+3+3+3+2+2), the
+downbeats and bars that follow from it, per-bar **syncopation**, the **swing
+ratio**, **polymeter** (a layer keeping its own bar length against the drums)
+and **cross-rhythms** (3:2, 4:3 …). It runs on numpy + librosa, no model, and
+works on any file the library can decode — Opus masters included.
+
+It exists because the ordinary analysis assumes ONE tempo and ONE fixed number
+of beats per bar for the whole track. Metamorphic music — 4/4 into 7/8 into
+5/4, a 13/8 riff, a 23/16 bridge — breaks both assumptions, and a single
+"BPM: 129, 4/4" is worse than useless for it.
+
+## Where to find it
+
+- **API:** `GET /api/rhythm/{entry_id}` returns the cached analysis for a
+  library entry (`status: pending` until it has run), `POST /api/rhythm/{entry_id}/run`
+  runs it now, `POST /api/rhythm/file` with `{"path": …}` analyzes any audio
+  file, `GET /api/rhythm/` lists the engine version and features.
+- **Report, from a terminal:**
+  `uv run python -m backend.modules.rhythm.report "data/uncanny/master/*.opus"`
+  prints every track's map; `--bars` prints every bar; `--json out.json` keeps
+  the full result.
+
+## How to read a meter map
+
+Each segment line reads like this:
+
+```
+  36.7-   71.7s  7/4 (2+2+3)   L=7  bars=11  bpm=131.8  sub=simple  conf=0.17
+ ?  0.1-   22.2s  3/4          L=3  bars=16  bpm=129.8  sub=simple  conf=0.05
+```
+
+- **L** is the bar length in *tracked beats*. The time signature is derived
+  from it: with a compound subdivision (each beat splitting in three) `L=2`
+  is 6/8 and `L=4` is 12/8; a fast odd pulse (over 160 bpm, 5/6/7/9/10/11/12)
+  is written in eighths; otherwise the tracked beat is the quarter.
+- **(2+2+3)** is the grouping — how the bar's beats bundle into twos and
+  threes. It comes from where the accents fall, so 7 as 2+2+3 and 7 as 3+2+2
+  are told apart.
+- **conf** is a confidence in 0–1. It is calibrated against *coprime* bar
+  lengths: 6 against 4 always scores well (both carry the duple alternation)
+  and says nothing, so it does not count; 7 against 4 does. On real mixes
+  stable readings sit around **0.15–0.4**. Anything under **0.10 is marked
+  `?`** — a guess, kept so the map has no holes, and it will flip with the
+  smallest change of evidence. Trust the un-marked segments; treat `?` as
+  "the accents here fit no bar length well".
+- **sub** is `simple` or `compound`. Compound needs onsets on BOTH thirds of
+  the beat; swung eighths sit on the second third alone and stay `simple`
+  with a swing ratio instead (1.0 straight, 2.0 triplet swing).
+- **Syncopation (LHL)** is Longuet-Higgins & Lee on the *low band* — the kick
+  and bass pushing against the pulse — because a hat on every beat fills
+  every rest in the full mix. WNBD and the off-beat ratio are read on the
+  full mix. All per bar, 0–1, with peak bars listed.
+- **Polymeter** names a layer (low / mid / high band, or a stem when given)
+  that keeps a bar length of its own: `mid keeps 3 (3:4)` is a melody cycling
+  in three over 4/4 drums. `displaced:+2` is the same bar, two beats late.
+- **Cross-rhythms** are tempogram peaks at non-octave ratios of the tempo
+  (3:2 a hemiola, 4:3, 5:4), with strength relative to the tempo's own peak.
+
+The rhythm section sets the bar. When the drums read 4 and the whole mix
+reads 12 because a melody cycles in 3, the map says 4/4 and the polymeter
+list says the melody keeps 3 — not 12/4.
+
+## Known limits
+
+- Groupings of long bars at the eighth level (12/8 read at 200 bpm) flicker
+  between 2+3+2+3+2 and 2+2+2+2+2+2 from segment to segment.
+- Absolute confidences on a dense mix are lower than on a clean recording;
+  read them relative to the track's own best segments.
+- A change of meter is placed within about a bar; a two-bar insert inside a
+  long window can still be absorbed by its neighbours.
+
+## For whoever works on the engine next
+
+The scoring — which bar length explains the accents — is the *small* part.
+Every one of these looked like a scoring problem and was upstream of it, and
+each cost real time to find. They apply to any beat-synchronous analysis in
+this codebase, not only this module.
+
+1. **librosa's beat tracker locks onto hats.** Onset strength is a *dB flux*:
+   an 8 ms broadband hat burst out of silence is a 40 dB step in every mel
+   band — the low ones included — while a 60 Hz kick fills two bands. In flux
+   terms the hat wins even in the low channel, so the beats sat half a beat
+   off the kicks (or two thirds off, on swung hats). Downbeats matched 0 %,
+   and every per-beat feature was measured on off-beats. The fix is to track
+   on broad flux plus the *low band's power derivative*, then choose the beat
+   phase as the fractional offset (twelfths of a beat) with the most
+   **low-band power** under the beats, then snap each beat to the local onset
+   peak so beats and onsets share one frame grid (`_align_phase`,
+   `_snap_to_peaks`).
+2. **Frame quantization reads as meter.** A beat is 25.84 frames at 100 bpm
+   (hop 512 / 22.05 kHz), so the beat grid drifts against the frame grid with
+   a ~6-beat cycle (5.5 at 128 bpm). A *peak* level per beat swings several
+   dB with sub-frame alignment, and that swing is periodic: 4/4 read as 6/4 at
+   100 bpm, 7 read as 5 at 128. Per-beat evidence must be **integrated**
+   (band power summed over the beat's span), which does not care where the
+   frames fall; spans start a quarter beat early so a kick a frame either side
+   of its beat lands in that beat (`_beat_energies`).
+3. **Cosine similarity on centered features is direction-only.** A plain
+   beat's centered feature vector is nearly zero, and its *direction* is
+   jitter — cosine then reports a periodicity of its own. Use distance.
+4. **Z-scoring a flat row inflates jitter to unit variance.** Scale with a
+   floored spread (`(x - mean) / (std + floor)`), so a row with no real
+   beat-to-beat structure barely counts (`_robust`, `_scale_rows`).
+5. **One beat in digital silence is −120 dB** (a trailing beat in the tail, a
+   gap) and owns the variance of its whole row, flattening every real
+   contrast: a perfect 3-cycle read as effect size 0.15. Floor dB energies at
+   60 dB under the row's loudest beat.
+6. **`librosa.beat.beat_track(bpm=array)` IS per-frame tempo** — the
+   docstring says "multichannel", but `bpm.shape[-1]` may equal the envelope
+   length and the DP follows it. The 0 % beat match on a tempo change was the
+   phase (item 1), never the tempo.
+
+Two more that shaped the design: a melody louder than the kick in its own
+band drags the composite reading to the lowest common multiple (12 over 4/4
+drums with a 3-cycle), so the meter is read on the low band alone first and
+the composite only confirms it; and swung eighths satisfy any "thirds carry
+the mass" compound rule — compound needs *both* thirds populated.
+
+The synthetic ground truth that caught all of this is `tests/rhythm_synth.py`
+(`MeterSegment`: any bar length, grouping, compound, swing, pushed patterns,
+a polymeter layer, a cross pulse), driven by `tests/test_rhythm_engine.py`.
+When something reads wrong on a real track, build the smallest synthetic
+track that shows it before touching a weight.

--- a/electron-ui/main/index.ts
+++ b/electron-ui/main/index.ts
@@ -800,9 +800,21 @@ function registerUpdaterHandlers(): void {
 // picked in the camera selector. Forcing the DirectShow capturer surfaces them.
 // Physical cameras keep working under DirectShow on Windows 10/11; remove this
 // switch only if a specific Media-Foundation-only device regresses.
-if (process.platform === 'win32') {
-  app.commandLine.appendSwitch('disable-features', 'MediaFoundationVideoCapture')
-}
+//
+// IsolateSandboxedIframes: Chromium moves every sandboxed srcdoc frame (the
+// Foundry's 24 custom-code pads, `sandbox="allow-scripts"`) into a renderer
+// process of its own. In this app that process grows about 250 MB a second
+// whether or not the pads' scripts run, is killed near 2.4 GB about ten
+// seconds after the frames load, and Chromium paints the dead frames grey.
+// Measured 2026-09-10 on Electron 42.11 / Chromium 148; browser tabs and
+// headless runs never isolate these frames, so it only showed in the desktop
+// app. With the feature off the frames stay sandboxed (opaque origin, no
+// same-origin access) inside the Foundry's own renderer, all of them stay
+// alive, and memory stays flat. Re-check on every Electron upgrade: the leak
+// is Chromium's and may be fixed upstream.
+const disabledFeatures = ['IsolateSandboxedIframes']
+if (process.platform === 'win32') disabledFeatures.push('MediaFoundationVideoCapture')
+app.commandLine.appendSwitch('disable-features', disabledFeatures.join(','))
 
 // Register custom protocol scheme before app is ready
 protocol.registerSchemesAsPrivileged([

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,17 @@ override-dependencies = [
 # Needed because the PyTorch CUDA index pins some packages (e.g. certifi) at
 # older versions than PyPI. Without this flag uv refuses to install them.
 index-strategy = "unsafe-best-match"
+# The lock must carry wheels for every platform theDAW ships to. Without this
+# list `uv lock` records whatever the index listed at that minute: on
+# 2026-09-10 onnxruntime-gpu 1.30.0 was locked twenty minutes before its Linux
+# x86_64 wheels reached PyPI, the lock kept only the aarch64 and Windows
+# wheels, and the first Linux CI run after the merge failed to install. With
+# the list, uv refuses to lock a version that lacks a wheel for either target.
+# scripts/check_lock.py (pre-commit hook + CI) proves the lock installs on both.
+required-environments = [
+  "sys_platform == 'linux' and platform_machine == 'x86_64'",
+  "sys_platform == 'win32' and platform_machine == 'AMD64'",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/check_lock.py
+++ b/scripts/check_lock.py
@@ -1,0 +1,69 @@
+"""Prove uv.lock installs on every platform theDAW ships to, before it is pushed.
+
+`uv lock` records whatever wheels the index listed at that minute. On
+2026-09-10 onnxruntime-gpu 1.30.0 was locked twenty minutes before its Linux
+x86_64 wheels reached PyPI; the lock carried only the aarch64 and Windows
+wheels, and the first Linux CI run after the merge failed with "no wheel for
+the current platform". This is the check that would have caught it on the
+developer's machine: `uv lock --check`, then a cross-platform dry-run sync per
+target with exactly the flags .github/workflows/test.yml installs with.
+
+Run from the repo root with any Python (it only shells out to uv):
+
+    python scripts/check_lock.py
+
+The pre-commit hook (.githooks/pre-commit) runs it whenever pyproject.toml or
+uv.lock is staged; the `lock` job in test.yml runs it on every pull request.
+When it fails, fix pyproject.toml / uv.lock (see tool.uv.required-environments)
+and never the CI.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# ubuntu-latest, the runner test.yml uses (glibc 2.39), and the Windows desktop
+# build. Keep the glibc tag at the runner's: a wheel tagged above it fails there.
+TARGETS = ("x86_64-manylinux_2_39", "windows")
+
+SYNC = (
+    "uv",
+    "sync",
+    "--frozen",
+    "--dry-run",
+    "--group",
+    "dev",
+    "--no-install-package",
+    "pyk4a-bundle",
+    "--no-progress",
+)
+
+
+def run(cmd: tuple[str, ...]) -> int:
+    print("$", " ".join(cmd), flush=True)
+    return subprocess.run(cmd, cwd=ROOT).returncode
+
+
+def main() -> int:
+    if run(("uv", "lock", "--check", "--no-progress")):
+        print(
+            "uv.lock is out of date with pyproject.toml: run `uv lock` and commit both."
+        )
+        return 1
+    for target in TARGETS:
+        if run((*SYNC, "--python-platform", target)):
+            print(
+                f"uv.lock cannot be installed on {target}. Fix pyproject.toml / uv.lock "
+                "(tool.uv.required-environments names the platforms), not the CI."
+            )
+            return 1
+    print(f"uv.lock installs on every target: {', '.join(TARGETS)}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/rhythm_synth.py
+++ b/tests/rhythm_synth.py
@@ -1,0 +1,199 @@
+"""Synthetic music with a KNOWN, CHANGING meter — ground truth for the rhythm
+engine tests.
+
+Builds on tests/chimera_synth.py's primitives (kick, thump, hat, decaying
+sine) but frees the bar: each :class:`MeterSegment` has its own tempo, bar
+length, grouping and subdivision, and segments follow one another the way a
+metamorphic piece does. Accent hierarchy per bar: downbeat kick +6 dB with a
+40 Hz thump, group-start kicks +3 dB, other beats plain, hats on the
+subdivisions at -12 dB.
+
+Optional layers per segment:
+  * ``beat_hits`` — which beats carry a kick (default all); with
+    ``offbeat_hits`` (eighth positions within the bar) this makes syncopated
+    patterns whose beats are silent after an off-beat note.
+  * ``swing`` — 0 straight .. 1 triplet swing (off-beat hat at 2/3).
+  * ``poly_cycle`` — a 440 Hz blip every N beats, its own cycle across the
+    bar line (a 3 over a 4).
+  * ``cross_pulse`` — a click every ``cross_pulse`` beats (1.5 -> a dotted
+    quarter against the quarter: 3:2 hemiola).
+
+Rendered at any sample rate; the tests use 22.05 kHz so no resample is needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from tests.chimera_synth import (
+    _HAT_DB,
+    _HAT_SEC,
+    _KICK_AMP,
+    _KICK_HZ,
+    _KICK_SEC,
+    _THUMP_HZ,
+    _add_at,
+    _db,
+    _decaying_sine,
+)
+
+_DOWNBEAT_DB = 6.0
+_GROUP_DB = 3.0
+_BLIP_HZ = 440.0
+_BLIP_SEC = 0.12
+_BLIP_DB = -8.0
+_CROSS_DB = -6.0
+
+
+def default_grouping(beats_per_bar: int) -> tuple[int, ...]:
+    """2s then the remainder: 7 -> (2, 2, 3), 5 -> (2, 3), 4 -> (2, 2),
+    3 -> (3,), 2 -> (2,)."""
+    if beats_per_bar <= 3:
+        return (beats_per_bar,)
+    parts: list[int] = []
+    rem = beats_per_bar
+    while rem > 3:
+        parts.append(2)
+        rem -= 2
+    parts.append(rem)
+    return tuple(parts)
+
+
+@dataclass(frozen=True)
+class MeterSegment:
+    """Frozen (and so hashable): the tests memoize analyses per segment tuple."""
+
+    bpm: float
+    beats_per_bar: int
+    bars: int
+    grouping: tuple[int, ...] | None = None
+    compound: bool = False
+    swing: float = 0.0
+    beat_hits: tuple[int, ...] | None = None
+    offbeat_hits: tuple[int, ...] = ()
+    poly_cycle: int = 0
+    cross_pulse: float = 0.0
+    hats: bool = True
+    # Hats on the beats instead of the off-beats: a pulse reference in the high
+    # band that leaves the low band free to push against it.
+    hat_on_beat: bool = False
+    # "beats": a kick on every position (the position IS the felt beat).
+    # "groups": the positions are the tatum (eighths, sixteenths): a hat ON
+    # every position, kicks on the group starts only, and the felt beats are
+    # the uneven groups, the way 19/16 as 3+3+3+3+3+2+2 is actually played.
+    # (With "beats", hats sit between the positions unless hat_on_beat.)
+    pulse: str = "beats"
+
+
+def meter_track(
+    segments: list[MeterSegment],
+    sr: int = 22050,
+    seed: int = 0,
+    lead_in_sec: float = 0.0,
+    tail_sec: float = 0.5,
+) -> tuple[np.ndarray, dict[str, Any]]:
+    """Render the segments back to back. Returns ``(mono float32, truth)`` with
+    ``truth = {beats, downbeats, bars: [(start, end, beats_per_bar)],
+    segments: [{start_sec, end_sec, bpm, beats_per_bar, grouping, compound}]}``
+    all in seconds."""
+    rng = np.random.default_rng(seed)
+    events: list[tuple[float, str, float]] = []  # (time, kind, gain)
+    truth: dict[str, Any] = {"beats": [], "downbeats": [], "bars": [], "segments": []}
+    t = float(lead_in_sec)
+    global_beat = 0
+    for seg in segments:
+        per = 60.0 / seg.bpm
+        length = seg.beats_per_bar
+        g = seg.grouping or default_grouping(length)
+        assert sum(g) == length, f"grouping {g} does not sum to {length}"
+        group_starts = {int(x) for x in np.cumsum((0,) + g[:-1])}
+        if seg.beat_hits is not None:
+            hits = set(seg.beat_hits)
+        elif seg.pulse == "groups":
+            hits = set(group_starts)
+        else:
+            hits = set(range(length))
+        seg_start = t
+        for _bar in range(seg.bars):
+            bar_start = t
+            for b in range(length):
+                truth["beats"].append(t)
+                if b == 0:
+                    truth["downbeats"].append(t)
+                if b in hits:
+                    if b == 0:
+                        events.append((t, "kick", _db(_DOWNBEAT_DB)))
+                        events.append((t, "thump", 1.0))
+                    elif b in group_starts:
+                        events.append((t, "kick", _db(_GROUP_DB)))
+                    else:
+                        events.append((t, "kick", 1.0))
+                if seg.hats and (seg.hat_on_beat or seg.pulse == "groups"):
+                    events.append((t, "hat", 1.0))
+                elif seg.hats:
+                    if seg.compound:
+                        for k in (1, 2):
+                            events.append((t + per * k / 3.0, "hat", 1.0))
+                    else:
+                        off = 0.5 + seg.swing * (2.0 / 3.0 - 0.5)
+                        events.append((t + per * off, "hat", 1.0))
+                if seg.poly_cycle and global_beat % seg.poly_cycle == 0:
+                    events.append((t, "blip", 1.0))
+                t += per
+                global_beat += 1
+            for p in seg.offbeat_hits:
+                events.append((bar_start + p * per / 2.0, "kick", 1.0))
+            if seg.cross_pulse:
+                n_cross = int(np.floor(length / seg.cross_pulse))
+                for k in range(n_cross):
+                    events.append((bar_start + k * seg.cross_pulse * per, "cross", 1.0))
+            truth["bars"].append((bar_start, t, length))
+        truth["segments"].append(
+            {
+                "start_sec": seg_start,
+                "end_sec": t,
+                "bpm": seg.bpm,
+                "beats_per_bar": length,
+                "grouping": tuple(g),
+                "compound": seg.compound,
+            }
+        )
+
+    n = int(round((t + tail_sec) * sr))
+    mono = np.zeros(n, dtype=np.float32)
+    kick = _decaying_sine(_KICK_HZ, _KICK_SEC, sr, tau=0.02) * _KICK_AMP
+    thump = _decaying_sine(_THUMP_HZ, _KICK_SEC * 1.5, sr, tau=0.03) * _KICK_AMP
+    blip = _decaying_sine(_BLIP_HZ, _BLIP_SEC, sr, tau=0.04) * _db(_BLIP_DB)
+    hat_n = int(_HAT_SEC * sr)
+    hat_env = np.linspace(1.0, 0.0, hat_n, dtype=np.float32)
+    click_n = int(0.01 * sr)
+    click_env = np.linspace(1.0, 0.0, click_n, dtype=np.float32)
+    for time, kind, gain in events:
+        s = int(round(time * sr))
+        if s >= n:
+            continue
+        if kind == "kick":
+            _add_at(mono, s, kick * gain)
+        elif kind == "thump":
+            _add_at(mono, s, thump * gain)
+        elif kind == "hat":
+            burst = (
+                rng.standard_normal(hat_n).astype(np.float32) * hat_env * _db(_HAT_DB)
+            )
+            _add_at(mono, s, burst * gain)
+        elif kind == "blip":
+            _add_at(mono, s, blip * gain)
+        elif kind == "cross":
+            burst = (
+                rng.standard_normal(click_n).astype(np.float32)
+                * click_env
+                * _db(_CROSS_DB)
+            )
+            _add_at(mono, s, burst * gain)
+    peak = float(np.abs(mono).max())
+    if peak > 0.98:
+        mono *= 0.98 / peak
+    return mono, truth

--- a/tests/test_plugin_gan_atomicity.py
+++ b/tests/test_plugin_gan_atomicity.py
@@ -1,0 +1,113 @@
+"""One unreadable .gan must not take out the plugin list — and a rebuild must
+never produce one.
+
+Reported as a 500 on ``/api/plugin/list`` while the bundled Ares surface was
+being repackaged: ``zipfile.BadZipFile: File is not a zip file``. Two faults met.
+``GanFile.save`` deflated straight into ``data/plugins/ares.gan``, so for the
+second or so it took to write 1.15 MB the library held a torn file; and
+``BadZipFile`` derives from ``Exception``, not ``OSError``, so the
+``except (ValueError, OSError)`` that exists to skip an unreadable bundle went
+straight past it and the whole endpoint failed for one bad file.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from backend.modules.plugin.gan_file import GanFile
+from backend.modules.plugin.owl_import import import_vst_foundry
+
+PROJECT = {
+    "canvasWidth": 400,
+    "canvasHeight": 300,
+    "elements": [
+        {
+            "id": "k1",
+            "name": "Cutoff",
+            "type": "Knob",
+            "x": 10,
+            "y": 20,
+            "width": 80,
+            "height": 80,
+        }
+    ],
+}
+
+
+def _package(tmp_path: Path, name: str):
+    pj = tmp_path / f"{name}.json"
+    pj.write_text(json.dumps(PROJECT), encoding="utf-8")
+    return import_vst_foundry(str(pj), name=name)
+
+
+def test_an_unreadable_gan_reports_itself_as_invalid_not_as_a_zip_error(
+    tmp_path: Path,
+):
+    # The guard around every .gan read is `except (ValueError, OSError)`. What a
+    # torn archive actually raises has to land inside it.
+    bad = tmp_path / "torn.gan"
+    bad.write_bytes(b"PK\x03\x04 and then the writer was still going")
+    with pytest.raises(ValueError):
+        GanFile.info(str(bad))
+
+
+def test_the_plugin_list_skips_the_unreadable_one_and_returns_the_rest(
+    tmp_path: Path, monkeypatch
+):
+    from backend.modules.plugin import router
+
+    monkeypatch.setattr(router, "GAN_DIR", tmp_path)
+    monkeypatch.setattr(router, "RUNTIME_DIR", tmp_path / "_runtime")
+    manifest, assets = _package(tmp_path, "good")
+    GanFile.save(manifest, assets, str(tmp_path / "good.gan"))
+    (tmp_path / "torn.gan").write_bytes(b"not a zip at all")
+
+    listed = router.list_plugins()["plugins"]
+    assert [p["name"] for p in listed] == ["good"], (
+        "one bad bundle must cost that bundle, not the endpoint"
+    )
+
+
+def test_a_rebuild_never_shows_a_reader_a_half_written_archive(
+    tmp_path: Path, monkeypatch
+):
+    # The sequence that produced the 500: a /list sweep opening the .gan at the
+    # moment a repackage is writing it. Sample the destination from inside the
+    # write itself — every look must find the whole previous bundle.
+    dest = tmp_path / "plugin.gan"
+    GanFile.save(*_package(tmp_path, "v1"), str(dest))
+
+    seen: list[object] = []
+    real_writestr = zipfile.ZipFile.writestr
+
+    def spy(self, zinfo_or_arcname, data, *args, **kwargs):
+        try:
+            seen.append(GanFile.info(str(dest))["name"])
+        except Exception as e:  # noqa: BLE001 — the failure IS the finding
+            seen.append(e)
+        return real_writestr(self, zinfo_or_arcname, data, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "writestr", spy)
+    GanFile.save(*_package(tmp_path, "v2"), str(dest))
+    monkeypatch.undo()
+
+    assert len(seen) > 1, "the spy has to have sampled the write in progress"
+    assert set(seen) == {"v1"}, f"a reader saw the rebuild mid-flight: {seen}"
+    assert GanFile.info(str(dest))["name"] == "v2", "and the rebuild still landed"
+
+
+def test_extracting_a_runtime_leaves_no_scratch_files_behind(tmp_path: Path):
+    # The runtime dir is served to the stage iframe as-is; a stray temp file
+    # would be served with it.
+    gan = tmp_path / "plugin.gan"
+    GanFile.save(*_package(tmp_path, "rt"), str(gan))
+    out = tmp_path / "runtime"
+    GanFile.extract(str(gan), str(out))
+
+    assert (out / "index.html").is_file()
+    assert (out / "manifest.json").is_file()
+    assert [p.name for p in out.rglob("*") if ".tmp" in p.name] == []

--- a/tests/test_rhythm_engine.py
+++ b/tests/test_rhythm_engine.py
@@ -1,0 +1,308 @@
+"""The rhythm engine on music with a known, changing meter.
+
+Every signal comes from tests/rhythm_synth.py (deterministic, CPU-only,
+rendered straight at the 22.05 kHz the engine works on). The assertions are
+about what the user asked for: metamorphic time signatures come back as a
+meter map with the right bar lengths in the right order and the changes
+placed within a bar; odd meters come back with their grouping; tempo changes
+are followed, not averaged; compound is told from simple; syncopation orders
+patterns the way a drummer would; a layer keeping its own cycle is reported as
+polymeter.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import numpy as np
+import pytest
+
+from backend.modules.rhythm import engine
+from backend.modules.rhythm.engine import (
+    analyze_rhythm,
+    fit_meter,
+    groupings,
+    pick_meter,
+)
+from tests.rhythm_synth import MeterSegment, meter_track
+
+SR = 22050
+
+
+def _matched(truth: list[float], found: list[float], tol: float) -> float:
+    """Fraction of ``truth`` times with a ``found`` time within ``tol``."""
+    if not truth:
+        return 1.0
+    f = np.asarray(found, dtype=np.float64)
+    if f.size == 0:
+        return 0.0
+    return float(np.mean([np.min(np.abs(f - t)) <= tol for t in truth]))
+
+
+@lru_cache(maxsize=None)
+def _analyze(*segs: MeterSegment) -> tuple[dict, dict]:
+    y, truth = meter_track(list(segs), sr=SR)
+    return analyze_rhythm(y, SR), truth
+
+
+# --------------------------------------------------------------------------
+# the scorer, on numbers
+# --------------------------------------------------------------------------
+
+
+def _accent_pattern(template: list[float], bars: int, noise: float, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    s = np.tile(np.asarray(template, dtype=np.float64), bars)
+    return s + rng.normal(0.0, noise, size=s.size)
+
+
+def test_groupings_are_every_composition_into_2s_and_3s():
+    assert groupings(4) == ((2, 2),)
+    assert set(groupings(7)) == {(2, 2, 3), (2, 3, 2), (3, 2, 2)}
+    assert set(groupings(5)) == {(2, 3), (3, 2)}
+    assert (3, 3) in groupings(6) and (2, 2, 2) in groupings(6)
+
+
+def test_a_seven_beat_accent_cycle_is_read_as_seven_with_its_grouping():
+    fit, conf = pick_meter(fit_meter(_accent_pattern([3, 0, 1, 0, 1, 0, 0], 10, 0.2)))
+    assert fit is not None
+    assert fit.beats_per_bar == 7
+    assert fit.grouping == (2, 2, 3)
+    assert fit.phase == 0
+    assert conf > 0.5
+
+
+def test_a_four_beat_cycle_is_four_not_eight_and_not_two():
+    fit, conf = pick_meter(fit_meter(_accent_pattern([3, 0, 1.5, 0], 12, 0.2)))
+    assert fit is not None
+    assert fit.beats_per_bar == 4
+    assert conf > 0.4
+
+
+def test_noise_reads_as_low_confidence():
+    _, conf = pick_meter(fit_meter(np.random.default_rng(1).normal(size=64)))
+    assert conf < 0.25
+
+
+# --------------------------------------------------------------------------
+# constant meters
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("length,bpm", [(4, 120.0), (3, 132.0), (5, 120.0), (7, 128.0)])
+def test_a_constant_meter_comes_back_as_one_segment(length: int, bpm: float):
+    res, truth = _analyze(MeterSegment(bpm=bpm, beats_per_bar=length, bars=24))
+    mm = res["meter_map"]
+    assert [m["beats_per_bar"] for m in mm] == [length], res["summary"]
+    assert abs(res["tempo"]["bpm"] - bpm) / bpm < 0.03
+    assert _matched(truth["downbeats"], res["downbeats"], tol=0.07) >= 0.85, res[
+        "summary"
+    ]
+    assert mm[0]["confidence"] > 0.3
+
+
+def test_seven_eight_comes_back_with_its_grouping():
+    res, _ = _analyze(MeterSegment(bpm=128.0, beats_per_bar=7, bars=24))
+    seg = res["meter_map"][0]
+    assert seg["grouping"] == [2, 2, 3]
+    assert seg["time_signature"].startswith("7/")
+    assert "2+2+3" in seg["time_signature"]
+
+
+# --------------------------------------------------------------------------
+# metamorphic
+# --------------------------------------------------------------------------
+
+
+def test_a_metamorphic_piece_maps_every_meter_in_order_within_a_bar():
+    res, truth = _analyze(
+        MeterSegment(bpm=120.0, beats_per_bar=4, bars=16),
+        MeterSegment(bpm=120.0, beats_per_bar=7, bars=12),
+        MeterSegment(bpm=120.0, beats_per_bar=5, bars=12),
+        MeterSegment(bpm=120.0, beats_per_bar=4, bars=16),
+    )
+    mm = res["meter_map"]
+    assert [m["beats_per_bar"] for m in mm] == [4, 7, 5, 4], res["summary"]
+    beat = 60.0 / 120.0
+    for found, want in zip(mm[1:], truth["segments"][1:]):
+        bar = want["beats_per_bar"] * beat
+        assert abs(found["start_sec"] - want["start_sec"]) <= bar + 0.05, (
+            f"{want['beats_per_bar']} starts at {found['start_sec']:.2f}, truth {want['start_sec']:.2f}"
+        )
+    assert _matched(truth["downbeats"], res["downbeats"], tol=0.07) >= 0.8
+
+
+def test_a_tempo_change_is_followed_not_averaged():
+    res, truth = _analyze(
+        MeterSegment(bpm=110.0, beats_per_bar=4, bars=16),
+        MeterSegment(bpm=140.0, beats_per_bar=4, bars=16),
+    )
+    segs = res["tempo"]["segments"]
+    assert len(segs) == 2, res["tempo"]
+    assert abs(segs[0]["bpm"] - 110.0) / 110.0 < 0.04
+    assert abs(segs[1]["bpm"] - 140.0) / 140.0 < 0.04
+    assert res["tempo"]["stable"] is False
+    assert _matched(truth["beats"], res["beats"], tol=0.07) >= 0.9
+    assert [m["beats_per_bar"] for m in res["meter_map"]] == [4]
+
+
+# --------------------------------------------------------------------------
+# subdivision, signature
+# --------------------------------------------------------------------------
+
+
+def test_compound_subdivision_is_told_from_simple():
+    six_eight, _ = _analyze(
+        MeterSegment(bpm=100.0, beats_per_bar=2, bars=24, compound=True)
+    )
+    four_four, _ = _analyze(MeterSegment(bpm=100.0, beats_per_bar=4, bars=24))
+    assert six_eight["meter_map"][0]["subdivision"] == "compound"
+    assert six_eight["meter_map"][0]["time_signature"] == "6/8"
+    assert four_four["meter_map"][0]["subdivision"] == "simple"
+    assert four_four["meter_map"][0]["time_signature"] == "4/4"
+
+
+# --------------------------------------------------------------------------
+# syncopation, swing
+# --------------------------------------------------------------------------
+
+
+def test_syncopation_orders_a_pushed_pattern_above_four_on_the_floor():
+    # Hats ON the beats: the pulse reference lives in the high band, and LHL is
+    # read on the low band pushing against it — a note on a weak position
+    # followed by a REST on a stronger one. (Off-beat hats would fill every
+    # rest; no hats at all leaves no pulse for the pushed pattern to push
+    # against, and a tracker cannot know which grid the author meant.)
+    straight, _ = _analyze(
+        MeterSegment(bpm=120.0, beats_per_bar=4, bars=16, hat_on_beat=True)
+    )
+    pushed, _ = _analyze(
+        MeterSegment(
+            bpm=120.0,
+            beats_per_bar=4,
+            bars=16,
+            beat_hits=(0,),
+            offbeat_hits=(3, 5),
+            hat_on_beat=True,
+        )
+    )
+    assert (
+        pushed["syncopation"]["mean_lhl"] > straight["syncopation"]["mean_lhl"] + 0.05
+    )
+    assert (
+        pushed["syncopation"]["mean_offbeat_ratio"]
+        > straight["syncopation"]["mean_offbeat_ratio"]
+    )
+    assert len(pushed["syncopation"]["curve"]) == len(pushed["bars"])
+
+
+def test_swing_ratio_reads_triplet_swing_and_straight_eighths():
+    swung, _ = _analyze(MeterSegment(bpm=120.0, beats_per_bar=4, bars=16, swing=1.0))
+    straight, _ = _analyze(MeterSegment(bpm=120.0, beats_per_bar=4, bars=16))
+    assert swung["syncopation"]["swing_ratio"] is not None
+    assert abs(swung["syncopation"]["swing_ratio"] - 2.0) < 0.35
+    assert straight["syncopation"]["swing_ratio"] is not None
+    assert abs(straight["syncopation"]["swing_ratio"] - 1.0) < 0.2
+
+
+# --------------------------------------------------------------------------
+# polymeter, cross-rhythm
+# --------------------------------------------------------------------------
+
+
+def test_a_layer_keeping_three_over_a_four_is_reported_as_polymeter():
+    res, _ = _analyze(MeterSegment(bpm=120.0, beats_per_bar=4, bars=24, poly_cycle=3))
+    assert [m["beats_per_bar"] for m in res["meter_map"]] == [4], res["summary"]
+    three = [p for p in res["polymeter"] if p["beats_per_bar"] == 3]
+    assert three, res["polymeter"]
+    assert three[0]["relation"] == "3:4"
+
+
+def test_a_dotted_quarter_pulse_shows_as_a_three_two_cross_rhythm():
+    res, _ = _analyze(
+        MeterSegment(bpm=120.0, beats_per_bar=4, bars=24, cross_pulse=1.5)
+    )
+    ratios = {c["ratio"] for c in res["cross_rhythms"]}
+    assert "2:3" in ratios or "3:2" in ratios, res["cross_rhythms"]
+
+
+# --------------------------------------------------------------------------
+# wide and additive meters — read at the tatum
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "length,grouping,tatum_bpm,den",
+    [
+        (11, (3, 3, 3, 2), 240.0, 8),
+        (13, (3, 3, 3, 2, 2), 240.0, 8),
+        (19, (3, 3, 3, 3, 3, 2, 2), 480.0, 16),
+        (23, (3, 3, 3, 3, 3, 2, 2, 2, 2), 480.0, 16),
+    ],
+)
+def test_wide_additive_meters_are_read_at_the_tatum(
+    length: int, grouping: tuple[int, ...], tatum_bpm: float, den: int
+):
+    # Kicks on the group starts only, hats on every eighth or sixteenth: the
+    # felt beats are uneven, the tatum is the only regular pulse, and the bar
+    # is a whole number of tatums only — 19/16 is 4.75 quarters.
+    res, truth = _analyze(
+        MeterSegment(
+            bpm=tatum_bpm,
+            beats_per_bar=length,
+            bars=16,
+            grouping=grouping,
+            pulse="groups",
+        )
+    )
+    mm = res["meter_map"]
+    assert [m["beats_per_bar"] for m in mm] == [length], res["summary"]
+    assert mm[0]["grouping"] == list(grouping), res["summary"]
+    assert mm[0]["denominator"] == den, res["summary"]
+    assert _matched(truth["downbeats"], res["downbeats"], tol=0.07) >= 0.8, res[
+        "summary"
+    ]
+
+
+def test_seven_eight_against_five_four_is_a_polymeter():
+    # Drums in 5/4 (kicks on the quarters, hats on the eighths); a melody
+    # cycling every seven eighths. 3.5 quarters is no bar length at the
+    # quarter, so the layer is read on the eighth grid: 7 against 10.
+    res, _ = _analyze(
+        MeterSegment(
+            bpm=240.0,
+            beats_per_bar=10,
+            bars=24,
+            grouping=(2, 2, 2, 2, 2),
+            pulse="groups",
+            poly_cycle=7,
+        )
+    )
+    mm = res["meter_map"]
+    assert len(mm) == 1 and mm[0]["numerator"] / mm[0]["denominator"] == 1.25, res[
+        "summary"
+    ]
+    seven = [p for p in res["polymeter"] if p["beats_per_bar"] == 7]
+    assert seven, res["polymeter"]
+    assert "7/8" in seven[0]["label"], seven[0]
+
+
+# --------------------------------------------------------------------------
+# the report
+# --------------------------------------------------------------------------
+
+
+def test_the_summary_reads_the_map_back():
+    res, _ = _analyze(
+        MeterSegment(bpm=120.0, beats_per_bar=4, bars=16),
+        MeterSegment(bpm=120.0, beats_per_bar=7, bars=12),
+    )
+    assert "4/4" in res["summary"] and "7/" in res["summary"]
+    assert res["version"] == engine.RHYTHM_VERSION
+    assert res["bars"] and res["bars"][0]["start_sec"] < res["bars"][-1]["start_sec"]
+
+
+def test_silence_and_shorts_do_not_crash():
+    assert analyze_rhythm(np.zeros(SR * 2, dtype=np.float32), SR)["meter_map"] == []
+    quiet = analyze_rhythm(np.zeros(SR * 10, dtype=np.float32), SR)
+    assert quiet["beats"] == [] or quiet["meter_map"] == [] or quiet["summary"]

--- a/tests/test_rhythm_router.py
+++ b/tests/test_rhythm_router.py
@@ -1,0 +1,56 @@
+"""The rhythm module's HTTP surface, against a synthetic two-meter file.
+
+The engine's own tests (test_rhythm_engine.py) prove the analysis; this proves
+the module mounts, answers, and hands the analysis through: a health report, a
+file analysis that reads the two meters in order, a 404 for a missing file, and
+a 200 ``pending`` for an entry nothing has analyzed — the Details panel polls
+that, and a 404 there paints the Network tab red for a normal state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import soundfile as sf
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.modules.rhythm.engine import RHYTHM_VERSION
+from backend.modules.rhythm.router import router
+from tests.rhythm_synth import MeterSegment, meter_track
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/rhythm")
+    return TestClient(app)
+
+
+def test_health_names_the_engine_version_and_features():
+    body = _client().get("/api/rhythm/").json()
+    assert body["module"] == "rhythm"
+    assert body["version"] == RHYTHM_VERSION
+    assert "meter_map" in body["features"] and "polymeter" in body["features"]
+
+
+def test_a_file_comes_back_with_its_meter_map(tmp_path: Path):
+    y, _ = meter_track([MeterSegment(120.0, 4, 8), MeterSegment(120.0, 7, 8)], sr=22050)
+    wav = tmp_path / "two-meters.wav"
+    sf.write(str(wav), y, 22050)
+    r = _client().post("/api/rhythm/file", json={"path": str(wav)})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert [m["beats_per_bar"] for m in body["meter_map"]] == [4, 7]
+    assert body["source"] == wav.name
+    assert body["elapsed_sec"] >= 0
+    assert body["summary"].startswith("Meter:")
+
+
+def test_a_missing_file_is_a_404_and_an_unanalyzed_entry_is_pending():
+    c = _client()
+    assert (
+        c.post("/api/rhythm/file", json={"path": "Z:/nowhere/none.wav"}).status_code
+        == 404
+    )
+    body = c.get("/api/rhythm/not-an-entry").json()
+    assert body == {"entry_id": "not-an-entry", "status": "pending"}

--- a/theDAW.bat
+++ b/theDAW.bat
@@ -5,6 +5,11 @@ title theDAW
 :: below resolve .venv / frontend\node_modules relative to the project.
 cd /d "%~dp0"
 
+:: -- Git hooks: the repo ships them in .githooks (ruff on every commit, the
+:: cross-platform lock check when pyproject/uv.lock are staged). One config
+:: line per clone, safe to repeat; ignored when git is absent.
+git config core.hooksPath .githooks >nul 2>&1
+
 :: -- uv cache on THIS repo's drive --------------------------------------
 :: uv installs wheels into .venv by hardlinking from its cache, but a hardlink
 :: cannot cross volumes. uv's default cache lives on the system drive, which is

--- a/theDAW.sh
+++ b/theDAW.sh
@@ -10,6 +10,11 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+# Git hooks: the repo ships them in .githooks (ruff on every commit, the
+# cross-platform lock check when pyproject/uv.lock are staged). One config
+# line per clone, safe to repeat; ignored when git is absent.
+git config core.hooksPath .githooks 2>/dev/null || true
+
 say()  { printf '\033[1;35m[theDAW]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[theDAW]\033[0m %s\n' "$*"; }
 die()  { printf '\033[1;31m[theDAW]\033[0m %s\n' "$*" >&2; exit 1; }

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,10 @@ resolution-markers = [
     "(python_full_version == '3.13.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "(python_full_version < '3.13' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.13' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
+required-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'AMD64' and sys_platform == 'win32'",
+]
 
 [manifest]
 overrides = [
@@ -2745,13 +2749,18 @@ dependencies = [
     { name = "protobuf", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/80/d96143329dbe925d434b016c890a5caa785fac8e14a1570e5d6818b63545/onnxruntime_gpu-1.30.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6acc0f4b3d5ac5f2984432faa59dd8fcce6775f8b43a7140afa0f322c7a703b1", size = 246685715, upload-time = "2026-09-10T16:13:10.1Z" },
     { url = "https://files.pythonhosted.org/packages/39/2b/97887b3f49ddad0d22b596a1e32a38a8e029cad81c6342da6d709cdc381c/onnxruntime_gpu-1.30.0-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:12af352b24145b3480794fcf327d313a240550e772a07fb182390872c1a642fc", size = 205731632, upload-time = "2026-09-10T15:53:07.466Z" },
     { url = "https://files.pythonhosted.org/packages/19/ef/e15db03ea1fce9bc60349add2604df8c39abac10d28d4eef27b621845139/onnxruntime_gpu-1.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:882da66f936e1f560b155118c5953dc45268cd92893abb8d31a940f4d1effb36", size = 160478594, upload-time = "2026-09-10T15:56:21.443Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ae/cfec0c21d039e4125fdc333e2e2032ed0a49eb50f9dd70b7f3819b339018/onnxruntime_gpu-1.30.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9aba23f903f434cc55d851aeb801afee19e287c202f4ab8f59d02f04caa90aed", size = 246688669, upload-time = "2026-09-10T16:13:21.504Z" },
     { url = "https://files.pythonhosted.org/packages/07/cd/99171c84362c9a3292ec909c2e8edd922dec21d65e28e83e9d809ad178c6/onnxruntime_gpu-1.30.0-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:0c68878729527a28202af6c1b7ebc2fc5a687e9f6e02bfb8796e39d1fe775fd7", size = 205732148, upload-time = "2026-09-10T15:53:16.111Z" },
     { url = "https://files.pythonhosted.org/packages/7e/d3/50fba71f4174f25f1e677ffe4b2ebc9f6c2a2aa8093c12e82c93792fd4e8/onnxruntime_gpu-1.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:cf494da233f3fc02bbeb2a3178e3ace7361b6b4fef7031b19c1e5aed5e9328ce", size = 160479611, upload-time = "2026-09-10T15:56:28.799Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/41/3ebd7b9648259adcf3abd245be862a0cb4c24d4b12f4f7b82d3e9fcf18f0/onnxruntime_gpu-1.30.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:675d519cab613bc42685ecb998f8e8e8c6d73143496681650d30ef14fedeade7", size = 246684982, upload-time = "2026-09-10T16:13:31.799Z" },
     { url = "https://files.pythonhosted.org/packages/f5/b0/6187754ea45ce90c116730115e4d856a6107b9e708580093c112def9a567/onnxruntime_gpu-1.30.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:c6df4b62538f98482dd5cebc91cba668c4b82156e872517c314a383c904a191d", size = 205776779, upload-time = "2026-09-10T15:53:24.926Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/75/09a6c97136c747608867a63114d988384e6ddb5507e08bbe9ced08744a4c/onnxruntime_gpu-1.30.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5aacc98f394a13f4891c0a07e60479d8fb0b1ea6f3328b6b38cfc88f9dfb05ea", size = 246693192, upload-time = "2026-09-10T16:13:41.775Z" },
     { url = "https://files.pythonhosted.org/packages/73/93/415e8100a3d7d4754f406fadbe86fa91d03058a9a6d7fa8a692722e9ceb8/onnxruntime_gpu-1.30.0-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:96cb15cff2f0dffaef3ae636560145d41be47bb73e3230113f2e946ca576014b", size = 205736852, upload-time = "2026-09-10T15:53:34.204Z" },
     { url = "https://files.pythonhosted.org/packages/50/fe/ed63f743d546fd089f98cfd415790b231ae8d3dba2208df8d22811f788a5/onnxruntime_gpu-1.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:794fc118cdbf340ed02b44c7527e557ea51746002d48105d493ea41f0c9a60d0", size = 161124661, upload-time = "2026-09-10T15:56:36.489Z" },
+    { url = "https://files.pythonhosted.org/packages/75/66/11c43d3d544380271aa14fd55c1e5be65f28fac007128e369f1192c9bfa9/onnxruntime_gpu-1.30.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a4dfbe80d4167ff5bc269f266778ee6d0eb771fd9f3c0c4d83757e7ae42fe3c8", size = 246687044, upload-time = "2026-09-10T16:13:52.095Z" },
     { url = "https://files.pythonhosted.org/packages/74/3d/33878b36bc473415ff7ed92ba751a5b5181d2779c74441c3584c68261dbc/onnxruntime_gpu-1.30.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:13d4cf97120882739da8572ba26e2a0f39caed4c69749a147d8f1a77f74a4690", size = 205750897, upload-time = "2026-09-10T15:53:43.295Z" },
 ]
 


### PR DESCRIPTION
This pull request introduces several improvements focused on cross-platform reliability, developer experience, and the robustness of the Foundry's .gan file handling and runtime. The most significant changes include enforcing cross-platform lockfile validity, adding a pre-commit hook for code and lockfile checks, improving .gan import diagnostics, and enhancing the runtime's handling of storage in sandboxed environments. Additionally, the test suite for .gan file import and runtime markup parsing has been expanded and clarified.

**Cross-platform dependency and workflow enforcement:**

* Added a pre-commit hook (`.githooks/pre-commit`) that runs Ruff checks and ensures `uv.lock` is up-to-date and valid for all supported platforms (Linux x86_64 and Windows) before allowing commits that touch `pyproject.toml` or `uv.lock`. This prevents platform-incomplete lockfiles from entering the repository.
* Introduced a dedicated `lock` job in the CI workflow (`.github/workflows/test.yml`) that verifies `uv.lock` installs correctly on all target platforms, using `scripts/check_lock.py`.
* Updated `.gitattributes` to enforce LF line endings for all files in `.githooks/`, ensuring hooks run correctly across platforms.
* Documented the lockfile enforcement policy and workflow in `CLAUDE.md`, emphasizing never to bypass these checks and to always fix underlying dependency issues instead of the checks themselves.

**.gan import and runtime improvements:**

* Enhanced `.gan` file import diagnostics: when images are omitted from import, a clear message is logged specifying which images were left out, improving transparency for users. [[1]](diffhunk://#diff-e30ef50479cf4cf6ff76a0fb160d0524afdfa60c299083a5a42bee76286620d2L322-R322) [[2]](diffhunk://#diff-e30ef50479cf4cf6ff76a0fb160d0524afdfa60c299083a5a42bee76286620d2L334-R340)
* In the Foundry's runtime, added a shim for `localStorage` and `sessionStorage` so that sandboxed iframes (with opaque origins) do not throw errors when element code tries to access storage; instead, an in-memory storage is provided for the frame's lifetime.
* Expanded and clarified the test suite for `.gan` import and runtime markup parsing, ensuring accurate reconstruction of element layouts, knob parameters, and handling of edge cases (e.g., off-canvas elements, missing wrappers, rotation recovery). [[1]](diffhunk://#diff-a9140e6a33d458f0f7aba2ae41a2f6b4a8f59752cdc7e061fa3d4f71f9c7b03fL1-R8) [[2]](diffhunk://#diff-a9140e6a33d458f0f7aba2ae41a2f6b4a8f59752cdc7e061fa3d4f71f9c7b03fL19-R88) [[3]](diffhunk://#diff-a9140e6a33d458f0f7aba2ae41a2f6b4a8f59752cdc7e061fa3d4f71f9c7b03fL85-R117)
* Added tests to verify the new storage shim works as intended and does not interfere with a real `localStorage` when present.

These changes collectively strengthen the reliability of the development workflow, improve user feedback during project import, and ensure the runtime is robust in sandboxed environments.