### PR TITLE
Docs rag refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 2. **Make a track.** Open the MAKE tab, type a prompt, press CREATE. Models do not download by themselves. Allow downloads once in **Settings → Models** and the first CREATE fetches the model it needs. The `small` model runs on a CPU. The `medium` model needs an NVIDIA GPU.
 3. **Do more with it.** Right-click the new track in the library to open it in EDIT, MIX, SCORE or SING, or to load it on a DJ deck. The assistant orb in the bottom left corner answers questions about the app from the manual.
 
-> The in-app **TOUR** shows every tab, and **Feature Notes** stay pinned to the few controls that carry no label — the library's edge tab, the LOG strip, the PANELS strip — until you have used them. The menu brings them back. The [User Guide](docs/USER_GUIDE.md) is the full reference.
+> The in-app **TOUR** shows every tab, and **Feature Notes** stay pinned to the few controls that carry no label — the LOG strip and the PANELS strip — until you have used them, and the header's **?** search takes you to anything that does have one. The menu brings them back. The [User Guide](docs/USER_GUIDE.md) is the full reference.
 
 ## What you can do
 
@@ -61,7 +61,7 @@
 
 **Included at no cost.** Stem separation up to 12 stems, a mastering suite, VST3 hosting, the HRTF spatializer The Owl, DJ decks with sync and Automix, audio-to-MIDI with engraving, LoRA training, forced-aligned lyrics with a whisper review, a rhyme and literary reading of any lyric, and export to WAV, MP3, FLAC, OGG, AIFF, Opus, M4A, MIDI, MusicXML and LRC. Every model in that list runs on the GPU when there is one, one at a time, and never twice for the same song.
 
