### PR TITLE
Footer redesign

### DIFF
--- a/frontend/src/components/audio/PlayerFooter.tsx
+++ b/frontend/src/components/audio/PlayerFooter.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Play, Pause, SkipBack, SkipForward, Volume2, Download, Share2, Heart, Repeat, VolumeX, Maximize2, MoreHorizontal, Cast, Check, Activity, ChevronUp } from 'lucide-react';
+import { Volume2, Download, Share2, Heart, Repeat, Shuffle, VolumeX, Maximize2, MoreHorizontal, Cast, Check, Activity, ChevronUp } from 'lucide-react';
 import { useGenerateStore } from '../../state/generateStore';
 import { usePlaybackStore } from '../../state/playbackStore';
 import { usePlayerStore } from '../../state/playerStore';
 import { useLibraryStore } from '../../state/libraryStore';
+import type { LibraryEntry } from '../../state/libraryStore';
 import { useAppUiStore } from '../../state/appUiStore';
 import { useEffectChainStore } from '../../state/effectChainStore';
 import {
@@ -42,7 +43,8 @@ const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
 const SEEK_STEP_SEC = 5;
 
 /**
- * The scrub strip: the footer's whole top edge, 16px tall, with the elapsed
+ * The scrub strip: the middle three-fifths of the footer's top edge, 16px
+ * tall, centred on the window so it is symmetric about PLAY, with the elapsed
  * and total times at its ends. It used to be a 3px line under the transport
  * buttons with a handle that only appeared on hover, which made the playhead
  * the hardest thing in the footer to reach. Now the hit area is the strip, the
@@ -125,7 +127,7 @@ const ScrubStrip: React.FC = () => {
   };
 
   return (
-    <div className="flex items-center gap-2.5 pl-36 pr-6 h-4 shrink-0">
+    <div className="flex items-center gap-2.5 w-3/5 mx-auto h-4 shrink-0">
       <span className="w-9 shrink-0 text-right text-[10px] font-mono tabular-nums text-zinc-400">
         {formatDuration(drag !== null ? drag * duration : currentTime)}
       </span>
@@ -148,25 +150,27 @@ const ScrubStrip: React.FC = () => {
         onPointerLeave={() => setHover(null)}
         onKeyDown={onKeyDown}
       >
-        {/* The rail: thin at rest, thicker under the pointer or keyboard focus. */}
-        <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-0.5 rounded-full bg-white/12 transition-[height] group-hover/scrub:h-1 group-focus-visible/scrub:h-1">
+        {/* The rail: flat and squared like the plate below (no rounding, no
+            gradient) — thin at rest, thicker under the pointer or keyboard focus. */}
+        <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-0.5 bg-white/10 transition-[height] group-hover/scrub:h-1 group-focus-visible/scrub:h-1">
           {hover !== null && drag === null && (
-            <div className="absolute inset-y-0 left-0 rounded-full bg-white/10" style={{ width: `${hover * 100}%` }} />
+            <div className="absolute inset-y-0 left-0 bg-white/10" style={{ width: `${hover * 100}%` }} />
           )}
           <div
-            className="absolute inset-y-0 left-0 rounded-full bg-linear-to-r from-purple-600 to-purple-400"
+            className="absolute inset-y-0 left-0 bg-purple-500"
             style={{ width: `${frac * 100}%` }}
           />
         </div>
+        {/* The playhead: a 2×10px cursor bar, no glow, widened under the hand. */}
         <div
