### PR TITLE
Orb transparent and theme keys

### DIFF
--- a/frontend/src/components/audio/FerroOrbCore.tsx
+++ b/frontend/src/components/audio/FerroOrbCore.tsx
@@ -20,6 +20,7 @@ import { createRenderGate } from '../../lib/renderGate';
 import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { vs as sphereVS } from './cymatics/sphere-shader';
 import { HybridSource, IdleSource, type FreqSource } from './cymatics/hybrid-source';
 import { getMasterGain } from '../../state/playerStore';
@@ -37,7 +38,12 @@ const FerroOrbCore: React.FC = () => {
 
     let renderer: THREE.WebGLRenderer;
     try {
-      renderer = new THREE.WebGLRenderer({ antialias: true });
+      // A transparent canvas: only the ferrofluid body and its bloom are
+      // painted, so the orb has no disc behind it and no hard edge — the app
+      // shows through around the sphere. premultipliedAlpha off, because the
+      // bloom pass blends additively over a cleared-to-transparent screen and a
+      // premultiplied canvas would darken the halo's fringe.
+      renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, premultipliedAlpha: false });
     } catch {
       // WebGL unavailable / context exhausted — the CSS gradient core beneath
       // this overlay stays visible, so the orb still renders.
@@ -56,10 +62,13 @@ const FerroOrbCore: React.FC = () => {
     const noiseViscosity = 1.2;
     const isFerrofluid = 1.0;
 
+    renderer.setClearColor(0x000000, 0);
+
     const scene = new THREE.Scene();
-    // The panels' backdrop dome resolves to this deep violet-black; a flat
-    // color here keeps bloom simple at 48px (the dome would be invisible).
-    scene.background = new THREE.Color(0x0e0912);
+    // No background: the scene clears to transparent and the sphere's own
+    // silhouette is the orb's edge. (It used to clear to a flat violet-black,
+    // which drew a disc behind the body with a hard rim against the app.)
+    scene.background = null;
 
     const camera = new THREE.PerspectiveCamera(FOV, 1, 0.1, 1000);
 
@@ -131,6 +140,12 @@ const FerroOrbCore: React.FC = () => {
     const composer = new EffectComposer(renderer);
     composer.addPass(renderPass);
     composer.addPass(bloomPass);
+    // The bloom pass must not be the pass that reaches the screen: when it is,
+    // it copies the frame with an opaque MeshBasicMaterial, which three
+    // compiles with OPAQUE and forces alpha to 1 — the whole canvas became a
+    // dark disc around the sphere. OutputPass copies the composed frame with
+    // its alpha intact, so everything outside the body stays transparent.
+    composer.addPass(new OutputPass());
 
     const applySize = () => {
       const w = container.clientWidth || 1;

--- a/frontend/src/components/audio/PlayerFooter.tsx
+++ b/frontend/src/components/audio/PlayerFooter.tsx
@@ -157,7 +157,7 @@ const ScrubStrip: React.FC = () => {
             <div className="absolute inset-y-0 left-0 bg-white/10" style={{ width: `${hover * 100}%` }} />
           )}
           <div
-            className="absolute inset-y-0 left-0 bg-purple-500"
+            className="absolute inset-y-0 left-0 bg-[rgb(var(--et-accent))]"
             style={{ width: `${frac * 100}%` }}
           />
         </div>
@@ -236,11 +236,11 @@ const MasterFxIndicator: React.FC = () => {
         onClick={openMix}
         aria-label={`${count} master effect${plural} live on the output — open MIX`}
         title={`${count} effect${plural} on the master insert${takers > 0 ? ', some of which take level' : ''}. Open MIX.`}
-        className="flex items-center gap-1.5 pl-2 pr-1.5 py-1 rounded-l border border-r-0 border-purple-500/40 bg-purple-500/10 text-purple-200 hover:bg-purple-500/20 hover:border-purple-400/70 transition-colors shadow-[0_0_12px_rgba(168,85,247,0.18)]"
+        className="flex items-center gap-1.5 pl-2 pr-1.5 py-1 rounded-l border border-r-0 border-[rgb(var(--et-accent)/0.4)] bg-[rgb(var(--et-accent)/0.1)] text-[rgb(var(--et-accent))] hover:bg-[rgb(var(--et-accent)/0.2)] hover:border-[rgb(var(--et-accent)/0.7)] transition-colors shadow-[0_0_12px_rgb(var(--et-accent)/0.18)]"
       >
         <Activity className="w-3 h-3" />
         <span className="text-[9px] font-black uppercase tracking-widest">Master FX</span>
-        <span className="text-[9px] font-mono text-purple-300">{count}</span>
+        <span className="text-[9px] font-mono text-[rgb(var(--et-accent))]">{count}</span>
       </button>
       <button
         type="button"
@@ -248,16 +248,16 @@ const MasterFxIndicator: React.FC = () => {
         aria-label={open ? 'Hide what is on the master insert' : 'Show what is on the master insert'}
         aria-expanded={open}
         aria-controls="master-fx-detail"
-        className="px-1 py-1 rounded-r border border-purple-500/40 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 hover:border-purple-400/70 transition-colors"
+        className="px-1 py-1 rounded-r border border-[rgb(var(--et-accent)/0.4)] bg-[rgb(var(--et-accent)/0.1)] text-[rgb(var(--et-accent))] hover:bg-[rgb(var(--et-accent)/0.2)] hover:border-[rgb(var(--et-accent)/0.7)] transition-colors"
       >
         <ChevronUp className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
       {open && (
         <div
           id="master-fx-detail"
-          className="absolute bottom-full right-0 mb-2 w-64 flex flex-col gap-2 p-2.5 rounded-lg border border-purple-500/30 bg-[#0a080f] shadow-[0_0_24px_rgba(168,85,247,0.2)]"
+          className="absolute bottom-full right-0 mb-2 w-64 flex flex-col gap-2 p-2.5 rounded-lg border border-[rgb(var(--et-accent)/0.3)] bg-[#0a080f] shadow-[0_0_24px_rgb(var(--et-accent)/0.2)]"
         >
-          <span className="text-[9px] font-black uppercase tracking-widest text-purple-300">On the master insert</span>
+          <span className="text-[9px] font-black uppercase tracking-widest text-[rgb(var(--et-accent))]">On the master insert</span>
           <p className="text-[10px] leading-snug text-zinc-400">
             These sit between the mix bus and the meter, so they shape everything the
             transport plays — in every tab, until they are switched off.
@@ -276,14 +276,14 @@ const MasterFxIndicator: React.FC = () => {
             <button
               type="button"
               onClick={openMix}
-              className="flex-1 px-2 py-1 rounded border border-white/10 text-[9px] font-black uppercase tracking-widest text-zinc-300 hover:border-purple-400/60 hover:text-purple-200 transition-colors"
+              className="flex-1 px-2 py-1 rounded border border-white/10 text-[9px] font-black uppercase tracking-widest text-zinc-300 hover:border-[rgb(var(--et-accent)/0.6)] hover:text-[rgb(var(--et-accent))] transition-colors"
             >
               Show in MIX
             </button>
             <button
               type="button"
               onClick={bypassLiveRack}
-              className="flex-1 px-2 py-1 rounded border border-purple-500/40 bg-purple-500/10 text-[9px] font-black uppercase tracking-widest text-purple-200 hover:bg-purple-500/20 hover:border-purple-400/70 transition-colors"
+              className="flex-1 px-2 py-1 rounded border border-[rgb(var(--et-accent)/0.4)] bg-[rgb(var(--et-accent)/0.1)] text-[9px] font-black uppercase tracking-widest text-[rgb(var(--et-accent))] hover:bg-[rgb(var(--et-accent)/0.2)] hover:border-[rgb(var(--et-accent)/0.7)] transition-colors"
             >
               Bypass all
             </button>
@@ -325,12 +325,12 @@ const transportKey = 'h-full w-8 flex flex-col items-center justify-center gap-0
  */
 const transportKeyOff = 'bg-white/5 text-zinc-400 hover:text-zinc-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),inset_0_0_0_100px_rgba(255,255,255,0.06)]';
 /**
- * …toggle ON: latched IN (inset shade, one tint step up) with purple ink — the
- * glyph and legend take currentColor, so nothing else is needed and no light is
- * added. A plain class rather than an `aria-pressed:` variant, so the scope's
- * accent remaps (purple-300 on dark themes, purple-700 on light) keep applying.
+ * …toggle ON: latched IN (inset shade, one tint step up) in the theme's accent
+ * ink (`--et-accent`, editThemes.ts: the theme's own hue, or purple on a
+ * neutral theme) — the glyph and legend take currentColor, so nothing else is
+ * needed and no light is added. Hover brightens the whole key a step.
  */
-const transportKeyOn = 'bg-white/10 text-purple-400 hover:text-purple-300 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] hover:shadow-[inset_0_1px_2px_rgba(0,0,0,0.6),inset_0_0_0_100px_rgba(255,255,255,0.04)]';
+const transportKeyOn = 'bg-white/10 text-[rgb(var(--et-accent))] hover:brightness-110 shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)] hover:shadow-[inset_0_1px_2px_rgba(0,0,0,0.6),inset_0_0_0_100px_rgba(255,255,255,0.04)]';
 /**
  * …disabled: the key keeps its cap — a dead START/END stays a tile in the grid,
  * not a hole — and only its glyph and legend dim, to 40 % of the live ink, so
@@ -347,12 +347,12 @@ const transportKeyDead = 'bg-white/5 text-zinc-400 [&>*]:opacity-40 shadow-[inse
 const transportPlayKey = 'h-full w-11 flex flex-col items-center justify-center gap-0.5 rounded-none select-none border-b transition-[color,box-shadow,border-color] duration-100 active:shadow-[inset_0_1px_2px_rgba(0,0,0,0.7)] focus-visible:relative focus-visible:z-10 disabled:pointer-events-none';
 const transportPlayRest = 'bg-white/10 text-zinc-100 border-b-transparent shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.1),inset_0_0_0_100px_rgba(255,255,255,0.08)]';
 /**
- * …while playing: the same fill and shadow, purple ink and a 1px etched purple
- * bottom edge (rgba(168,85,247), sitting 1px above the plate's own hairline) —
- * the grammar of a latched LOOP/RAND, so it reads across the room on the DJ/VJ
- * tabs where this key is the master transport. No glow.
+ * …while playing: the same fill and shadow, accent ink and a 1px etched accent
+ * bottom edge (sitting 1px above the plate's own hairline) — the grammar of a
+ * latched LOOP/RAND, so it reads across the room on the DJ/VJ tabs where this
+ * key is the master transport. No glow.
  */
-const transportPlayOn = 'bg-white/10 text-purple-400 hover:text-purple-300 border-b-purple-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.1),inset_0_0_0_100px_rgba(255,255,255,0.06)]';
+const transportPlayOn = 'bg-white/10 text-[rgb(var(--et-accent))] hover:brightness-110 border-b-[rgb(var(--et-accent))] shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.1),inset_0_0_0_100px_rgba(255,255,255,0.06)]';
 const transportPlayDead = 'bg-white/10 text-zinc-100 [&>*]:opacity-40 border-b-transparent shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]';
 /**
  * The etched legend under each glyph. Decorative (aria-hidden — the key's
@@ -366,7 +366,7 @@ const keyLabel = 'text-[8px] font-mono uppercase tracking-widest leading-none';
 /**
  * The four motion glyphs, hard-cornered (no rounded joins) so they read as one
  * engraved set at 14px — lucide's round joins go soft that small. Fill-only in
- * currentColor, so the key's ink, hover ink and ON purple flow straight in.
+ * currentColor, so the key's ink, hover ink and ON accent flow straight in.
  */
 const Glyph: React.FC<{ d: string; className?: string }> = ({ d, className }) => (
   <svg viewBox="0 0 14 14" fill="currentColor" aria-hidden="true" focusable="false" className={className}>
@@ -630,7 +630,7 @@ export const PlayerFooter: React.FC = () => {
               {displayLabel ?? 'No output loaded'}
             </h4>
             <div className="flex items-center gap-2">
-              <span className="text-[9px] text-purple-400 font-mono uppercase tracking-widest border border-purple-500/20 px-1 rounded-xs bg-purple-500/5">
+              <span className="text-[9px] text-[rgb(var(--et-accent))] font-mono uppercase tracking-widest border border-[rgb(var(--et-accent)/0.25)] px-1 rounded-xs bg-[rgb(var(--et-accent)/0.06)]">
                 {lastModelName ? lastModelName.toUpperCase() : (displayLabel ? 'LIBRARY' : 'IDLE')}
               </span>
               <span className="text-[10px] text-zinc-500 font-mono">

--- a/frontend/src/components/layout/ProcessingLog.tsx
+++ b/frontend/src/components/layout/ProcessingLog.tsx
@@ -346,8 +346,11 @@ export const LogBody: React.FC = () => {
 // high-contrast inverse (light chip, dark text) so state is unmissable.
 const ACTION_BASE =
   'relative w-full h-full overflow-hidden rounded-lg border font-black uppercase tracking-widest text-[9px] leading-tight flex items-center justify-center text-center px-1 transition-colors disabled:cursor-not-allowed';
-const ACTION_IDLE = 'bg-white/8 hover:bg-white/15 border-white/15 text-zinc-200';
-const ACTION_HOT = 'bg-zinc-100 hover:bg-white border-white/80 text-black';
+// Both states draw on the theme's accent (`--et-accent`, editThemes.ts): a
+// neutral white block read as foreign on the hued themes. Idle is a tinted
+// ghost of it; hot is the solid accent with the ink that reads on it.
+const ACTION_IDLE = 'bg-[rgb(var(--et-accent)/0.12)] hover:bg-[rgb(var(--et-accent)/0.22)] border-[rgb(var(--et-accent)/0.45)] text-[rgb(var(--et-accent))]';
+const ACTION_HOT = 'bg-[rgb(var(--et-accent))] hover:brightness-110 border-[rgb(var(--et-accent))] text-[rgb(var(--et-accent-ink))]';
 
 export const LogActionButton: React.FC = () => {
   const centerTab     = useAppUiStore((s) => s.centerTab);

--- a/frontend/src/lib/editThemes.ts
+++ b/frontend/src/lib/editThemes.ts
@@ -646,18 +646,50 @@ export function resolveEditThemeVars(
 ): ResolvedEditTheme {
   if (id === CUSTOM_IMAGE_ID && customImage) {
     return {
-      vars: {
+      vars: withAccent({
         ...DEFAULT_ET_VARS,
         ...CUSTOM_IMAGE_VARS,
         // Scrim gradient over the image keeps foreground content legible.
         '--et-root-bg': `linear-gradient(rgba(6,6,10,0.45), rgba(6,6,10,0.45)), url("${customImage}") center / cover no-repeat`,
-      },
+      }, false),
       light: false,
     };
   }
   const theme = editThemeById(id) ?? editThemeById('obsidian') ?? EDIT_THEMES[0];
   return {
-    vars: { ...DEFAULT_ET_VARS, ...theme.vars },
+    vars: withAccent({ ...DEFAULT_ET_VARS, ...theme.vars }, !!theme.light),
     light: !!theme.light,
   };
+}
+
+const parseTriplet = (v: string | undefined): [number, number, number] | null => {
+  if (!v) return null;
+  const n = v.trim().split(/\s+/).map(Number);
+  return n.length === 3 && n.every((x) => Number.isFinite(x)) ? [n[0], n[1], n[2]] : null;
+};
+
+/** A tint whose channels spread less than this is a grey, not a hue. */
+const NEUTRAL_CHROMA = 30;
+
+/**
+ * `--et-accent` / `--et-accent-ink`: the hue the footer's latched transport
+ * keys, the scrub fill and the action button use, and the ink that reads on
+ * a solid fill of it. A hued theme's accent is its own tint (Navy & Gold's
+ * gold, Sage & Terracotta's clay) so the chrome stops fighting the theme; a
+ * neutral theme keeps the app's purple, darkened on light grounds. A theme
+ * that sets `--et-accent` itself is left alone.
+ */
+export function withAccent(vars: Record<string, string>, light: boolean): Record<string, string> {
+  const out = { ...vars };
+  if (!out['--et-accent']) {
+    const tint = parseTriplet(out['--et-tint']);
+    const chroma = tint ? Math.max(...tint) - Math.min(...tint) : 0;
+    out['--et-accent'] = tint && chroma >= NEUTRAL_CHROMA ? tint.join(' ') : light ? '126 34 206' : '168 85 247';
+  }
+  if (!out['--et-accent-ink']) {
+    const a = parseTriplet(out['--et-accent']) ?? [168, 85, 247];
+    const luminance = (0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2]) / 255;
+    out['--et-accent-ink'] = luminance > 0.6 ? '0 0 0' : '255 255 255';
+  }
+  return out;
 }

--- a/frontend/src/orb-kit/styles/gantasmo-orb.css
+++ b/frontend/src/orb-kit/styles/gantasmo-orb.css
@@ -217,9 +217,11 @@
 
 /* The ferrofluid canvas IS the body for this orb, so the stock purple gradient
    core underneath it only ever showed as a rim around the canvas edge — another
-   ring by another name. Same for the face's white drop-shadow halo. */
+   ring by another name. Same for the face's white drop-shadow halo. The canvas
+   is transparent (FerroOrbCore clears to alpha 0), so the core has NO fill at
+   all: a flat colour here drew a disc with a hard edge around the body. */
 .gantasmo-orb-theme.orb-2x .orb-core-main {
-    background: #05040a;
+    background: transparent;
 }
 
 .gantasmo-orb-theme.orb-2x .gantasmo-face svg {


### PR DESCRIPTION
This pull request makes significant improvements to theming and visual rendering in the audio player UI, focusing on two main areas: (1) introducing a dynamic accent color system for consistent theming across components, and (2) updating the ferrofluid orb rendering for proper transparency and compositing. The changes ensure that UI elements adapt their accent color based on the current theme, and that the orb's canvas is truly transparent, allowing for seamless integration with the application's background.

**Theming and Accent Color System Updates:**

* Introduced the `withAccent` function in `editThemes.ts` to automatically set `--et-accent` and `--et-accent-ink` CSS variables based on the theme's tint, falling back to purple for neutral themes, and ensuring readable ink on any background. All relevant UI components now use these variables instead of hardcoded purple values.
* Refactored all accent color usages in `PlayerFooter.tsx`, including scrub strips, master FX indicators, transport keys, and output labels, to use `rgb(var(--et-accent))` and related variables, ensuring consistent theming across the UI. [[1]](diffhunk://#diff-f4aff1c8ead3c887ff2ed6307283cc4c7b21fefb5b49936e7954fdabb6aa4672L160-R160) [[2]](diffhunk://#diff-f4aff1c8ead3c887ff2ed6307283cc4c7b21fefb5b49936e7954fdabb6aa4672L239-R260) [[3]](diffhunk://#diff-f4aff1c8ead3c887ff2ed6307283cc4c7b21fefb5b49936e7954fdabb6aa4672L279-R286) [[4]](diffhunk://#diff-f4aff1c8ead3c887ff2ed6307283cc4c7b21fefb5b49936e7954fdabb6aa4672L328-R333) [[5]](diffhunk://#diff-f4aff1c8ead3c887ff2ed6307283cc4c7b21fefb5b49936e7954fdabb6aa4672L350-R355) [[6]](diffhunk://#diff-f4aff1c8ead3c887ff2ed6307283cc4c7b21fefb5b49936e7954fdabb6aa4672L369-R369) [[7]](diffhunk://#diff-f4aff1c8ead3c887ff2ed6307283cc4c7b21fefb5b49936e7954fdabb6aa4672L633-R633)
* Updated action button styles in `ProcessingLog.tsx` to use the new accent color system for both idle and active states, replacing previous neutral or purple backgrounds with theme-appropriate colors.

**Ferrofluid Orb Rendering Improvements:**

* Modified `FerroOrbCore.tsx` to render the orb on a fully transparent canvas by setting `alpha: true` and `premultipliedAlpha: false` on the renderer, clearing the background to transparency, and adding an `OutputPass` to preserve alpha in the final composited image. This removes the hard disc behind the orb and allows the app background to show through. [[1]](diffhunk://#diff-b407133bb93cdbfa678897ad1aad7433400680e7922f0f79a412bda54f963526R23) [[2]](diffhunk://#diff-b407133bb93cdbfa678897ad1aad7433400680e7922f0f79a412bda54f963526L40-R46) [[3]](diffhunk://#diff-b407133bb93cdbfa678897ad1aad7433400680e7922f0f79a412bda54f963526R65-R71) [[4]](diffhunk://#diff-b407133bb93cdbfa678897ad1aad7433400680e7922f0f79a412bda54f963526R143-R148)
* Updated `gantasmo-orb.css` to set the orb core's background to transparent, matching the new rendering logic and ensuring no unwanted disc or rim appears around the orb.