-**Only in theDAW.** [theDAW-XR](https://github.com/gantasmo/theDAW-XR) hand-tracked control on Meta Quest 3, Chimera clip fusion, DRAW (draw on a canvas to play generative music), native Audima Sway motion-controller support, The Foundry plugin designer, import of Ableton, Reaper, FL Studio, Audacity, Audition, Bitwig and Resolume projects, the first non-Mac port of Magenta RealTime 2, and sixteen themes plus a custom theme built from any image.
+**Only in theDAW.** [theDAW-XR](https://github.com/gantasmo/theDAW-XR) hand-tracked control on Meta Quest 3, Chimera clip fusion, DRAW (draw on a canvas to play generative music), native Audima Sway motion-controller support, The Foundry plugin designer, import of Ableton, Reaper, FL Studio, Audacity, Audition, Bitwig and Resolume projects, the first non-Mac port of Magenta RealTime 2, and 28 themes plus a custom theme built from any image.
 
 ---
 
@@ -301,13 +301,16 @@ ARC checkpoints are post-trained for 8-step inference at `cfg_scale=1`. RF check
 
 ```python
 from stable_audio_3 import StableAudioModel
+from backend.lib.audio_io import load_audio   # never torchaudio.load — see docs/guides/audio-io.md
 pipe = StableAudioModel.from_pretrained("medium")
 
 # Text-to-audio
 audio = pipe.generate(prompt="Lo-fi boom bap meets orchestral strings, 84 BPM", duration=180)
 
 # Audio-to-audio. init_noise_level sets how far the result moves from the source.
-audio = pipe.generate(init_audio=torchaudio.load("in.wav"), init_noise_level=0.9,
+wav, sr = load_audio("in.wav")               # returns (tensor, sample_rate)
+audio = pipe.generate(init_audio=(sr, wav),  # the pipeline wants (sample_rate, tensor)
+                      init_noise_level=0.9,
                       prompt="bossa nova bassline", duration=30)
 
 # LoRA adapters stack; the strength can be changed at runtime.
@@ -327,7 +330,7 @@ audio = pipe.generate(
 
 ## Themes and layout
 
-**Change the theme.** The hamburger menu opens Change Theme: sixteen themes (dark, metallic, paper, pastel and colour families) plus a custom theme built from any background image. A theme recolours every surface through shared design tokens. The screenshots on this page use **Brushed Steel**. Obsidian is the default.
+**Change the theme.** The hamburger menu opens Change Theme: 28 themes in seven groups (dark, metal, duotone, light, light duotone, pastel and gradient) plus a custom theme built from any background image. A theme recolours every surface through shared design tokens. The screenshots on this page use **Brushed Steel**. Obsidian is the default.
 
 <p align="center">
   <img src="docs/readme/themes/obsidian.png" alt="Obsidian theme" width="150">
@@ -384,7 +387,7 @@ The GitHub **[Wiki](https://github.com/gantasmo/theDAW/wiki)** has the same inde
 | **ML pipeline** | `stable_audio_3/` | The DiT diffusion transformer, the SAME autoencoder, all samplers, LoRA training and inference, distribution-shift schedules. |
 | **FastAPI backend** | `backend/server.py` | The HTTP server on port 8600: a generation job queue, FFmpeg audio processing, and model introspection. |
 | **Backend modules** | `backend/modules/` | A plugin system. Each subdirectory has a `module.json` and a `router.py`. The loader mounts every enabled module and isolates failures: `analysis`, `chimera`, `effects`, `library`, `lyrics`, `midi`, `notation`, `stems`, `vocal`, `suno`, `magenta`, the XR bridges, `foundry`, `underfit`, and the rest. |
-| **theDAW interface** | `frontend/` | React 19, Vite 7, Tailwind 4, Zustand 5. Thirteen tabs (MAKE, EDIT, MIX, PERFORM, DJ, VJ, SWAY, FOUNDRY, UNDERFIT, NODEFI, LOOM, LEARN, TOUR), the library and Catalogue, and the bottom panel (Levels, Visualize, MIDI, Sequence, DRAW, Score, Sing, Details, Media, SLIDE, SWAY). The dev server on port 5173 proxies `/api/*` to the backend. |
+| **theDAW interface** | `frontend/` | React 19, Vite 7, Tailwind 4, Zustand 5. Thirteen tabs (MAKE, EDIT, MIX, PERFORM, DJ, VJ, SWAY, FOUNDRY, UNDERFIT, NODEFI, LOOM, LEARN, TOUR), the library and Catalogue, and the bottom panel (Levels, Visualize, MIDI, Sequence, DRAW, Score, Sing, Lyric, Details, SLIDE, SWAY). The dev server on port 5173 proxies `/api/*` to the backend. |
 | **Sidecars** | `sidecars/` | The vendored `magenta-rt2-nvidia` port, the `questcast` and `queststitch` Quest bridges, and the `magenta` studio sidecar. Demucs and whisper build their own isolated environments on first use. |
 
 ```text

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ theDAW generates its own documentation from the running app. `scripts/screenshot
 
 **Out of memory on the Medium model.** Use the `small` model, a shorter `duration`, or close other CUDA processes.
 
-**Static or noise from the Medium model on Windows.** Check `GET /api/health` for `flash_attention_active`. On Turing GPUs (RTX 20xx, GTX 16xx) it reads false by design and the model runs on an equivalent fallback. On Ampere or newer with a broken wheel, reinstall a matching wheel from [kingbri1/flash-attention](https://github.com/kingbri1/flash-attention/releases).
+**Static or noise from the Medium model on Windows.** Check `GET /api/health` for `flash_attention_active`. On Turing GPUs (RTX 20xx, GTX 16xx) it reads false by design and the model runs on an equivalent fallback. On Ampere or newer with a broken wheel, re-sync it — `uv sync --reinstall-package flash-attn`. The wheel has to match **torch 2.14 + CUDA 13**, which is what this project pins; `pyproject.toml` selects the `flash_attn-2.8.3+cu130torch2.14-cp3XX-cp3XX-win_amd64.whl` asset for your Python minor from [mjun0812/flash-attention-prebuild-wheels v0.10.2](https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/tag/v0.10.2). A wheel built for any other torch/CUDA pair will not import.
 
 [User Guide §23](docs/USER_GUIDE.md#23-troubleshooting) has the full list.
 

--- a/backend/rag.py
+++ b/backend/rag.py
@@ -48,10 +48,15 @@ DOC_PATHS = [
     # its confidence and `?` marks, syncopation, swing, polymeter, cross-rhythms
     # — and the six things that silently break any beat-synchronous analysis.
     PROJECT_ROOT / "docs" / "guides" / "rhythm-analysis.md",
-    # Onboarding: the pinned labels on the library rail, LOG and PANELS, why
-    # they retire themselves, and the menu entry that brings them back. Indexed
-    # because "where is the library?" is exactly what gets asked here.
+    # Onboarding: the header's "?" feature search, the pinned LOG and PANELS
+    # labels, why they retire themselves, and the menu entry that brings them
+    # back. Indexed because "where is the library?" is exactly what gets asked
+    # here — and the "?" search is now the answer to it.
     PROJECT_ROOT / "docs" / "guides" / "feature-notes.md",
+    # The app-wide theme system: the 28 themes plus the custom-image theme, what
+    # a theme does and does not recolour, the derived accent, and the --et-*
+    # variables. "How do I change the colours?" has no other doc.
+    PROJECT_ROOT / "docs" / "guides" / "themes.md",
     PROJECT_ROOT / "docs" / "guides" / "foundry.md",
     PROJECT_ROOT / "docs" / "guides" / "underfit.md",
     PROJECT_ROOT / "docs" / "UI" / "hover-text-guide.md",
@@ -79,12 +84,20 @@ DOC_PATHS = [
     # punches, the routing that travels in a .tasmo, the shipped performance
     # templates, and the Kargyraa Sub subharmonic bass engine.
     PROJECT_ROOT / "docs" / "guides" / "sway-perform-live.md",
+    # LOOM (the thirteenth tab) and the Shard Index underneath it: what a shard
+    # is, how the crate and the colony work, the generators and free meters, and
+    # the /api/shards routes. Nothing else in the index mentions either.
+    PROJECT_ROOT / "docs" / "guides" / "loom-and-shards.md",
     # Code-grounded reference tree (July 2026): one page per subsystem listing
     # every feature with the exact models/libraries it uses, the full HTTP API by
     # router cluster, and the offline/performance story. Each page cites its
     # source as path:line — when a feature changes, update its page in the same
     # commit so the assistant keeps answering from the current behavior.
     PROJECT_ROOT / "docs" / "OFFLINE-AND-PERFORMANCE.md",
+    # backend/lib/audio_io.py as THE audio I/O layer, and the standing rule that
+    # torchaudio.load / save are never called. Indexed so the assistant stops
+    # handing people torchaudio snippets that raise in this venv.
+    PROJECT_ROOT / "docs" / "guides" / "audio-io.md",
     PROJECT_ROOT / "docs" / "reference" / "README.md",
     PROJECT_ROOT / "docs" / "reference" / "features" / "00-overview.md",
     PROJECT_ROOT / "docs" / "reference" / "features" / "01-generation-core.md",

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -24,7 +24,7 @@ Two named volumes persist state across container recreation:
 
 ## GPU enablement
 
-The torch 2.7.1+cu126 wheels baked into the image bundle the CUDA userspace
+The torch 2.14.0+cu130 wheels baked into the image bundle the CUDA userspace
 libraries, so the image itself contains no CUDA toolkit and needs none. GPU
 access requires two things on the host:
 
@@ -66,7 +66,7 @@ and the rest of the app keeps working.
 
 ## Image size expectations
 
-Expect roughly 9 to 11 GB uncompressed. The bulk is the cu126 torch stack
+Expect roughly 9 to 11 GB uncompressed. The bulk is the cu130 torch stack
 (the wheels bundle CUDA userspace), followed by the scientific Python set and
 the baked embedder. The frontend build stage contributes only the compiled
 `dist` output.

--- a/docs/OFFLINE-AND-PERFORMANCE.md
+++ b/docs/OFFLINE-AND-PERFORMANCE.md
@@ -2,7 +2,7 @@
 
 ## Optimization: running a multi-model stack on a modest GPU
 
-theDAW never holds the whole system in memory at once. It is a FastAPI backend (`backend/server.py`, bound to `localhost:8600` by `backend/run.py:10-16`) plus a React/Vite frontend, and almost every heavy component is **deferred, lazily loaded, single-resident, or pushed into a separate process**. The result is that the parts that are actually running at any moment fit a small GPU, while everything else stays cold on disk.
+theDAW never holds the whole system in memory at once. It is a FastAPI backend (`backend/server.py`, bound to `localhost:8600` by `backend/run.py` `uvicorn.run(...)`, `:39-42`) plus a React/Vite frontend, and almost every heavy component is **deferred, lazily loaded, single-resident, or pushed into a separate process**. The result is that the parts that are actually running at any moment fit a small GPU, while everything else stays cold on disk.
 
 ### 1. Pick a small model, then run it in half precision
 
@@ -26,17 +26,17 @@ Duration drives the latent sequence length directly, and the request path aligns
 
 The torch / torchaudio / matplotlib / `stable_audio_3` graph (~9.6s of imports) is kept **off module scope** and imported inside the handlers that use it:
 
-> "Heavy imports … total ~9.6s and are deliberately kept OFF module scope so uvicorn binds :8600 in ~1s instead of after the whole torch/XLA stack loads" — `server.py:38-46`
+> "Heavy imports … total ~9.6s and are deliberately kept OFF module scope so uvicorn binds :8600 in ~1s instead of after the whole torch/XLA stack loads" — `server.py:39-45`
 
-The heavy stack is then warmed in a background daemon thread **after** the port is bound (`_warm_heavy`, `server.py:135-172`, started at `server.py:861`), and the model catalog import is itself lazy and cached (`_generation_models`, `server.py:123-132`). RAG embeddings load only on the first assistant query (`server.py:870-872`).
+The heavy stack is then warmed in a background daemon thread **after** the port is bound (`_warm_heavy`, `server.py:136`, started at `server.py:955`), and the model catalog import is itself lazy and cached (`_generation_models`, `server.py:124`). RAG embeddings load only on the first assistant query (`backend/rag.py` `retrieve()`; see the note at `server.py:964`).
 
 ### 5. Models load on demand, one GPU-resident at a time
 
-No checkpoint is loaded at startup — "generation models load on demand" (`server.py:863-868`). When a model is first needed it is loaded and cached (`_get_or_load_generation_pipeline`, `server.py:303-365`), and a **single-resident policy** keeps only one big model on the GPU: switching models parks the previous pipeline in CPU RAM for a fast bit-identical swap when there is ≥10 GB free RAM, otherwise evicts it entirely (`_park_or_evict_other_generation_pipelines`, `server.py:214-265`, `_PARK_MIN_FREE_RAM_GB=10.0` at `:211`).
+No checkpoint is loaded at startup — "generation models load on demand" (`server.py:957-962`). When a model is first needed it is loaded and cached (`_get_or_load_generation_pipeline`, `server.py:306`), and a **single-resident policy** keeps only one big model on the GPU: switching models parks the previous pipeline in CPU RAM for a fast bit-identical swap when there is ≥10 GB free RAM, otherwise evicts it entirely (`_park_or_evict_other_generation_pipelines`, `server.py:217`, `_PARK_MIN_FREE_RAM_GB = 10.0` at `:214`).
 
 ### 6. Non-destructive VRAM offload for co-resident GPU work
 
-`POST /api/model/offload` parks the SA3 model(s) in CPU RAM to free VRAM (e.g. for the Magenta sidecar) without a disk reload, and `/api/model/onload` swaps them straight back — "a pure tensor transfer (no dtype change, bit-identical weights)" (`server.py:1065-1088` `_move_pipelines`, `:1090-1155`). Before any SA3 load/wake, a resident Magenta engine is stopped first to avoid stacking two GPU/commit loads (`_ensure_gpu_clear_of_magenta`, `server.py:267-300`).
+`POST /api/model/offload` parks the SA3 model(s) in CPU RAM to free VRAM (e.g. for the Magenta sidecar) without a disk reload, and `/api/model/onload` swaps them straight back — "a pure tensor transfer (no dtype change, bit-identical weights)" (`_move_pipelines`, `server.py:1303`). Before any SA3 load/wake, a resident Magenta engine is stopped first to avoid stacking two GPU/commit loads (`_ensure_gpu_clear_of_magenta`, `server.py:270`).
 
 ### 7. Frontend: code-split, lazy panels, separate mobile bundle
 
@@ -44,11 +44,11 @@ Every workspace tab is `React.lazy` so "its JS — and its heavy deps (wavesurfe
 
 ### 8. Bounded caches and idle-gated background work
 
-Spectrograms are an LRU capped at 20 (`server.py:113-120`), finished generate-jobs are pruned past 40 (`server.py:1497-1508`), and model-resolution events cap at 200 (`model_configs.py:22`). Deferred work (analysis, stems, MIDI, notation backfill) runs through an idle-gated queue that checks `is_idle()` before pulling jobs (`server.py:876-902`; `backend/core/idle.py:35-115`), so background compute never competes with an active generation.
+Spectrograms are an LRU capped at 20 (`_SPEC_CACHE_MAX_SIZE`, `server.py:115`), finished generate-jobs are pruned past 40 (`_prune_jobs`, `server.py:1786`), and model-resolution events cap at 200 (`model_configs.py:22`). Deferred work (analysis, stems, MIDI, notation backfill) runs through an idle-gated queue that checks `is_idle()` before pulling jobs (`server.py:968-980`; `backend/core/idle.py` `is_idle()`, `:69`), so background compute never competes with an active generation.
 
 ### 9. Heavy/exotic stacks isolated in sidecar processes
 
-The JAX/CUDA Magenta RealTime engine runs in a **separate WSL2 process** on `:8777`, spawned on demand and health-probed, not loaded into the API process (`backend/modules/magenta/sidecar.py:36,84,201-258`). Stem separation runs in the Demucs/LARSNET `integration-package` sidecar (`backend/modules/stems/module.json`), and Whisper transcription runs in its own isolated venv (`pyproject.toml:187`). This keeps the always-on backend light and lets the OS reclaim their memory when idle.
+The JAX/CUDA Magenta RealTime engine runs in a **separate WSL2 process** on `:8777`, spawned on demand and health-probed, not loaded into the API process (`backend/modules/magenta/sidecar.py:36,84,201-258`). Stem separation runs in the Demucs/LARSNET `integration-package` sidecar (`backend/modules/stems/module.json`), and Whisper transcription runs in its own isolated venv (`pyproject.toml:249`, the `.whisper_venv` ruff exclude). This keeps the always-on backend light and lets the OS reclaim their memory when idle.
 
 ### 10. On-demand, local-first model download
 
@@ -58,12 +58,12 @@ Weights are resolved **local folder → HF cache → download**, every step logg
 
 ## No cloud, no datacenters: run the core fully offline
 
-The entire creative core of theDAW runs on the local machine. The backend is a localhost FastAPI server (`backend/run.py:10-16`, `host="0.0.0.0"`, port 8600) and the frontend is a localhost Vite app (`vite.config.ts:88`, port 5173). Generation, decoding, stems, effects, the DAW, and the VJ engine all execute on-device; the only things that ever touch the internet are optional and can be skipped.
+The entire creative core of theDAW runs on the local machine. The backend is a localhost FastAPI server (`backend/run.py:39-42`, `host="0.0.0.0"`, port 8600) and the frontend is a localhost Vite app (`vite.config.ts:88`, port 5173). Generation, decoding, stems, effects, the DAW, and the VJ engine all execute on-device; the only things that ever touch the internet are optional and can be skipped.
 
 ### Local-first, no account required
 
 - **Audio generation** runs entirely on the local DiT + SAME autoencoder (`stable_audio_3/model.py`, `pipeline.py`). Model weights are fetched from Hugging Face **once** and then served from the local folder / HF cache forever after (`model_configs.py:147-191`). A hard offline switch exists: `SA3_LOCAL_ONLY=1` refuses any network access and requires the files be on disk (`model_configs.py:334-354`, `:428-444`). Drop the checkpoints under `models/` (or point `SA3_LOCAL_MODELS_DIR` / `local_models.txt` at them, `model_configs.py:194-213`) and generation needs no network at all.
-- **Generated output is written to local disk**, not a cloud bucket: audio, spectrogram PNGs, and metadata land in `data/generations/…` (`server.py:412-419`, `:474-520`).
+- **Generated output is written to local disk**, not a cloud bucket: audio, spectrogram PNGs, and metadata land in `data/generations/…` (`theDAW_GENERATIONS_DIR` overrides the location, `server.py:443`).
 - **Stem separation** is a local Demucs/LARSNET sidecar (`backend/modules/stems/module.json`).
 - **Effects / mastering / export** are local DSP: FFmpeg (`backend/modules/effects/module.json`), plus `scipy`, `pyloudnorm`, and JUCE/VST3 hosting via `pedalboard` (`pyproject.toml:36,81`).
 - **MIDI, notation, and DAW import** are local libraries — `basic-pitch` + `piano-transcription-inference` (`pyproject.toml:48-56`), `music21` (`:60`), and the `.flp`/`.rpp`/`.aup3`/`.tasmo` parsers (`:81-91`).
@@ -74,6 +74,13 @@ The Magenta RealTime "MAKE" engine is a local sidecar too (WSL2/CUDA on `:8777`,
 ### Optional cloud — present, gated, and skippable
 
 Nothing below is required to make music:
+
+> **On the `path:line` citations.** Line numbers on this page are correct as of
+> the commit that last touched it, and `backend/server.py` in particular moves
+> under refactors — it lost ~100 lines when audio I/O was routed through
+> `backend/lib/audio_io.py`. Where a claim rests on a named function or
+> constant, the symbol is cited alongside the line, and the symbol is the part
+> to trust: search for it rather than jumping to the number.
 
 - **Assistant LLM providers** are multi-provider and include **fully local** backends — Ollama, LM Studio, llama.cpp, and vLLM, all pointed at localhost with `env_key=None` (`backend/assistant_routes.py:299-326`). The cloud providers (Gemini, OpenAI, Anthropic, xAI, Groq, OpenRouter) each require an API key that is only read from the environment (`assistant_routes.py:249-298`, keys enumerated `:70-74`); with no key they are simply unavailable. The assistant panel is lazy-mounted only when the orb chat is opened (`App.tsx:14-17`), and its RAG document retrieval degrades gracefully — without `chromadb` "the server logs a non-fatal warning and the assistant runs without document retrieval" (`pyproject.toml:24-30`).
 - **Suno** is an optional cloud proxy module (marked with a "Cloud" icon, `backend/modules/suno/module.json`) for those who want it; the local generator does not depend on it.
@@ -91,23 +98,23 @@ Once the model weights are on disk, **a musician can run theDAW's core — text-
 - Chunked attention (chunk_size=128) and sliding-window attention in autoencoder resampling blocks -> stable_audio_3/models/autoencoders.py:41, :61-63
 - Overlapping chunked encode/decode bounds peak AE memory for any clip length -> stable_audio_3/models/autoencoders.py:556-600, :602-644 (exposed model.py:485-538)
 - Gradient checkpointing available in AE transformer blocks -> stable_audio_3/models/autoencoders.py:48, :177-178
-- Variable-length generation: sample size aligned to chunk grid, mask_padding_attention + effective-length schedule avoid padding compute -> stable_audio_3/model.py:312-317, :378-407; backend/server.py:586-639
-- Heavy imports (torch/torchaudio/stable_audio_3, ~9.6s) kept off module scope so uvicorn binds :8600 in ~1s -> backend/server.py:38-46
-- Heavy stack warmed in background thread after port bind; catalog import lazy+cached -> backend/server.py:135-172, :861, :123-132
-- Models load on demand, none at startup -> backend/server.py:303-365, :863-868
-- Single GPU-resident policy: previous pipeline parked in CPU RAM (>=10GB free) or evicted -> backend/server.py:214-265, :211
-- Non-destructive VRAM offload/onload swaps model CPU<->GPU with no disk reload -> backend/server.py:1065-1088, :1090-1155
-- Magenta sidecar cleared from GPU before SA3 load to avoid Windows commit-limit crash -> backend/server.py:267-300
+- Variable-length generation: sample size aligned to chunk grid, mask_padding_attention + effective-length schedule avoid padding compute -> stable_audio_3/model.py:312-317, :378-407; backend/server.py `_compute_request_sample_size` :615
+- Heavy imports (torch/torchaudio/matplotlib/stable_audio_3, ~9.6s) kept off module scope so uvicorn binds :8600 in ~1s -> backend/server.py:39-45
+- Heavy stack warmed in background thread after port bind; catalog import lazy+cached -> backend/server.py `_warm_heavy` :136, started :955; `_generation_models` :124
+- Models load on demand, none at startup -> backend/server.py `_get_or_load_generation_pipeline` :306; :957-962
+- Single GPU-resident policy: previous pipeline parked in CPU RAM (>=10GB free) or evicted -> backend/server.py `_park_or_evict_other_generation_pipelines` :217, `_PARK_MIN_FREE_RAM_GB` :214
+- Non-destructive VRAM offload/onload swaps model CPU<->GPU with no disk reload -> backend/server.py `_move_pipelines` :1303
+- Magenta sidecar cleared from GPU before SA3 load to avoid Windows commit-limit crash -> backend/server.py `_ensure_gpu_clear_of_magenta` :270
 - Frontend tab views code-split via React.lazy so heavy deps load only on first open -> frontend/src/components/layout/DAWCenterPanel.tsx:16-41
 - Assistant chunk (react-markdown + @google/genai) deferred until orb chat opened -> frontend/src/App.tsx:14-17, :437-446
 - Vite manualChunks split stable vendors; separate small mobile-companion entry bundle -> frontend/vite.config.ts:54-77
 - DJ/VJ tabs stay mounted-but-hidden with VJ iframe render loop paused (~0% GPU backgrounded) -> frontend/src/components/layout/DAWCenterPanel.tsx:22-30
-- Bounded caches: spectrogram LRU=20, generate-jobs pruned at 40, resolution events cap 200 -> backend/server.py:113-120, :1497-1508; model_configs.py:22
-- Idle-gated background worker queue checks is_idle() before running analysis/stems/midi/notation work -> backend/server.py:876-902; backend/core/idle.py:35-115
-- Heavy stacks isolated in sidecar processes (Magenta WSL2/JAX :8777, Demucs stems, Whisper venv) -> backend/modules/magenta/sidecar.py:36,84,201-258; backend/modules/stems/module.json; pyproject.toml:187
+- Bounded caches: spectrogram LRU=20, generate-jobs pruned at 40, resolution events cap 200 -> backend/server.py `_SPEC_CACHE_MAX_SIZE` :115, `_prune_jobs` :1786; model_configs.py:22
+- Idle-gated background worker queue checks is_idle() before running analysis/stems/midi/notation work -> backend/server.py:968-980; backend/core/idle.py `is_idle()` :69
+- Heavy stacks isolated in sidecar processes (Magenta WSL2/JAX :8777, Demucs stems, Whisper venv) -> backend/modules/magenta/sidecar.py:36,84,201-258; backend/modules/stems/module.json; pyproject.toml:249
 - On-demand local-first model resolution (local folder -> HF cache -> download) with live progress and mirror fallback -> stable_audio_3/model_configs.py:147-191, :85-144; backend/modules/modeldl/router.py:65-107,144-208
 - Fully offline switch SA3_LOCAL_ONLY=1 blocks all network model fetch -> stable_audio_3/model_configs.py:334-354, :428-444
-- Generated audio/spectrograms/metadata written to local disk (data/generations) -> backend/server.py:412-419, :474-520
+- Generated audio/spectrograms/metadata written to local disk (data/generations) -> backend/server.py:443 (`theDAW_GENERATIONS_DIR`)
 - Local LLM assistant providers (Ollama/LM Studio/llama.cpp/vLLM) with no API key; cloud providers key-gated and optional -> backend/assistant_routes.py:299-326, :249-298
 - RAG retrieval degrades gracefully without chromadb (non-fatal) -> pyproject.toml:24-30
 - Suno and genaiproxy are optional cloud modules, not required by local generation -> backend/modules/suno/module.json; backend/modules/genaiproxy/module.json

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -260,12 +260,37 @@ Six controls arranged in a 3-column grid:
 
 | Control | Type | Notes |
 |---|---|---|
-| **Model** | Dropdown | `small` and `medium` for primary inference, plus `magenta-small` for Magenta RealTime 2 (§27) and `suno` for Suno cloud generation (§26). Picking Magenta drops Steps to 1 and brings up the MRT2 conditioning controls. The Suno entry opens the Aurora Cloud Console in place of the local panel. The `small-rf` and `medium-rf` checkpoints are rectified-flow training bases surfaced through the Underfit trainer (§11) rather than inference models; selecting an `-rf` variant for a direct render raises Steps to 50 and CFG to 7.0 to run it, and the ARC `small` and `medium` checkpoints are the intended generation path. |
+| **Model** | Dropdown | `small` and `medium` for primary inference, plus `magenta-small` for Magenta RealTime 2 (§27) and `suno` for Suno cloud generation (§26). Picking Magenta drops Steps to 1 and brings up the MRT2 conditioning controls. The Suno entry opens the Aurora Cloud Console in place of the local panel, and `lyria` (Lyria 3 Pro) opens the Lyria panel in place of it (§6.2.1). The `small-rf` and `medium-rf` checkpoints are rectified-flow training bases surfaced through the Underfit trainer (§11) rather than inference models; selecting an `-rf` variant for a direct render raises Steps to 50 and CFG to 7.0 to run it, and the ARC `small` and `medium` checkpoints are the intended generation path. |
 | **Duration (s)** | Integer | Total output length in seconds. Small model: max 120 s. Medium and Large: max 380 s. |
 | **Batch** | Integer | Number of simultaneous variations. Each variation produces a distinct library entry with its own seed. |
 | **Steps** | Integer | Sampler denoising steps. ARC default: 8. RF default: 50. |
 | **CFG** | Float | Classifier-free guidance scale. ARC default: 1.0. RF default: 7.0. Higher values increase adherence to the prompt and can introduce artifacts. |
 | **Seed** | Integer + reroll button | Use −1 for a random seed on each run. The reroll button generates and displays a new random seed without submitting a job. |
+
+#### 6.2.1 Lyria 3 Pro
+
+Choosing **Lyria 3 Pro (Cloud)** in the Model dropdown replaces the whole MAKE
+surface with the Lyria 3 Pro app, embedded whole and unmodified. It is its own
+project (`StarskreamEXE/lyria-3-pro`), it ships its own Express server, SPA,
+settings and library, and theDAW spawns it as a sidecar on port 5188 and frames
+it. The model dropdown stays on screen above it, because without one you would
+be stranded inside the frame with no route back to Stable Audio.
+
+It is framed rather than absorbed on purpose: at its own origin the app's
+relative `/api/*` fetches resolve against its own server, so it needs no CORS,
+no base URL and no client rewrite, and its viewport styling, portals, window
+event bus and Ctrl+Enter binding all apply to its own document and cannot
+collide with theDAW's. It drives its own transport, so there is no bridge
+between the two.
+
+The sidecar is request-driven: the Node process only starts when someone
+actually opens the panel, and the panel retries while it comes up. Once warmed,
+the frame stays mounted so a round trip to Stable Audio does not restart the
+server or lose its in-app state. `POST /api/lyria/install` clones the project
+and runs its `npm install` in the background (it needs `git`), so Settings can
+repair a missing Lyria without handing you a command line, and
+`GET`/`POST`/`DELETE /api/lyria/key` manage the `GEMINI_API_KEY` theDAW passes
+to it. A pop-out button opens it in its own window.
 
 ### 6.3 Advanced Generation Panel
 
@@ -1685,7 +1710,7 @@ latents = ae.encode(waveform, sr)
 audio_out = ae.decode(latents)
 ```
 
-Batch encoding, chunked processing, and dataset pre-encoding for LoRA training: see [docs/workflows/autoencoder.md](autoencoder.md).
+Batch encoding, chunked processing, and dataset pre-encoding for LoRA training: see [docs/workflows/autoencoder.md](workflows/autoencoder.md).
 
 ### 20.5 LoRA at Inference
 
@@ -1858,7 +1883,7 @@ Eight adapter types are available, trading parameter count against expressivenes
 | `--base_precision` | none | Cast frozen base weights to `bf16` after applying LoRA. Reduces VRAM usage; LoRA parameters stay in fp32. |
 | `--lora_checkpoint` | none | Existing checkpoint to resume from. Loaded with `strict=False`. |
 
-Full training walkthrough: [docs/workflows/lora.md](lora.md).
+Full training walkthrough: [docs/workflows/lora.md](workflows/lora.md).
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -222,7 +222,7 @@ The application window has five regions:
 
 **Global bottom dock:** pinned across the bottom of the app are two independent columns, the bottom multi-tab panel on the left (Levels / Visualize / MIDI / Sequence / DRAW / Score / Sing / Lyric / Details / SLIDE / SWAY) and the processing log on the right, aligned under the library rail. Each column has its own height, collapse toggle, and resize handle, so expanding or resizing one does not move the other, and the dock stays put regardless of the library panel's state.
 
-**Docs modal:** click the Docs button in the header to open this guide in-app. The modal supports anchor links, syntax-highlighted Markdown tables and code blocks, raw Markdown download, and browser print/PDF export. This guide is one document in the assistant's RAG corpus (the full list is in `backend/rag.py`), so revising it improves both the in-app manual and the assistant's grounding.
+**Docs modal:** open the **?** help popover and click **Docs** beside its search field to read this guide in-app. The modal supports anchor links, syntax-highlighted Markdown tables and code blocks, raw Markdown download, and browser print/PDF export. This guide is one document in the assistant's RAG corpus (the full list is in `backend/rag.py`), so revising it improves both the in-app manual and the assistant's grounding.
 
 **Mobile access share:** click the QR/link button in the header to copy or scan the current LAN or tunnel URL for mobile performance access. This is useful with the VJ tab and any browser-based controller or viewer.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -106,7 +106,7 @@ All in-browser audio (library playback, waveform editor preview, step sequencer,
 
 ### Prerequisites
 
-Put these on the PATH first: **[uv](https://docs.astral.sh/uv/getting-started/installation/)** (Python env + packages), **[Node.js](https://nodejs.org/) v20.19+ / v22.12+** (frontend + VJ sidecar, includes npm; the Vite 7 floor), **[FFmpeg](https://www.gyan.dev/ffmpeg/builds/)** (every audio path: effects, exports, ingest, MIDI, YouTube import), **Git** (clone with `--recurse-submodules` for the Magenta sidecar source), and an **NVIDIA driver 550+** for the Medium model and Magenta (the Small model runs on CPU). On Windows, `theDAW.bat` verifies uv/node/npm, warns on missing FFmpeg, and bootstraps the venv + `node_modules` on first run (§4); the Windows specifics are in [windows/setup-guide.md](windows/setup-guide.md).
+Put these on the PATH first: **[uv](https://docs.astral.sh/uv/getting-started/installation/)** (Python env + packages), **[Node.js](https://nodejs.org/) v20.19+ / v22.12+** (frontend + VJ sidecar, includes npm; the Vite 7 floor), **[FFmpeg](https://www.gyan.dev/ffmpeg/builds/)** (every audio path: effects, exports, ingest, MIDI, YouTube import), **Git** (clone with `--recurse-submodules` for the Magenta sidecar source), and an **NVIDIA driver 580+** — the R580 branch, which CUDA 13 requires — for the Medium model and Magenta (the Small model runs on CPU). Turing (sm_75) through Blackwell are supported. On Windows, `theDAW.bat` verifies uv/node/npm, warns on missing FFmpeg, and bootstraps the venv + `node_modules` on first run (§4); the Windows specifics are in [windows/setup-guide.md](windows/setup-guide.md).
 
 ### Base Python environment
 
@@ -116,7 +116,7 @@ uv sync
 
 ### Linux
 
-No separate CUDA step: `pyproject.toml` maps Linux x86_64 to the cu126
+No separate CUDA step: `pyproject.toml` maps Linux x86_64 to the cu130
 torch/torchaudio index under `[tool.uv.sources]`, so plain `uv sync` installs
 the GPU build. The full walkthrough — prerequisites (Node from nvm, ffmpeg), the
 `pyk4a-bundle` glibc caveat, the `./theDAW.sh` launcher, and what differs from
@@ -130,14 +130,11 @@ uv sync --group dev
 
 ### Windows-specific requirements
 
-`pyproject.toml` includes CUDA 12.8 wheel sources for torch, torchaudio, and Flash Attention under `[tool.uv.sources]`. Running `uv sync` on Windows installs all of them automatically. No additional flags or manual wheel downloads are required for Python 3.10 with CUDA 12.8.
+`pyproject.toml` includes CUDA 13.0 (cu130) wheel sources for torch, torchaudio, and Flash Attention under `[tool.uv.sources]`. Running `uv sync` on Windows installs all of them automatically. No additional flags and no manual wheel downloads are required for the project's Python 3.12 venv with CUDA 13.0.
 
-On a different CUDA or Python version, install PyTorch manually:
-```powershell
-uv pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu128
-```
+`uv sync` is the only supported install path. `[tool.uv] required-environments` names Linux x86_64 and Windows AMD64, so `uv lock` refuses a version that has no wheels for both, and `scripts/check_lock.py` proves the lock installs on each of them — hand-installing an off-lock wheel breaks that guarantee.
 
-`soundfile` is included in the base dependencies. Flash Attention is conditionally installed (`sys_platform == 'win32' and python_version < '3.11'`); the wheel URL in `pyproject.toml` targets Python 3.10 with CUDA 12.8 and torch 2.7.0. For other combinations, download a matching wheel from [kingbri1/flash-attention](https://github.com/kingbri1/flash-attention/releases).
+`soundfile` is a base dependency, and libsndfile is what every audio read and write actually runs on, through `backend/lib/audio_io.py` (§20.2). Flash Attention is conditionally installed (`sys_platform == 'win32' and python_version < '3.15'`); `pyproject.toml` pins one prebuilt [mjun0812/flash-attention-prebuild-wheels](https://github.com/mjun0812/flash-attention-prebuild-wheels) wheel per Python minor — cp312, cp313 and cp314, all `flash_attn-2.8.3+cu130torch2.14`. On Windows this package is the only FlashAttention-2 there is, because torch's built-in flash SDPA kernel is not compiled under MSVC, and `transformer.py` gates it off below sm_80 regardless.
 
 Full walkthrough: [docs/windows/setup-guide.md](windows/setup-guide.md).
 
@@ -187,19 +184,21 @@ cd frontend && npm run dev
 
 The application window has five regions:
 
-- **Full-width header** (top): the theDAW logo, a global search input, and action buttons (Docs, mobile access QR/link, Settings, user avatar, AI Assistant orb).
+- **Full-width header** (top): the theDAW logo, the center workspace tabs, and four actions on the right — mobile access QR/link, the **?** help search, **IMPORT**, and the app menu (§37).
 - **Center workspace**: the center tab bar at the top and the active workspace below it, including that tab's own controls and run action.
 - **Library rail** (right, collapsible): browse and route library material without leaving the active workspace.
 - **Global bottom dock**: the bottom multi-tab panel and the processing log, side by side.
 - **Player footer** (bottom): a fixed transport bar.
 
-**Full-width header:** a fixed bar spanning the entire window width. It holds the theDAW logo dot, a global search input, the app menu (§37), and the action buttons listed above. There is no left panel and no left-panel toggle; the only collapsible side panel is the Library rail on the right.
+**Full-width header:** a fixed bar spanning the entire window width. It holds the theDAW logo dot, the center tab bar, and the four right-hand actions above, in that order. Settings opens only from the app menu — the header gear was retired; Docs opens from inside the **?** help popover; the global search moved to the player footer; and the AI Assistant orb is a free-floating draggable element over the app rather than a header button. There is no left panel and no left-panel toggle; the only collapsible side panel is the Library rail on the right.
+
+**The ? help search:** the **?** button opens a search over the feature registry — the same entries the Feature Tour and the pinned Feature Notes read, so the three can never drift apart. Type what you are after and each hit says what the thing is, how to use it, and which tab it lives in; **LOCATE** hands the id to the solo spotlight, which switches workspace, opens the panel the control lives in, and rings the real control on the real screen. The field takes focus on open, Down steps into the results, Up comes back out of the top of them, Enter locates the best hit, and Escape closes and hands focus back to the button. **Docs** sits beside the input and still opens this manual untouched.
 
 **IMPORT** sits between the ? help button and the ☰ app menu on every tab. It opens a small menu: **Audio files…** adds tracks to the library (pick several at once; the newest is selected and the library rail opens), **Open project…** opens a saved `.tasmo`, **DAW project…** imports an Ableton set. You can also drop audio files straight onto the IMPORT button.
 
 **Dropping files from the desktop.** Anywhere a library track can be dropped also takes audio files dragged in from File Explorer or Finder: the library list itself, the EDIT timeline (each file becomes a clip, extra files on new tracks), the MAKE init and inpaint slots, the MIX source, the Chimera stack, the MIDI panel's song box, the DJ decks, sampler pads, NEXT queue and prepared sets, the Media bucket and, for video and image files, the VJ tab. The file is imported into the library first (it shows up in the library rail with the newest selected) and then lands where you dropped it, exactly as a library track would.
 
-**Center tab switching:** the active workspace is controlled by the center tab bar (`CenterTabBar`). Each tab carries its own accent color. Legacy navigation targets such as `create`, `advanced`, `edit`, and `train` are translated into these center tabs, so assistant actions, library sends, and older shortcuts still route correctly — and the assistant can reach every workspace plus the Library rail, reporting an honest failure rather than a false success if a target does not exist. Alongside the nine below, the bar also carries **NodeF.I.** (§40), **SWAY**, and **Tour**. The nine core tabs are:
+**Center tab switching:** the active workspace is controlled by the center tab bar (`CenterTabBar`). Each tab carries its own accent color. Legacy navigation targets such as `create`, `advanced`, `edit`, and `train` are translated into these center tabs, so assistant actions, library sends, and older shortcuts still route correctly — and the assistant can reach every workspace plus the Library rail, reporting an honest failure rather than a false success if a target does not exist. There are thirteen tabs, in this on-screen order: MAKE, EDIT, MIX, PERFORM, DJ, VJ, SWAY, FOUNDRY, UNDERFIT, NODEFI, LOOM, LEARN, TOUR. Alongside the nine core tabs below, the bar carries **SWAY** (§35), **NodeF.I.** (§40), **LOOM** and **Tour**. The nine core tabs are:
 
 - **MAKE**: generate audio from a text prompt with the AI models (§6).
 - **EDIT**: arrange clips on a timeline, add effects and automation, and export (§7).
@@ -211,7 +210,9 @@ The application window has five regions:
 - **Underfit**: train LoRA finetunes in the embedded Underfit dashboard (§11).
 - **Learn**: lineage, genealogy, and the guides and assistant (§12).
 
-**Shell surfaces from the app menu:** three surfaces sit above the workspaces and open from the header. The **app menu** (§37) is the hamburger button in the header icon cluster; it groups project operations, data operations, device deploy, layout and settings, and help. The **HOME overlay** (§38) is a full-screen launcher with one card per workspace tab, a task row, and a show-at-startup preference; it appears after the boot intro and reopens from the menu. The **Feature Tour** (§38) is a six-step guided walkthrough that spotlights real controls; it starts from the menu or the HOME task row.
+**LOOM** is the thirteenth tab: the Shard Index drawn as one living colony that grows a generation every bar. It has its own guide, [guides/loom-and-shards.md](guides/loom-and-shards.md).
+
+**Shell surfaces from the app menu:** three surfaces sit above the workspaces and open from the header. The **app menu** (§37) is the hamburger button in the header icon cluster; it groups project operations, data operations, device deploy, layout and settings, and help. The **HOME overlay** (§38) is a full-screen launcher with one card per workspace tab, a task row, and a show-at-startup preference; it appears after the boot intro and reopens from the menu. The **Feature Tour** (§38) is a chaptered guided walkthrough that spotlights real controls; it starts from the menu or the HOME task row.
 
 **PERFORM tab:** the Perform workspace (`SessionView`) imports a DAW project or a `.tasmo` file and performs its scene/clip grid live. The project controls live in the tab header (a path input, Browse, and Import), so the session grid gets the full remaining height. Clicking or focusing the path input opens a dropdown of recent projects: ArrowDown and ArrowUp move through the list, Enter opens the highlighted entry, Escape closes the dropdown, and one click on an entry imports it immediately. The recent list persists across backend restarts (`data/recent_projects.json`).
 
@@ -219,19 +220,25 @@ The application window has five regions:
 
 **Right-side library rail:** the Library is a collapsible panel on the right edge. A compact, vertically-centered pull handle on the right edge of the work area (present in every workspace) toggles it open or closed, and a drag handle on the rail's inner edge resizes it; the width persists between 280 px and 640 px. Expanded fully, the rail becomes the full-width Catalogue. This lets MAKE, MIX, LEARN, VJ, and editor workflows stay visible while browsing or routing library material.
 
-**Global bottom dock:** pinned across the bottom of the app are two independent columns, the bottom multi-tab panel on the left (Visualize / Piano / Sequence / Details / Media / SLIDE / Score) and the processing log on the right, aligned under the library rail. Each column has its own height, collapse toggle, and resize handle, so expanding or resizing one does not move the other, and the dock stays put regardless of the library panel's state.
+**Global bottom dock:** pinned across the bottom of the app are two independent columns, the bottom multi-tab panel on the left (Levels / Visualize / MIDI / Sequence / DRAW / Score / Sing / Lyric / Details / SLIDE / SWAY) and the processing log on the right, aligned under the library rail. Each column has its own height, collapse toggle, and resize handle, so expanding or resizing one does not move the other, and the dock stays put regardless of the library panel's state.
 
 **Docs modal:** click the Docs button in the header to open this guide in-app. The modal supports anchor links, syntax-highlighted Markdown tables and code blocks, raw Markdown download, and browser print/PDF export. This guide is one document in the assistant's RAG corpus (the full list is in `backend/rag.py`), so revising it improves both the in-app manual and the assistant's grounding.
 
 **Mobile access share:** click the QR/link button in the header to copy or scan the current LAN or tunnel URL for mobile performance access. This is useful with the VJ tab and any browser-based controller or viewer.
 
-**AI Assistant panel:** click the orb icon in the header to open the collapsible assistant panel. It streams chat from any configured LLM provider with RAG context retrieved from the document corpus registered in `backend/rag.py` (this guide plus the other manuals and guides), supports file attachments and voice input, and exposes provider and key-pool controls. See [§19.11](#1911-assistant) for the API reference.
+**AI Assistant panel:** click the assistant orb — a free-floating element you can drag anywhere over the app, not a header button — to open the collapsible assistant panel. It streams chat from any configured LLM provider with RAG context retrieved from the document corpus registered in `backend/rag.py` (this guide plus the other manuals and guides), supports file attachments and voice input, and exposes provider and key-pool controls. See [§19.11](#1911-assistant) for the API reference.
 
-**Viewport scaling:** the UI applies a CSS `zoom` factor based on viewport width (0.85 below 1440 px; 0.95 at 1440 to 1919 px; 1.1 at 1920 px and above). Shell height calculations compensate so the layout tiles cleanly down to the footer.
+**Viewport scaling:** the Shell renders under a CSS `zoom` that fits a fixed logical canvas — 1600 x 820 CSS px — into the real window:
+
+```
+zoom = clamp(0.6, min(innerWidth / 1600, (innerHeight - 64) / 820), 1.1)
+```
+
+It is rounded to two decimals (stable across sub-pixel resize jitter), recomputed on every resize, and published as the `--layout-zoom` custom property on the `.dense-layout` root (`frontend/src/lib/layoutScale.ts`). The 64 px player footer sits outside the zoomed subtree, so the layout always tiles cleanly down to it. This replaced three width-only tiers (0.85 / 0.95 / 1.1) that had no height term, so a short window lost shell height it could not spare.
 
 ![UI shell with center tabs and right library rail](screenshots/01-shell-make.png)
 
-![Header actions (Docs, share, settings, assistant)](screenshots/01-shell-make__header-actions.png)
+![Header actions (mobile share, help search, import, app menu)](screenshots/01-shell-make__header-actions.png)
 
 ---
 
@@ -1069,7 +1076,9 @@ The picker also lists procedural synth voices grouped as **Bass**, **Lead / Chor
 
 ## 16. Bottom Panel Tabs
 
-The bottom panel is collapsible and vertically resizable (drag the grip handle above it), and a maximize toggle expands any tab to fill the window. Ten tabs are available, in order: Levels, Visualize, Piano, Sequence, DRAW, Score, Details, Media, SLIDE, and SWAY. Development builds add an eleventh, **XR Bus**, a tester for the XR control bus (§34.4); production builds hide the tab and remap a persisted selection so it can never strand you on a missing tab.
+The bottom panel is collapsible and vertically resizable (drag the grip handle above it), and a maximize toggle expands any tab to fill the window. Eleven tabs are available, in order: Levels, Visualize, MIDI, Sequence, DRAW, Score, Sing, Lyric, Details, SLIDE, and SWAY. Development builds add a twelfth, **XR Bus**, a tester for the XR control bus (§34.4); production builds hide the tab and remap a persisted selection so it can never strand you on a missing tab.
+
+Two tabs carry their own layout toggle in the tab row. **Details** switches between Details alone, Media alone, and both side by side; **Sing** switches between **Lyrics**, **Both**, **Score** and **Study** (the lyrics beside the literary analysis). What each tab *is* lives in the feature registry under `panel-<id>`, so the hover tooltip on a tab and the sentence the **?** help search returns for it are the same sentence.
 
 The panel's tab strip reads as part of the footer rather than a separate slab: it carries the footer's tinted-blur treatment and hairline border, the group toggle is a labelled **PANELS** button showing the active tab, and both dock bodies animate outward from the button that opened them.
 
@@ -1099,9 +1108,9 @@ Text in the overlay uses `textShadow` for legibility against any visualization b
 
 ![The real-time spectral analyzer](screenshots/visualizer.png)
 
-### 16.2 Piano
+### 16.2 MIDI
 
-Full piano roll interface embedded in the bottom panel. See [§15](#15-piano-roll).
+The tab reads **MIDI** in the tab row. It is the full piano roll interface embedded in the bottom panel. See [§15](#15-piano-roll).
 
 ### 16.3 Sequence
 
@@ -1130,9 +1139,11 @@ Displays full metadata for the currently selected library entry.
 
 **Prompt inference:** When the entry has been analyzed (§13.8), the **PROMPT INFERENCE** box derives a Stable Audio prompt and semantic tags from the analysis, and **USE AS PROMPT** copies the text into the MAKE prompt field. See §33.6.
 
-### 16.5 Media
+### 16.5 Media (a pane of Details)
 
-A session-scoped file holding area for arbitrary audio files. Contents are cleared on page reload.
+Media is not its own tab any more. It is one of the DETAILS tab's three layouts, chosen with the **Details tab layout** toggle in the tab row: Details alone, Media alone, or both side by side.
+
+It is a session-scoped file holding area for arbitrary audio files. Contents are cleared on page reload.
 
 - **Dropzone** accepts drag-and-drop or click-to-upload. Supported formats: WAV, MP3, FLAC, OGG, AAC, M4A, Opus. Library entries can be dragged in directly using the `application/x-thedaw-library-id` transfer protocol to locate the source file from the backend store.
 - **Per-item display**: filename, MIME type, file size.
@@ -1184,33 +1195,45 @@ The Sway's six expressive-motion dimensions (`strike`, `sway`, `pulse`, `glide`,
 
 The Sing tab shows the selected song's lyrics large and centred and moves them with the track line by line and word by word. Lyrics come from the entry's Lyrics field (Suno imports and tagged files fill it), a paste, an LRC file or whisper. **ALIGN** keeps your words and times every one of them against the vocal stem with a forced aligner; whisper then reviews the result in a separate job and underlines words it heard differently. **TAP** stamps line starts by hand while the song plays. **AUTO** runs ALIGN by itself when a song opens with lyrics but no timings. **PITCH** shows the vocal's melody and scores what you sing into the microphone. **EXPORT** writes LRC. The full walkthrough, the `lyrics` settings and the API are in [guides/sing-along-and-lyrics.md](guides/sing-along-and-lyrics.md).
 
+### 16.12 Lyric
+
+The writing surface: a notebook of lyric drafts that is not tied to a library track, with the analysis pane beside it. Write here, analyse from here, and mark rhymes by hand here — hand-made marks are stored against a lyric document, so MARK is only offered on a notebook draft. See [guides/lyric-notebook.md](guides/lyric-notebook.md) and [guides/lyric-analysis.md](guides/lyric-analysis.md).
+
 ## 17. Player Footer
 
-A fixed bar at the bottom of the viewport (z-index 50), visible and functional across all tabs and workspace modes.
+A fixed 64 px bar at the bottom of the viewport (z-index 50), visible and functional across all tabs and workspace modes. It sits outside the Shell's zoomed subtree (§5), so it is the one region that never scales. Two rows: a scrub strip on top, and a control row beneath it laid out as three tracks — now playing, the transport plate, up next and the utilities.
 
-### 17.1 Track Information (left region)
+### 17.1 Now playing (left region)
 
-- **Thumbnail**: an animated music-note icon with a purple pulse during playback.
+- **Orb speech bubble**: on wide windows (xl and up) the assistant orb's tip bubble occupies the leftmost slot, where the global search used to sit.
 - **Title**: the current `playerStore.currentLabel`, truncated to fit the column.
-- **Model chip**: derived from `useGenerateStore.lastModelName`. Shows `LIBRARY` for entries loaded from the library and `IDLE` when nothing has been generated or loaded.
+- **Model chip**: derived from `useGenerateStore.lastModelName`, drawn in the active theme's accent. Shows `LIBRARY` for entries loaded from the library and `IDLE` when nothing has been generated or loaded.
 - **Duration readout**: `MM:SS // 48kHz`, read from `playerStore.duration`.
+- **Like** and **Share** appear on hover or keyboard focus. In VJ mode a **VJ** chip also shows how many items the current set holds and whether the VJ has acknowledged it.
 
 ### 17.2 Transport (center region)
 
-| Control | Description |
+The transport is a single matte plate of five labelled keys on a hairline grid, held on the exact viewport centre by the surrounding `1fr · auto · 1fr` layout (an even key count either side of PLAY is what keeps it there):
+
+| Key | Description |
 |---|---|
-| **Loop** | Toggles looped playback in `playerStore`. Active state shown in purple. |
-| **Skip to start** | Calls `playerStore.seekByFraction(0)`. |
-| **Play / Pause** | Primary playback toggle. In EDIT workspace mode with no editor audio loaded, the first press triggers an offline render of the waveform editor timeline, loads the result into `playerStore`, and begins playback. Subsequent presses toggle playback natively. |
-| **Skip to end** | Calls `playerStore.seekByFraction(1)`. |
-| **Fullscreen** | Toggles browser fullscreen on `document.documentElement`. |
+| **LOOP** | Toggles looped playback in `playerStore`. A latched key draws in the active theme's accent (`--et-accent`), not a fixed purple. |
+| **START** | Calls `playerStore.seekByFraction(0)`. |
+| **PLAY / PAUSE** | Primary playback toggle; the printed legend flips with the glyph. In EDIT workspace mode with no editor audio loaded, the first press triggers an offline render of the waveform editor timeline, loads the result into `playerStore`, and begins playback. Subsequent presses toggle playback natively. |
+| **END** | Calls `playerStore.seekByFraction(1)`. |
+| **RAND** | Random order: any other library track plays next instead of the following one. |
 
-**Progress bar:** a horizontal track showing playback position. Click anywhere to seek (`playerStore.seekByFraction`). On hover, a circular scrubber handle appears at the current position. Time labels at left and right show current time and total duration. The footer synchronizes its playhead with the Waveform Editor; scrubbing the progress bar updates the editor timeline position when the editor timeline is the active audio source.
+Fullscreen is no longer on the plate — it is a window utility and sits with Mute, Volume and Download on the right (§17.3).
 
-### 17.3 Utilities (right region)
+**Scrub strip:** the footer's first row is a scrub strip, centred at three-fifths of the footer width with the elapsed and total times either side of it. The rail is a flat hairline that thickens under the pointer or keyboard focus; the filled part draws in the theme accent, and the playhead is a small cursor bar that widens under the hand. Click or drag anywhere to seek, and a time bubble follows the pointer. It is a real slider for assistive technology (`role="slider"` with `aria-valuetext`): Left/Right and Up/Down step by 5 s, Shift multiplies the step by six, and Home and End jump to the ends. The footer synchronizes its playhead with the Waveform Editor; scrubbing updates the editor timeline position when the editor timeline is the active audio source.
 
+### 17.3 Up next and utilities (right region)
+
+- **Up Next** (xl and up) mirrors the Now Playing block on the right: the next library entry's title and duration under an **Up Next** chip. Clicking it loads that track; with RAND on it is a random other entry, which the tooltip says. It reads "Nothing queued" when the library has nothing to follow with.
+- **Master FX indicator** is a chip that appears whenever the global master insert has effects on it. It says how many, and its tooltip says whether any of them take level; clicking it opens MIX, and the chevron beside it expands a list of what is on the insert. It draws in the theme accent and is hidden when the insert is empty.
 - **Mute toggle** switches the `playbackStore` mute flag. The volume icon changes to a red `VolumeX` when muted.
-- **Volume slider**: an overlay `<input type="range">` drives `playbackStore.volume` (0 to 100). The visual fill scales proportionally. The combined `volume × !muted` value is forwarded to `playerStore.setMasterGain`, which drives the shared Web Audio master gain node.
+- **Volume**: a `SlideTrack` (a custom `role="slider"`, keyboard-operable) drives `playbackStore.volume` (0 to 100). The combined `volume × !muted` value is forwarded to `playerStore.setMasterGain`, which drives the shared Web Audio master gain node.
+- **Fullscreen** toggles browser fullscreen on `document.documentElement`. It moved here from the transport plate.
 - **Download** retrieves the library entry whose `id` matches `playerStore.currentEntryId` and triggers a browser file download.
 - **More** is decorative.
 
@@ -1610,9 +1633,10 @@ audio = pipe.generate(
 ### 20.2 Audio-to-audio
 
 ```python
-import torchaudio
+from backend.lib.audio_io import load_audio
 
-init_audio = torchaudio.load("/path/to/audio.wav")
+waveform, sr = load_audio("/path/to/audio.wav")
+init_audio = (sr, waveform)   # the pipeline takes (sample_rate, tensor)
 audio = pipe.generate(
     init_audio=init_audio,
     init_noise_level=0.9,
@@ -1621,10 +1645,24 @@ audio = pipe.generate(
 )
 ```
 
+> **Do not call `torchaudio.load` or `torchaudio.save`.** From 2.9 they decode
+> through torchcodec, which loads FFmpeg's *shared* libraries at import — no
+> ordinary Windows ffmpeg build ships them, so the call raises "Could not load
+> libtorchcodec". `backend/lib/audio_io.py` reads and writes through libsndfile,
+> falls back to the ffmpeg CLI for containers libsndfile cannot open, never
+> clamps, and returns the same `(tensor[channels, frames], sample_rate)` shape
+> `torchaudio.load` used to. torchaudio stays in the project for transforms only.
+>
+> Note the order: `load_audio` returns `(tensor, sample_rate)`, and the pipeline
+> wants `(sample_rate, tensor)`.
+
 ### 20.3 Inpainting
 
 ```python
-inpaint_audio = torchaudio.load("/path/to/audio.wav")
+from backend.lib.audio_io import load_audio
+
+waveform, sr = load_audio("/path/to/audio.wav")
+inpaint_audio = (sr, waveform)
 audio = pipe.generate(
     inpaint_audio=inpaint_audio,
     inpaint_mask_start_seconds=4.0,
@@ -1642,7 +1680,7 @@ audio = pipe.generate(
 from stable_audio_3 import AutoencoderModel
 
 ae = AutoencoderModel.from_pretrained("same-l")
-waveform, sr = torchaudio.load("audio.wav")
+waveform, sr = load_audio("audio.wav")
 latents = ae.encode(waveform, sr)
 audio_out = ae.decode(latents)
 ```
@@ -1832,7 +1870,13 @@ Flash Attention is not loaded correctly. Verify:
 ```bash
 uv run python -c "import flash_attn; from flash_attn import flash_attn_func; print('Version:', flash_attn.__version__)"
 ```
-Any import error means the wheel does not match the installed Python, PyTorch, and CUDA combination. Reinstall from [kingbri1/flash-attention](https://github.com/kingbri1/flash-attention/releases).
+Any import error means the wheel does not match the installed Python, PyTorch, and CUDA combination. The wheel must be built for **torch 2.14 and CUDA 13** — that is what this project pins, and a wheel for any other pair will not import. `uv sync` installs the right one, so the fix is almost always to re-sync:
+
+```powershell
+uv sync --reinstall-package flash-attn
+```
+
+The wheels themselves are the `flash_attn-2.8.3+cu130torch2.14-cp3XX-cp3XX-win_amd64.whl` assets on [mjun0812/flash-attention-prebuild-wheels release v0.10.2](https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/tag/v0.10.2), one per Python minor (cp312, cp313, cp314); `pyproject.toml` pins them under `[tool.uv.sources]`.
 
 ### "FlashAttention only supports Ampere GPUs or newer"
 
@@ -2361,8 +2405,8 @@ The app menu (`HamburgerMenu`) is the hamburger button in the header icon cluste
 - **Project**: **New Project** clears the workspace for a fresh session. **Open Project** loads a saved `.tasmo` file. **Save Project** writes the current session to a `.tasmo` file. **Import DAW Project** brings in a project written by another DAW. **Open Project** and **Import DAW Project** are also reachable from the header IMPORT button, which is on screen on every tab.
 - **Data**: **Backup / Migrate**, **Check for Updates**, and **Restore Previous Version** open the maintenance dialogs described in §39.
 - **Devices**: **Deploy to Quest** opens the headset deploy dialog described in §34.8.
-- **App**: **Edit Layout** toggles Design Mode for the draggable panel layouts (its row shows an accent dot while active). **Settings** opens the Settings modal. **Docs** opens this guide (§5).
-- **Help**: **Feature Tour** starts the guided walkthrough, and **Home Screen** reopens the HOME overlay, both covered in §38.
+- **App**: **Edit Layout** toggles Design Mode for the draggable panel layouts (its row shows an accent dot while active). **Change Theme** opens the theme picker ([guides/themes.md](guides/themes.md)). **Settings** opens the Settings modal — this menu is the only way in, the header gear having been retired. **Docs** opens this guide (§5).
+- **Help**: **Feature Tour** starts the guided walkthrough, **Hide Feature Notes** / **Show Feature Notes** turns the pinned labels off or brings every one of them back (dismissed ones included), and **Home Screen** reopens the HOME overlay. All three are covered in §38 and [guides/feature-notes.md](guides/feature-notes.md).
 
 ### 37.2 The .tasmo project format
 
@@ -2378,20 +2422,24 @@ theDAW saves and loads native projects as `.tasmo` files through the `project` m
 
 ### 38.1 HOME overlay
 
-The HOME overlay (`HomeScreen`) is a full-screen launcher. It appears after the boot intro finishes and reopens on demand from the app menu's **Home Screen** item (§37). The top row shows the theDAW wordmark and a version chip. Below the hero line sit the workspace cards, one per center tab (MAKE, EDIT, MIX, Perform, DJ, VJ, Foundry, Underfit, Learn); each card shows the tab's name and its one-line description, and clicking a card opens that workspace and dismisses the overlay.
+The HOME overlay (`HomeScreen`) is a full-screen launcher. It appears after the boot intro finishes and reopens on demand from the app menu's **Home Screen** item (§37). The top row shows the theDAW wordmark and a version chip. Below the hero line sit the workspace cards, one per center tab — MAKE, EDIT, MIX, Perform, DJ, VJ, SWAY, Foundry, Underfit, NodeF.I., LOOM, Learn and Tour; each card shows the tab's name and its one-line description, and clicking a card opens that workspace and dismisses the overlay.
 
 A slim task row sits under the cards with **Open Project**, **Import Audio** (shown when an import handler is available), and **Feature Tour**. A **Show at startup** checkbox controls whether HOME appears on the next launch; the preference persists on its own (the overlay's open state always resets per launch). Escape dismisses the overlay.
 
 ### 38.2 Feature Tour
 
-The Feature Tour is a six-step guided walkthrough (`TOUR_STEPS`). It starts from the app menu's **Feature Tour** item or the HOME task row. Each step switches to the relevant tab and spotlights a real on-screen control:
+The Feature Tour is a chaptered guided walkthrough (`TOUR_CHAPTERS` and `TOUR_STEPS` in `frontend/src/onboarding/tourSteps.tsx`). It starts from the app menu's **Feature Tour** item or the HOME task row and opens on a chapter picker: take the six chapters in order, or open the one you need and leave. Each step switches to the relevant tab, opens the panel the control lives in, and spotlights the real on-screen control — the overlay swallows clicks, so a step shows you a control rather than asking you to operate one.
 
-1. **Settings**: open the app menu and go to Settings to enable or download the models and modules a feature needs.
-2. **Make music**: type a prompt in MAKE to generate audio.
-3. **Chimera**: braid two or more sounds into one by adding clips to the Chimera stack in MAKE (§6.3.1), shown with a splice motif.
-4. **Draw sound**: the DRAW panel turns a sketch into generative music.
-5. **Stems anywhere**: right-click a library track and choose Separate stems, or enable auto-stems in Settings.
-6. **Train a custom LoRA**: train on a personal dataset in the Underfit tab (§11).
+1. **Getting started** — the shell: workspaces, library, the dock, the transport, the menu.
+2. **Making music** — prompts, models, starting from audio, Chimera, DRAW and SEQUENCE.
+3. **Editing and mixing** — the timeline, the effect rack, meters, spectrum and track details.
+4. **Performing** — PERFORM, DJ, VJ, SWAY and the SLIDE control surface.
+5. **Words and notes** — Score, karaoke, lyric analysis, the rhyme web and the piano roll.
+6. **The deep end** — LOOM, NodeF.I., FOUNDRY, UNDERFIT, the assistant, LEARN and TOUR.
+
+Chapters exist because the whole walk is forty-one steps, which is not a sitting — and because the center panel warm-mounts each heavy workspace the first time it is visited, so one linear pass would start a WebGL visuals engine, a map, a 3D graph and four sidecar iframes on a machine whose owner has not made a sound yet. A chapter mounts what you opened and nothing else.
+
+The same feature registry backs the header's **?** help search and the pinned Feature Notes, so a control named in one is findable in the others.
 
 ---
 
@@ -2405,7 +2453,15 @@ The app menu's **Data** section (§37) holds backup, restore, and update operati
 
 ### 39.2 Update checks and version restore
 
-**Check for Updates** opens the update dialog, backed by the `updates` module (`/api/updates`). It compares the installed version, read from `pyproject.toml`, against the latest published release on GitHub, and caches the result on disk for six hours. **Restore Previous Version** opens the same dialog on its releases list, so an install can move to an earlier published release.
+**Check for Updates** opens the update dialog, backed by the `updates` module (`/api/updates`). It compares the installed version, read from `pyproject.toml`, against the latest published release on GitHub, and caches the result on disk for six hours (`?force=true` bypasses the cache). Being offline never produces an error page: the check returns "unknown" with the reason attached.
+
+When an update is available the dialog installs it, and how depends on the install kind `GET /check` detects:
+
+- **A git clone** (theDAW.bat, theDAW.sh, Pinokio, dev Electron) is updated in place by `POST /api/updates/apply`. The backend pulls, then exits with code **89**; the launcher that spawned it reads that code as "pull done", syncs dependencies and respawns, while the dialog polls `/api/updates/apply-status` and then `/api/health` and reloads the page when the backend is back. A clone with uncommitted local changes is refused with a 409 rather than overwritten, and a missing `git` returns 503.
+- **The packaged Windows app** downloads the installer through electron-updater — the progress bar is that download — then quits and runs it.
+- **The macOS dmg** is unsigned and cannot self-update, so the button downloads the new dmg for you to open.
+
+If anything fails, the dialog shows the log tail with **Try again** and **Release page**. **Restore Previous Version** opens the same dialog on its releases list; moving *backward* is release-driven, so it hands you that release's download page rather than switching versions for you. The full walkthrough is [guides/backup-and-updates.md](guides/backup-and-updates.md).
 
 ---
 

--- a/docs/guides/audio-io.md
+++ b/docs/guides/audio-io.md
@@ -1,0 +1,115 @@
+# Audio I/O: `backend/lib/audio_io.py`
+
+Every audio file theDAW reads or writes goes through one module,
+`backend/lib/audio_io.py`. It is libsndfile (through `soundfile`) with the
+ffmpeg CLI as a fallback, it is float-native, and it never clamps a float
+export.
+
+**The standing rule: never call `torchaudio.load` or `torchaudio.save`.** Not in
+backend code, not in a module, not in a snippet in a doc. They do not work in
+this environment, and this page explains why so nobody has to rediscover it.
+
+## Why torchaudio is not the answer
+
+From torchaudio 2.9 onward, `load` and `save` decode through **torchcodec**,
+which loads FFmpeg's *shared* libraries at import time. No ordinary Windows
+ffmpeg install carries them — the winget build and the gyan "essentials" and
+"full" builds are all static — so the moment the project moved to torchaudio
+2.11, every `torchaudio.load` in the app raised:
+
+```
+RuntimeError: Could not load libtorchcodec. ... FFmpeg
+```
+
+on the development machine, and would have on every user's. torchcodec is not in
+`uv.lock` and is not going in.
+
+`torchaudio.save` had a second problem of its own: it stopped honouring
+`encoding` and `bits_per_sample`, so a float export came back requantized —
+exactly the loss `backend/lib/audio_depth.py` exists to prevent.
+
+torchaudio is still a dependency, and it is still the right tool for
+**transforms** — resample, spectrograms. It is used for nothing else.
+
+## What the module does instead
+
+libsndfile 1.2 reads and writes everything the app produces: WAV at every depth
+including float, FLAC, OGG Vorbis and Opus, MP3, AIFF, W64 and CAF. It does it
+without clamping, which several tool paths already depend on. The containers it
+cannot open — m4a/aac, webm, anything with a video track — are decoded by the
+ffmpeg CLI the app already requires, to a float WAV in a temp file, and then
+read back through libsndfile.
+
+## The API
+
+```python
+from backend.lib.audio_io import load_audio, load_audio_array, save_audio, save_subtype
+```
+
+### `load_audio(src, *, format=None) -> (torch.Tensor, int)`
+
+Decodes a path, `bytes`, or a file-like object to a torch tensor shaped
+`[channels, frames]` plus the sample rate — the same shape `torchaudio.load`
+returned, so a call site swaps one name for another and nothing else.
+
+```python
+waveform, sr = load_audio("/path/to/audio.wav")
+```
+
+> Watch the order at the pipeline boundary. `load_audio` returns
+> `(tensor, sample_rate)`; `StableAudioModel.generate` wants `init_audio` and
+> `inpaint_audio` as `(sample_rate, tensor)`. Build the tuple explicitly:
+> `init_audio = (sr, waveform)`.
+
+### `load_audio_array(src, *, format=None) -> (np.ndarray, int)`
+
+The same decode without importing torch: a float32 array shaped
+`[channels, frames]`. libsndfile first, the ffmpeg CLI for anything it cannot
+open. Never clamps. This is what you want in a module that has no other reason
+to pull torch in.
+
+### `save_audio(dst, audio, samplerate, *, format=None, subtype=None) -> str | None`
+
+Writes a torch tensor or an ndarray shaped `(channels, frames)` to a path or a
+file-like object, and returns the subtype it actually used. A tensor on any
+device is accepted; it is detached, moved to CPU and cast to float32 for you. A
+1-D input is treated as mono.
+
+`format` is inferred from the destination's extension, and is **required** when
+writing to a file-like object, which has no extension to read.
+
+Fixed-point subtypes get a −1..1 clip, because integer PCM wraps rather than
+saturates on overflow. Float subtypes deliberately do not: a peak above 0 dBFS
+surviving intact is the entire point of asking for float.
+
+### `save_subtype(fmt, wav_bit_depth) -> str | None`
+
+The libsndfile subtype for a generated file at a requested depth. The defaults
+encode a real decision:
+
+| Format | `16` | `24` | `32f` |
+|---|---|---|---|
+| WAV | `PCM_16` | `PCM_24` | `FLOAT` |
+| FLAC | `PCM_16` | `PCM_24` | `PCM_24` (FLAC is lossless but never float) |
+| OGG / OGA | `VORBIS` | `VORBIS` | `VORBIS` (Vorbis has no PCM word length) |
+
+`PCM_16` stays the default. It halves the on-disk footprint at no perceptible
+cost on generative audio, and every finished job also carries its audio
+base64-encoded in the `JOBS` dict until it is pruned, so the depth is paid for
+twice. `32f` is the escape hatch for output going straight back into a float
+session — the EDIT timeline, a VST chain, the Chimera stack — where every
+requantization along the way compounds.
+
+## Notes for contributors
+
+- If you find a `torchaudio.load` or `torchaudio.save` anywhere, it is a bug.
+  Replace it; do not work around the error.
+- The ffmpeg fallback runs with `stdin=subprocess.DEVNULL`. The backend does not
+  always own a console, and an inherited handle makes ffmpeg's console reader
+  block forever.
+- A failed decode with no ffmpeg on PATH raises a `RuntimeError` naming both the
+  libsndfile error and the missing binary, so the log says which of the two
+  things went wrong.
+
+See also: [Windows troubleshooting](../windows/troubleshooting.md) for the
+"Could not load libtorchcodec" entry a user might hit.

--- a/docs/guides/backup-and-updates.md
+++ b/docs/guides/backup-and-updates.md
@@ -64,9 +64,42 @@ The backend picks the newest published stable release as the latest candidate. I
 The dialog shows one of several states:
 
 - **Up to date**: the installed version matches or exceeds the latest release.
-- **Update available**: the latest release is newer. The dialog shows the new version, its publish date, an excerpt of the release notes, and an Open release page control that opens the release in the system browser.
+- **Update available**: the latest release is newer. The dialog shows the new version, its publish date, an excerpt of the release notes, an install button appropriate to the install kind, and an Open release page control that opens the release in the system browser.
 - **Indeterminate**: the version strings could not be compared numerically. The dialog reports the latest published version and leaves the comparison to the reader.
 - **Offline**: the release server could not be reached. The dialog shows an amber message and the Check again control becomes Retry.
+
+### Installing an update
+
+When an update is available the dialog offers to install it, and the check
+result says how: `GET /check` reports an `install_kind` alongside the version
+comparison. Three kinds, one button.
+
+**A git clone** — theDAW.bat, theDAW.sh, Pinokio, or a dev Electron run — has a
+`.git` at the repo root and is updated in place. The dialog asks for
+confirmation, then posts `/api/updates/apply`. The backend pulls, then exits
+with sentinel code **89**. The process that spawned it (`backend._supervisor`,
+`backend._devstack`, or the Electron shell through the supervisor) reads that
+code as "pull done", runs the dependency sync, and respawns the backend. The
+sync runs *between* processes on purpose: on Windows `uv sync` cannot replace a
+DLL the running interpreter has already loaded, so a sync from inside the
+backend fails exactly when a release bumps torch or numpy. Meanwhile the dialog
+shows a progress bar and a log tail, polling `/api/updates/apply-status` and
+then `/api/health`, and reloads the page when the backend answers again.
+
+A clone with uncommitted local changes is refused with a 409 rather than
+overwritten — commit or stash first. A missing `git` on the backend's PATH
+returns 503, and a second `/apply` while one is running returns the running
+one rather than starting another.
+
+**The packaged Windows app** has no `.git`. There the Electron shell downloads
+the installer through electron-updater — the progress bar is that download —
+then quits and runs it. The renderer never calls `/apply`.
+
+**The packaged macOS app** ships as an unsigned dmg and cannot self-update, so
+the button downloads the new dmg for you to open.
+
+If anything fails, the dialog shows the log tail with **Try again** and
+**Release page**.
 
 ### The six-hour cache and offline behavior
 
@@ -78,4 +111,4 @@ A network failure never produces a server error. When offline, the check returns
 
 The Previous versions section expands to list up to ten recent releases. The first time it opens, the dialog loads the release list from the backend. Each row shows the release tag, name, and publish date, and opens that release's page in the system browser.
 
-Restoring an older version is release-driven. The backend surfaces release metadata and download-page URLs only. It performs no automatic version switching. To move to a specific version, download that release's installer from its release page and run it. Back up data first from the Backup / Migrate dialog before changing versions.
+Moving *forward* is automatic — see [Installing an update](#installing-an-update). Moving *backward* is not. The `releases` endpoint surfaces release metadata and download-page URLs only, and the backend performs no automatic downgrade. To move to a specific older version, download that release's installer from its release page and run it, or, on a clone, check out its tag. Back up data first from the Backup / Migrate dialog before changing versions either way.

--- a/docs/guides/feature-notes.md
+++ b/docs/guides/feature-notes.md
@@ -7,23 +7,35 @@ a close button.
 
 They exist because of a real report: someone spent a long time hunting for the
 Library, read the docs and asked the assistant, and only found it by eventually
-noticing the slim tab on the right edge of the window. The feature tour did not
-save them, and structurally cannot — a tour is a sequence you click through
-once and then it is gone, so it teaches nothing about an affordance you next
-meet three sessions later. A note stays pinned to the thing until you have
-actually used it.
+noticing the slim tab on the right edge of the window.
 
-## The three notes
+Two things came out of that, and neither of them is a note. The rail tab now
+carries the **LIBRARY** wordmark, so the control says what it is. And the
+header's **?** button searches the feature registry and will take you to
+anything it names, so "where is X?" has a direct answer at last.
+
+Feature Notes are what is left over: a pinned label beside the few controls that
+still carry none. The feature tour did not save that user and structurally
+cannot — a tour is a sequence you click through once and then it is gone, so it
+teaches nothing about an affordance you next meet three sessions later. A note
+stays pinned to the thing until you have actually used it.
+
+## The two notes
 
 | Note | Points at |
 |---|---|
-| **Library** | The slim tab on the right edge of the window that slides the library out. |
 | **Log** | The LOG strip at the bottom right — machine stats and every job the app has run. |
 | **Panels** | The bottom strip that opens the panel tabs: Score, Sing, Lyric, Levels, MIDI and the rest. |
 
-Three is deliberate. A note on every control would be the same as no notes at
-all; the bar for adding one is whether a new user could find that affordance
-without being told.
+The Library used to head this list and no longer qualifies: its edge tab carries
+the LIBRARY wordmark now, and the first rule is that a control which says what
+it is does not get a note. (`featureRegistry.test.ts` asserts there is no
+library note, so it cannot creep back.)
+
+Two is deliberate. A note on every control would be the same as no notes at all;
+the bar for adding one is whether a new user could find that affordance without
+being told — and for anything that *is* labelled, the **?** search will take you
+to it.
 
 ## They retire themselves
 

--- a/docs/guides/feature-notes.md
+++ b/docs/guides/feature-notes.md
@@ -37,6 +37,30 @@ the bar for adding one is whether a new user could find that affordance without
 being told — and for anything that *is* labelled, the **?** search will take you
 to it.
 
+## Finding anything: the ? search
+
+The header's **?** button is the direct answer to "where is X?". It searches the
+**feature registry** — the same data the Feature Tour walks and the notes point
+at, so the three cannot drift apart from one another — and every hit says what
+the thing is, how to use it, and which tab it lives in.
+
+The part a document search cannot do is the last button on each card. A registry
+entry carries a selector, so **LOCATE** hands the id to the solo spotlight: the
+app switches workspace, opens the panel the control lives in, and rings the real
+control on the real screen. Nothing is closed again afterwards — you asked to be
+taken there.
+
+Keyboard: the field takes focus when the popover opens, Down steps into the
+results, Up comes back out of the top of them, Enter locates the best hit, and
+Escape closes and hands focus back to the **?** button. With nothing typed it
+shows a handful of featured entries rather than an empty list.
+
+**Docs** sits beside the input, one click further in, and still opens the full
+manual untouched. It used to be the header's only help affordance, which is
+exactly the problem the search was built to fix: a 185 KB manual whose own
+search filters headings by substring only answers "where is the library?" for
+someone who already knows the heading is called Library.
+
 ## They retire themselves
 
 A note disappears the first moment you use the thing it points at — open the

--- a/docs/guides/feature-notes.md
+++ b/docs/guides/feature-notes.md
@@ -64,7 +64,7 @@ someone who already knows the heading is called Library.
 ## They retire themselves
 
 A note disappears the first moment you use the thing it points at — open the
-library once and the library note is gone for good, without your having to
+LOG strip once and the Log note is gone for good, without your having to
 dismiss it. Closing one by hand does the same thing permanently.
 
 The state is remembered per browser, so notes do not come back on the next
@@ -82,8 +82,8 @@ close.
 
 A note never sits on top of what it is pointing at, and the whole layer ignores
 the mouse, so a note can never swallow a click meant for the control beneath
-it. Positions are measured live rather than fixed, so notes follow the library
-tab as the window, the dock height and the rail width change, and a control
+it. Positions are measured live rather than fixed, so notes follow the strips they
+point at as the window, the dock height and the rail width change, and a control
 hard against an edge of the screen still gets its card fully on screen. Each
 note is wired to its target for screen readers, so the hint is not
 sighted-only.

--- a/docs/guides/foundry.md
+++ b/docs/guides/foundry.md
@@ -119,5 +119,3 @@ When the layout is ready, the toolbar offers three outputs:
 - If the tab shows "VST Foundry did not start," see the
   [Windows troubleshooting guide](../windows/troubleshooting.md); the
   `/api/foundry/status` endpoint reports the project path, port, and any issues.
-</content>
-</invoke>

--- a/docs/guides/loom-and-shards.md
+++ b/docs/guides/loom-and-shards.md
@@ -1,0 +1,198 @@
+# LOOM and the Shard Index
+
+LOOM is the thirteenth workspace tab. It plays your own catalogue back to you as
+a colony of living cells: every song in the library is cut into **shards** —
+beat-aligned fragments of each stem — and a colony is a graph of cells that pull
+shards out of that index, tempo-matched and key-matched, on the grid.
+
+Two things make it work, and both are useful on their own:
+
+- the **Shard Index** (`backend/modules/shards`), a searchable store of every
+  fragment of every analysed song, with the descriptors already computed for it;
+- the **Beat Clock** (`frontend/src/lib/beatClock.ts`), one bar-and-beat phase
+  on the shared AudioContext that LOOM, the DJ shard pads, PERFORM slots and
+  NodeF.I. all read, so "next bar" means the same thing everywhere.
+
+The design document behind all of this is [docs/design/loom.md](../design/loom.md).
+
+## The Shard Index
+
+A **shard** is one fragment of one stem of one song, cut on that song's own
+downbeats. Each carries what the library already knew about that moment:
+
+| Field | What it is |
+|---|---|
+| `role` | `drums`, `kick`, `snare`, `hihat`, `cymbals`, `toms`, `bass`, `vocals`, `guitar`, `piano`, `other`, or `mix` when the song has no stems |
+| `beats`, `bar_index` | Length in beats (1, 2, 4, 8 or 16) and which bar of the song it came from |
+| `bpm`, `key`, `scale`, `camelot` | The song's tempo and key at extraction — what makes conforming possible |
+| `pc_root` | The shard's own chroma argmax (0–11), or −1 when it is flat |
+| `rms_db`, `low_frac`, `onset_density`, `centroid_hz` | Loudness, low-end share, how busy it is, how bright |
+| `onset_mask` | 16 bits: which sixteenths inside the shard carry an onset. This is what "sounds like this rhythm" searches on |
+| `energy` | The shard's RMS percentile *within its own song*, 0–1, so a quiet song's loud bar still reads as loud |
+| `section` | `intro`, `build`, `peak`, `body` or `outro`, from the chimera phrase analysis |
+| `chord`, `words` | The chord symbol and the lyric words inside that window, when a chord track or aligned lyrics exist |
+
+Sharding needs the song's `analysis` row (the beat times). It runs through the
+same pipeline coordinator as stems, MIDI and lyrics, so it de-dupes and never
+fights the GPU lane. A song that has never been sharded is cut on first
+reference, and anything asking for it sees status `sharding` until the rows
+land.
+
+Stems matter here. A song with no stems is sharded from its mix and every shard
+has role `mix`; once stems exist, the mix shards are replaced by per-stem ones,
+which is what makes "give me a kick from anywhere" possible.
+
+### Conforming
+
+The index stores crops, not renders. `GET /api/shards/{shard_id}/audio` cuts the
+WAV on demand, and two query parameters conform it on the way out: `?bpm=` time-
+stretches the crop to the asked-for tempo, and `?semitones=` transposes it. A
+ranked query also returns a `transpose` per row when you gave it a target key,
+so the caller knows what to ask for. Results are cached under
+`data/cache/shards`.
+
+### Taste memory
+
+`POST /api/shards/keep` records that you kept a pairing of two shards. It bumps
+a weight in `shard_pairings`, and the ranker reads those counts back as a
+**novelty** term — a combination you have already used scores lower, so the
+index keeps offering you something you have not heard. It is the only part of
+the ranking that learns.
+
+## The colony
+
+Open the **LOOM** tab. The left two-thirds is the dish; the right is a pane
+switcher with **CELL**, **CODE** and **CRATE**.
+
+### The crate
+
+CRATE is where songs go in. Pick one from the dropdown and it is added and
+sharded; the row then says how many shards it has and the song's key and tempo.
+An empty crate is not an error — loops with an empty crate search the whole
+index instead. Below the crate is a browser: pick a song and a stem, and every
+one-bar shard is listed with its bar number, energy, chord and lyric words.
+The play button auditions one on the next beat; **pin** locks the selected loop
+cell to that exact bar instead of a query.
+
+### Cells
+
+A colony is a graph, not a grid of lanes. Its nodes are cells, and there are
+five kinds:
+
+| Cell | What it does |
+|---|---|
+| **loop** | Plays a shard — a stem loop, a bar of bass, a word — for `beats`, or holds until the next trigger. Carries gain, transpose, pan, cutoff, resonance, glide and a stereo `space` mode (fixed, orbit, pingpong, random). |
+| **rule** | A generator that emits a symbol per step of the colony's bar. |
+| **gate** | Lets triggers through by chance (`?60`) or by lap (`!2:4`). |
+| **mod** | Colours what passes through it — `=cut.3,gain-6`, `+trans12`. |
+| **colony** | A whole graph as one cell, with its own meter and tempo. Colonies nest without limit, which is where the fractal comes from. |
+
+Edges carry triggers: `pulse -> kick`, `swarm -> bass on=0`,
+`pulse -> maybe -> dark -> bass`. A trigger into a colony starts its bar.
+
+Add cells with the toolbar's **+** buttons or a right-click on the dish, wire
+them by dragging from a cell's nub, and edit the selected one in the CELL pane
+with buttons, chips and sliders. Nothing here needs typing.
+
+### The generators
+
+A **rule** cell runs one of nine generators over its alphabet of shard queries:
+
+| Generator | What it emits |
+|---|---|
+| `fib` | Fibonacci word over the first two symbols; drifts one step per lap. |
+| `fractal` | Self-similar sequences: `thue` (Thue–Morse), `cantor` (dust), `dragon` (curve turns), `sierpinski` (one triangle row per lap). |
+| `euclid` | Euclidean rhythm — hits spread as evenly as possible across the span, rotated per lap. |
+| `life` | Conway's Game of Life: rows are the alphabet, one generation per lap. `form AABA` replays sections. |
+| `rand` | Seeded random pick per cell per lap; `p` is the chance a cell plays. |
+| `frag` | One-beat fragments of the alphabet, shuffled and re-resolved every lap. |
+| `echo` | A shard and its decaying repeats every N cells. |
+| `accel` | Accelerando or ritardando: step time warps from × `from` to × `to` across the span. |
+| `gliss` | Glissando: transpose sweeps from → to semitones across the span. |
+
+### Meters
+
+Meters are free. `meter 7/8 groups=3+2+2`, `meter 11/8 groups=3+3+3+2`,
+`meter 5/4`. A colony's bar is num/den whole notes at its own tempo, and the
+`groups` accent the downbeat of each group — which shapes both what you hear and
+how the colony is drawn. Nested colonies can each be in a different meter.
+
+### It grows
+
+The colony is alive while it plays. The header's **grow** slider sets how eagerly
+it buds, prunes and mutates on every bar; 0 freezes it. **max** caps the number
+of cells, and **✚ grow** takes one growth step now. **BUD** on a selected cell
+grows a child off it.
+
+**grain** picks the shard length the colony reaches for when it buds — 1 beat is
+chopped, 16 beats is four-bar drones. **swing** lands the odd steps of every
+rule late: 50% is straight, 67% a triplet feel.
+
+The header reads out the live state: cell count, the root meter, the current bar,
+the growth generation, the key, the crate size, and — in amber — anything that is
+silent and why.
+
+### The dish
+
+The canvas is not a diagram. Loops and colonies are raymarched gooey orbs in
+their stem's colours, swelling and brightening when they fire; the cells are
+creatures with a muscle phase and bonds that breathe and pass that phase down
+the chain; every connection is a Verlet rope grown between two membranes that
+sags, goes taut and creeps; a firing loop seeds hyphal tips that grow, branch
+and fuse; the floor is a hex lattice that crystallizes outward from a fire; and
+a Life rule shows its actual grid with its past generations stacked behind it.
+The physics runs on a fixed 1/120 s step and nothing moves fast.
+
+### The code pane
+
+The colony is also plain text, and that text is the score. **CODE** shows the
+whole colony; the CELL pane can show one cell's line on request. The text is the
+colony — editing it and applying is the same thing as building it on the dish,
+which is what makes the notation a live-coding surface rather than an export
+format. The header says `code edited — apply to hear it` while the two differ,
+and lists parse errors by count.
+
+**Templates** (`frontend/src/data/loomTemplates.ts`) ship as starting points,
+including a 7/8 · 11/8 · 5/4 nested-colony example.
+
+## API
+
+Prefix `/api/shards`.
+
+```http
+GET    /api/shards/{entry_id}         the entry's shards (empty list when not sharded)
+POST   /api/shards/{entry_id}/run     (re)shard the entry now  — ?force=true
+POST   /api/shards/query              ranked shards for a query
+POST   /api/shards/pairings           complements for a shard, or between two entries
+POST   /api/shards/keep               remember a kept pairing (taste memory)
+GET    /api/shards/{shard_id}/audio   WAV crop, optionally conformed (?bpm=&semitones=)
+```
+
+`POST /query` takes `{role?, beats?, entry?, exclude_entry?, camelot_of?, key?,
+scale?, bpm?, stretch_max?, energy?: [lo, hi], section?, mask_like?, text?,
+limit?}` and returns `{count, camelot, shards}`. Ranking is a weighted sum of
+key distance in Camelot space, tempo feasibility (`|log2(bpm / shard.bpm)|`
+after octave folding, bounded by `stretch_max`), energy match, rhythm-mask
+similarity against `mask_like`, and novelty from the kept-pairing counts.
+`camelot_of` takes an entry id and uses that song's key; `key` + `scale` names
+one directly, and also makes each result carry the `transpose` that would fit it.
+
+`POST /pairings` works two ways. Given a `shard_id` it returns that shard plus
+its ranked complements from the rest of the library. Given `entry_a` and
+`entry_b` it returns the best pairs *between* two songs — which is the "what of
+mine goes with what of mine" question.
+
+`POST /keep` takes `{a_id, b_id}` and returns the new `weight`.
+
+`GET /{shard_id}/audio` returns `audio/wav`. It reads the stem file when the
+shard names one and the mix otherwise, and 404s when the source audio is no
+longer on disk.
+
+The whole module needs the library database; without it every route answers 503.
+
+## Where else shards turn up
+
+The Shard Index is not LOOM's private store. The same engine backs quantized
+launches from the DJ pads, PERFORM slots, NodeF.I. nodes and SWAY punches, all
+against the same Beat Clock — so a pad press anywhere in the app is a launch
+that is already beat-matched and key-matched rather than a raw sample trigger.

--- a/docs/guides/lyric-analysis.md
+++ b/docs/guides/lyric-analysis.md
@@ -97,11 +97,31 @@ strong break inside a line) and meter — named only when a line's actual stress
 pattern fits a named foot, so you get "iambic tetrameter" when the line really
 is one and nothing when it is not.
 
-### Meaning: the optional interpretive pass
+### Meaning: what is computed, and what is asked for
 
-Metaphor, simile, irony, imagery, symbolism, puns and double meanings are
-readings, not measurements, so they are not computed — they are asked for.
-Tick **READ THE MEANING TOO** and pick a provider before you analyse.
+Most of what a reader calls a double meaning is not interpretive at all. It is a
+fact about the language, and the checkable ones are computed on every analysis,
+with no model and no key:
+
+- **Homophone play** — two spellings in the lyric that sound identical:
+  "sole" / "soul", "their" / "there". The dictionary proves it, so this is the
+  strongest finding in the family.
+- **Heteronyms** — one spelling with two readings and two meanings: "record",
+  "live", "tear". Which one was sung is a choice, and the rhyme depends on it,
+  so the fork is worth pointing at.
+- **A second sense** — "bars", "hook", "change", "cold". A curated list, because
+  there is no machine-readable sense inventory in this repo and a sense count
+  invented from spelling would be a lie. A word that recurs is the stronger
+  claim (the same word twice, meaning two things, is antanaclasis); a single
+  occurrence is a nudge, pitched just below the pane's default confidence floor
+  so it only shows when you ask for it.
+- **Homophone echo** — a word whose identical-sounding partner is *not* in the
+  lyric. The ear cannot tell them apart, so the second reading is available
+  whether or not it was meant.
+
+Metaphor, simile, irony, imagery and symbolism are readings, not measurements,
+so those are not computed — they are asked for. Tick **READ THE MEANING TOO**
+and pick a provider before you analyse.
 
 The pass uses whatever LLM key the assistant already has (Gemini, OpenAI,
 Anthropic, Grok, Groq, OpenRouter, in that probe order); nothing extra to set
@@ -142,9 +162,64 @@ The row of controls above the sheet is both the legend and the filter:
 |---|---|
 | The five family checkboxes | Show or hide a whole family, with its shape and its count beside it. **Sound is off by default** — alliteration, assonance and consonance fire on most of a lyric by their nature (78% of words carry a mark with every family on, against 48% without), and a highlighter over everything says nothing. |
 | **FLOOR** | Hide findings the detector is less sure of than this. Starts at 50%. |
-| **LINKS** | Draw internal, leonine and cross-line rhymes as arcs over the sheet — they are invisible in a flat list and they are the interesting part of a rap lyric. On by default. |
+| **OFF / NEAR / ALL** (wires) | How much of the wiring is drawn over the sheet — internal, leonine and cross-line rhymes as arcs, which are invisible in a flat list and are the interesting part of a rap lyric. **NEAR** is the default: connections within two lines. **ALL** draws every one, with a live count beside it. **OFF** still wires the finding you currently have open, in full. |
+| **WEB** | Open the whole lyric as one chart — see [The web](#the-web) below. |
+| **A- / A+ / B** | Lyric text size and weight. Shared with the writing surface, so both panes read the same. |
 | **STRESS** | One dot per syllable beside each line, filled where the stress falls. Off by default, and hidden when the pane is narrow. |
-| **KARAOKE OVERLAY** | Underline the same devices on the karaoke words while the song plays. On by default. |
+| **TIE** | Tie the two panes together: select a word while writing and it lights here; pick a word here and the caret lands on it over there. |
+| **FOLLOW** | Scroll this sheet with the song, the way the karaoke does. Needs a song playing in the SING tab. |
+| **ON KARAOKE** | Underline the same devices on the karaoke words while the song plays. On by default. |
+| **MARK** | Mark the lyric yourself — see [Your own marks](#your-own-marks) below. Offered only on a LYRIC-notebook draft; a song opened straight from the library shows **MARK IN THE LYRIC TAB** instead. |
+
+### The long-range shapes
+
+Above the sheet sits a map of the shapes that are too big to see on the words.
+Each is one band across the width of the song, with a code, the lines it spans,
+and tick marks where it actually lands:
+
+| Code | What it is |
+|---|---|
+| **RUN** | Consecutive lines all landing on one rhyme. |
+| **CHAIN** | One rhyme threaded across a long stretch, gaps included. |
+| **CALL** | A rhyme returning after a long gap, or in a later section. |
+| **ENDS** | A section tied at both ends: its first line rhymes with its last. |
+
+Click a band to light that shape up on the lyric. Section boundaries are drawn
+through the map as faint cuts, so a callback that crosses from verse to chorus
+reads as one. The map keeps the long shapes and says how many shorter ones it
+left out; all of them are in the findings list either way.
+
+### The web
+
+**WEB** opens the whole lyric as one chart. The sheet draws findings *on* the
+words, which is the right place to read them and the wrong place to see the
+shape — a callback across three verses is a wire that leaves the top of the
+screen. The web is the other view: one node per line, every connection drawn
+as an arc, and nothing else on the page.
+
+- **ARC** lays the lines down a vertical spine in reading order and bows each
+  connection out to the side. Distance is preserved, so a callback across forty
+  lines is a forty-line arc and looks like one.
+- **RING** closes that spine into a circle and draws the connections as chords.
+  Distance stops being legible and density starts being: a song whose chorus
+  answers every verse is a starburst.
+
+It renders to SVG and nothing else — no canvas, no layout library — so the
+export *is* the picture on the screen rather than a redraw of it. Export as SVG,
+or as PNG rasterised at whatever scale you ask for.
+
+### Your own marks
+
+The engine finds what it can prove. **MARK** is where you say what you hear:
+click the words that rhyme — two, three, as many as you like — and name them as
+one mark, with a verdict of your own. Your marks are drawn as boxes, never as
+another underline, so they never read as something the engine claimed.
+
+Marks are saved against a lyric **document**, which is why the toggle only
+appears on a LYRIC-notebook draft; a song opened from the library has nowhere to
+keep them and shows **MARK IN THE LYRIC TAB** instead. The engine never writes
+to them, so a mark survives a re-analysis unchanged. Spans that name no word in
+the document are dropped on save, and the response says how many.
 
 Findings honour their character offsets, so a multisyllabic rhyme marks
 "ele|VATION" rather than the whole word. The karaoke overlay stays
@@ -249,7 +324,15 @@ POST   /api/lyricanalysis/{entry_id}/run     {force, llm, provider, model, api_k
 GET    /api/lyricanalysis/{entry_id}/job     the analysis running for this subject, if any
 DELETE /api/lyricanalysis/{entry_id}         delete the stored analysis
 GET    /api/lyricanalysis/jobs/{job_id}      job status and result
+
+GET    /api/lyricanalysis/documents/{doc_id}/marks   the writer's own marks on this draft
+PUT    /api/lyricanalysis/documents/{doc_id}/marks   replace the whole set
 ```
+
+A mark is a set of word positions the writer picked by hand, saved with a name
+and a verdict. `GET` anchors them onto the words as they are now and names the
+ids the lyric has moved out from under; `PUT` replaces the whole set, mints ids
+server-side, and drops spans that no longer match a word.
 
 `{entry_id}` is either a library entry or a lyric document id (`lyricdoc_` plus
 32 hex characters), so one pane reads a song or a notebook page without knowing

--- a/docs/guides/lyric-analysis.md
+++ b/docs/guides/lyric-analysis.md
@@ -81,10 +81,20 @@ one letter per line, sections separated by spaces.
 ### Sound, repetition and structure
 
 Sound devices are found from the phones: a repeated word-initial consonant
-within three words is alliteration, a repeated stressed vowel within four is
-assonance, a repeated non-initial consonant with at least three carriers is
-consonance, and a dense enough run of s/z/sh/ch or p/b/t/d/k/g over a six-word
-window is sibilance or plosives.
+within three words is alliteration, a repeated non-initial consonant with at
+least three carriers is consonance, and a dense enough run of s/z/sh/ch or
+p/b/t/d/k/g over a six-word window is sibilance or plosives.
+
+Assonance is not an exact-phone match. It is a run of words ringing on one vowel
+**colour**, within a tolerance — so "green / grin" belongs together the way an
+ear hears it rather than the way a dictionary spells it. Two rules keep that
+honest. Every member of a run is measured against every other member, not just
+against the one before it, because chaining neighbour to neighbour lets a run
+drift the whole length of the vowel space one comfortable step at a time
+("green / grin / grand / grunt" comes out as one run, which is an artefact of
+the walk and not a finding). And a run may reach across a line break, but only
+so far, so a vowel does not tie the whole song together. A run that rings on
+more than one vowel reports both, with how far apart they are.
 
 Repetition is found from the words: lines that open alike (anaphora), close
 alike (epistrophe), do both (symploce), hand the last word to the next line

--- a/docs/guides/lyric-notebook.md
+++ b/docs/guides/lyric-notebook.md
@@ -111,7 +111,14 @@ PUT    /api/lyricanalysis/documents/{doc_id}         {title?, text?, language?, 
 DELETE /api/lyricanalysis/documents/{doc_id}         delete the draft and its analysis
 POST   /api/lyricanalysis/documents/{doc_id}/duplicate
 POST   /api/lyricanalysis/documents/{doc_id}/attach  {entry_id, write_lyrics}
+GET    /api/lyricanalysis/documents/{doc_id}/marks   the writer's own marks
+PUT    /api/lyricanalysis/documents/{doc_id}/marks   replace the whole set
 ```
+
+The two `marks` routes are the writer's hand-made rhyme marks, described in
+[Your own marks](lyric-analysis.md#your-own-marks). They live on the document
+rather than on the analysis, which is why marking is offered on a draft and not
+on a song opened straight from the library.
 
 A document id is `lyricdoc_` plus 32 hex characters, minted by the backend and
 never taken from a request. `PUT` sends only the fields that changed; passing

--- a/docs/guides/sing-along-and-lyrics.md
+++ b/docs/guides/sing-along-and-lyrics.md
@@ -128,7 +128,7 @@ the queued job then finds it done.
 - Timings autosave a moment after each change and when playback pauses.
 - Once a song has been analysed in STUDY, its rhymes and devices are drawn on
   the karaoke words as they are sung, one underline shape per family. Turn it
-  off with KARAOKE OVERLAY in the analysis pane.
+  off with ON KARAOKE in the analysis pane.
 
 ## Export
 

--- a/docs/guides/themes.md
+++ b/docs/guides/themes.md
@@ -1,0 +1,114 @@
+# Themes
+
+theDAW recolours the whole app, not just one tab. Open the app menu (the ☰
+button at the top right) and choose **Change Theme**. Picking a swatch applies
+it immediately, so the modal doubles as a live preview; Escape closes it. Your
+choice persists across launches.
+
+There are 28 themes in seven groups, plus a custom background image.
+
+| Group | Themes |
+|---|---|
+| Dark | Midnight, Obsidian, Graphite |
+| Metal | Silver & Black, Brushed Steel, Titanium |
+| Duotone | Navy & Gold, Charcoal & Amber, Forest & Cream, Burgundy & Rose, Slate & Copper, Ink & Cyan, Plum & Mint |
+| Light | Porcelain, Ash Grey, Paper |
+| Light Duotone | Cocoa & Sand, Olive & Bone, Cream & Navy, Blush & Charcoal, Sage & Terracotta |
+| Pastel | Pastel Mint, Pastel Lavender, Pastel Peach, Pastel Sky |
+| Gradient | Aurora, Sunset, Deep Sea |
+
+**Obsidian** is the default. **Midnight** reproduces the app's original
+hardcoded palette exactly, so it is the "no theme" option.
+
+## A custom background image
+
+**Choose an image…** in the modal picks a picture from disk and uses it as the
+app's backdrop. It is stored as a data URL so it survives a reload without
+depending on a file path that might move. A scrim gradient is laid over it and
+every surface switches to translucent values, so the image shows through the
+timeline while the panels stay readable. Clearing the image returns you to
+Obsidian.
+
+## What a theme changes, and what it does not
+
+A theme changes **neutral chrome only**: backgrounds, borders, subtle fills, and
+the text tiers that have to stay legible on them. It does not touch semantic
+colour. Purple still means selection, red still means danger, amber still means
+warning, and a stem's colour is still that stem's colour — a theme that repainted
+those would be changing what the app is telling you.
+
+Modals portaled to `<body>` sit outside the themed subtree and keep the default
+dark chrome.
+
+## The accent
+
+One thing a theme *does* get to recolour is the accent: the hue the footer's
+latched transport keys, PLAY's playing edge, the scrub fill, the model chip, the
+master-FX pill and the CREATE / PROCESS button all draw in.
+
+It is derived rather than hand-picked (`withAccent` in
+`frontend/src/lib/editThemes.ts`):
+
+- A **hued** theme uses its own tint — Navy & Gold's gold, Sage & Terracotta's
+  clay — so the chrome stops fighting the theme it sits in.
+- A **neutral** theme (one whose tint channels spread by less than 30) keeps the
+  app's purple: `168 85 247` on dark grounds, a darker `126 34 206` on light
+  ones so it still carries contrast.
+- A theme that sets `--et-accent` itself is left alone.
+
+`--et-accent-ink` — the text that sits *on* a solid fill of the accent — is
+computed from the accent's relative luminance, so a pale gold accent gets black
+text and a deep navy one gets white.
+
+## For developers
+
+### How it is wired
+
+The Shell root and the player footer carry the class `edit-theme-scope` plus the
+resolved `--et-*` variables as inline style. A block of **unlayered** CSS in
+`frontend/src/index.css` remaps the neutral chrome onto those variables — every
+`bg-black/α` surface, every `bg-white/α` fill, every `border-white/α` or hex
+border, and every hardcoded text utility onto an ink tier.
+
+Unlayered rules beat Tailwind's utilities layer, which is the whole trick: no
+per-element class edits were needed to make the app themeable, and because
+Midnight's values reproduce the original palette exactly, an un-themed app is
+pixel-identical to what it was before themes existed.
+
+The scope also drives the app design tokens (`--bg`, `--panel`,
+`--panel-border`), so token-built boxes and hardware cards re-theme along with
+the hardcoded-utility surfaces rather than staying dark islands.
+
+### The variables
+
+| Variable | Role |
+|---|---|
+| `--et-root-bg` | The app backdrop: a solid colour, a gradient, or an image |
+| `--et-shade` | The rgb triple every `bg-black/α` surface resolves to |
+| `--et-canvas` | The deepest surface — the scrolling timeline background |
+| `--et-panel` | The primary panel surface (the track-header column) |
+| `--et-popup` | Floating panels and overlays |
+| `--et-elevated` | Raised surfaces. Light themes give this a light value so they never carry dark islands |
+| `--et-line` | The rgb triple for `border-white/α` dividers |
+| `--et-line-hex` | The solid hex border |
+| `--et-tint` | The rgb triple for `bg-white/α` subtle fills |
+| `--et-ink` | Primary text — at least 7:1 against this theme's surfaces |
+| `--et-ink-2` | Secondary labels — at least 4.5:1 |
+| `--et-ink-3` | Muted and meta text floor — at least 4.5:1 |
+| `--et-ink-inv` | Text on solid accent fills (stays white on light themes) |
+| `--et-border` | The interactive-control border floor — at least 3:1 |
+| `--et-accent` / `--et-accent-ink` | Derived; see [The accent](#the-accent) |
+
+The ink tiers are chosen **per theme** against that theme's own canvas, panel,
+popup and elevated surfaces, to WCAG 2.1 contrast. That is why they are listed
+explicitly on every theme rather than computed: a ratio that holds on Obsidian
+does not hold on Paper.
+
+### Adding a theme
+
+Add an entry to `EDIT_THEMES` in `frontend/src/lib/editThemes.ts` with an `id`,
+a `label`, a `group` from the list above, `light: true` if it is a light theme,
+and a `vars` object holding only the overrides — everything unset falls back to
+`DEFAULT_ET_VARS`. Pick the four ink values against *your* surfaces and check
+the contrast; do not copy another theme's. Leave `--et-accent` out unless the
+derived one is wrong for the theme.

--- a/docs/guides/ui-controls-guide.md
+++ b/docs/guides/ui-controls-guide.md
@@ -4,6 +4,30 @@ A complete breakdown of every control in the generation interface. No jargon, no
 
 ---
 
+## Driving a knob or a fader
+
+Every continuous control in theDAW — the MIX knobs, the DJ FX sends, the track
+faders, the SLIDE surface — answers to the same four gestures.
+
+| Gesture | What it does |
+|---|---|
+| **Drag** up or down | Moves the value. Hold **Shift** for a quarter-speed fine drag. |
+| **Double-click** | Resets to that control's default. A bipolar control goes back to centre. |
+| **Arrow keys** | One step per press, or ten steps with **Shift**. **Home** and **End** jump to the top and the bottom. |
+| **Wheel** | One step per notch, ten with **Shift** — **but only when the control has focus.** |
+
+That last rule is deliberate and it is the one worth knowing. An unmodified
+wheel over an *unfocused* knob does nothing to it: the page scrolls underneath
+instead. These controls carry live level, so a knob you are merely scrolling
+past must not move — it used to walk its value with no undo entry and no cue
+that anything had happened.
+
+Focus is cheap to get. Clicking a control focuses it (the click still starts a
+drag as normal), and so does tabbing to it. Once it is focused, the wheel works
+and the page no longer scrolls under the pointer.
+
+---
+
 ## Prompting
 
 | Control | What it does |

--- a/docs/linux/setup-guide.md
+++ b/docs/linux/setup-guide.md
@@ -2,7 +2,8 @@
 
 Linux x86_64 is a supported target for the backend and the web UI. The
 dependency graph already maps it (`pyproject.toml` `[tool.uv.sources]` pulls
-the cu126 torch/torchaudio wheels for `sys_platform == 'linux'`), every pull
+the cu130 torch/torchaudio wheels for `sys_platform == 'linux'` on
+`x86_64`), every pull
 request runs `uv sync` + the test suite on `ubuntu-latest`, and the root
 `Dockerfile` runs the whole app on Debian. What has been missing is this page
 and a shell launcher — `theDAW.bat` is Windows-only.
@@ -28,11 +29,11 @@ the steps by hand.
 
 | Tool | Why | Install |
 |---|---|---|
-| **uv** | Python env + every Python dependency (pulls its own CPython 3.10) | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+| **uv** | Python env + every Python dependency (pulls its own CPython 3.12) | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 | **Node ≥ 20.19** (22.12 recommended) | Frontend dev server and the VJ sidecar | See below — distro packages are usually too old |
 | **ffmpeg** | All audio I/O: effects, exports, library ingest, MIDI, YouTube | `apt-get install ffmpeg` |
 | **git**, **build-essential**, **libglib2.0-0** | Submodules; native builds; `opencv-python-headless` runtime | `apt-get install git build-essential libglib2.0-0` |
-| **NVIDIA driver + CUDA 12.x** | GPU generation (the Medium model requires it; Small runs on CPU) | Distro / NVIDIA instructions |
+| **NVIDIA driver 580+ (R580 branch, for CUDA 13)** | GPU generation (the Medium model requires it; Small runs on CPU) | Distro / NVIDIA instructions |
 
 > **Node from apt is too old.** Ubuntu 22.04 and 24.04 ship Node 18/20.x
 > below the `>=20.19` floor in `frontend/package.json`. Use nvm:
@@ -59,10 +60,10 @@ uv sync --group dev
 cd frontend && npm install && cd ..
 ```
 
-`uv sync` installs torch + torchaudio from the cu126 index automatically —
+`uv sync` installs torch + torchaudio from the cu130 index automatically —
 there is no `--index-url` step and no manual CUDA wheel selection. A prebuilt
-`manylinux2014_x86_64` aubio wheel is committed under `wheels/`, so nothing
-needs a compiler.
+cp312 `manylinux2014_x86_64` aubio wheel is committed under `wheels/`, so
+nothing needs a compiler.
 
 ### If `uv sync` fails on `pyk4a-bundle`
 
@@ -137,8 +138,9 @@ curl -s http://localhost:8600/api/health
 ```
 
 `torch.cuda.is_available()` should print `True` on an NVIDIA machine with a
-working driver. If it prints `False`, the cu126 wheel installed but the driver
-is missing or too old for CUDA 12.6 — `nvidia-smi` will say.
+working driver. If it prints `False`, the cu130 wheel installed but the driver
+is missing or older than 580, which is what CUDA 13.0 requires — `nvidia-smi`
+will say which is installed.
 
 ## Models
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,8 +1,20 @@
 # theDAW Reference
 
-The complete, code-grounded reference for theDAW: what every feature does, which
-models and libraries it uses, and the full HTTP API. Every claim on these pages
-cites the source it came from as `path:line`.
+A code-grounded reference for theDAW: what each feature does, which models and
+libraries it uses, and the HTTP API by router cluster. Every claim on these
+pages cites the source it came from as `path:line`; line numbers are correct as
+of the commit that last touched the page, so trust a cited symbol name over a
+cited number.
+
+It is not yet complete. Five mounted modules have no route table here —
+`/api/rhythm`, `/api/shards`, `/api/lyricanalysis`, `/api/lyrics` and
+`/api/lyria` — and two workspaces, SWAY and LOOM, have no feature page. Until
+they do, their guides are the reference: [rhythm](../guides/rhythm-analysis.md),
+[LOOM and the Shard Index](../guides/loom-and-shards.md),
+[lyric analysis](../guides/lyric-analysis.md),
+[the lyric notebook](../guides/lyric-notebook.md),
+[sing-along and lyrics](../guides/sing-along-and-lyrics.md) and
+[SWAY](../guides/sway-perform-live.md).
 
 ## It runs on your machine
 
@@ -61,6 +73,14 @@ rule and the shared module contract.
 | [Audio / DSP modules](api/02-audio-dsp-modules.md) | chimera, stems, analysis, convert, effects, mastering, notation, vocal, midi |
 | [Studio / project / plugin modules](api/03-studio-project-plugin-modules.md) | foundry, project, dawimport, underfit, vj, magenta, plugin, vst, library, settings |
 | [TOUR / XR / cloud modules](api/04-tour-xr-cloud-modules.md) | tour, quest suite, xrcontrol, akvj, suno, genaiproxy |
+
+Not yet covered by a page: `lyrics`, `lyricanalysis`, `rhythm`, `shards` and
+`lyria`. Their routes are documented in the guides linked at the top of this
+page — [LOOM and the Shard Index](../guides/loom-and-shards.md) for
+`/api/shards`, [lyric analysis](../guides/lyric-analysis.md) and [the lyric
+notebook](../guides/lyric-notebook.md) for `/api/lyricanalysis`,
+[rhythm analysis](../guides/rhythm-analysis.md) for `/api/rhythm`, and
+[sing-along and lyrics](../guides/sing-along-and-lyrics.md) for `/api/lyrics`.
 
 ## How these pages are maintained
 

--- a/docs/reference/api/00-conventions.md
+++ b/docs/reference/api/00-conventions.md
@@ -32,6 +32,22 @@ admin route referenced there (`PATCH /api/modules/{name}/enabled`).
 This is why a route can 404 on one machine and work on another: the module is
 off in Settings. It is not a missing endpoint.
 
+### Off, or broken?
+
+A module can also fail to mount — a bad import, a `SyntaxError` — and the
+symptom is identical: every one of its routes 404s. The loader records the
+reason rather than swallowing it. `load_modules` writes a `module name → reason`
+map to `app.state.module_load_errors` and logs the failure at ERROR with the
+traceback, and `GET /api/modules/all` returns `_loaded: false` plus a
+`_load_error` string for any module that tried and failed
+(`backend/modules/loader.py:16-21`, `:54-65`; `backend/server.py:1028-1052`).
+
+So there are three states, and the endpoint distinguishes them: enabled and
+loaded, disabled by `module.json`, or enabled but broken with the reason
+attached. The last one used to be invisible — the underfit module shipped with
+a `SyntaxError` for three days and the tab merely looked like a network
+problem.
+
 ## The shared tool contract
 
 Modules in the effect/tool families are built with `build_router(family, tools)`

--- a/docs/reference/api/03-studio-project-plugin-modules.md
+++ b/docs/reference/api/03-studio-project-plugin-modules.md
@@ -195,8 +195,10 @@ Hosts the Audima SwayCommand performance app as an embedded iframe, the same sid
 ### updates — `/api/updates`
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/updates/check?force=` | Compare installed vs latest GitHub release (`updates/router.py:177`) |
-| GET | `/api/updates/releases` | Up to 10 recent releases (`:218`) |
+| GET | `/api/updates/check?force=` | Compare installed vs latest GitHub release; also reports `install_kind` and the release assets (`updates/router.py:224`) |
+| POST | `/api/updates/apply` | Pull a git-clone install and restart it (exit 89 → the supervisor syncs deps and respawns). 400 for the packaged app, 409 on a dirty tree or an apply already running, 503 without git (`:407`) |
+| GET | `/api/updates/apply-status` | Progress of the last `/apply` (`:401`) |
+| GET | `/api/updates/releases` | Up to 10 recent releases (`:448`) |
 
 ### delivery — `/api/edit/delivery` (delivery/export tool family)
 Router is built by `build_router("delivery", TOOLS)` (`backend/core/module_base.py:45`), so it exposes the shared tool-family surface. Tools: codec_matrix, smart_export, high_quality_src, dither, metadata, batch_export (`backend/modules/delivery/router.py:154`).

--- a/docs/reference/features/00-overview.md
+++ b/docs/reference/features/00-overview.md
@@ -22,7 +22,7 @@ Full detail: [Generation core](01-generation-core.md).
 ## Frontend: one tab per workspace
 
 The workspace tabs are declared in one place, `CENTER_TABS`
-(`frontend/src/state/appUiStore.ts:17`):
+(`frontend/src/state/appUiStore.ts:19`) — thirteen of them:
 
 | Tab | What it is | Page |
 |---|---|---|
@@ -32,9 +32,11 @@ The workspace tabs are declared in one place, `CENTER_TABS`
 | PERFORM | Live scene/clip grid | [08](08-perform-foundry-nodefi.md) |
 | DJ | Two-deck console | [07](07-dj.md) |
 | VJ | Live visuals engine | [09](09-vj-live-visuals.md) |
+| SWAY | Gesture / SwayCommand live performance deck | [sway-perform-live guide](../../guides/sway-perform-live.md) |
 | FOUNDRY | Plugin/VST interface designer | [08](08-perform-foundry-nodefi.md) |
 | UNDERFIT | LoRA finetune trainer | [11](11-underfit-lora.md) |
 | NODEFI | Node-graph generation pipelines | [08](08-perform-foundry-nodefi.md) |
+| LOOM | The Shard Index as one living colony, grown bar by bar | [loom-and-shards guide](../../guides/loom-and-shards.md) |
 | LEARN | Guides, docs, in-app assistant | [13](13-assistant-llm-suno.md) |
 | TOUR | Venue discovery and tour routing | [12](12-tour-planner.md) |
 

--- a/docs/reference/features/01-generation-core.md
+++ b/docs/reference/features/01-generation-core.md
@@ -41,4 +41,6 @@ Adapters load onto a live model and blend at runtime. Types: `lora`, `dora-rows`
 Resolution is local-first (local folder → HF cache → download), with `SA3_LOCAL_ONLY=1` forcing disk-only (`stable_audio_3/model_configs.py:147`, `:334`). Gated ARC repos fall back to an ungated public mirror with identical weights so a tokenless first run still works (`:74`). After the one-time download of the checkpoint and the ~2 GB T5Gemma encoder, no network or cloud key is needed.
 
 ### Key libraries (verbatim from pyproject.toml)
-`torch==2.7.1`, `torchaudio==2.7.1`, `transformers>=5.8.0`, `huggingface-hub>=1.7.1`, `safetensors>=0.7.0`, `einops>=0.8.2`; on Windows a pinned `flash-attn` 2.8.3 cu128/cp310 wheel, with a graceful `torch.scaled_dot_product_attention` fallback when Flash Attention is absent (`stable_audio_3/models/transformer.py:22`, `:697`).
+`torch==2.14.0`, `torchaudio==2.11.0` (both from the cu130 index), `transformers>=5.8.0`, `huggingface-hub>=1.7.1`, `safetensors>=0.7.0`, `einops>=0.8.2`; on Windows a pinned `flash-attn` 2.8.3+cu130torch2.14 wheel per Python minor (cp312–cp314), with a graceful `torch.scaled_dot_product_attention` fallback when Flash Attention is absent (`stable_audio_3/models/transformer.py:22`, `:697`).
+
+torchaudio is used for **transforms only**. All audio I/O goes through `backend/lib/audio_io.py` — libsndfile with an ffmpeg-CLI fallback — never `torchaudio.load` / `save`, which decode through torchcodec and need FFmpeg's shared libraries at import.

--- a/docs/reference/features/13-assistant-llm-suno.md
+++ b/docs/reference/features/13-assistant-llm-suno.md
@@ -18,7 +18,7 @@ Default models per provider are configured in the provider catalog (for example 
 
 Ask the assistant to do something ("switch to advanced", "set the prompt to epic orchestral and generate") and it drives the UI directly. Providers with native function calling receive an OpenAI-style tool schema (`theDAW_TOOLS`, converted to Anthropic tool format for Claude); other models emit `<action>{...}</action>` blocks the frontend executes. Actions cover navigation, prompt editing, every generation parameter, generate/abort/status, and a full **timeline-editing vocabulary**.
 
-**Navigation reaches every workspace.** `navigateTo()` resolves all twelve center tabs plus the library rail, and returns false — reported back to the model — on an unknown target, instead of silently no-opping while claiming success (`frontend/src/state/appUiStore.ts`).
+**Navigation reaches every workspace.** `navigateTo()` resolves all thirteen center tabs plus the library rail, and returns false — reported back to the model — on an unknown target, instead of silently no-opping while claiming success (`frontend/src/state/appUiStore.ts`).
 
 **Editor tools.** Twelve `editor_*` tools let the assistant read and modify the EDIT arrangement: `editor_get_state`, `add_track`, `remove_track`, `set_track`, `move_clip`, `remove_clip`, `split_clip`, `select_clip`, `set_playhead`, `set_bpm`, `set_loop`, and `add_marker`. They are implemented against `editorStore` with honest error strings, and the assistant's app context now reports the real active tab plus a bounded arrangement summary (tracks, clips, playhead, selection, loop, BPM) — previously it was architecturally blind to the timeline and was always told the user was on CREATE.
 

--- a/docs/wiki/theDAW/Getting-Started.md
+++ b/docs/wiki/theDAW/Getting-Started.md
@@ -17,7 +17,7 @@ uv run uvicorn backend.server:app --host 0.0.0.0 --port 8600 --reload   # backen
 cd frontend && npm run dev                                              # frontend
 ```
 
-On Windows, `uv sync` installs CUDA 12.8 torch and torchaudio plus the pre-built Flash Attention wheel automatically.
+On Windows, `uv sync` installs CUDA 13.0 torch and torchaudio plus the pre-built Flash Attention wheel automatically.
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ On Windows, `uv sync` installs CUDA 12.8 torch and torchaudio plus the pre-built
 | [Node.js](https://nodejs.org/) 20.19+ or 22.12+ | Frontend dev server and the VJ sidecar. |
 | [FFmpeg](https://www.gyan.dev/ffmpeg/builds/) on PATH | All audio I/O: effects, exports, library ingest, MIDI conversion, import. |
 | [Git](https://git-scm.com/) | Clones the repo; `--recurse-submodules` brings in the Magenta sidecar source. |
-| NVIDIA driver 550+ | Runs the Medium model and Magenta. The Small model runs on CPU. |
+| NVIDIA driver 580+ (R580 branch) | Runs the Medium model and Magenta. The Small model runs on CPU. |
 
 ## Reference
 

--- a/docs/wiki/theDAW/Troubleshooting.md
+++ b/docs/wiki/theDAW/Troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-**Static glitch output on the Medium model.** Flash Attention is not installed correctly. Verify it with `uv run python -c "from flash_attn import flash_attn_func; import flash_attn; print(flash_attn.__version__)"` and reinstall a wheel matching the Python, torch, and CUDA combination from [kingbri1/flash-attention](https://github.com/kingbri1/flash-attention/releases).
+**Static glitch output on the Medium model.** Flash Attention is not installed correctly. Verify it with `uv run python -c "from flash_attn import flash_attn_func; import flash_attn; print(flash_attn.__version__)"`, then re-sync it with `uv sync --reinstall-package flash-attn`. The wheel has to match **torch 2.14 + CUDA 13**, which is what this project pins; `pyproject.toml` selects the `flash_attn-2.8.3+cu130torch2.14-cp3XX-cp3XX-win_amd64.whl` asset for your Python minor from [mjun0812/flash-attention-prebuild-wheels v0.10.2](https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/tag/v0.10.2). A wheel built for any other torch/CUDA pair will not import.
 
 **"API UNREACHABLE" banner.** The backend is not listening on port 8600. Test it with `curl http://localhost:8600/api/health`. On Windows, `.\theDAW.bat` clears stale processes automatically.
 

--- a/docs/windows/setup-guide.md
+++ b/docs/windows/setup-guide.md
@@ -1,6 +1,6 @@
 # theDAW — Windows Setup Guide
 
-> Targets Windows 11 with an NVIDIA GPU and Python 3.10. theDAW is a React +
+> Targets Windows 11 with an NVIDIA GPU and Python 3.12. theDAW is a React +
 > FastAPI application; this guide covers the Windows-specific pieces the README
 > links to here.
 
@@ -32,12 +32,12 @@ detail and fallbacks.
 
 | Tool | Why |
 |------|-----|
-| Python 3.10 | The Windows Flash Attention + cu128 torch wheels are built for cp310. Python 3.11+ skips the Flash Attention wheel and the Medium GPU path degrades. `uv` can install 3.10 for you (`uv python install 3.10`). |
+| Python 3.12 | The repo pins it (`.python-version`, `requires-python >= 3.12`), and it is what the committed aubio wheel, the CUDA-13 onnxruntime-gpu wheels and the tested Flash Attention wheel are built for. `uv` installs it for you (`uv python install 3.12`). |
 | [uv](https://docs.astral.sh/uv/getting-started/installation/) | Creates the venv and installs torch/CUDA + Flash Attention. |
 | [Node.js](https://nodejs.org/) v20.19+ / v22.12+ | Frontend dev server + VJ sidecar (the Vite 7 floor). Includes npm. |
 | [FFmpeg](https://www.gyan.dev/ffmpeg/builds/) on PATH | All audio I/O: effects, exports, library ingest, MIDI conversion, YouTube/SoundCloud import. |
 | Git | Cloning the repo (use `--recurse-submodules` so the Magenta sidecar source is present). |
-| NVIDIA GPU + Driver 550+ | CUDA support for the Medium model and the Magenta sidecar. The Small model runs on CPU. |
+| NVIDIA GPU + Driver 580+ | CUDA 13 needs a driver on the R580 branch or newer. Turing (sm_75) through Blackwell are supported. Runs the Medium model and the Magenta sidecar; the Small model runs on CPU. |
 | Hugging Face account | Only if a model repo you load requires authentication. |
 
 > **`winget` not found?** Some commands below use `winget` (Windows Package
@@ -76,13 +76,15 @@ hf auth login
 
 ## What `uv sync` installs automatically on Windows
 
-`pyproject.toml` pins CUDA 12.8 wheels for torch and torchaudio and the prebuilt
-Flash Attention wheel under `[tool.uv.sources]`, gated to Windows and Python
-3.10. A plain `uv sync --group dev` on Windows therefore pulls:
+`pyproject.toml` pins CUDA 13.0 (cu130) wheels for torch and torchaudio and the
+prebuilt Flash Attention wheel under `[tool.uv.sources]`, gated to Windows and
+Python 3.12-3.14. A plain `uv sync --group dev` on Windows therefore pulls:
 
-- **torch 2.7.1+cu128** and **torchaudio 2.7.1+cu128** (from the cu128 index)
-- **flash-attn 2.8.3** (the [kingbri1](https://github.com/kingbri1/flash-attention/releases) prebuilt cp310 wheel)
-- **soundfile** (a base dependency; torchaudio's audio backend on Windows)
+- **torch 2.14.0+cu130** and **torchaudio 2.11.0+cu130** (from the cu130 index)
+- **flash-attn 2.8.3+cu130torch2.14** (the [mjun0812](https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/tag/v0.10.2) prebuilt cp312 wheel)
+- **soundfile** (a base dependency; libsndfile is what `backend/lib/audio_io.py`
+  reads and writes every file with. torchaudio is kept for transforms only — its
+  own `load` / `save` go through torchcodec now and are never called here)
 
 There is no manual torch reinstall, no manual wheel download, and no separate
 `soundfile` install. Those were required on the old upstream layout and are now
@@ -96,10 +98,11 @@ handled by `pyproject.toml`.
 > slower, with a one-line `flash_attn disabled on …` notice in the LOG panel.
 > No configuration is needed.
 
-> **Why Python 3.10?** The Flash Attention wheel is built for cp310, and
-> `pyproject.toml` only requests flash-attn on `python_version < '3.11'`. On
-> Python 3.11+ that wheel is skipped, so use Python 3.10 for the supported
-> Windows GPU path.
+> **Why Python 3.12?** `requires-python` is `>= 3.12` and `.python-version`
+> pins 3.12, which is also what the committed aubio wheel and the CUDA-13
+> onnxruntime-gpu wheels are built for. `pyproject.toml` requests flash-attn on
+> `python_version < '3.15'` and carries a wheel for cp312, cp313 and cp314, so
+> 3.13 and 3.14 get Flash Attention too — 3.12 is the tested one.
 
 ---
 
@@ -123,8 +126,8 @@ sidecar down cleanly when it exits. See the
 .\.venv\Scripts\python.exe -c "
 import torch
 print('torch', torch.__version__, '| CUDA:', torch.cuda.is_available())
-import torchaudio
-print('torchaudio backends:', torchaudio.list_audio_backends())
+from backend.lib.audio_io import load_audio, save_audio
+print('audio I/O: libsndfile via backend.lib.audio_io')
 import flash_attn
 print('flash_attn', flash_attn.__version__)
 "
@@ -133,10 +136,14 @@ print('flash_attn', flash_attn.__version__)
 Expected output:
 
 ```
-torch 2.7.1+cu128 | CUDA: True
-torchaudio backends: ['soundfile']
+torch 2.14.0+cu130 | CUDA: True
+audio I/O: libsndfile via backend.lib.audio_io
 flash_attn 2.8.3
 ```
+
+The audio check imports the app's own I/O layer rather than asking torchaudio
+for a backend list: torchaudio's `load` / `save` are not used here at all, so
+what they report says nothing about whether the app can read a file.
 
 ---
 
@@ -188,33 +195,33 @@ backend's GPU offload to share VRAM.
 
 ## Fallbacks
 
-These are only needed if the automatic install above did not apply (for example
-a non-3.10 Python, a different CUDA version, or `uv sync` resolving CPU torch).
+`uv sync` is the supported install path, and it is the only one the lock guard
+can vouch for: `[tool.uv] required-environments` names Linux x86_64 and Windows
+AMD64, so `uv lock` refuses a version without wheels for both, and
+`scripts/check_lock.py` (the pre-commit hook and CI) proves the lock installs on
+each. Hand-installing an off-lock wheel puts the venv somewhere nothing has
+tested. Re-sync instead of reaching for `uv pip install`.
 
 ### `uv sync` installed CPU-only torch
 
 ```powershell
-uv pip install torch==2.7.1+cu128 torchaudio==2.7.1+cu128 --index-url https://download.pytorch.org/whl/cu128 --reinstall
+uv sync --reinstall-package torch --reinstall-package torchaudio
 ```
 
-### A different Python or CUDA version
+`[tool.uv.sources]` maps both to the cu130 index on Windows, so a re-sync is the
+fix. If it still resolves CPU torch, something else is interfering — a custom
+index in `UV_INDEX_URL`, an offline cache, or a venv built for another platform.
 
-Flash Attention has no official Windows wheels, so match a prebuilt one to your
-Python version from [kingbri1/flash-attention](https://github.com/kingbri1/flash-attention/releases):
+### A different Python version
 
-| Python | Wheel |
-|--------|-------|
-| 3.10 | `flash_attn-2.8.3+cu128torch2.7.0cxx11abiFALSE-cp310-cp310-win_amd64.whl` |
-| 3.11 | `flash_attn-2.8.3+cu128torch2.7.0cxx11abiFALSE-cp311-cp311-win_amd64.whl` |
-| 3.12 | `flash_attn-2.8.3+cu128torch2.7.0cxx11abiFALSE-cp312-cp312-win_amd64.whl` |
-| 3.13 | `flash_attn-2.8.3+cu128torch2.7.0cxx11abiFALSE-cp313-cp313-win_amd64.whl` |
+`pyproject.toml` carries a prebuilt Flash Attention wheel for cp312, cp313 and
+cp314 — the `flash_attn-2.8.3+cu130torch2.14-cp3XX-cp3XX-win_amd64.whl` assets on
+[mjun0812/flash-attention-prebuild-wheels v0.10.2](https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/tag/v0.10.2).
+Python 3.15 and later get no wheel and fall back to PyTorch's SDPA path.
 
-```powershell
-uv pip install https://github.com/kingbri1/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu128torch2.7.0cxx11abiFALSE-cp310-cp310-win_amd64.whl
-```
-
-The wheel's CUDA version must match your torch build (these are cu128, so pair
-them with `torch==2.7.1+cu128`).
+A wheel has to match **both** the torch version and the CUDA version it was
+built against. This project is torch 2.14 + CUDA 13; a wheel for any other pair
+will not import, whatever Python it says on the filename.
 
 ### Other Windows issues
 

--- a/docs/windows/troubleshooting.md
+++ b/docs/windows/troubleshooting.md
@@ -4,21 +4,34 @@ Common issues and fixes specific to running Stable Audio 3 on Windows.
 
 ---
 
-## torchaudio: "Couldn't find appropriate backend"
+## torchaudio: "Could not load libtorchcodec"
 
 **Symptom:**
 ```
-RuntimeError: Couldn't find appropriate backend to handle uri output.wav and format None.
+RuntimeError: Could not load libtorchcodec. ... FFmpeg
 ```
 
-**Cause:** torchaudio has no audio I/O backend installed. `soundfile` is now a
-base dependency, so `uv sync` installs it automatically; this only appears if a
-custom or partial environment dropped it.
+**Cause:** from 2.9, `torchaudio.load` and `torchaudio.save` decode through
+torchcodec, which loads FFmpeg's *shared* libraries at import. No ordinary
+Windows ffmpeg build carries them — the winget, gyan "essentials" and gyan
+"full" builds are all static — so the call fails on every Windows machine.
+torchcodec is not in `uv.lock` and is not meant to be.
 
-**Fix:**
-```powershell
-uv pip install soundfile
+theDAW therefore never calls `torchaudio.load` / `save`. All audio I/O is
+`backend/lib/audio_io.py`, which reads and writes through libsndfile
+(`soundfile`) and falls back to the ffmpeg CLI for the containers libsndfile
+cannot open (m4a/aac, webm, anything with a video track). torchaudio stays in
+the project for its transforms — resample, spectrograms — and nothing else.
+
+**Fix:** if you see this, something is calling torchaudio directly. Use the
+app's loader instead:
+
+```python
+from backend.lib.audio_io import load_audio, save_audio
 ```
+
+If `soundfile` itself is missing from a hand-built environment, `uv sync`
+restores it — it is a base dependency.
 
 ---
 
@@ -29,17 +42,25 @@ uv pip install soundfile
 >>> torch.cuda.is_available()
 False
 >>> torch.__version__
-'2.7.1+cpu'
+'2.14.0+cpu'
 ```
 
 **Cause:** `uv sync` resolved CPU torch instead of the CUDA build. On Windows,
-`pyproject.toml` maps torch to the cu128 index automatically, so this usually
+`pyproject.toml` maps torch to the cu130 index automatically, so this usually
 means a custom index, an offline cache, or a non-Windows resolution interfered.
 
 **Fix:**
 ```powershell
-uv pip install torch==2.7.1+cu128 torchaudio==2.7.1+cu128 --index-url https://download.pytorch.org/whl/cu128 --reinstall
+uv sync --reinstall-package torch --reinstall-package torchaudio
 ```
+
+Re-sync rather than `uv pip install` a wheel by hand: `scripts/check_lock.py`
+and the pre-commit hook verify that the lock installs on both shipped platforms,
+and an off-lock wheel is outside what that check covers.
+
+`torch.cuda.is_available()` can also read `False` on a correctly installed cu130
+build when the driver is older than **580** — the R580 branch is what CUDA 13
+requires. `nvidia-smi` reports the installed driver version.
 
 ---
 
@@ -51,23 +72,25 @@ missing MSVC/CUDA toolkit.
 **Cause:** flash-attn has no official Windows wheels. Building from source
 requires Visual Studio Build Tools with MSVC and the matching CUDA toolkit.
 
-**Fix:** Use pre-built wheels. Match your Python version:
+**Fix:** there is nothing to build — `pyproject.toml` already pins a prebuilt
+wheel per Python minor under `[tool.uv.sources]`, so `uv sync` installs one:
+
+```powershell
+uv sync --reinstall-package flash-attn
+```
 
 | Python | Wheel |
 |--------|-------|
-| 3.10 | `flash_attn-2.8.3+cu128torch2.7.0cxx11abiFALSE-cp310-cp310-win_amd64.whl` |
-| 3.11 | `flash_attn-2.8.3+cu128torch2.7.0cxx11abiFALSE-cp311-cp311-win_amd64.whl` |
-| 3.12 | `flash_attn-2.8.3+cu128torch2.7.0cxx11abiFALSE-cp312-cp312-win_amd64.whl` |
-| 3.13 | `flash_attn-2.8.3+cu128torch2.7.0cxx11abiFALSE-cp313-cp313-win_amd64.whl` |
+| 3.12 | `flash_attn-2.8.3+cu130torch2.14-cp312-cp312-win_amd64.whl` |
+| 3.13 | `flash_attn-2.8.3+cu130torch2.14-cp313-cp313-win_amd64.whl` |
+| 3.14 | `flash_attn-2.8.3+cu130torch2.14-cp314-cp314-win_amd64.whl` |
 
-Download from: https://github.com/kingbri1/flash-attention/releases/tag/v2.8.3
+They are the release assets on
+https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/tag/v0.10.2
 
-```powershell
-uv pip install https://github.com/kingbri1/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu128torch2.7.0cxx11abiFALSE-cp310-cp310-win_amd64.whl
-```
-
-**Important:** Your PyTorch CUDA version must match the wheel. These wheels
-require cu128, so use `torch==2.7.1+cu128`.
+**Important:** the wheel's torch and CUDA versions must both match your build.
+These are **torch 2.14 + cu130**, which is what `uv sync` installs. A wheel built
+against any other pair will install and then fail to import.
 
 ---
 

--- a/docs/workflows/autoencoder.md
+++ b/docs/workflows/autoencoder.md
@@ -5,14 +5,23 @@ Stable Audio 3 uses a 44.1k stereo audio autoencoder to compress waveforms into 
 ## Encoding audio to latents
 
 ```python
-import torchaudio
+from backend.lib.audio_io import load_audio
 from stable_audio_3 import AutoencoderModel
 
 ae = AutoencoderModel.from_pretrained("same-l")  # "same-s" (small), "same-l" (medium/large)
-waveform, sr = torchaudio.load("audio.wav")
+waveform, sr = load_audio("audio.wav")
 latents = ae.encode(waveform, sr)
 # → (1, latent_dim, latent_time)
 ```
+
+> `torchaudio.load` and `torchaudio.save` are not usable in this environment.
+> Since 2.9 they decode through torchcodec, which loads FFmpeg's *shared*
+> libraries at import — no ordinary Windows ffmpeg build has them — and
+> `save` also stopped honouring `encoding` / `bits_per_sample`, so a float
+> export came back requantized. `backend/lib/audio_io.py` reads and writes
+> through libsndfile (falling back to the ffmpeg CLI for containers libsndfile
+> cannot open), never clamps a float subtype, and returns the same
+> `(tensor[channels, frames], sample_rate)` shape `torchaudio.load` did.
 
 Resampling, channel conversion, and padding are handled automatically. The latent time dimension is `samples // downsampling_ratio` (4096 for all current models). At 44.1 kHz, 10 seconds of stereo audio produces 216 latent frames, with a latent dimension of 256.
 
@@ -26,14 +35,14 @@ latents = ae.encode([waveform_a, waveform_b], sr=[44100, 22050])
 ## Decoding latents to audio
 
 ```python
-import torchaudio
+from backend.lib.audio_io import save_audio
 from stable_audio_3 import AutoencoderModel
 
 ae = AutoencoderModel.from_pretrained("same-l")
 audio_out = ae.decode(latents)
 # → (1, 2, samples)
 
-torchaudio.save("reconstructed.wav", audio_out[0].cpu(), ae.sample_rate)
+save_audio("reconstructed.wav", audio_out[0].cpu(), ae.sample_rate)
 ```
 
 ## Chunked processing for long audio
@@ -41,11 +50,11 @@ torchaudio.save("reconstructed.wav", audio_out[0].cpu(), ae.sample_rate)
 For audio that is too long to encode or decode in a single forward pass, pass `chunked=True`. `chunk_size` and `overlap` are both measured in latent frames (not audio samples).
 
 ```python
-import torchaudio
+from backend.lib.audio_io import load_audio
 from stable_audio_3 import AutoencoderModel
 
 ae = AutoencoderModel.from_pretrained("same-l")
-waveform, sr = torchaudio.load("audio.wav")
+waveform, sr = load_audio("audio.wav")
 
 latents = ae.encode(waveform, sr, chunked=True, chunk_size=128, overlap=32)
 audio_out = ae.decode(latents, chunked=True, chunk_size=128, overlap=32)

--- a/docs/workflows/inference.md
+++ b/docs/workflows/inference.md
@@ -56,11 +56,12 @@ Overview of the main controls
 Using init audio, you can edit an existing recording to change the style, genres and mood to create variations. Use the prompt to control the variation.
 
 ```python
-import torchaudio
+from backend.lib.audio_io import load_audio
 from stable_audio_3 import StableAudioModel
 
 model = StableAudioModel.from_pretrained("medium")
-init_audio = torchaudio.load("/path/to/some/audio.wav")
+waveform, sr = load_audio("/path/to/some/audio.wav")
+init_audio = (sr, waveform)   # note the order: (sample_rate, tensor)
 audio = model.generate(
     init_audio=init_audio,
     init_noise_level=0.9,
@@ -69,9 +70,16 @@ audio = model.generate(
 )
 ```
 
+> Two things about that load. `torchaudio.load` / `save` are not usable here —
+> since 2.9 they decode through torchcodec, which needs FFmpeg's *shared*
+> libraries at import — so `backend/lib/audio_io.py` is the loader: libsndfile,
+> with an ffmpeg-CLI fallback, and no clamping. And it returns
+> `(tensor, sample_rate)` while the pipeline wants `(sample_rate, tensor)`, so
+> the tuple is built explicitly rather than passed straight through.
+
 
 ## Controls
-- **`init_audio`** - The source audio as a `(sample_rate, tensor)` tuple (e.g. from `torchaudio.load()`). The audio will be noised and then denoised.
+- **`init_audio`** - The source audio as a `(sample_rate, tensor)` tuple — e.g. `(sr, waveform)` from `backend.lib.audio_io.load_audio()`, which returns them the other way round. The audio will be noised and then denoised.
 - **`init_noise_level`** — Controls how much the init audio influences the output (range: `0.0`–`1.0`, default: `1.0`). At `1.0` the init audio is fully replaced by noise and has no effect (pure generation). Lower values preserve more of the original — for example `0.1` produces a close variation, while `0.5` is a halfway blend between the original and pure generation.
 
 The other controls for text to audio are the same, however the `prompt` is now used to control how the audio will be edited. The [Prompt Guide](../guides/prompting.md) has some examples for this
@@ -80,11 +88,12 @@ The other controls for text to audio are the same, however the `prompt` is now u
 Inpainting lets you regenerate a specific region of an existing audio file while keeping the rest intact, useful for fixing a section, swapping out a sound, or extending a loop.
 
 ```python
-import torchaudio
+from backend.lib.audio_io import load_audio
 from stable_audio_3 import StableAudioModel
 
 model = StableAudioModel.from_pretrained("medium")
-inpaint_audio = torchaudio.load("/path/to/some/audio.wav")
+waveform, sr = load_audio("/path/to/some/audio.wav")
+inpaint_audio = (sr, waveform)   # note the order: (sample_rate, tensor)
 audio = model.generate(
     inpaint_audio=inpaint_audio,
     inpaint_mask_start_seconds=4.0,
@@ -97,11 +106,12 @@ audio = model.generate(
 You can also *extend* an audio by performing continuation. Simply choose a duration that is longer than your `inpaint_audio` and set `mask_start_seconds` to be the length of your audio file.
 
 ```python
-import torchaudio
+from backend.lib.audio_io import load_audio
 from stable_audio_3 import StableAudioModel
 
 model = StableAudioModel.from_pretrained("medium")
-inpaint_audio = torchaudio.load("/path/to/some/audio.wav") # Assume this is 10s long
+waveform, sr = load_audio("/path/to/some/audio.wav")  # assume this is 10s long
+inpaint_audio = (sr, waveform)   # note the order: (sample_rate, tensor)
 audio = model.generate(
     inpaint_audio=inpaint_audio,
     inpaint_mask_start_seconds=10.0,
@@ -112,7 +122,7 @@ audio = model.generate(
 
 ## Controls
 
-- **`inpaint_audio`** — The source audio as a `(sample_rate, tensor)` tuple (e.g. from `torchaudio.load()`). The region outside the mask is preserved; only the masked region is regenerated.
+- **`inpaint_audio`** — The source audio as a `(sample_rate, tensor)` tuple — e.g. `(sr, waveform)` from `backend.lib.audio_io.load_audio()`, which returns them the other way round. The region outside the mask is preserved; only the masked region is regenerated.
 - **`inpaint_mask_start_seconds`** — Start of the region to regenerate, in seconds.
 - **`inpaint_mask_end_seconds`** — End of the region to regenerate, in seconds.
 
@@ -124,11 +134,12 @@ When using batch size > 1, certain controls can be customized per-batch.
 For example, with batch_size=4:
 
 ```python
-import torchaudio
+from backend.lib.audio_io import load_audio
 from stable_audio_3 import StableAudioModel
 
 model = StableAudioModel.from_pretrained("medium")
-inpaint_audio = torchaudio.load("/path/to/some/audio1.wav")
+waveform, sr = load_audio("/path/to/some/audio1.wav")
+inpaint_audio = (sr, waveform)   # note the order: (sample_rate, tensor)
 
 audio = model.generate(
     inpaint_audio=inpaint_audio,

--- a/docs/workflows/inference.md
+++ b/docs/workflows/inference.md
@@ -1,7 +1,7 @@
 # Stable Audio 3 Inference Methods
 An overview of the different inference modes. The Python interface is shown below; the same parameters are exposed in theDAW's MAKE tab.
 
-> New to diffusion/RF models? See [Model Overview](../guides/how-inference-works.md)
+> New to diffusion/RF models? See [Model Overview](../guides/model-overview.md#how-inference-works)
 > for a conceptual overview before diving in.
 
 ## Loading the Model

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -260,12 +260,37 @@ Six controls arranged in a 3-column grid:
 
 | Control | Type | Notes |
 |---|---|---|
-| **Model** | Dropdown | `small` and `medium` for primary inference, plus `magenta-small` for Magenta RealTime 2 (§27) and `suno` for Suno cloud generation (§26). Picking Magenta drops Steps to 1 and brings up the MRT2 conditioning controls. The Suno entry opens the Aurora Cloud Console in place of the local panel. The `small-rf` and `medium-rf` checkpoints are rectified-flow training bases surfaced through the Underfit trainer (§11) rather than inference models; selecting an `-rf` variant for a direct render raises Steps to 50 and CFG to 7.0 to run it, and the ARC `small` and `medium` checkpoints are the intended generation path. |
+| **Model** | Dropdown | `small` and `medium` for primary inference, plus `magenta-small` for Magenta RealTime 2 (§27) and `suno` for Suno cloud generation (§26). Picking Magenta drops Steps to 1 and brings up the MRT2 conditioning controls. The Suno entry opens the Aurora Cloud Console in place of the local panel, and `lyria` (Lyria 3 Pro) opens the Lyria panel in place of it (§6.2.1). The `small-rf` and `medium-rf` checkpoints are rectified-flow training bases surfaced through the Underfit trainer (§11) rather than inference models; selecting an `-rf` variant for a direct render raises Steps to 50 and CFG to 7.0 to run it, and the ARC `small` and `medium` checkpoints are the intended generation path. |
 | **Duration (s)** | Integer | Total output length in seconds. Small model: max 120 s. Medium and Large: max 380 s. |
 | **Batch** | Integer | Number of simultaneous variations. Each variation produces a distinct library entry with its own seed. |
 | **Steps** | Integer | Sampler denoising steps. ARC default: 8. RF default: 50. |
 | **CFG** | Float | Classifier-free guidance scale. ARC default: 1.0. RF default: 7.0. Higher values increase adherence to the prompt and can introduce artifacts. |
 | **Seed** | Integer + reroll button | Use −1 for a random seed on each run. The reroll button generates and displays a new random seed without submitting a job. |
+
+#### 6.2.1 Lyria 3 Pro
+
+Choosing **Lyria 3 Pro (Cloud)** in the Model dropdown replaces the whole MAKE
+surface with the Lyria 3 Pro app, embedded whole and unmodified. It is its own
+project (`StarskreamEXE/lyria-3-pro`), it ships its own Express server, SPA,
+settings and library, and theDAW spawns it as a sidecar on port 5188 and frames
+it. The model dropdown stays on screen above it, because without one you would
+be stranded inside the frame with no route back to Stable Audio.
+
+It is framed rather than absorbed on purpose: at its own origin the app's
+relative `/api/*` fetches resolve against its own server, so it needs no CORS,
+no base URL and no client rewrite, and its viewport styling, portals, window
+event bus and Ctrl+Enter binding all apply to its own document and cannot
+collide with theDAW's. It drives its own transport, so there is no bridge
+between the two.
+
+The sidecar is request-driven: the Node process only starts when someone
+actually opens the panel, and the panel retries while it comes up. Once warmed,
+the frame stays mounted so a round trip to Stable Audio does not restart the
+server or lose its in-app state. `POST /api/lyria/install` clones the project
+and runs its `npm install` in the background (it needs `git`), so Settings can
+repair a missing Lyria without handing you a command line, and
+`GET`/`POST`/`DELETE /api/lyria/key` manage the `GEMINI_API_KEY` theDAW passes
+to it. A pop-out button opens it in its own window.
 
 ### 6.3 Advanced Generation Panel
 
@@ -1685,7 +1710,7 @@ latents = ae.encode(waveform, sr)
 audio_out = ae.decode(latents)
 ```
 
-Batch encoding, chunked processing, and dataset pre-encoding for LoRA training: see [docs/workflows/autoencoder.md](autoencoder.md).
+Batch encoding, chunked processing, and dataset pre-encoding for LoRA training: see [docs/workflows/autoencoder.md](workflows/autoencoder.md).
 
 ### 20.5 LoRA at Inference
 
@@ -1858,7 +1883,7 @@ Eight adapter types are available, trading parameter count against expressivenes
 | `--base_precision` | none | Cast frozen base weights to `bf16` after applying LoRA. Reduces VRAM usage; LoRA parameters stay in fp32. |
 | `--lora_checkpoint` | none | Existing checkpoint to resume from. Loaded with `strict=False`. |
 
-Full training walkthrough: [docs/workflows/lora.md](lora.md).
+Full training walkthrough: [docs/workflows/lora.md](workflows/lora.md).
 
 ---
 

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -222,7 +222,7 @@ The application window has five regions:
 
 **Global bottom dock:** pinned across the bottom of the app are two independent columns, the bottom multi-tab panel on the left (Levels / Visualize / MIDI / Sequence / DRAW / Score / Sing / Lyric / Details / SLIDE / SWAY) and the processing log on the right, aligned under the library rail. Each column has its own height, collapse toggle, and resize handle, so expanding or resizing one does not move the other, and the dock stays put regardless of the library panel's state.
 
-**Docs modal:** click the Docs button in the header to open this guide in-app. The modal supports anchor links, syntax-highlighted Markdown tables and code blocks, raw Markdown download, and browser print/PDF export. This guide is one document in the assistant's RAG corpus (the full list is in `backend/rag.py`), so revising it improves both the in-app manual and the assistant's grounding.
+**Docs modal:** open the **?** help popover and click **Docs** beside its search field to read this guide in-app. The modal supports anchor links, syntax-highlighted Markdown tables and code blocks, raw Markdown download, and browser print/PDF export. This guide is one document in the assistant's RAG corpus (the full list is in `backend/rag.py`), so revising it improves both the in-app manual and the assistant's grounding.
 
 **Mobile access share:** click the QR/link button in the header to copy or scan the current LAN or tunnel URL for mobile performance access. This is useful with the VJ tab and any browser-based controller or viewer.
 

--- a/frontend/public/USER_GUIDE.md
+++ b/frontend/public/USER_GUIDE.md
@@ -106,7 +106,7 @@ All in-browser audio (library playback, waveform editor preview, step sequencer,
 
 ### Prerequisites
 
-Put these on the PATH first: **[uv](https://docs.astral.sh/uv/getting-started/installation/)** (Python env + packages), **[Node.js](https://nodejs.org/) v20.19+ / v22.12+** (frontend + VJ sidecar, includes npm; the Vite 7 floor), **[FFmpeg](https://www.gyan.dev/ffmpeg/builds/)** (every audio path: effects, exports, ingest, MIDI, YouTube import), **Git** (clone with `--recurse-submodules` for the Magenta sidecar source), and an **NVIDIA driver 550+** for the Medium model and Magenta (the Small model runs on CPU). On Windows, `theDAW.bat` verifies uv/node/npm, warns on missing FFmpeg, and bootstraps the venv + `node_modules` on first run (§4); the Windows specifics are in [windows/setup-guide.md](windows/setup-guide.md).
+Put these on the PATH first: **[uv](https://docs.astral.sh/uv/getting-started/installation/)** (Python env + packages), **[Node.js](https://nodejs.org/) v20.19+ / v22.12+** (frontend + VJ sidecar, includes npm; the Vite 7 floor), **[FFmpeg](https://www.gyan.dev/ffmpeg/builds/)** (every audio path: effects, exports, ingest, MIDI, YouTube import), **Git** (clone with `--recurse-submodules` for the Magenta sidecar source), and an **NVIDIA driver 580+** — the R580 branch, which CUDA 13 requires — for the Medium model and Magenta (the Small model runs on CPU). Turing (sm_75) through Blackwell are supported. On Windows, `theDAW.bat` verifies uv/node/npm, warns on missing FFmpeg, and bootstraps the venv + `node_modules` on first run (§4); the Windows specifics are in [windows/setup-guide.md](windows/setup-guide.md).
 
 ### Base Python environment
 
@@ -116,7 +116,7 @@ uv sync
 
 ### Linux
 
-No separate CUDA step: `pyproject.toml` maps Linux x86_64 to the cu126
+No separate CUDA step: `pyproject.toml` maps Linux x86_64 to the cu130
 torch/torchaudio index under `[tool.uv.sources]`, so plain `uv sync` installs
 the GPU build. The full walkthrough — prerequisites (Node from nvm, ffmpeg), the
 `pyk4a-bundle` glibc caveat, the `./theDAW.sh` launcher, and what differs from
@@ -130,14 +130,11 @@ uv sync --group dev
 
 ### Windows-specific requirements
 
-`pyproject.toml` includes CUDA 12.8 wheel sources for torch, torchaudio, and Flash Attention under `[tool.uv.sources]`. Running `uv sync` on Windows installs all of them automatically. No additional flags or manual wheel downloads are required for Python 3.10 with CUDA 12.8.
+`pyproject.toml` includes CUDA 13.0 (cu130) wheel sources for torch, torchaudio, and Flash Attention under `[tool.uv.sources]`. Running `uv sync` on Windows installs all of them automatically. No additional flags and no manual wheel downloads are required for the project's Python 3.12 venv with CUDA 13.0.
 
-On a different CUDA or Python version, install PyTorch manually:
-```powershell
-uv pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu128
-```
+`uv sync` is the only supported install path. `[tool.uv] required-environments` names Linux x86_64 and Windows AMD64, so `uv lock` refuses a version that has no wheels for both, and `scripts/check_lock.py` proves the lock installs on each of them — hand-installing an off-lock wheel breaks that guarantee.
 
-`soundfile` is included in the base dependencies. Flash Attention is conditionally installed (`sys_platform == 'win32' and python_version < '3.11'`); the wheel URL in `pyproject.toml` targets Python 3.10 with CUDA 12.8 and torch 2.7.0. For other combinations, download a matching wheel from [kingbri1/flash-attention](https://github.com/kingbri1/flash-attention/releases).
+`soundfile` is a base dependency, and libsndfile is what every audio read and write actually runs on, through `backend/lib/audio_io.py` (§20.2). Flash Attention is conditionally installed (`sys_platform == 'win32' and python_version < '3.15'`); `pyproject.toml` pins one prebuilt [mjun0812/flash-attention-prebuild-wheels](https://github.com/mjun0812/flash-attention-prebuild-wheels) wheel per Python minor — cp312, cp313 and cp314, all `flash_attn-2.8.3+cu130torch2.14`. On Windows this package is the only FlashAttention-2 there is, because torch's built-in flash SDPA kernel is not compiled under MSVC, and `transformer.py` gates it off below sm_80 regardless.
 
 Full walkthrough: [docs/windows/setup-guide.md](windows/setup-guide.md).
 
@@ -187,19 +184,21 @@ cd frontend && npm run dev
 
 The application window has five regions:
 
-- **Full-width header** (top): the theDAW logo, a global search input, and action buttons (Docs, mobile access QR/link, Settings, user avatar, AI Assistant orb).
+- **Full-width header** (top): the theDAW logo, the center workspace tabs, and four actions on the right — mobile access QR/link, the **?** help search, **IMPORT**, and the app menu (§37).
 - **Center workspace**: the center tab bar at the top and the active workspace below it, including that tab's own controls and run action.
 - **Library rail** (right, collapsible): browse and route library material without leaving the active workspace.
 - **Global bottom dock**: the bottom multi-tab panel and the processing log, side by side.
 - **Player footer** (bottom): a fixed transport bar.
 
-**Full-width header:** a fixed bar spanning the entire window width. It holds the theDAW logo dot, a global search input, the app menu (§37), and the action buttons listed above. There is no left panel and no left-panel toggle; the only collapsible side panel is the Library rail on the right.
+**Full-width header:** a fixed bar spanning the entire window width. It holds the theDAW logo dot, the center tab bar, and the four right-hand actions above, in that order. Settings opens only from the app menu — the header gear was retired; Docs opens from inside the **?** help popover; the global search moved to the player footer; and the AI Assistant orb is a free-floating draggable element over the app rather than a header button. There is no left panel and no left-panel toggle; the only collapsible side panel is the Library rail on the right.
+
+**The ? help search:** the **?** button opens a search over the feature registry — the same entries the Feature Tour and the pinned Feature Notes read, so the three can never drift apart. Type what you are after and each hit says what the thing is, how to use it, and which tab it lives in; **LOCATE** hands the id to the solo spotlight, which switches workspace, opens the panel the control lives in, and rings the real control on the real screen. The field takes focus on open, Down steps into the results, Up comes back out of the top of them, Enter locates the best hit, and Escape closes and hands focus back to the button. **Docs** sits beside the input and still opens this manual untouched.
 
 **IMPORT** sits between the ? help button and the ☰ app menu on every tab. It opens a small menu: **Audio files…** adds tracks to the library (pick several at once; the newest is selected and the library rail opens), **Open project…** opens a saved `.tasmo`, **DAW project…** imports an Ableton set. You can also drop audio files straight onto the IMPORT button.
 
 **Dropping files from the desktop.** Anywhere a library track can be dropped also takes audio files dragged in from File Explorer or Finder: the library list itself, the EDIT timeline (each file becomes a clip, extra files on new tracks), the MAKE init and inpaint slots, the MIX source, the Chimera stack, the MIDI panel's song box, the DJ decks, sampler pads, NEXT queue and prepared sets, the Media bucket and, for video and image files, the VJ tab. The file is imported into the library first (it shows up in the library rail with the newest selected) and then lands where you dropped it, exactly as a library track would.
 
-**Center tab switching:** the active workspace is controlled by the center tab bar (`CenterTabBar`). Each tab carries its own accent color. Legacy navigation targets such as `create`, `advanced`, `edit`, and `train` are translated into these center tabs, so assistant actions, library sends, and older shortcuts still route correctly — and the assistant can reach every workspace plus the Library rail, reporting an honest failure rather than a false success if a target does not exist. Alongside the nine below, the bar also carries **NodeF.I.** (§40), **SWAY**, and **Tour**. The nine core tabs are:
+**Center tab switching:** the active workspace is controlled by the center tab bar (`CenterTabBar`). Each tab carries its own accent color. Legacy navigation targets such as `create`, `advanced`, `edit`, and `train` are translated into these center tabs, so assistant actions, library sends, and older shortcuts still route correctly — and the assistant can reach every workspace plus the Library rail, reporting an honest failure rather than a false success if a target does not exist. There are thirteen tabs, in this on-screen order: MAKE, EDIT, MIX, PERFORM, DJ, VJ, SWAY, FOUNDRY, UNDERFIT, NODEFI, LOOM, LEARN, TOUR. Alongside the nine core tabs below, the bar carries **SWAY** (§35), **NodeF.I.** (§40), **LOOM** and **Tour**. The nine core tabs are:
 
 - **MAKE**: generate audio from a text prompt with the AI models (§6).
 - **EDIT**: arrange clips on a timeline, add effects and automation, and export (§7).
@@ -211,7 +210,9 @@ The application window has five regions:
 - **Underfit**: train LoRA finetunes in the embedded Underfit dashboard (§11).
 - **Learn**: lineage, genealogy, and the guides and assistant (§12).
 
-**Shell surfaces from the app menu:** three surfaces sit above the workspaces and open from the header. The **app menu** (§37) is the hamburger button in the header icon cluster; it groups project operations, data operations, device deploy, layout and settings, and help. The **HOME overlay** (§38) is a full-screen launcher with one card per workspace tab, a task row, and a show-at-startup preference; it appears after the boot intro and reopens from the menu. The **Feature Tour** (§38) is a six-step guided walkthrough that spotlights real controls; it starts from the menu or the HOME task row.
+**LOOM** is the thirteenth tab: the Shard Index drawn as one living colony that grows a generation every bar. It has its own guide, [guides/loom-and-shards.md](guides/loom-and-shards.md).
+
+**Shell surfaces from the app menu:** three surfaces sit above the workspaces and open from the header. The **app menu** (§37) is the hamburger button in the header icon cluster; it groups project operations, data operations, device deploy, layout and settings, and help. The **HOME overlay** (§38) is a full-screen launcher with one card per workspace tab, a task row, and a show-at-startup preference; it appears after the boot intro and reopens from the menu. The **Feature Tour** (§38) is a chaptered guided walkthrough that spotlights real controls; it starts from the menu or the HOME task row.
 
 **PERFORM tab:** the Perform workspace (`SessionView`) imports a DAW project or a `.tasmo` file and performs its scene/clip grid live. The project controls live in the tab header (a path input, Browse, and Import), so the session grid gets the full remaining height. Clicking or focusing the path input opens a dropdown of recent projects: ArrowDown and ArrowUp move through the list, Enter opens the highlighted entry, Escape closes the dropdown, and one click on an entry imports it immediately. The recent list persists across backend restarts (`data/recent_projects.json`).
 
@@ -219,19 +220,25 @@ The application window has five regions:
 
 **Right-side library rail:** the Library is a collapsible panel on the right edge. A compact, vertically-centered pull handle on the right edge of the work area (present in every workspace) toggles it open or closed, and a drag handle on the rail's inner edge resizes it; the width persists between 280 px and 640 px. Expanded fully, the rail becomes the full-width Catalogue. This lets MAKE, MIX, LEARN, VJ, and editor workflows stay visible while browsing or routing library material.
 
-**Global bottom dock:** pinned across the bottom of the app are two independent columns, the bottom multi-tab panel on the left (Visualize / Piano / Sequence / Details / Media / SLIDE / Score) and the processing log on the right, aligned under the library rail. Each column has its own height, collapse toggle, and resize handle, so expanding or resizing one does not move the other, and the dock stays put regardless of the library panel's state.
+**Global bottom dock:** pinned across the bottom of the app are two independent columns, the bottom multi-tab panel on the left (Levels / Visualize / MIDI / Sequence / DRAW / Score / Sing / Lyric / Details / SLIDE / SWAY) and the processing log on the right, aligned under the library rail. Each column has its own height, collapse toggle, and resize handle, so expanding or resizing one does not move the other, and the dock stays put regardless of the library panel's state.
 
 **Docs modal:** click the Docs button in the header to open this guide in-app. The modal supports anchor links, syntax-highlighted Markdown tables and code blocks, raw Markdown download, and browser print/PDF export. This guide is one document in the assistant's RAG corpus (the full list is in `backend/rag.py`), so revising it improves both the in-app manual and the assistant's grounding.
 
 **Mobile access share:** click the QR/link button in the header to copy or scan the current LAN or tunnel URL for mobile performance access. This is useful with the VJ tab and any browser-based controller or viewer.
 
-**AI Assistant panel:** click the orb icon in the header to open the collapsible assistant panel. It streams chat from any configured LLM provider with RAG context retrieved from the document corpus registered in `backend/rag.py` (this guide plus the other manuals and guides), supports file attachments and voice input, and exposes provider and key-pool controls. See [§19.11](#1911-assistant) for the API reference.
+**AI Assistant panel:** click the assistant orb — a free-floating element you can drag anywhere over the app, not a header button — to open the collapsible assistant panel. It streams chat from any configured LLM provider with RAG context retrieved from the document corpus registered in `backend/rag.py` (this guide plus the other manuals and guides), supports file attachments and voice input, and exposes provider and key-pool controls. See [§19.11](#1911-assistant) for the API reference.
 
-**Viewport scaling:** the UI applies a CSS `zoom` factor based on viewport width (0.85 below 1440 px; 0.95 at 1440 to 1919 px; 1.1 at 1920 px and above). Shell height calculations compensate so the layout tiles cleanly down to the footer.
+**Viewport scaling:** the Shell renders under a CSS `zoom` that fits a fixed logical canvas — 1600 x 820 CSS px — into the real window:
+
+```
+zoom = clamp(0.6, min(innerWidth / 1600, (innerHeight - 64) / 820), 1.1)
+```
+
+It is rounded to two decimals (stable across sub-pixel resize jitter), recomputed on every resize, and published as the `--layout-zoom` custom property on the `.dense-layout` root (`frontend/src/lib/layoutScale.ts`). The 64 px player footer sits outside the zoomed subtree, so the layout always tiles cleanly down to it. This replaced three width-only tiers (0.85 / 0.95 / 1.1) that had no height term, so a short window lost shell height it could not spare.
 
 ![UI shell with center tabs and right library rail](screenshots/01-shell-make.png)
 
-![Header actions (Docs, share, settings, assistant)](screenshots/01-shell-make__header-actions.png)
+![Header actions (mobile share, help search, import, app menu)](screenshots/01-shell-make__header-actions.png)
 
 ---
 
@@ -1069,7 +1076,9 @@ The picker also lists procedural synth voices grouped as **Bass**, **Lead / Chor
 
 ## 16. Bottom Panel Tabs
 
-The bottom panel is collapsible and vertically resizable (drag the grip handle above it), and a maximize toggle expands any tab to fill the window. Ten tabs are available, in order: Levels, Visualize, Piano, Sequence, DRAW, Score, Details, Media, SLIDE, and SWAY. Development builds add an eleventh, **XR Bus**, a tester for the XR control bus (§34.4); production builds hide the tab and remap a persisted selection so it can never strand you on a missing tab.
+The bottom panel is collapsible and vertically resizable (drag the grip handle above it), and a maximize toggle expands any tab to fill the window. Eleven tabs are available, in order: Levels, Visualize, MIDI, Sequence, DRAW, Score, Sing, Lyric, Details, SLIDE, and SWAY. Development builds add a twelfth, **XR Bus**, a tester for the XR control bus (§34.4); production builds hide the tab and remap a persisted selection so it can never strand you on a missing tab.
+
+Two tabs carry their own layout toggle in the tab row. **Details** switches between Details alone, Media alone, and both side by side; **Sing** switches between **Lyrics**, **Both**, **Score** and **Study** (the lyrics beside the literary analysis). What each tab *is* lives in the feature registry under `panel-<id>`, so the hover tooltip on a tab and the sentence the **?** help search returns for it are the same sentence.
 
 The panel's tab strip reads as part of the footer rather than a separate slab: it carries the footer's tinted-blur treatment and hairline border, the group toggle is a labelled **PANELS** button showing the active tab, and both dock bodies animate outward from the button that opened them.
 
@@ -1099,9 +1108,9 @@ Text in the overlay uses `textShadow` for legibility against any visualization b
 
 ![The real-time spectral analyzer](screenshots/visualizer.png)
 
-### 16.2 Piano
+### 16.2 MIDI
 
-Full piano roll interface embedded in the bottom panel. See [§15](#15-piano-roll).
+The tab reads **MIDI** in the tab row. It is the full piano roll interface embedded in the bottom panel. See [§15](#15-piano-roll).
 
 ### 16.3 Sequence
 
@@ -1130,9 +1139,11 @@ Displays full metadata for the currently selected library entry.
 
 **Prompt inference:** When the entry has been analyzed (§13.8), the **PROMPT INFERENCE** box derives a Stable Audio prompt and semantic tags from the analysis, and **USE AS PROMPT** copies the text into the MAKE prompt field. See §33.6.
 
-### 16.5 Media
+### 16.5 Media (a pane of Details)
 
-A session-scoped file holding area for arbitrary audio files. Contents are cleared on page reload.
+Media is not its own tab any more. It is one of the DETAILS tab's three layouts, chosen with the **Details tab layout** toggle in the tab row: Details alone, Media alone, or both side by side.
+
+It is a session-scoped file holding area for arbitrary audio files. Contents are cleared on page reload.
 
 - **Dropzone** accepts drag-and-drop or click-to-upload. Supported formats: WAV, MP3, FLAC, OGG, AAC, M4A, Opus. Library entries can be dragged in directly using the `application/x-thedaw-library-id` transfer protocol to locate the source file from the backend store.
 - **Per-item display**: filename, MIME type, file size.
@@ -1184,33 +1195,45 @@ The Sway's six expressive-motion dimensions (`strike`, `sway`, `pulse`, `glide`,
 
 The Sing tab shows the selected song's lyrics large and centred and moves them with the track line by line and word by word. Lyrics come from the entry's Lyrics field (Suno imports and tagged files fill it), a paste, an LRC file or whisper. **ALIGN** keeps your words and times every one of them against the vocal stem with a forced aligner; whisper then reviews the result in a separate job and underlines words it heard differently. **TAP** stamps line starts by hand while the song plays. **AUTO** runs ALIGN by itself when a song opens with lyrics but no timings. **PITCH** shows the vocal's melody and scores what you sing into the microphone. **EXPORT** writes LRC. The full walkthrough, the `lyrics` settings and the API are in [guides/sing-along-and-lyrics.md](guides/sing-along-and-lyrics.md).
 
+### 16.12 Lyric
+
+The writing surface: a notebook of lyric drafts that is not tied to a library track, with the analysis pane beside it. Write here, analyse from here, and mark rhymes by hand here — hand-made marks are stored against a lyric document, so MARK is only offered on a notebook draft. See [guides/lyric-notebook.md](guides/lyric-notebook.md) and [guides/lyric-analysis.md](guides/lyric-analysis.md).
+
 ## 17. Player Footer
 
-A fixed bar at the bottom of the viewport (z-index 50), visible and functional across all tabs and workspace modes.
+A fixed 64 px bar at the bottom of the viewport (z-index 50), visible and functional across all tabs and workspace modes. It sits outside the Shell's zoomed subtree (§5), so it is the one region that never scales. Two rows: a scrub strip on top, and a control row beneath it laid out as three tracks — now playing, the transport plate, up next and the utilities.
 
-### 17.1 Track Information (left region)
+### 17.1 Now playing (left region)
 
-- **Thumbnail**: an animated music-note icon with a purple pulse during playback.
+- **Orb speech bubble**: on wide windows (xl and up) the assistant orb's tip bubble occupies the leftmost slot, where the global search used to sit.
 - **Title**: the current `playerStore.currentLabel`, truncated to fit the column.
-- **Model chip**: derived from `useGenerateStore.lastModelName`. Shows `LIBRARY` for entries loaded from the library and `IDLE` when nothing has been generated or loaded.
+- **Model chip**: derived from `useGenerateStore.lastModelName`, drawn in the active theme's accent. Shows `LIBRARY` for entries loaded from the library and `IDLE` when nothing has been generated or loaded.
 - **Duration readout**: `MM:SS // 48kHz`, read from `playerStore.duration`.
+- **Like** and **Share** appear on hover or keyboard focus. In VJ mode a **VJ** chip also shows how many items the current set holds and whether the VJ has acknowledged it.
 
 ### 17.2 Transport (center region)
 
-| Control | Description |
+The transport is a single matte plate of five labelled keys on a hairline grid, held on the exact viewport centre by the surrounding `1fr · auto · 1fr` layout (an even key count either side of PLAY is what keeps it there):
+
+| Key | Description |
 |---|---|
-| **Loop** | Toggles looped playback in `playerStore`. Active state shown in purple. |
-| **Skip to start** | Calls `playerStore.seekByFraction(0)`. |
-| **Play / Pause** | Primary playback toggle. In EDIT workspace mode with no editor audio loaded, the first press triggers an offline render of the waveform editor timeline, loads the result into `playerStore`, and begins playback. Subsequent presses toggle playback natively. |
-| **Skip to end** | Calls `playerStore.seekByFraction(1)`. |
-| **Fullscreen** | Toggles browser fullscreen on `document.documentElement`. |
+| **LOOP** | Toggles looped playback in `playerStore`. A latched key draws in the active theme's accent (`--et-accent`), not a fixed purple. |
+| **START** | Calls `playerStore.seekByFraction(0)`. |
+| **PLAY / PAUSE** | Primary playback toggle; the printed legend flips with the glyph. In EDIT workspace mode with no editor audio loaded, the first press triggers an offline render of the waveform editor timeline, loads the result into `playerStore`, and begins playback. Subsequent presses toggle playback natively. |
+| **END** | Calls `playerStore.seekByFraction(1)`. |
+| **RAND** | Random order: any other library track plays next instead of the following one. |
 
-**Progress bar:** a horizontal track showing playback position. Click anywhere to seek (`playerStore.seekByFraction`). On hover, a circular scrubber handle appears at the current position. Time labels at left and right show current time and total duration. The footer synchronizes its playhead with the Waveform Editor; scrubbing the progress bar updates the editor timeline position when the editor timeline is the active audio source.
+Fullscreen is no longer on the plate — it is a window utility and sits with Mute, Volume and Download on the right (§17.3).
 
-### 17.3 Utilities (right region)
+**Scrub strip:** the footer's first row is a scrub strip, centred at three-fifths of the footer width with the elapsed and total times either side of it. The rail is a flat hairline that thickens under the pointer or keyboard focus; the filled part draws in the theme accent, and the playhead is a small cursor bar that widens under the hand. Click or drag anywhere to seek, and a time bubble follows the pointer. It is a real slider for assistive technology (`role="slider"` with `aria-valuetext`): Left/Right and Up/Down step by 5 s, Shift multiplies the step by six, and Home and End jump to the ends. The footer synchronizes its playhead with the Waveform Editor; scrubbing updates the editor timeline position when the editor timeline is the active audio source.
 
+### 17.3 Up next and utilities (right region)
+
+- **Up Next** (xl and up) mirrors the Now Playing block on the right: the next library entry's title and duration under an **Up Next** chip. Clicking it loads that track; with RAND on it is a random other entry, which the tooltip says. It reads "Nothing queued" when the library has nothing to follow with.
+- **Master FX indicator** is a chip that appears whenever the global master insert has effects on it. It says how many, and its tooltip says whether any of them take level; clicking it opens MIX, and the chevron beside it expands a list of what is on the insert. It draws in the theme accent and is hidden when the insert is empty.
 - **Mute toggle** switches the `playbackStore` mute flag. The volume icon changes to a red `VolumeX` when muted.
-- **Volume slider**: an overlay `<input type="range">` drives `playbackStore.volume` (0 to 100). The visual fill scales proportionally. The combined `volume × !muted` value is forwarded to `playerStore.setMasterGain`, which drives the shared Web Audio master gain node.
+- **Volume**: a `SlideTrack` (a custom `role="slider"`, keyboard-operable) drives `playbackStore.volume` (0 to 100). The combined `volume × !muted` value is forwarded to `playerStore.setMasterGain`, which drives the shared Web Audio master gain node.
+- **Fullscreen** toggles browser fullscreen on `document.documentElement`. It moved here from the transport plate.
 - **Download** retrieves the library entry whose `id` matches `playerStore.currentEntryId` and triggers a browser file download.
 - **More** is decorative.
 
@@ -1610,9 +1633,10 @@ audio = pipe.generate(
 ### 20.2 Audio-to-audio
 
 ```python
-import torchaudio
+from backend.lib.audio_io import load_audio
 
-init_audio = torchaudio.load("/path/to/audio.wav")
+waveform, sr = load_audio("/path/to/audio.wav")
+init_audio = (sr, waveform)   # the pipeline takes (sample_rate, tensor)
 audio = pipe.generate(
     init_audio=init_audio,
     init_noise_level=0.9,
@@ -1621,10 +1645,24 @@ audio = pipe.generate(
 )
 ```
 
+> **Do not call `torchaudio.load` or `torchaudio.save`.** From 2.9 they decode
+> through torchcodec, which loads FFmpeg's *shared* libraries at import — no
+> ordinary Windows ffmpeg build ships them, so the call raises "Could not load
+> libtorchcodec". `backend/lib/audio_io.py` reads and writes through libsndfile,
+> falls back to the ffmpeg CLI for containers libsndfile cannot open, never
+> clamps, and returns the same `(tensor[channels, frames], sample_rate)` shape
+> `torchaudio.load` used to. torchaudio stays in the project for transforms only.
+>
+> Note the order: `load_audio` returns `(tensor, sample_rate)`, and the pipeline
+> wants `(sample_rate, tensor)`.
+
 ### 20.3 Inpainting
 
 ```python
-inpaint_audio = torchaudio.load("/path/to/audio.wav")
+from backend.lib.audio_io import load_audio
+
+waveform, sr = load_audio("/path/to/audio.wav")
+inpaint_audio = (sr, waveform)
 audio = pipe.generate(
     inpaint_audio=inpaint_audio,
     inpaint_mask_start_seconds=4.0,
@@ -1642,7 +1680,7 @@ audio = pipe.generate(
 from stable_audio_3 import AutoencoderModel
 
 ae = AutoencoderModel.from_pretrained("same-l")
-waveform, sr = torchaudio.load("audio.wav")
+waveform, sr = load_audio("audio.wav")
 latents = ae.encode(waveform, sr)
 audio_out = ae.decode(latents)
 ```
@@ -1832,7 +1870,13 @@ Flash Attention is not loaded correctly. Verify:
 ```bash
 uv run python -c "import flash_attn; from flash_attn import flash_attn_func; print('Version:', flash_attn.__version__)"
 ```
-Any import error means the wheel does not match the installed Python, PyTorch, and CUDA combination. Reinstall from [kingbri1/flash-attention](https://github.com/kingbri1/flash-attention/releases).
+Any import error means the wheel does not match the installed Python, PyTorch, and CUDA combination. The wheel must be built for **torch 2.14 and CUDA 13** — that is what this project pins, and a wheel for any other pair will not import. `uv sync` installs the right one, so the fix is almost always to re-sync:
+
+```powershell
+uv sync --reinstall-package flash-attn
+```
+
+The wheels themselves are the `flash_attn-2.8.3+cu130torch2.14-cp3XX-cp3XX-win_amd64.whl` assets on [mjun0812/flash-attention-prebuild-wheels release v0.10.2](https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/tag/v0.10.2), one per Python minor (cp312, cp313, cp314); `pyproject.toml` pins them under `[tool.uv.sources]`.
 
 ### "FlashAttention only supports Ampere GPUs or newer"
 
@@ -2361,8 +2405,8 @@ The app menu (`HamburgerMenu`) is the hamburger button in the header icon cluste
 - **Project**: **New Project** clears the workspace for a fresh session. **Open Project** loads a saved `.tasmo` file. **Save Project** writes the current session to a `.tasmo` file. **Import DAW Project** brings in a project written by another DAW. **Open Project** and **Import DAW Project** are also reachable from the header IMPORT button, which is on screen on every tab.
 - **Data**: **Backup / Migrate**, **Check for Updates**, and **Restore Previous Version** open the maintenance dialogs described in §39.
 - **Devices**: **Deploy to Quest** opens the headset deploy dialog described in §34.8.
-- **App**: **Edit Layout** toggles Design Mode for the draggable panel layouts (its row shows an accent dot while active). **Settings** opens the Settings modal. **Docs** opens this guide (§5).
-- **Help**: **Feature Tour** starts the guided walkthrough, and **Home Screen** reopens the HOME overlay, both covered in §38.
+- **App**: **Edit Layout** toggles Design Mode for the draggable panel layouts (its row shows an accent dot while active). **Change Theme** opens the theme picker ([guides/themes.md](guides/themes.md)). **Settings** opens the Settings modal — this menu is the only way in, the header gear having been retired. **Docs** opens this guide (§5).
+- **Help**: **Feature Tour** starts the guided walkthrough, **Hide Feature Notes** / **Show Feature Notes** turns the pinned labels off or brings every one of them back (dismissed ones included), and **Home Screen** reopens the HOME overlay. All three are covered in §38 and [guides/feature-notes.md](guides/feature-notes.md).
 
 ### 37.2 The .tasmo project format
 
@@ -2378,20 +2422,24 @@ theDAW saves and loads native projects as `.tasmo` files through the `project` m
 
 ### 38.1 HOME overlay
 
-The HOME overlay (`HomeScreen`) is a full-screen launcher. It appears after the boot intro finishes and reopens on demand from the app menu's **Home Screen** item (§37). The top row shows the theDAW wordmark and a version chip. Below the hero line sit the workspace cards, one per center tab (MAKE, EDIT, MIX, Perform, DJ, VJ, Foundry, Underfit, Learn); each card shows the tab's name and its one-line description, and clicking a card opens that workspace and dismisses the overlay.
+The HOME overlay (`HomeScreen`) is a full-screen launcher. It appears after the boot intro finishes and reopens on demand from the app menu's **Home Screen** item (§37). The top row shows the theDAW wordmark and a version chip. Below the hero line sit the workspace cards, one per center tab — MAKE, EDIT, MIX, Perform, DJ, VJ, SWAY, Foundry, Underfit, NodeF.I., LOOM, Learn and Tour; each card shows the tab's name and its one-line description, and clicking a card opens that workspace and dismisses the overlay.
 
 A slim task row sits under the cards with **Open Project**, **Import Audio** (shown when an import handler is available), and **Feature Tour**. A **Show at startup** checkbox controls whether HOME appears on the next launch; the preference persists on its own (the overlay's open state always resets per launch). Escape dismisses the overlay.
 
 ### 38.2 Feature Tour
 
-The Feature Tour is a six-step guided walkthrough (`TOUR_STEPS`). It starts from the app menu's **Feature Tour** item or the HOME task row. Each step switches to the relevant tab and spotlights a real on-screen control:
+The Feature Tour is a chaptered guided walkthrough (`TOUR_CHAPTERS` and `TOUR_STEPS` in `frontend/src/onboarding/tourSteps.tsx`). It starts from the app menu's **Feature Tour** item or the HOME task row and opens on a chapter picker: take the six chapters in order, or open the one you need and leave. Each step switches to the relevant tab, opens the panel the control lives in, and spotlights the real on-screen control — the overlay swallows clicks, so a step shows you a control rather than asking you to operate one.
 
-1. **Settings**: open the app menu and go to Settings to enable or download the models and modules a feature needs.
-2. **Make music**: type a prompt in MAKE to generate audio.
-3. **Chimera**: braid two or more sounds into one by adding clips to the Chimera stack in MAKE (§6.3.1), shown with a splice motif.
-4. **Draw sound**: the DRAW panel turns a sketch into generative music.
-5. **Stems anywhere**: right-click a library track and choose Separate stems, or enable auto-stems in Settings.
-6. **Train a custom LoRA**: train on a personal dataset in the Underfit tab (§11).
+1. **Getting started** — the shell: workspaces, library, the dock, the transport, the menu.
+2. **Making music** — prompts, models, starting from audio, Chimera, DRAW and SEQUENCE.
+3. **Editing and mixing** — the timeline, the effect rack, meters, spectrum and track details.
+4. **Performing** — PERFORM, DJ, VJ, SWAY and the SLIDE control surface.
+5. **Words and notes** — Score, karaoke, lyric analysis, the rhyme web and the piano roll.
+6. **The deep end** — LOOM, NodeF.I., FOUNDRY, UNDERFIT, the assistant, LEARN and TOUR.
+
+Chapters exist because the whole walk is forty-one steps, which is not a sitting — and because the center panel warm-mounts each heavy workspace the first time it is visited, so one linear pass would start a WebGL visuals engine, a map, a 3D graph and four sidecar iframes on a machine whose owner has not made a sound yet. A chapter mounts what you opened and nothing else.
+
+The same feature registry backs the header's **?** help search and the pinned Feature Notes, so a control named in one is findable in the others.
 
 ---
 
@@ -2405,7 +2453,15 @@ The app menu's **Data** section (§37) holds backup, restore, and update operati
 
 ### 39.2 Update checks and version restore
 
-**Check for Updates** opens the update dialog, backed by the `updates` module (`/api/updates`). It compares the installed version, read from `pyproject.toml`, against the latest published release on GitHub, and caches the result on disk for six hours. **Restore Previous Version** opens the same dialog on its releases list, so an install can move to an earlier published release.
+**Check for Updates** opens the update dialog, backed by the `updates` module (`/api/updates`). It compares the installed version, read from `pyproject.toml`, against the latest published release on GitHub, and caches the result on disk for six hours (`?force=true` bypasses the cache). Being offline never produces an error page: the check returns "unknown" with the reason attached.
+
+When an update is available the dialog installs it, and how depends on the install kind `GET /check` detects:
+
+- **A git clone** (theDAW.bat, theDAW.sh, Pinokio, dev Electron) is updated in place by `POST /api/updates/apply`. The backend pulls, then exits with code **89**; the launcher that spawned it reads that code as "pull done", syncs dependencies and respawns, while the dialog polls `/api/updates/apply-status` and then `/api/health` and reloads the page when the backend is back. A clone with uncommitted local changes is refused with a 409 rather than overwritten, and a missing `git` returns 503.
+- **The packaged Windows app** downloads the installer through electron-updater — the progress bar is that download — then quits and runs it.
+- **The macOS dmg** is unsigned and cannot self-update, so the button downloads the new dmg for you to open.
+
+If anything fails, the dialog shows the log tail with **Try again** and **Release page**. **Restore Previous Version** opens the same dialog on its releases list; moving *backward* is release-driven, so it hands you that release's download page rather than switching versions for you. The full walkthrough is [guides/backup-and-updates.md](guides/backup-and-updates.md).
 
 ---
 


### PR DESCRIPTION
This pull request updates documentation throughout the project to reflect recent feature additions, improvements to onboarding, and technical changes, especially around theming, onboarding features, and backend details. The most important changes include expanded theme support, improved onboarding/search documentation, updated technical references (especially for audio I/O and backend), and various clarifications for users and developers.

**Feature and UX Documentation Updates:**

* Increased the number of available themes from 16 to 28, with updated theme groupings and clearer documentation on how to change and customize themes (`README.md`, `docs/guides/themes.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R64) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L330-R333) [[3]](diffhunk://#diff-9bd49e3684193fd323df3fde0d42b9b2e832844fa7a1320349d88161c7165e06L51-R59)
* Updated onboarding documentation to reference the new header "?" feature search, clarified the role of pinned labels (LOG and PANELS), and improved guidance for new users (`README.md`, `backend/rag.py`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39) [[2]](diffhunk://#diff-9bd49e3684193fd323df3fde0d42b9b2e832844fa7a1320349d88161c7165e06L51-R59)

**Technical and Backend Documentation Improvements:**

* Documented the use of `backend/lib/audio_io.py` as the exclusive audio I/O layer, replacing `torchaudio.load` in all examples and references, and added a note on why this is required (`README.md`, `backend/rag.py`, `docs/OFFLINE-AND-PERFORMANCE.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R304-R313) [[2]](diffhunk://#diff-9bd49e3684193fd323df3fde0d42b9b2e832844fa7a1320349d88161c7165e06R87-R100) [[3]](diffhunk://#diff-aed854a63374fa39aa8e2fa7dc86685f17ae6358d0d018aecbc6994cb6c50f99R78-R84)
* Updated technical references and line numbers throughout backend documentation to match recent refactors, including FastAPI server startup, model loading, caching, and the use of path:line citations for maintainability (`docs/OFFLINE-AND-PERFORMANCE.md`). [[1]](diffhunk://#diff-aed854a63374fa39aa8e2fa7dc86685f17ae6358d0d018aecbc6994cb6c50f99L5-R5) [[2]](diffhunk://#diff-aed854a63374fa39aa8e2fa7dc86685f17ae6358d0d018aecbc6994cb6c50f99L29-R51) [[3]](diffhunk://#diff-aed854a63374fa39aa8e2fa7dc86685f17ae6358d0d018aecbc6994cb6c50f99L61-R66) [[4]](diffhunk://#diff-aed854a63374fa39aa8e2fa7dc86685f17ae6358d0d018aecbc6994cb6c50f99R78-R84)

**Other Notable Updates:**

* Clarified troubleshooting steps for the Medium model on Windows, specifying the required `flash_attn` wheel version and installation method (`README.md`).
* Updated Docker documentation to reflect the move to torch 2.14.0+cu130, replacing previous references to 2.7.1+cu126 (`docs/DOCKER.md`). [[1]](diffhunk://#diff-005fcade827e716a352a3d1d3c65f153687096adee7029e3d2924f037dd7efd4L27-R27) [[2]](diffhunk://#diff-005fcade827e716a352a3d1d3c65f153687096adee7029e3d2924f037dd7efd4L69-R69)
* Expanded documentation of the frontend's bottom panel to include the new "Lyric" tab (`README.md`).

These changes ensure the documentation accurately reflects the current state of the application, improves onboarding and troubleshooting, and clarifies technical requirements and architecture for both users and contributors.