-          className={`absolute top-1/2 w-2.5 h-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow-[0_0_8px_rgba(168,85,247,0.8)] transition-[opacity,transform] ${
+          className={`absolute top-1/2 w-0.5 h-2.5 -translate-x-1/2 -translate-y-1/2 bg-white transition-[opacity,scale] ${
             canSeek ? 'opacity-100' : 'opacity-0'
-          } ${drag !== null ? 'scale-125' : 'group-hover/scrub:scale-125 group-focus-visible/scrub:scale-125'}`}
+          } ${drag !== null ? 'scale-x-150' : 'group-hover/scrub:scale-x-150 group-focus-visible/scrub:scale-x-150'}`}
           style={{ left: `${frac * 100}%` }}
         />
         {canSeek && shown !== null && (
           <span
-            className="absolute bottom-full mb-1.5 -translate-x-1/2 whitespace-nowrap rounded border border-purple-500/30 bg-[#0a080f] px-1.5 py-0.5 text-[10px] font-mono tabular-nums text-purple-200 pointer-events-none"
+            className="absolute bottom-full mb-1.5 -translate-x-1/2 whitespace-nowrap rounded-xs border border-white/12 bg-[#0a080f] px-1.5 py-0.5 text-[10px] font-mono tabular-nums text-zinc-200 pointer-events-none"
             style={{ left: `${shown * 100}%` }}
           >
             {formatDuration(shown * duration)}
@@ -293,6 +297,87 @@ const MasterFxIndicator: React.FC = () => {
 /** A quiet icon button in the footer's secondary row. */
 const iconButton = 'p-1.5 rounded-md text-zinc-500 hover:text-white hover:bg-white/5 transition-colors disabled:opacity-30 disabled:pointer-events-none';
 
+/**
+ * A transport key on the matte plate: squared, flat, borderless. The plate's
+ * own p-px/gap-px well is the grid between keys, so a key must NEVER carry a
+ * border-white/N class — index.css floors any bordered button to
+ * rgb(var(--et-border)) (a >= 3:1 line) and the hairline grid turns hard. The
+ * plate must likewise never gain overflow-hidden or a clip-path: keyboard focus
+ * is the scope's 2px ink outline (index.css), drawn OUTSIDE the key, which is
+ * why a focused key only lifts itself above its neighbours (relative + z-10)
+ * and adds no ring of its own.
+ *
+ * The OFF / ON / DEAD strings below are exclusive — each owns the key's bg and
+ * text — because the scope's ink remaps are unlayered: a `disabled:` or
+ * `hover:` utility stacked on `text-zinc-400` would lose to the remapped base
+ * class, so state switches the whole string, never layers on top of it.
+ */
+const transportKey = 'h-full w-8 flex flex-col items-center justify-center gap-0.5 rounded-none first:rounded-l-xs last:rounded-r-xs select-none transition-[color,box-shadow] duration-100 active:shadow-[inset_0_1px_2px_rgba(0,0,0,0.7)] focus-visible:relative focus-visible:z-10 disabled:pointer-events-none';
+/**
+ * …at rest / toggle OFF: a 5% tile with a 1px etched top highlight (a hairline,
+ * not a glow). `bg-white/5`, `text-zinc-400` and `hover:text-zinc-100` are
+ * theme-remapped by UNLAYERED rules, which is why hover and press never use a
+ * `hover:bg-*` / `active:bg-*` utility: a layered variant loses to the remapped
+ * base fill and paints nothing. The hover fill is an inset box-shadow with a
+ * 100px spread (a translucent layer over the tile, under the glyph) and the
+ * press is the inset shade on the key string; shadows are never remapped.
+ * `bg-white/4|6|8` are not remapped at all: never "tune" the tile to those.
+ */
+const transportKeyOff = 'bg-white/5 text-zinc-400 hover:text-zinc-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),inset_0_0_0_100px_rgba(255,255,255,0.06)]';
+/**
+ * …toggle ON: latched IN (inset shade, one tint step up) with purple ink — the
+ * glyph and legend take currentColor, so nothing else is needed and no light is
+ * added. A plain class rather than an `aria-pressed:` variant, so the scope's
+ * accent remaps (purple-300 on dark themes, purple-700 on light) keep applying.
+ */
+const transportKeyOn = 'bg-white/10 text-purple-400 hover:text-purple-300 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] hover:shadow-[inset_0_1px_2px_rgba(0,0,0,0.6),inset_0_0_0_100px_rgba(255,255,255,0.04)]';
+/**
+ * …disabled: the key keeps its cap — a dead START/END stays a tile in the grid,
+ * not a hole — and only its glyph and legend dim, to 40 % of the live ink, so
+ * the cue survives every theme (a fixed dead-ink hex read as live on the light
+ * themes, and any zinc step is floored up to a live tier by the remaps).
+ */
+const transportKeyDead = 'bg-white/5 text-zinc-400 [&>*]:opacity-40 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]';
+/**
+ * The PLAY key: the plate's double-width key, one tint step lighter, primary
+ * ink. `border-b` is always present (transparent at rest) so the playing edge
+ * never shifts layout; neither border-b colour is in the scope's border-floor
+ * list, so nothing floors it.
+ */
+const transportPlayKey = 'h-full w-11 flex flex-col items-center justify-center gap-0.5 rounded-none select-none border-b transition-[color,box-shadow,border-color] duration-100 active:shadow-[inset_0_1px_2px_rgba(0,0,0,0.7)] focus-visible:relative focus-visible:z-10 disabled:pointer-events-none';
+const transportPlayRest = 'bg-white/10 text-zinc-100 border-b-transparent shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.1),inset_0_0_0_100px_rgba(255,255,255,0.08)]';
+/**
+ * …while playing: the same fill and shadow, purple ink and a 1px etched purple
+ * bottom edge (rgba(168,85,247), sitting 1px above the plate's own hairline) —
+ * the grammar of a latched LOOP/RAND, so it reads across the room on the DJ/VJ
+ * tabs where this key is the master transport. No glow.
+ */
+const transportPlayOn = 'bg-white/10 text-purple-400 hover:text-purple-300 border-b-purple-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.1),inset_0_0_0_100px_rgba(255,255,255,0.06)]';
+const transportPlayDead = 'bg-white/10 text-zinc-100 [&>*]:opacity-40 border-b-transparent shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]';
+/**
+ * The etched legend under each glyph. Decorative (aria-hidden — the key's
+ * aria-label is its name, and the legend always sits inside that name: LOOP
+ * in "Looping on", RAND in "Random order on"),
+ * it inherits the key's ink, so rest / hover / ON / dead all flow through the
+ * button's class. 8px has no scale token (the file already uses 9px and 10px).
+ */
+const keyLabel = 'text-[8px] font-mono uppercase tracking-widest leading-none';
+
+/**
+ * The four motion glyphs, hard-cornered (no rounded joins) so they read as one
+ * engraved set at 14px — lucide's round joins go soft that small. Fill-only in
+ * currentColor, so the key's ink, hover ink and ON purple flow straight in.
+ */
+const Glyph: React.FC<{ d: string; className?: string }> = ({ d, className }) => (
+  <svg viewBox="0 0 14 14" fill="currentColor" aria-hidden="true" focusable="false" className={className}>
+    <path d={d} />
+  </svg>
+);
+const GLYPH_PLAY = 'M3 1.5 12.5 7 3 12.5Z';
+const GLYPH_PAUSE = 'M3 2h3v10H3zM8 2h3v10H8z';
+const GLYPH_TO_START = 'M2 2h2v10H2zM12 2 5 7l7 5z';
+const GLYPH_TO_END = 'M2 2l7 5-7 5zM10 2h2v10h-2z';
+
 export const PlayerFooter: React.FC = () => {
   const [isLiked, setIsLiked] = useState(false);
 
@@ -343,6 +428,28 @@ export const PlayerFooter: React.FC = () => {
   const load = usePlayerStore((s) => s.load);
   const currentEntryId = usePlayerStore((s) => s.currentEntryId);
   const libraryEntries = useLibraryStore((s) => s.entries);
+
+  // Shuffle (the RAND key) — local to the footer: playerStore carries no shuffle
+  // state and transportControlSource mirrors play/loop only, so this resets on
+  // a footer remount and does not reach controllers; it belongs in playerStore
+  // if it ever has to persist or reach the mobile transport. When on, "up next"
+  // is a random OTHER library entry, drawn once per current entry: the pick is
+  // pinned to the entry it was drawn for (`forId`), so re-renders never re-roll
+  // it, a new current entry draws afresh, and a library refresh that removes
+  // the picked entry draws again. Held in state and written from an effect —
+  // never a ref written during render.
+  const [isShuffle, setIsShuffle] = useState(false);
+  const [shufflePick, setShufflePick] = useState<{ forId: string | null; pick: LibraryEntry | null }>({ forId: null, pick: null });
+  useEffect(() => {
+    if (!isShuffle) return;
+    setShufflePick((prev) => {
+      const others = libraryEntries.filter((e) => e.id !== currentEntryId);
+      const pickId = prev.forId === currentEntryId ? prev.pick?.id : undefined;
+      const kept = pickId !== undefined ? others.find((e) => e.id === pickId) : undefined;
+      if (kept) return kept === prev.pick ? prev : { forId: currentEntryId, pick: kept };
+      return { forId: currentEntryId, pick: others[Math.floor(Math.random() * others.length)] ?? null };
+    });
+  }, [isShuffle, currentEntryId, libraryEntries]);
 
   // Last-generation metadata (used when nothing's been explicitly loaded yet).
   const lastFilename = useGenerateStore((s) => s.lastFilename);
@@ -457,7 +564,7 @@ export const PlayerFooter: React.FC = () => {
 
   // "Up next" — no formal play queue yet, so derive the next track from the
   // library in newest-first order (wraps at the end). Clicking it loads it.
-  const nextEntry = React.useMemo(() => {
+  const sequentialNext = React.useMemo(() => {
     if (libraryEntries.length === 0) return null;
     const sorted = [...libraryEntries].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
     if (!currentEntryId) return sorted[0] ?? null;
@@ -465,6 +572,13 @@ export const PlayerFooter: React.FC = () => {
     if (idx < 0) return sorted[0] ?? null;
     return sorted[(idx + 1) % sorted.length] ?? null;
   }, [libraryEntries, currentEntryId]);
+  // With RAND on (and a second entry to draw from), up next is the random pick
+  // instead — once the effect above has drawn it for THIS entry; the one render
+  // before that falls back to the sequential next, never to the entry already
+  // playing. `loadNext` loads whichever this resolves to.
+  const nextEntry = isShuffle && libraryEntries.length > 1 && shufflePick.forId === currentEntryId
+    ? shufflePick.pick
+    : sequentialNext;
 
   const loadNext = () => {
     if (!nextEntry) return;
@@ -482,26 +596,33 @@ export const PlayerFooter: React.FC = () => {
     }
   };
 
+  // The dead keys: START needs a track (or the editor's render path); PLAY also
+  // counts the live tabs, where it is the master transport with no track loaded.
+  const startDisabled = !inEditorMode && !hasTrack;
+  const playDisabled = !isVjMode && !inEditorMode && !hasTrack;
+
   return (
     <footer
       className="edit-theme-scope fixed bottom-0 left-0 right-0 h-16 bg-[#0a080f]/95 backdrop-blur-xl border-t border-white/5 z-50 flex flex-col group"
       data-et-light={editTheme.light ? '1' : undefined}
       style={editTheme.vars as React.CSSProperties}
     >
-      {/* Row 1: the scrub strip along the footer's top edge, full width from
-          the orb's clearance to the right padding. Its height is FOOTER_H
-          (lib/layoutScale.ts) minus the 48px row below; change both together. */}
+      {/* Row 1: the scrub strip, centred, the middle 3/5 of the footer width
+          (w-3/5 mx-auto), clear of the orb from 1024px up. Its height is
+          FOOTER_H (lib/layoutScale.ts) minus the 48px row below; change both
+          together. */}
       <ScrubStrip />
 
       {/* Row 2: now playing · transport · up next + utilities. One row, so
-          nothing stacks inside 48px any more. */}
-      <div className="flex-1 min-h-0 flex items-center gap-4 px-6 pb-0.5">
-        {/* 1. Orb speech bubble + Now Playing. flex-1 (mirrors section 3) so the
-            now-playing readout fills the space between the bubble and the centred
-            transport, and the PLAY button still lands on the true viewport centre.
-            The orb sticks to the bottom-left corner and overlaps the footer, so
-            pad left past it: 16px margin + the 112px orb = 128, plus clearance. */}
-        <div className="flex items-center gap-3 flex-1 min-w-0 pl-36">
+          nothing stacks inside 48px any more. An explicit 1fr · auto · 1fr grid,
+          because only a grid keeps the two side tracks equal with padding
+          inside them: as a flex-1 pair, section 1's 144px orb clearance made it
+          144px wider and pushed PLAY 72px right of the window centre. */}
+      <div className="flex-1 min-h-0 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-4 px-6 pb-0.5">
+        {/* 1. Orb speech bubble + Now Playing, in the left track. The orb
+            sticks to the bottom-left corner and overlaps the footer, so pad left
+            past it: 16px margin + the 112px orb = 128, plus clearance. */}
+        <div className="flex items-center gap-3 min-w-0 pl-36">
           {/* The orb's speech bubble, in the slot G-Search used to hold. */}
           <OrbTipBubble className="hidden xl:block" />
           <div className="flex flex-col min-w-0 flex-1 gap-0.5">
@@ -509,7 +630,7 @@ export const PlayerFooter: React.FC = () => {
               {displayLabel ?? 'No output loaded'}
             </h4>
             <div className="flex items-center gap-2">
-              <span className="text-[9px] text-purple-400 font-mono uppercase tracking-widest border border-purple-500/20 px-1 rounded bg-purple-500/5">
+              <span className="text-[9px] text-purple-400 font-mono uppercase tracking-widest border border-purple-500/20 px-1 rounded-xs bg-purple-500/5">
                 {lastModelName ? lastModelName.toUpperCase() : (displayLabel ? 'LIBRARY' : 'IDLE')}
               </span>
               <span className="text-[10px] text-zinc-500 font-mono">
@@ -550,45 +671,55 @@ export const PlayerFooter: React.FC = () => {
           </div>
         </div>
 
-        {/* 2. Transport — one row of controls, centred between the two flex-1
-            side sections so PLAY stays on the viewport centre. The playhead is
-            in the strip above, so this cluster no longer stacks. */}
-        <div data-tour="transport" className="shrink-0 flex items-center gap-4">
+        {/* 2. Transport — one matte plate: LOOP · START · PLAY · END · RAND on a
+            hairline grid (the plate's p-px/gap-px well IS the grid; keys carry
+            no borders or the theme floors them to a 3:1 line). 2+2 about PLAY
+            so the flex-1 side sections keep it on the viewport centre. The
+            playhead is in the strip above. Fullscreen lives with the window
+            utilities on the right (its handler, aria-label, title and icon are
+            unchanged) — an even key count is what keeps PLAY dead centre. The
+            wrapper is a div, so its border-white/8 stays a hairline (the scope's
+            button border floor never touches it), and `bg-black/40` /
+            `border-white/8` are both theme-remapped. Never give it
+            overflow-hidden or a clip-path: the keys' focus outline draws
+            outside them. */}
+        <div data-tour="transport" className="shrink-0 flex items-stretch h-9 p-px gap-px rounded-xs border border-white/8 bg-black/40 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
           <button
             type="button"
             onClick={toggleLoop}
             aria-label={isLooping ? 'Looping on' : 'Looping off'}
             aria-pressed={isLooping}
             title={isLooping ? 'Looping on' : 'Looping off'}
-            className={`${iconButton} ${isLooping ? 'text-purple-400 hover:text-purple-300' : ''}`}
+            className={`${transportKey} ${isLooping ? transportKeyOn : transportKeyOff}`}
           >
-            <Repeat className="w-3.5 h-3.5" />
+            <Repeat className="w-3.5 h-3.5" strokeWidth={1.5} absoluteStrokeWidth strokeLinecap="square" strokeLinejoin="miter" />
+            <span aria-hidden="true" className={keyLabel}>LOOP</span>
           </button>
           <button
             type="button"
             onClick={() => seekByFraction(0)}
-            disabled={!inEditorMode && !hasTrack}
+            disabled={startDisabled}
             aria-label="Jump to start"
             title="Jump to start"
-            className={iconButton}
+            className={`${transportKey} ${startDisabled ? transportKeyDead : transportKeyOff}`}
           >
-            <SkipBack className="w-4 h-4 fill-current" />
+            <Glyph d={GLYPH_TO_START} className="w-3.5 h-3.5" />
+            <span aria-hidden="true" className={keyLabel}>START</span>
           </button>
           <button
             type="button"
             onClick={handleToggle}
-            disabled={!isVjMode && !inEditorMode && !hasTrack}
+            disabled={playDisabled}
             aria-label={displayIsPlaying ? 'Pause' : 'Play'}
             title={displayIsPlaying ? 'Pause' : 'Play'}
-            className={`w-7.5 h-7.5 rounded-full flex items-center justify-center text-white bg-linear-to-br from-purple-400 to-purple-700 ring-1 ring-white/15 transition-all hover:scale-105 hover:brightness-110 active:scale-95 disabled:opacity-40 disabled:pointer-events-none ${
-              displayIsPlaying
-                ? 'shadow-[0_0_18px_rgba(168,85,247,0.6)]'
-                : 'shadow-[0_0_10px_rgba(168,85,247,0.25)]'
-            }`}
+            className={`${transportPlayKey} ${playDisabled ? transportPlayDead : displayIsPlaying ? transportPlayOn : transportPlayRest}`}
           >
             {displayIsPlaying
-              ? <Pause className="w-3.5 h-3.5 fill-current" />
-              : <Play className="w-3.5 h-3.5 fill-current ml-0.5" />}
+              ? <Glyph d={GLYPH_PAUSE} className="w-4 h-4" />
+              : <Glyph d={GLYPH_PLAY} className="w-4 h-4 ml-0.5" />}
+            {/* The legend flips with the glyph so the printed word stays inside
+                the accessible name (label-in-name). */}
+            <span aria-hidden="true" className={keyLabel}>{displayIsPlaying ? 'PAUSE' : 'PLAY'}</span>
           </button>
           <button
             type="button"
@@ -596,34 +727,39 @@ export const PlayerFooter: React.FC = () => {
             disabled={!hasTrack}
             aria-label="Jump to end"
             title="Jump to end"
-            className={iconButton}
+            className={`${transportKey} ${hasTrack ? transportKeyOff : transportKeyDead}`}
           >
-            <SkipForward className="w-4 h-4 fill-current" />
+            <Glyph d={GLYPH_TO_END} className="w-3.5 h-3.5" />
+            <span aria-hidden="true" className={keyLabel}>END</span>
           </button>
           <button
             type="button"
-            onClick={toggleFullscreen}
-            aria-label="Toggle fullscreen"
-            title="Toggle fullscreen"
-            className={iconButton}
+            onClick={() => setIsShuffle((v) => !v)}
+            aria-label={isShuffle ? 'Random order on' : 'Random order off'}
+            aria-pressed={isShuffle}
+            title="Random order: any other library track plays next"
+            className={`${transportKey} ${isShuffle ? transportKeyOn : transportKeyOff}`}
           >
-            <Maximize2 className="w-3.5 h-3.5" />
+            <Shuffle className="w-3.5 h-3.5" strokeWidth={1.5} absoluteStrokeWidth strokeLinecap="square" strokeLinejoin="miter" />
+            <span aria-hidden="true" className={keyLabel}>RAND</span>
           </button>
         </div>
 
-        {/* 3. Up Next (mirrors Now Playing) + Utilities. flex-1 (mirrors section 1)
-            so the up-next readout fills the space between the transport and the
-            utilities, right-aligned. */}
-        <div className="flex items-center gap-4 flex-1 min-w-0 justify-end">
+        {/* 3. Up Next (mirrors Now Playing) + Utilities, right-aligned in the
+            right track. */}
+        <div className="flex items-center gap-4 min-w-0 justify-end">
           {/* Up Next — mirror of the Now Playing block, right-aligned. Click loads
-              the next track (no formal queue yet, so it's the next library entry).
-              Hidden on narrow windows so the transport and action button keep room. */}
+              the next track (no formal queue yet, so it's the next library entry —
+              or a random other one while RAND is on, which the title says).
+              Hidden below xl: at 1024px the right track is 382px and the
+              utilities alone take 340 of them, so at lg it collapsed to 0px and
+              its second row spilled over the plate. */}
           <button
             type="button"
             onClick={loadNext}
             disabled={!nextEntry}
-            title={nextEntry ? `Play next: ${nextEntry.title}` : 'Nothing queued'}
-            className="group/next hidden lg:flex flex-col min-w-0 flex-1 items-end text-right gap-0.5 disabled:cursor-default"
+            title={nextEntry ? `Play next${isShuffle ? ' (random)' : ''}: ${nextEntry.title}` : 'Nothing queued'}
+            className="group/next hidden xl:flex flex-col min-w-0 flex-1 items-end text-right gap-0.5 disabled:cursor-default"
           >
             <h4 className="text-[13px] font-bold text-zinc-300 group-hover/next:text-white transition-colors truncate tracking-tight leading-tight w-full">
               {nextEntry?.title ?? 'Nothing queued'}
@@ -632,7 +768,7 @@ export const PlayerFooter: React.FC = () => {
               <span className="text-[10px] text-zinc-500 font-mono">
                 {nextEntry ? formatDuration(nextEntry.duration) : '--:--'}
               </span>
-              <span className="text-[9px] text-emerald-400 font-mono uppercase tracking-widest border border-emerald-500/20 px-1 rounded bg-emerald-500/5">
+              <span className="text-[9px] text-emerald-400 font-mono uppercase tracking-widest border border-emerald-500/20 px-1 rounded-xs bg-emerald-500/5">
                 Up Next
               </span>
             </div>
@@ -657,6 +793,17 @@ export const PlayerFooter: React.FC = () => {
             <div className="h-6 w-px bg-white/5" />
 
             <div className="flex items-center gap-1">
+              {/* Fullscreen — a window utility, so it sits here rather than on the
+                  transport plate (handler, aria-label, title and icon unchanged). */}
+              <button
+                type="button"
+                onClick={toggleFullscreen}
+                aria-label="Toggle fullscreen"
+                title="Toggle fullscreen"
+                className={iconButton}
+              >
+                <Maximize2 className="w-3.5 h-3.5" />
+              </button>
               <button
                 type="button"
                 onClick={handleDownload}

--- a/frontend/src/components/audio/PlayerFooter.tsx
+++ b/frontend/src/components/audio/PlayerFooter.tsx
@@ -36,68 +36,146 @@ const formatDuration = (sec: number | null | undefined): string => {
   return `${m}:${s.toString().padStart(2, '0')}`;
 };
 
+const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
+
+/** Arrow keys move the playhead by this much; Shift multiplies it by six. */
+const SEEK_STEP_SEC = 5;
+
 /**
- * The time readouts + scrub bar, isolated so the per-frame `currentTime` tick
- * re-renders ONLY this row — previously the whole footer (both side sections,
- * the transport cluster, the action button) re-rendered every animation frame,
- * which is exactly the kind of cost a fixed chrome element must not have.
+ * The scrub strip: the footer's whole top edge, 16px tall, with the elapsed
+ * and total times at its ends. It used to be a 3px line under the transport
+ * buttons with a handle that only appeared on hover, which made the playhead
+ * the hardest thing in the footer to reach. Now the hit area is the strip, the
+ * handle is always there once a track is loaded, a hover shows the time under
+ * the pointer, dragging scrubs, and the keyboard seeks.
+ *
+ * Isolated so the per-frame `currentTime` tick re-renders ONLY this strip —
+ * the footer shell (side sections, transport, action button) must not pay
+ * that cost.
  */
-const TransportProgressRow: React.FC = () => {
-  const progressRef = useRef<HTMLDivElement | null>(null);
+const ScrubStrip: React.FC = () => {
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const dragRef = useRef(false);
   const currentTime = usePlayerStore((s) => s.currentTime);
   const engineDuration = usePlayerStore((s) => s.duration);
+  const hasTrack = usePlayerStore((s) => s.hasTrack);
   const seekByFraction = usePlayerStore((s) => s.seekByFraction);
   const lastDurationSec = useGenerateStore((s) => s.lastDurationSec);
-  const centerTab = useAppUiStore((s) => s.centerTab);
-  const vjSetCount = useVjSetStatusStore((s) => s.count);
-  const vjSetAcked = useVjSetStatusStore((s) => s.acked);
-  const vjSetName = useVjSetStatusStore((s) => s.name);
-  const isVjMode = centerTab === 'vj' || centerTab === 'dj';
+  // Fraction under the pointer while dragging; the strip follows it instead of
+  // the engine so the handle never lags the hand.
+  const [drag, setDrag] = useState<number | null>(null);
+  const [hover, setHover] = useState<number | null>(null);
 
-  const displayDuration = engineDuration > 0 ? engineDuration : (lastDurationSec ?? 0);
-  const progressPct = displayDuration > 0 ? Math.min(100, (currentTime / displayDuration) * 100) : 0;
+  const duration = engineDuration > 0 ? engineDuration : (lastDurationSec ?? 0);
+  const canSeek = hasTrack && duration > 0;
+  const frac = drag ?? (duration > 0 ? clamp01(currentTime / duration) : 0);
+  const shown = drag ?? hover;
 
-  const handleProgressClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    const el = progressRef.current;
-    if (!el || displayDuration <= 0) return;
-    const rect = el.getBoundingClientRect();
-    seekByFraction((e.clientX - rect.left) / rect.width);
+  const fracAt = (clientX: number): number => {
+    const el = trackRef.current;
+    if (!el) return frac;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 ? clamp01((clientX - r.left) / r.width) : frac;
+  };
+  const onDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!canSeek) return;
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    const el = e.currentTarget;
+    el.setPointerCapture?.(e.pointerId);
+    // Focus before preventDefault, or the widget never becomes activeElement
+    // and the keyboard seek below is unreachable by mouse (same trap SlideTrack
+    // documents).
+    el.focus({ preventScroll: true });
+    dragRef.current = true;
+    const f = fracAt(e.clientX);
+    setDrag(f);
+    seekByFraction(f);
+    e.preventDefault();
+  };
+  const onMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const f = fracAt(e.clientX);
+    if (dragRef.current) {
+      setDrag(f);
+      seekByFraction(f);
+    } else {
+      setHover(canSeek ? f : null);
+    }
+  };
+  const onUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (dragRef.current) {
+      dragRef.current = false;
+      seekByFraction(fracAt(e.clientX));
+      setDrag(null);
+    }
+    e.currentTarget.releasePointerCapture?.(e.pointerId);
+  };
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!canSeek) return;
+    const step = (SEEK_STEP_SEC * (e.shiftKey ? 6 : 1)) / duration;
+    let handled = true;
+    switch (e.key) {
+      case 'ArrowRight': case 'ArrowUp': seekByFraction(clamp01(frac + step)); break;
+      case 'ArrowLeft': case 'ArrowDown': seekByFraction(clamp01(frac - step)); break;
+      case 'Home': seekByFraction(0); break;
+      case 'End': seekByFraction(1); break;
+      default: handled = false;
+    }
+    // stopPropagation too: the window-level editor shortcuts share these keys.
+    if (handled) { e.preventDefault(); e.stopPropagation(); }
   };
 
   return (
-    <div className="w-full flex items-center gap-3">
-      {isVjMode && vjSetCount > 0 && (
-        <span
-          className={`flex items-center gap-1 px-1.5 py-0.5 rounded border text-[9px] font-mono uppercase tracking-widest shrink-0 ${
-            vjSetAcked
-              ? 'border-emerald-500/40 bg-emerald-500/5 text-emerald-300'
-              : 'border-amber-500/40 bg-amber-500/5 text-amber-300'
-          }`}
-          title={
-            vjSetAcked
-              ? `VJ set "${vjSetName ?? ''}" loaded — ${vjSetCount} item${vjSetCount === 1 ? '' : 's'}`
-              : `Sending set "${vjSetName ?? ''}" to the VJ…`
-          }
-        >
-          {vjSetAcked ? <Check className="w-3 h-3" /> : <Cast className="w-3 h-3" />}
-          VJ {vjSetCount}
-        </span>
-      )}
-      <span className="text-[10px] font-mono text-zinc-500 w-8 text-right">{formatDuration(currentTime)}</span>
+    <div className="flex items-center gap-2.5 pl-36 pr-6 h-4 shrink-0">
+      <span className="w-9 shrink-0 text-right text-[10px] font-mono tabular-nums text-zinc-400">
+        {formatDuration(drag !== null ? drag * duration : currentTime)}
+      </span>
       <div
-        ref={progressRef}
-        onClick={handleProgressClick}
-        className="flex-1 h-0.75 bg-white/5 rounded-full relative group/bar cursor-pointer"
+        ref={trackRef}
+        role="slider"
+        aria-label="Playback position"
+        aria-valuemin={0}
+        aria-valuemax={Math.round(duration)}
+        aria-valuenow={Math.round(frac * duration)}
+        aria-valuetext={`${formatDuration(frac * duration)} of ${formatDuration(duration)}`}
+        aria-disabled={!canSeek}
+        tabIndex={canSeek ? 0 : -1}
+        className={`group/scrub relative flex-1 h-4 select-none outline-none ${canSeek ? 'cursor-pointer' : 'cursor-default'}`}
+        style={{ touchAction: 'none' }}
+        onPointerDown={onDown}
+        onPointerMove={onMove}
+        onPointerUp={onUp}
+        onPointerCancel={onUp}
+        onPointerLeave={() => setHover(null)}
+        onKeyDown={onKeyDown}
       >
-        <div className="absolute inset-0 bg-white/5" />
-        <div
-          className="absolute inset-y-0 left-0 bg-linear-to-r from-purple-600 to-purple-400 rounded-full"
-          style={{ width: `${progressPct}%` }}
-        >
-          <div className="hidden group-hover/bar:block absolute right-0 top-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full shadow-[0_0_8px_rgba(139,92,246,0.6)]" />
+        {/* The rail: thin at rest, thicker under the pointer or keyboard focus. */}
+        <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-0.5 rounded-full bg-white/12 transition-[height] group-hover/scrub:h-1 group-focus-visible/scrub:h-1">
+          {hover !== null && drag === null && (
+            <div className="absolute inset-y-0 left-0 rounded-full bg-white/10" style={{ width: `${hover * 100}%` }} />
+          )}
+          <div
+            className="absolute inset-y-0 left-0 rounded-full bg-linear-to-r from-purple-600 to-purple-400"
+            style={{ width: `${frac * 100}%` }}
+          />
         </div>
+        <div
+          className={`absolute top-1/2 w-2.5 h-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow-[0_0_8px_rgba(168,85,247,0.8)] transition-[opacity,transform] ${
+            canSeek ? 'opacity-100' : 'opacity-0'
+          } ${drag !== null ? 'scale-125' : 'group-hover/scrub:scale-125 group-focus-visible/scrub:scale-125'}`}
+          style={{ left: `${frac * 100}%` }}
+        />
+        {canSeek && shown !== null && (
+          <span
+            className="absolute bottom-full mb-1.5 -translate-x-1/2 whitespace-nowrap rounded border border-purple-500/30 bg-[#0a080f] px-1.5 py-0.5 text-[10px] font-mono tabular-nums text-purple-200 pointer-events-none"
+            style={{ left: `${shown * 100}%` }}
+          >
+            {formatDuration(shown * duration)}
+          </span>
+        )}
       </div>
-      <span className="text-[10px] font-mono text-zinc-500 w-8">{formatDuration(displayDuration)}</span>
+      <span className="w-9 shrink-0 text-[10px] font-mono tabular-nums text-zinc-400">
+        {formatDuration(duration)}
+      </span>
     </div>
   );
 };
@@ -212,6 +290,9 @@ const MasterFxIndicator: React.FC = () => {
   );
 };
 
+/** A quiet icon button in the footer's secondary row. */
+const iconButton = 'p-1.5 rounded-md text-zinc-500 hover:text-white hover:bg-white/5 transition-colors disabled:opacity-30 disabled:pointer-events-none';
+
 export const PlayerFooter: React.FC = () => {
   const [isLiked, setIsLiked] = useState(false);
 
@@ -248,8 +329,8 @@ export const PlayerFooter: React.FC = () => {
   const toggleMute = usePlaybackStore((s) => s.toggleMute);
 
   // Engine state — deliberately NO `currentTime` subscription here: the
-  // per-frame tick lives in TransportProgressRow so the footer shell doesn't
-  // re-render 60×/s.
+  // per-frame tick lives in ScrubStrip so the footer shell doesn't re-render
+  // 60×/s.
   const engineLabel = usePlayerStore((s) => s.currentLabel);
   const engineDuration = usePlayerStore((s) => s.duration);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
@@ -311,6 +392,9 @@ export const PlayerFooter: React.FC = () => {
   // live transport rather than a disabled audio-only state.
   const isVjMode = centerTab === 'vj' || centerTab === 'dj';
   const isDjMode = centerTab === 'dj';
+  const vjSetCount = useVjSetStatusStore((s) => s.count);
+  const vjSetAcked = useVjSetStatusStore((s) => s.acked);
+  const vjSetName = useVjSetStatusStore((s) => s.name);
 
   // DJ master transport — the footer ▶ drives the DJ decks/set (not the global
   // single-track player) while on the DJ tab.
@@ -390,163 +474,215 @@ export const PlayerFooter: React.FC = () => {
     })();
   };
 
+  const toggleFullscreen = () => {
+    if (document.fullscreenElement) {
+      void document.exitFullscreen();
+    } else {
+      void document.documentElement.requestFullscreen();
+    }
+  };
+
   return (
     <footer
-      className="edit-theme-scope fixed bottom-0 left-0 right-0 h-14 bg-[#0a080f]/95 backdrop-blur-xl border-t border-white/5 z-50 px-6 flex items-center gap-4 group"
+      className="edit-theme-scope fixed bottom-0 left-0 right-0 h-16 bg-[#0a080f]/95 backdrop-blur-xl border-t border-white/5 z-50 flex flex-col group"
       data-et-light={editTheme.light ? '1' : undefined}
       style={editTheme.vars as React.CSSProperties}
     >
-      {/* 1. Orb speech bubble + Now Playing. flex-1 (mirrors section 3) so the
-          now-playing readout fills the space between the bubble and the centred
-          transport, and the PLAY button still lands on the true viewport centre.
-          The orb sticks to the bottom-left corner and overlaps the footer, so
-          pad left past it: 16px margin + the 112px orb = 128, plus clearance. */}
-      <div className="flex items-center gap-3 flex-1 min-w-0 pl-36">
-        {/* The orb's speech bubble, in the slot G-Search used to hold. */}
-        <OrbTipBubble className="hidden xl:block" />
-        <div className="flex flex-col min-w-0 flex-1">
-          <h4 className="text-[13px] font-bold text-zinc-100 truncate tracking-tight">
-            {displayLabel ?? 'No output loaded'}
-          </h4>
-          <div className="flex items-center gap-2">
-            <span className="text-[9px] text-purple-400 font-mono uppercase tracking-widest border border-purple-500/20 px-1 rounded bg-purple-500/5">
-              {lastModelName ? lastModelName.toUpperCase() : (displayLabel ? 'LIBRARY' : 'IDLE')}
-            </span>
-            <span className="text-[10px] text-zinc-500 font-mono">
-              {displayDuration > 0 ? `${formatDuration(displayDuration)} // 48kHz` : '--:-- // 48kHz'}
-            </span>
+      {/* Row 1: the scrub strip along the footer's top edge, full width from
+          the orb's clearance to the right padding. Its height is FOOTER_H
+          (lib/layoutScale.ts) minus the 48px row below; change both together. */}
+      <ScrubStrip />
+
+      {/* Row 2: now playing · transport · up next + utilities. One row, so
+          nothing stacks inside 48px any more. */}
+      <div className="flex-1 min-h-0 flex items-center gap-4 px-6 pb-0.5">
+        {/* 1. Orb speech bubble + Now Playing. flex-1 (mirrors section 3) so the
+            now-playing readout fills the space between the bubble and the centred
+            transport, and the PLAY button still lands on the true viewport centre.
+            The orb sticks to the bottom-left corner and overlaps the footer, so
+            pad left past it: 16px margin + the 112px orb = 128, plus clearance. */}
+        <div className="flex items-center gap-3 flex-1 min-w-0 pl-36">
+          {/* The orb's speech bubble, in the slot G-Search used to hold. */}
+          <OrbTipBubble className="hidden xl:block" />
+          <div className="flex flex-col min-w-0 flex-1 gap-0.5">
+            <h4 className="text-[13px] font-bold text-zinc-100 truncate tracking-tight leading-tight">
+              {displayLabel ?? 'No output loaded'}
+            </h4>
+            <div className="flex items-center gap-2">
+              <span className="text-[9px] text-purple-400 font-mono uppercase tracking-widest border border-purple-500/20 px-1 rounded bg-purple-500/5">
+                {lastModelName ? lastModelName.toUpperCase() : (displayLabel ? 'LIBRARY' : 'IDLE')}
+              </span>
+              <span className="text-[10px] text-zinc-500 font-mono">
+                {displayDuration > 0 ? `${formatDuration(displayDuration)} // 48kHz` : '--:-- // 48kHz'}
+              </span>
+              {isVjMode && vjSetCount > 0 && (
+                <span
+                  className={`flex items-center gap-1 px-1.5 py-0.5 rounded border text-[9px] font-mono uppercase tracking-widest shrink-0 ${
+                    vjSetAcked
+                      ? 'border-emerald-500/40 bg-emerald-500/5 text-emerald-300'
+                      : 'border-amber-500/40 bg-amber-500/5 text-amber-300'
+                  }`}
+                  title={
+                    vjSetAcked
+                      ? `VJ set "${vjSetName ?? ''}" loaded — ${vjSetCount} item${vjSetCount === 1 ? '' : 's'}`
+                      : `Sending set "${vjSetName ?? ''}" to the VJ…`
+                  }
+                >
+                  {vjSetAcked ? <Check className="w-3 h-3" /> : <Cast className="w-3 h-3" />}
+                  VJ {vjSetCount}
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-0.5 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+            <button
+              type="button"
+              onClick={() => setIsLiked(!isLiked)}
+              aria-label={isLiked ? 'Unlike' : 'Like'}
+              aria-pressed={isLiked}
+              className={`${iconButton} ${isLiked ? 'text-pink-500 hover:text-pink-400' : ''}`}
+            >
+              <Heart className={`w-3.5 h-3.5 ${isLiked ? 'fill-current' : ''}`} />
+            </button>
+            <button type="button" aria-label="Share" className={iconButton}>
+              <Share2 className="w-3.5 h-3.5" />
+            </button>
           </div>
         </div>
-        <div className="flex items-center gap-1 ml-2 opacity-0 group-hover:opacity-100 transition-opacity">
-          <button onClick={() => setIsLiked(!isLiked)} className={`p-1.5 transition-colors ${isLiked ? 'text-pink-500' : 'text-zinc-600 hover:text-white'}`}>
-             <Heart className={`w-3.5 h-3.5 ${isLiked ? 'fill-current' : ''}`} />
-          </button>
-          <button className="p-1.5 text-zinc-600 hover:text-white transition-colors">
-             <Share2 className="w-3.5 h-3.5" />
-          </button>
-        </div>
-      </div>
 
-      {/* 2. Main Transport Control — fixed-width + centred between the two
-          flex-1 side sections so the PLAY button stays on the viewport centre. */}
-      <div data-tour="transport" className="shrink min-w-72 w-136 max-w-2xl flex flex-col items-center gap-1">
-        <div className="flex items-center gap-5">
+        {/* 2. Transport — one row of controls, centred between the two flex-1
+            side sections so PLAY stays on the viewport centre. The playhead is
+            in the strip above, so this cluster no longer stacks. */}
+        <div data-tour="transport" className="shrink-0 flex items-center gap-4">
           <button
+            type="button"
             onClick={toggleLoop}
-            className={`p-1 transition-colors ${isLooping ? 'text-purple-400' : 'text-zinc-600 hover:text-white'}`}
+            aria-label={isLooping ? 'Looping on' : 'Looping off'}
+            aria-pressed={isLooping}
             title={isLooping ? 'Looping on' : 'Looping off'}
+            className={`${iconButton} ${isLooping ? 'text-purple-400 hover:text-purple-300' : ''}`}
           >
-            <Repeat className="w-4 h-4" />
+            <Repeat className="w-3.5 h-3.5" />
           </button>
           <button
+            type="button"
             onClick={() => seekByFraction(0)}
-            className="text-zinc-500 hover:text-white transition-colors disabled:opacity-30"
             disabled={!inEditorMode && !hasTrack}
+            aria-label="Jump to start"
             title="Jump to start"
+            className={iconButton}
           >
-            <SkipBack className="w-5 h-5 fill-current" />
+            <SkipBack className="w-4 h-4 fill-current" />
           </button>
           <button
+            type="button"
             onClick={handleToggle}
             disabled={!isVjMode && !inEditorMode && !hasTrack}
-            className="w-9 h-9 rounded-full bg-white text-black flex items-center justify-center hover:scale-105 active:scale-95 transition-all shadow-[0_0_15px_rgba(255,255,255,0.2)] disabled:opacity-40 disabled:pointer-events-none"
+            aria-label={displayIsPlaying ? 'Pause' : 'Play'}
             title={displayIsPlaying ? 'Pause' : 'Play'}
+            className={`w-7.5 h-7.5 rounded-full flex items-center justify-center text-white bg-linear-to-br from-purple-400 to-purple-700 ring-1 ring-white/15 transition-all hover:scale-105 hover:brightness-110 active:scale-95 disabled:opacity-40 disabled:pointer-events-none ${
+              displayIsPlaying
+                ? 'shadow-[0_0_18px_rgba(168,85,247,0.6)]'
+                : 'shadow-[0_0_10px_rgba(168,85,247,0.25)]'
+            }`}
           >
-            {displayIsPlaying ? <Pause className="w-5 h-5 fill-current" /> : <Play className="w-5 h-5 fill-current ml-0.5" />}
+            {displayIsPlaying
+              ? <Pause className="w-3.5 h-3.5 fill-current" />
+              : <Play className="w-3.5 h-3.5 fill-current ml-0.5" />}
           </button>
           <button
+            type="button"
             onClick={() => seekByFraction(1)}
-            className="text-zinc-500 hover:text-white transition-colors disabled:opacity-30"
             disabled={!hasTrack}
+            aria-label="Jump to end"
             title="Jump to end"
+            className={iconButton}
           >
-            <SkipForward className="w-5 h-5 fill-current" />
+            <SkipForward className="w-4 h-4 fill-current" />
           </button>
           <button
-            onClick={() => {
-              if (document.fullscreenElement) {
-                void document.exitFullscreen();
-              } else {
-                void document.documentElement.requestFullscreen();
-              }
-            }}
-            className="p-1 text-zinc-600 hover:text-white transition-colors"
+            type="button"
+            onClick={toggleFullscreen}
+            aria-label="Toggle fullscreen"
             title="Toggle fullscreen"
+            className={iconButton}
           >
-            <Maximize2 className="w-4 h-4" />
+            <Maximize2 className="w-3.5 h-3.5" />
           </button>
         </div>
 
-        <TransportProgressRow />
-      </div>
+        {/* 3. Up Next (mirrors Now Playing) + Utilities. flex-1 (mirrors section 1)
+            so the up-next readout fills the space between the transport and the
+            utilities, right-aligned. */}
+        <div className="flex items-center gap-4 flex-1 min-w-0 justify-end">
+          {/* Up Next — mirror of the Now Playing block, right-aligned. Click loads
+              the next track (no formal queue yet, so it's the next library entry).
+              Hidden on narrow windows so the transport and action button keep room. */}
+          <button
+            type="button"
+            onClick={loadNext}
+            disabled={!nextEntry}
+            title={nextEntry ? `Play next: ${nextEntry.title}` : 'Nothing queued'}
+            className="group/next hidden lg:flex flex-col min-w-0 flex-1 items-end text-right gap-0.5 disabled:cursor-default"
+          >
+            <h4 className="text-[13px] font-bold text-zinc-300 group-hover/next:text-white transition-colors truncate tracking-tight leading-tight w-full">
+              {nextEntry?.title ?? 'Nothing queued'}
+            </h4>
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] text-zinc-500 font-mono">
+                {nextEntry ? formatDuration(nextEntry.duration) : '--:--'}
+              </span>
+              <span className="text-[9px] text-emerald-400 font-mono uppercase tracking-widest border border-emerald-500/20 px-1 rounded bg-emerald-500/5">
+                Up Next
+              </span>
+            </div>
+          </button>
+          <div className="flex items-center gap-4 shrink-0">
+            <MasterFxIndicator />
+            <div className="flex items-center gap-2.5">
+              <button
+                type="button"
+                onClick={toggleMute}
+                aria-label={isMuted ? 'Unmute' : 'Mute'}
+                aria-pressed={isMuted}
+                title={isMuted ? 'Unmute' : 'Mute'}
+                className={iconButton}
+              >
+                {isMuted || volume === 0 ? <VolumeX className="w-4 h-4 text-red-400" /> : <Volume2 className="w-4 h-4" />}
+              </button>
+              <SlideTrack min={0} max={100} step={1} value={volume}
+                onChange={(v) => setVolume(v)} className="w-24" ariaLabel="Volume" />
+            </div>
 
-      {/* 3. Up Next (mirrors Now Playing) + Utilities. flex-1 (mirrors section 1)
-          so the up-next readout fills the space between the transport and the
-          utilities, right-aligned. The pr-20 mirrors section 1's pl-20 (orb
-          clearance) so the two flex-1 sides stay equal and the transport — and
-          its PLAY button — lands on the true viewport centre (aligned with the
-          bottom-panel expand chevron). */}
-      <div className="flex items-center gap-3 flex-1 min-w-0 justify-end">
-        {/* Up Next — mirror of the Now Playing block, right-aligned. Click loads
-            the next track (no formal queue yet, so it's the next library entry).
-            Hidden on narrow windows so the transport and action button keep room. */}
-        <button
-          type="button"
-          onClick={loadNext}
-          disabled={!nextEntry}
-          title={nextEntry ? `Play next: ${nextEntry.title}` : 'Nothing queued'}
-          className="group/next hidden lg:flex flex-col min-w-0 flex-1 items-end text-right disabled:cursor-default"
-        >
-          <h4 className="text-[13px] font-bold text-zinc-300 group-hover/next:text-white transition-colors truncate tracking-tight w-full">
-            {nextEntry?.title ?? 'Nothing queued'}
-          </h4>
-          <div className="flex items-center gap-2">
-            <span className="text-[10px] text-zinc-500 font-mono">
-              {nextEntry ? formatDuration(nextEntry.duration) : '--:--'}
-            </span>
-            <span className="text-[9px] text-emerald-400 font-mono uppercase tracking-widest border border-emerald-500/20 px-1 rounded bg-emerald-500/5">
-              Up Next
-            </span>
-          </div>
-        </button>
-        <div className="flex items-center gap-5 shrink-0">
-          <MasterFxIndicator />
-          <div className="flex items-center gap-3">
-            <button onClick={toggleMute} className="text-zinc-500 hover:text-white transition-colors" title={isMuted ? 'Unmute' : 'Mute'}>
-              {isMuted || volume === 0 ? <VolumeX className="w-4 h-4 text-red-400" /> : <Volume2 className="w-4 h-4" />}
-            </button>
-            <SlideTrack min={0} max={100} step={1} value={volume}
-              onChange={(v) => setVolume(v)} className="w-20" ariaLabel="Volume" />
-          </div>
+            <div className="h-6 w-px bg-white/5" />
 
-          <div className="h-6 w-px bg-white/5" />
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={handleDownload}
+                disabled={!hasTrack}
+                aria-label="Download current track"
+                title="Download current track"
+                className={iconButton}
+              >
+                <Download className="w-4 h-4" />
+              </button>
+              <button type="button" aria-label="More options" title="More options" className={iconButton}>
+                <MoreHorizontal className="w-4 h-4" />
+              </button>
+            </div>
 
-          <div className="flex items-center gap-2">
-            <button
-              onClick={handleDownload}
-              disabled={!hasTrack}
-              className="p-2 border border-white/5 rounded-lg hover:border-purple-500/50 hover:bg-purple-500/5 transition-all text-zinc-500 hover:text-purple-400 disabled:opacity-30 disabled:pointer-events-none"
-              title="Download current track"
-            >
-               <Download className="w-4 h-4" />
-            </button>
-            <button className="p-2 border border-white/5 rounded-lg hover:border-white/20 transition-all text-zinc-500 hover:text-white">
-               <MoreHorizontal className="w-4 h-4" />
-            </button>
-          </div>
+            <div className="h-6 w-px bg-white/5" />
 
-          <div className="h-6 w-px bg-white/5" />
-
-          {/* The workspace action button (CREATE / PROCESS / TRAIN / …) — lives
-              at the footer's bottom-right on EVERY tab. Rounded 2×1, sized to
-              sit inside the 56px footer. */}
-          <div data-tour="action-button" className="shrink-0 w-20 h-10">
-            <LogActionButton />
+            {/* The workspace action button (CREATE / PROCESS / TRAIN / …) — lives
+                at the footer's bottom-right on EVERY tab. Rounded 2×1, sized to
+                sit inside the 48px row. */}
+            <div data-tour="action-button" className="shrink-0 w-20 h-10">
+              <LogActionButton />
+            </div>
           </div>
         </div>
       </div>
-
     </footer>
   );
 };
-

--- a/frontend/src/components/layout/Shell.tsx
+++ b/frontend/src/components/layout/Shell.tsx
@@ -283,7 +283,8 @@ export const Shell: React.FC = () => {
       style={{
         ...({ '--layout-zoom': String(layoutZoom) } as React.CSSProperties),
         zoom: layoutZoom,
-        height: 'calc((100vh - 3.5rem) / var(--layout-zoom))',
+        // FOOTER_H (lib/layoutScale.ts) is the fixed, unzoomed PlayerFooter below.
+        height: `calc((100vh - ${FOOTER_H}px) / var(--layout-zoom))`,
         ...(editTheme.vars as React.CSSProperties),
       }}
     >
@@ -705,7 +706,7 @@ const ShellBottomDock: React.FC = () => {
   // Dock-body height — shared by the multi-tab panel (in-flow) and the floating
   // LOG overlay. Maximized fills the work area. The height MUST be computed in
   // the same zoom-aware space as the .dense-layout root (height =
-  // calc((100vh - 3.5rem) / var(--layout-zoom))); a raw `100vh` calc here ignores
+  // calc((100vh - FOOTER_H) / var(--layout-zoom))); a raw `100vh` calc here ignores
   // --layout-zoom and, at zoom > 1, overflows the root's overflow-hidden so the
   // dock's own bottom (e.g. the Score viewer's page/zoom controls) is clipped.
   // Reserve 4.5rem inside the root for the header (h-11 = 44px) + the always-on
@@ -722,7 +723,7 @@ const ShellBottomDock: React.FC = () => {
     Math.min(multiHeight, Math.floor(workAreaH * DOCK_MAX_FRACTION_OF_WORK)),
   );
   const bodyHeight = multiMaximized
-    ? 'calc((100vh - 3.5rem) / var(--layout-zoom) - 4.5rem)'
+    ? `calc((100vh - ${FOOTER_H}px) / var(--layout-zoom) - 4.5rem)`
     : `${effectiveMultiHeight}px`;
   // The LOG strip section auto-fits its content (the telemetry readouts + the
   // fixed action button). Mirror its measured width into logWidth so the LOG

--- a/frontend/src/lib/layoutScale.ts
+++ b/frontend/src/lib/layoutScale.ts
@@ -30,8 +30,9 @@ import { useEffect, useState } from 'react';
 
 export const DESIGN_W = 1600;
 export const DESIGN_SHELL_H = 820;
-/** PlayerFooter height (h-20) — fixed, outside the zoomed subtree. */
-export const FOOTER_H = 56;
+/** PlayerFooter height (h-16: a 16px scrub strip over a 48px control row) —
+ *  fixed, outside the zoomed subtree. PlayerFooter's `h-16` must match. */
+export const FOOTER_H = 64;
 export const LAYOUT_ZOOM_MIN = 0.6;
 export const LAYOUT_ZOOM_MAX = 1.1;
 

--- a/frontend/src/lib/layoutScale.ts
+++ b/frontend/src/lib/layoutScale.ts
@@ -2,7 +2,7 @@
  * Continuous, width AND height aware shell scale.
  *
  * The DAW is designed against a fixed logical canvas (DESIGN_W x DESIGN_SHELL_H
- * CSS px for the Shell, plus the unzoomed 56px (h-14) PlayerFooter beneath it). The
+ * CSS px for the Shell, plus the unzoomed FOOTER_H px (h-16) PlayerFooter beneath it). The
  * Shell renders under CSS `zoom` so that canvas always fits the real window:
  *
  *   zoom = clamp(MIN, min(innerWidth / DESIGN_W, (innerHeight - FOOTER_H) / DESIGN_SHELL_H), MAX)


### PR DESCRIPTION
This pull request updates the layout scaling logic and related constants to improve consistency and maintainability, specifically by changing the way the footer height is defined and referenced throughout the codebase. The main change is updating the value of `FOOTER_H` from 56px to 64px and ensuring all layout calculations consistently use this value instead of hardcoded numbers.

**Layout scaling and footer height consistency:**

* Updated the `FOOTER_H` constant in `layoutScale.ts` from 56px to 64px and clarified its documentation to match the actual PlayerFooter height (`h-16`).
* Replaced hardcoded footer height values (`3.5rem` or `56px`) in `Shell.tsx` with the `FOOTER_H` constant for all relevant `calc()` expressions, ensuring consistent layout scaling. [[1]](diffhunk://#diff-50788eb4f31ab61bd22ee002824fe8b21e5da586e8cd7e9a928e00dfe9a9b868L286-R287) [[2]](diffhunk://#diff-50788eb4f31ab61bd22ee002824fe8b21e5da586e8cd7e9a928e00dfe9a9b868L725-R726)
* Updated code comments in both `Shell.tsx` and `layoutScale.ts` to reference `FOOTER_H` instead of hardcoded values, improving clarity and maintainability. [[1]](diffhunk://#diff-50788eb4f31ab61bd22ee002824fe8b21e5da586e8cd7e9a928e00dfe9a9b868L708-R709) [[2]](diffhunk://#diff-116c039a7c0cbf279a7bd39ce933afc4d55220e8db240f43f612833883d5bd6fL5-R5)