### PR TITLE
Global io devices

### DIFF
--- a/backend/modules/settings/store.py
+++ b/backend/modules/settings/store.py
@@ -23,7 +23,7 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 
 
 DEFAULT_SETTINGS: dict[str, Any] = {
@@ -118,6 +118,35 @@ DEFAULT_SETTINGS: dict[str, Any] = {
         # here, so this default is what lets the PATCH land.
         "musescore_path": "",
     },
+    "io": {
+        # Global input/output device choices, plus per-surface overrides.
+        #
+        # Every slot stores BOTH the browser deviceId and the label the device
+        # had when it was chosen. deviceIds are salted per-origin and rotate
+        # when site data is cleared, so the id alone is not portable between
+        # the browser build (:5173) and the desktop app (app://) that the same
+        # user switches between with app.launch_mode. The label is the recovery
+        # key: the frontend resolves by id, then by label, then falls back to
+        # the system default WITH a visible notice — never silently.
+        #
+        # Empty id AND empty label = "use the system default".
+        "audio_output": {"id": "", "label": ""},  # main mix
+        "cue_output": {"id": "", "label": ""},  # DJ headphone pre-listen
+        "audio_input": {"id": "", "label": ""},  # microphone
+        # 'all' (every port, including one plugged in later) | 'some' (ports).
+        "midi_inputs": {"mode": "all", "ports": []},
+        "midi_output": {"id": "", "label": ""},  # MIDI thru; '' = send nothing
+        "visual_display": {"id": "", "label": ""},  # Electron display for pop-outs
+        # Per-surface overrides keyed by surface id (see frontend
+        # state/ioSurfaces.ts), each value a {id,label} ref. A surface with NO
+        # entry follows the global slot; an entry of {"id":"","label":""} means
+        # "the OS default, ignoring the global".
+        #
+        # NOTE: `patch()` assigns a dict-valued key WHOLESALE — it does not
+        # deep-merge — so a caller must always PATCH the complete object for
+        # `overrides` (and for every slot above), never a fragment.
+        "overrides": {},
+    },
 }
 
 
@@ -190,6 +219,11 @@ def _merge_defaults(payload: dict[str, Any]) -> dict[str, Any]:
         # Migration v6 → v7: add the `notation` section (artist). New section,
         # already filled from DEFAULT_SETTINGS above; re-persist the bump.
         merged.setdefault("notation", deepcopy(DEFAULT_SETTINGS["notation"]))
+    if old_version < 8:
+        # Migration v7 → v8: add the `io` section (global device choices +
+        # per-surface overrides). New section, already filled from
+        # DEFAULT_SETTINGS above; this branch re-persists the bumped schema.
+        merged.setdefault("io", deepcopy(DEFAULT_SETTINGS["io"]))
 
     merged["schema_version"] = SCHEMA_VERSION
     return merged

--- a/docs/IN-THE-WORKS.md
+++ b/docs/IN-THE-WORKS.md
@@ -250,6 +250,41 @@ driven in the live app yet; items stay here until that happens.
   `frontend/src/components/layout/score/chords/ChordStripCanvas.tsx`,
   `frontend/src/components/layout/score/chords/ChordDiagram.tsx`
 
+## P2 — device I/O follow-ups (added 2026-09-12, from the global I/O menu)
+
+The global input/output menu shipped with these three deliberately left out;
+each is a written reason in the PR, not an oversight.
+
+- [ ] **Camera picker for the VJ (phase 2).** theDAW cannot enumerate cameras for
+  the VJ: deviceIds are salted per origin and the VJ iframe runs on the backend
+  origin, so a host-side list is wrong by construction. The list has to be
+  enumerated INSIDE the VJ and travel up. Protocol to add: host →
+  `{type:'sa3-vj/camera', on, deviceId?}`, VJ →
+  `{type:'sa3-vj/camera-devices', devices:[{id,label}], active}`. Needs
+  `gantasmo/VJ-9000` cloned, edited, rebuilt and `electron-ui/resources/vj-dist`
+  re-staged. Note `frontend/src/state/slideStore.ts` (`VisualControl.kind` is
+  `'range' | 'toggle'`) cannot carry a picker — both `ingestManifest` and
+  `applyFromVj` branch exhaustively, so a select kind is a four-site change
+  across two repos. — M — `frontend/src/views/VJView.tsx:103-107,626-628`,
+  `backend/modules/vj/sidecar.py:181`
+- [ ] **Output routing for the 17 edit-module windows.** Each page owns its own
+  AudioContext inside a same-origin iframe, so a `'thedaw-sink'` message would
+  only move the two pages that play through an `<audio>` element — a control
+  that works for 2 of 17 is worse than none. Doing it properly means the pages
+  register their context with `theDAWKit` (a new `registerContext`) and the kit
+  applies `setSinkId` to both. Extend
+  `frontend/src/components/audio/effects/editModulesContract.test.ts:31` with the
+  fourth protocol token so the pages cannot drift. — S —
+  `frontend/public/edit-modules/module-kit.js`,
+  `frontend/src/components/audio/EffectGuiStage.tsx:122-129`
+- [ ] **Assistant voice input off the Web Speech API.** `AssistantPanel` builds a
+  `SpeechRecognition`, which has no device parameter, so it always takes the OS
+  default no matter what the I/O menu says (the menu says so, in words).
+  Migrating it to the `MediaRecorder` + `/api/assistant/transcribe` path the
+  UNDERFIT orb already uses would put it on the chosen microphone. — S —
+  `frontend/src/orb-kit/AssistantPanel.tsx:183`,
+  `frontend/src/views/underfit/UnderfitAssistantOrb.tsx:333-345`
+
 ## P0 — breaks the app's primary action
 
 - [ ] **ABORT is client-side only.** No cancel route exists; the job finishes on the GPU, writes artifacts to the library, and holds `_generation_job_lock` so the next CREATE queues behind it. — M — `backend/server.py:105,1351`, `frontend/src/state/generateStore.ts:759`

--- a/electron-ui/main/index.ts
+++ b/electron-ui/main/index.ts
@@ -5,6 +5,7 @@ import {
   dialog,
   protocol,
   net,
+  screen,
   session,
   shell,
 } from 'electron'
@@ -506,11 +507,17 @@ function createWindow(): void {
       return false
     }
   }
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  mainWindow.webContents.setWindowOpenHandler(({ url, frameName, features }) => {
     if (isExternal(url)) {
       void shell.openExternal(url)
       return { action: 'deny' }
     }
+    // The VJ pop-out asks for a specific monitor (Settings -> Inputs & outputs
+    // -> Pop-out screen). It travels in the window.open features string because
+    // that is the only channel available from inside the click handler — and
+    // the call HAS to stay in the gesture or the pop-out is blocked.
+    const bounds = requestedDisplayBounds(frameName, features)
+    if (bounds) return { action: 'allow', overrideBrowserWindowOptions: bounds }
     return { action: 'allow' }
   })
   mainWindow.webContents.on('will-navigate', (event, url) => {
@@ -525,6 +532,36 @@ function createWindow(): void {
   // backend is ready — exactly like the web app. This keeps ONE background the
   // whole time and keeps the desktop + web boot flows in sync.
   loadRenderer()
+}
+
+/**
+ * Where a pop-out asked to be placed. Returns null when the window is not one
+ * we position, when no display was asked for, or when that display is gone —
+ * in which case Chromium's own default placement applies.
+ */
+function requestedDisplayBounds(
+  frameName: string,
+  features: string,
+): { x: number; y: number; width: number; height: number } | null {
+  if (frameName !== 'sa3-vj-window') return null
+  const match = /(?:^|,)\s*thedawDisplay=([^,]+)/.exec(features || '')
+  const wanted = match?.[1]?.trim()
+  if (!wanted) return null
+  try {
+    const target = screen.getAllDisplays().find((d) => String(d.id) === wanted)
+    if (!target) return null
+    const area = target.workArea
+    const width = Math.min(1280, area.width)
+    const height = Math.min(800, area.height)
+    return {
+      x: Math.round(area.x + (area.width - width) / 2),
+      y: Math.round(area.y + (area.height - height) / 2),
+      width,
+      height,
+    }
+  } catch {
+    return null
+  }
 }
 
 function loadRenderer(): void {
@@ -687,6 +724,23 @@ function registerIpcHandlers(): void {
   // into the MIX area: the backend sidecar reparents the editor under this HWND.
   // getNativeWindowHandle() returns a Buffer holding the pointer; encode it as a
   // decimal string so it survives JSON/IPC without precision loss.
+  // The monitors this machine has, so the renderer can offer them as a choice
+  // for pop-out windows. Web has no equivalent API, which is why that row reads
+  // "desktop app only" in a browser.
+  ipcMain.handle('display:list', () => {
+    try {
+      const primary = screen.getPrimaryDisplay().id
+      return screen.getAllDisplays().map((d) => ({
+        id: String(d.id),
+        label: `${d.label || `Display ${d.id}`} (${d.size.width}x${d.size.height})${d.id === primary ? ' · primary' : ''}`,
+        bounds: d.workArea,
+        primary: d.id === primary,
+      }))
+    } catch {
+      return []
+    }
+  })
+
   ipcMain.handle('window:getNativeHandle', () => {
     if (!mainWindow) return null
     try {

--- a/electron-ui/preload/index.ts
+++ b/electron-ui/preload/index.ts
@@ -16,6 +16,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Screen-space content-area bounds (DIP) for converting an element rect into
   // absolute screen pixels.
   getContentBounds: () => ipcRenderer.invoke('window:getContentBounds'),
+  // Monitors attached to this machine, for the pop-out screen choice in
+  // Settings -> Inputs & outputs. Absent in a browser, which is what makes that
+  // row render as "desktop app only" rather than as a dead dropdown.
+  listDisplays: () => ipcRenderer.invoke('display:list'),
   // Subscribe to OS file-open events (double-clicked .tasmo / .gan). Returns a
   // disposer so the renderer can unsubscribe (StrictMode-safe).
   onOpenFile: (cb: (filePath: string) => void) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,6 +59,10 @@ import { startPoseRouting } from './state/poseRouting';
 import { startXrViz, stopXrViz } from './state/xrViz';
 import { useMidiDevicesStore } from './state/midiDevicesStore';
 import { isMidiAudioMuted, useMidiTriggerStore } from './state/midiTriggerStore';
+import { midiInputConfig, startIoDevices, useIoDevicesStore } from './state/ioDevicesStore';
+import { midiPortAllowed } from './lib/midiPortFilter';
+import { setMidiOutputPorts } from './state/midiOutBus';
+import { useFeatureToggleStore } from './state/featureToggleStore';
 import { useGanStore } from './state/ganStore';
 import { useProjectStore } from './state/projectStore';
 import { useAppUiStore } from './state/appUiStore';
@@ -191,6 +195,15 @@ export default function App() {
     void useModuleStore.getState().load();
   }, [isBackendReady]);
 
+  // ONE device-change subscription for the whole app, plus the boot read of the
+  // saved input/output choices. Idempotent — it only ever runs once. Waits for
+  // the backend so the first /api/settings round trip lands rather than
+  // failing and leaving every device on the system default.
+  useEffect(() => {
+    if (!isBackendReady) return;
+    startIoDevices();
+  }, [isBackendReady]);
+
   useEffect(() => {
     logInfo('system', 'theDAW UI initialized');
   }, []);
@@ -219,12 +232,22 @@ export default function App() {
   // the synth voice has its own envelope that naturally decays.
   // Hot-plug aware via MIDIAccess.onstatechange.
   const midiEnabled = useMidiTriggerStore((s) => s.enabled);
+  // Which ports are let through (Settings -> Inputs & outputs). Re-attaching on
+  // a change is the whole point, so the effect depends on a stable key rather
+  // than the object identity a settings refresh would churn.
+  const midiInputKey = useFeatureToggleStore((s) => {
+    const cfg = s.settings.io?.midi_inputs;
+    const ports = Array.isArray(cfg?.ports) ? cfg.ports : [];
+    return `${cfg?.mode ?? 'all'}:${ports.map((p) => p.id || p.label).join(',')}`;
+  });
   useEffect(() => {
     // Gated behind the master MIDI toggle: until the user turns MIDI on
     // we never call requestMIDIAccess(), so Chrome's permission prompt +
     // Web MIDI deprecation notice only appear on explicit opt-in.
     if (!midiEnabled) {
       useMidiDevicesStore.getState().setMidiInputs([]);
+      useIoDevicesStore.getState().setMidiPorts([]);
+      setMidiOutputPorts([]);
       return;
     }
     if (typeof navigator === 'undefined' || !('requestMIDIAccess' in navigator)) return;
@@ -256,14 +279,29 @@ export default function App() {
     };
 
     const attach = (a: MIDIAccess) => {
+      const cfg = midiInputConfig();
       const names: string[] = [];
+      const ports: Array<{ id: string; label: string }> = [];
       a.inputs.forEach((input) => {
-        input.onmidimessage = onMidiMessage;
+        // Filter HERE, at the Web MIDI boundary, where the port id still
+        // exists — never inside publishMidi, which also carries the Quest
+        // bridge and the synthetic Sway surface and would silence both.
+        input.onmidimessage = midiPortAllowed(input, cfg) ? onMidiMessage : null;
         names.push(input.name ?? 'unnamed');
+        ports.push({ id: input.id, label: input.name ?? 'unnamed' });
       });
       // Publish the connected device names so the SLIDE/DJ controller pickers
       // can auto-detect a profile by name (and show what's plugged in).
       useMidiDevicesStore.getState().setMidiInputs(names);
+      // And the {id,label} pairs for the I/O menu: names alone are not
+      // identities (two identical controllers collide, and unplug/replug
+      // reorders the list).
+      const outs: Array<{ id: string; name: string; send: (data: number[]) => void }> = [];
+      a.outputs.forEach((out) => {
+        outs.push({ id: out.id, name: out.name ?? 'unnamed', send: (data) => out.send(data) });
+      });
+      setMidiOutputPorts(outs);
+      useIoDevicesStore.getState().setMidiPorts(ports);
     };
 
     // Pass an explicit MIDIOptions ({ sysex: false }) — we don't need SysEx for
@@ -303,8 +341,10 @@ export default function App() {
         });
         access.onstatechange = null;
       }
+      setMidiOutputPorts([]);
+      useIoDevicesStore.getState().setMidiPorts([]);
     };
-  }, [midiEnabled]);
+  }, [midiEnabled, midiInputKey]);
 
   // Auto-enable the Sway DAW-control mirror when the Audima Sway is the detected
   // controller — until the user manually toggles it, after which their choice

--- a/frontend/src/components/audio/IoDeviceSelect.tsx
+++ b/frontend/src/components/audio/IoDeviceSelect.tsx
@@ -1,0 +1,258 @@
+/**
+ * The one device picker.
+ *
+ * Every place that used to roll its own `<select>` of `enumerateDevices()`
+ * results renders this instead, so they share one option vocabulary ("Default
+ * (Scarlett 2i2)" vs "System default" vs a named device), one story for the
+ * pre-permission state, and one visible answer when the saved device is gone.
+ * Before this there were three pickers with three different first-option
+ * labels, two of which invented names like "Input 4f2a1b" out of a device id.
+ *
+ * Accessibility (CLAUDE.md rule 3): a native <select> with a stable `id`, a
+ * matching `name`, and a real <label htmlFor> — visible or sr-only, never
+ * absent. The warning chips are plain text next to it, not a title-only hint.
+ */
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { registerSinkElement } from '../../lib/audioSink';
+import {
+  FOLLOW_GLOBAL,
+  type DeviceRef,
+  type LiveDevice,
+  type Resolved,
+} from '../../lib/ioResolve';
+import { overrideSelectValue } from '../../lib/ioResolve';
+import {
+  deviceRefFromId,
+  liveDevices,
+  resolveGlobal,
+  setGlobalDevice,
+  setSurfaceOverrideFromSelect,
+  surfaceOverride,
+  useIoDevicesStore,
+  useResolvedGlobal,
+  useResolvedSurface,
+  type IoSlot,
+} from '../../state/ioDevicesStore';
+import { GLOBAL_SLOT_FOR_KIND, surfaceById, type SurfaceId } from '../../state/ioSurfaces';
+import { SELECT } from '../layout/settings/shared';
+
+interface Option {
+  value: string;
+  text: string;
+}
+
+
+/** The shared presentational half: label + select + the honest status chips. */
+const DeviceSelect: React.FC<{
+  id: string;
+  label: string;
+  title?: string;
+  value: string;
+  options: Option[];
+  onPick: (value: string) => void;
+  disabled?: boolean;
+  /** Shown instead of the list when the platform cannot route at all. */
+  unsupported?: string;
+  /** Blank labels: the list is not trustworthy yet, so say why. */
+  labelsKnown: boolean;
+  missing?: DeviceRef;
+  showLabel?: boolean;
+  labelClassName?: string;
+  className?: string;
+}> = ({
+  id,
+  label,
+  title,
+  value,
+  options,
+  onPick,
+  disabled,
+  unsupported,
+  labelsKnown,
+  missing,
+  showLabel,
+  labelClassName = 'text-[11px] font-mono uppercase tracking-wider text-zinc-400 shrink-0',
+  className = '',
+}) => (
+  <>
+    <label htmlFor={id} className={showLabel ? labelClassName : 'sr-only'}>
+      {label}
+    </label>
+    <select
+      id={id}
+      name={id}
+      value={value}
+      onChange={(e) => onPick(e.target.value)}
+      aria-label={label}
+      title={unsupported || title || label}
+      disabled={disabled || !!unsupported}
+      className={`${SELECT} ${className}`}
+      style={{ colorScheme: 'dark' }}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.text}
+        </option>
+      ))}
+    </select>
+    {unsupported && <span className="text-[11px] font-mono text-amber-300/80">{unsupported}</span>}
+    {!unsupported && missing && (
+      <span className="inline-flex items-center gap-1 text-[11px] font-mono text-amber-300">
+        <AlertTriangle className="w-3 h-3 shrink-0" />
+        not connected — using the system default
+      </span>
+    )}
+    {!unsupported && !labelsKnown && (
+      <span className="text-[11px] font-mono text-zinc-500">
+        device names appear once something opens the mic
+      </span>
+    )}
+  </>
+);
+
+/** Live devices that are safe to name. A blank label is never invented into one. */
+const namedDevices = (live: LiveDevice[]): LiveDevice[] => live.filter((d) => d.label !== '');
+
+/**
+ * Keep the current value selectable even when the device is not in the list —
+ * otherwise a saved choice renders as a blank box and looks lost.
+ *
+ * The wording distinguishes the two ways that happens: a device we KNOW is
+ * absent says so, while one we simply cannot see yet (no permission, so every
+ * label is blank) is named without any claim about it.
+ */
+const withCurrent = (
+  options: Option[],
+  value: string,
+  saved: DeviceRef | undefined,
+  known: 'missing' | 'unverified',
+): Option[] => {
+  if (!value || options.some((o) => o.value === value)) return options;
+  const name = saved?.label || 'Saved device';
+  return [...options, { value, text: known === 'missing' ? `${name} (not connected)` : name }];
+};
+
+/* ── per-surface override ─────────────────────────────────────────────────── */
+
+export const IoSurfaceSelect: React.FC<{
+  surface: SurfaceId;
+  /** DOM id; also used as the `name`. */
+  id?: string;
+  /** Accessible name; visible when `showLabel`. */
+  label?: string;
+  showLabel?: boolean;
+  labelClassName?: string;
+  className?: string;
+}> = ({ surface, id, label, showLabel, labelClassName, className }) => {
+  const def = surfaceById(surface);
+  const kind = def?.kind ?? 'audioIn';
+  const resolved: Resolved = useResolvedSurface(surface);
+  const live = useIoDevicesStore((s) => (kind === 'audioIn' ? s.audioIn : s.audioOut));
+  const labelsKnown = useIoDevicesStore((s) => s.labelsKnown);
+  const globalResolved = resolveGlobal(GLOBAL_SLOT_FOR_KIND[kind]);
+  const override = surfaceOverride(surface);
+
+  const globalName = globalResolved.label || 'system default';
+  const options = withCurrent(
+    [
+      { value: FOLLOW_GLOBAL, text: `Default (${globalName})` },
+      { value: '', text: 'System default' },
+      ...namedDevices(live).map((d) => ({ value: d.id, text: d.label })),
+    ],
+    overrideSelectValue(override),
+    override,
+    resolved.source === 'missing' ? 'missing' : 'unverified',
+  );
+
+  const domId = id ?? `io-surface-${surface}`;
+  return (
+    <DeviceSelect
+      id={domId}
+      label={label ?? `${def?.label ?? surface} device`}
+      title={def?.hint}
+      value={overrideSelectValue(override)}
+      options={options}
+      onPick={(v) => void setSurfaceOverrideFromSelect(surface, v)}
+      labelsKnown={labelsKnown}
+      missing={resolved.source === 'missing' ? resolved.missing : undefined}
+      showLabel={showLabel}
+      labelClassName={labelClassName}
+      className={className}
+    />
+  );
+};
+
+/* ── a global slot ───────────────────────────────────────────────────────── */
+
+export const IoGlobalSelect: React.FC<{
+  slot: IoSlot;
+  id?: string;
+  label: string;
+  showLabel?: boolean;
+  labelClassName?: string;
+  className?: string;
+  /** Set when the runtime cannot route this slot at all; disables the list. */
+  unsupported?: string;
+}> = ({ slot, id, label, showLabel, labelClassName, className, unsupported }) => {
+  const resolved = useResolvedGlobal(slot);
+  const kind = slot === 'audio_input' ? 'audioIn' : slot === 'midi_output' ? 'midiOut' : slot === 'visual_display' ? 'display' : 'audioOut';
+  const live = useIoDevicesStore((s) =>
+    kind === 'audioIn' ? s.audioIn : kind === 'midiOut' ? s.midiOut : kind === 'display' ? s.display : s.audioOut,
+  );
+  const labelsKnown = useIoDevicesStore((s) =>
+    kind === 'audioIn' || kind === 'audioOut' ? s.labelsKnown : true,
+  );
+  // A device that is gone still shows as the chosen one — the setting is kept
+  // so re-plugging it restores it, and a select that silently jumped back to
+  // "System default" would hide that.
+  const saved: DeviceRef | undefined =
+    resolved.missing ?? (resolved.deviceId ? { id: resolved.deviceId, label: resolved.label } : undefined);
+  const current = saved?.id ?? '';
+
+  const firstOption =
+    slot === 'midi_output' ? "Don't send MIDI" : slot === 'visual_display' ? 'Same window' : 'System default';
+  const options = withCurrent(
+    [
+      { value: '', text: firstOption },
+      ...namedDevices(live).map((d) => ({ value: d.id, text: d.label })),
+    ],
+    current,
+    saved,
+    resolved.source === 'missing' ? 'missing' : 'unverified',
+  );
+
+  return (
+    <DeviceSelect
+      id={id ?? `io-global-${slot}`}
+      label={label}
+      value={current}
+      options={options}
+      onPick={(v) => void setGlobalDevice(slot, deviceRefFromId(slot, v))}
+      unsupported={unsupported}
+      labelsKnown={labelsKnown}
+      missing={resolved.source === 'missing' ? resolved.missing : undefined}
+      showLabel={showLabel}
+      labelClassName={labelClassName}
+      className={className}
+    />
+  );
+};
+
+/**
+ * An <audio> element that follows a surface's OUTPUT setting.
+ *
+ * These elements sit outside the shared Web Audio graph, so
+ * AudioContext.setSinkId does not move them; they register with the element
+ * registry instead and get re-pointed whenever the setting changes.
+ */
+export const SurfaceAudio: React.FC<
+  React.AudioHTMLAttributes<HTMLAudioElement> & { surface: SurfaceId }
+> = ({ surface, ...rest }) => {
+  const ref = React.useRef<HTMLAudioElement | null>(null);
+  React.useEffect(() => registerSinkElement(surface, ref.current), [surface]);
+  return <audio ref={ref} {...rest} />;
+};
+
+/** Non-hook read for a component that only needs the id (effect deps). */
+export const currentDeviceIds = (kind: 'audioIn' | 'audioOut'): LiveDevice[] => liveDevices(kind);

--- a/frontend/src/components/audio/MicRecorder.tsx
+++ b/frontend/src/components/audio/MicRecorder.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
   Mic, Square, Play, Pause, Trash2, Wand2, PenLine, Layers, Save, X,
 } from 'lucide-react';
+import { registerSinkElement } from '../../lib/audioSink';
+import { surfaceDeviceId, useIoDevicesStore } from '../../state/ioDevicesStore';
 import { logError, logInfo } from '../../state/logStore';
 import { useLibraryStore } from '../../state/libraryStore';
 import {
@@ -96,13 +98,21 @@ export const MicRecorder: React.FC<Props> = ({ onClose, embedded = false }) => {
       return;
     }
     try {
+      // The chosen microphone (global, or this surface's own override), as a
+      // SOFT constraint so a device that vanished between the enumerate and
+      // the open degrades to the OS default instead of throwing.
+      const deviceId = surfaceDeviceId('micRecorder');
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: {
+          ...(deviceId ? { deviceId } : {}),
+          // Voice-memo profile: deliberately the OPPOSITE of the pitch paths,
+          // where all three of these distort f0 and are forced off.
           echoCancellation: true,
           noiseSuppression: true,
           autoGainControl: true,
         },
       });
+      useIoDevicesStore.getState().notePermissionGranted();
       streamRef.current = stream;
       const mime = pickMime();
       const opts = mime ? { mimeType: mime } : undefined;
@@ -256,6 +266,10 @@ export const MicRecorder: React.FC<Props> = ({ onClose, embedded = false }) => {
       setBusy(false);
     }
   };
+
+  // The take preview plays through its own element, outside the shared graph,
+  // so it follows the 'preview' surface's output rather than the main mix.
+  useEffect(() => registerSinkElement('preview', audioElRef.current), [blobUrl]);
 
   const audioEl = (
     <audio

--- a/frontend/src/components/audio/MicRecorder.tsx
+++ b/frontend/src/components/audio/MicRecorder.tsx
@@ -5,6 +5,7 @@ import {
 import { registerSinkElement } from '../../lib/audioSink';
 import { surfaceDeviceId, useIoDevicesStore } from '../../state/ioDevicesStore';
 import { logError, logInfo } from '../../state/logStore';
+import { describeMicFailure } from '../../lib/micErrors';
 import { useLibraryStore } from '../../state/libraryStore';
 import {
   sendAudioToEditor, sendAudioToInit, sendAudioToInpaint,
@@ -145,9 +146,14 @@ export const MicRecorder: React.FC<Props> = ({ onClose, embedded = false }) => {
         setElapsedSec((Date.now() - startedAtRef.current) / 1000);
       }, 250);
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      setError(msg);
-      logError('mic', `getUserMedia failed: ${msg}`);
+      // "NotFoundError: Requested device not found" told the user nothing about
+      // what to do. describeMicFailure names the cause and the fix, and marks
+      // the no-microphone case as the ordinary state of a machine rather than a
+      // fault worth an error line.
+      const failure = describeMicFailure(e, 'recording');
+      setError(failure.message);
+      if (failure.benign) logInfo('mic', failure.message);
+      else logError('mic', failure.message);
     }
   };
 

--- a/frontend/src/components/audio/PlayerFooter.tsx
+++ b/frontend/src/components/audio/PlayerFooter.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Volume2, Download, Share2, Heart, Repeat, Shuffle, VolumeX, Maximize2, MoreHorizontal, Cast, Check, Activity, ChevronUp } from 'lucide-react';
+import { Volume2, Download, Share2, Heart, Repeat, Shuffle, VolumeX, Maximize2, MoreHorizontal, Cast, Check, Activity, ChevronUp, Headphones, Speaker } from 'lucide-react';
 import { useGenerateStore } from '../../state/generateStore';
 import { usePlaybackStore } from '../../state/playbackStore';
 import { usePlayerStore } from '../../state/playerStore';
@@ -13,6 +13,8 @@ import {
 } from '../../state/mixLiveRack';
 import { callEditorPlay, isEditorPlaybackRegistered } from '../../state/editorPlaybackBridge';
 import { SlideTrack } from './SlideTrack';
+import { IoGlobalSelect } from './IoDeviceSelect';
+import { useIoDevicesStore, useResolvedGlobal } from '../../state/ioDevicesStore';
 import { OrbTipBubble } from './OrbTipBubble';
 import {
   toggleVjPlayback,
@@ -198,6 +200,97 @@ const ScrubStrip: React.FC = () => {
  * all returns the master to a clean passthrough from wherever the user is
  * standing. It sits next to the volume control because that is the symptom.
  */
+/**
+ * Output device, where the symptom is.
+ *
+ * Plugging headphones in mid-session is the moment a person reaches for this,
+ * and making them open the hamburger → Settings for it is the wrong
+ * ergonomics. Mains + cue only; the full menu is one click away.
+ *
+ * Custom control (CLAUDE.md rule 3): a button carrying its own accessible name,
+ * expanded state and the id of the panel it controls — NOT wrapped in a label.
+ */
+const AudioOutIndicator: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const main = useResolvedGlobal('audio_output');
+  const supports = useIoDevicesStore((s) => s.supports);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('pointerdown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const missing = main.source === 'missing';
+  const name = main.label || 'System default';
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={`Audio output device: ${missing ? 'not connected' : name}`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-controls="footer-audio-out"
+        title={missing ? `${name} is not connected — playing on the system default` : `Output: ${name}`}
+        className={`${iconButton} ${missing ? 'text-amber-400 hover:text-amber-300' : ''}`}
+      >
+        <Speaker className="w-4 h-4" />
+      </button>
+      <div
+        id="footer-audio-out"
+        hidden={!open}
+        role="dialog"
+        aria-label="Audio output devices"
+        className="absolute bottom-full right-0 mb-2 z-50 w-80 rounded-md border border-purple-500/30 bg-[#0c0a14] p-2 shadow-xl flex flex-col gap-2"
+      >
+        <div className="flex items-center gap-1.5">
+          <Speaker className="w-3 h-3 text-zinc-500 shrink-0" />
+          <IoGlobalSelect
+            slot="audio_output"
+            id="footer-main-out"
+            label="Main output"
+            showLabel
+            className="flex-1"
+            unsupported={supports.ctxSink ? undefined : 'the desktop app can move this'}
+          />
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Headphones className="w-3 h-3 text-zinc-500 shrink-0" />
+          <IoGlobalSelect
+            slot="cue_output"
+            id="footer-cue-out"
+            label="Cue output"
+            showLabel
+            className="flex-1"
+            unsupported={supports.elementSink ? undefined : 'not routable here'}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            window.dispatchEvent(new CustomEvent('thedaw:open-settings'));
+          }}
+          className="self-start text-[11px] font-mono uppercase tracking-widest text-purple-300 hover:text-purple-100"
+        >
+          All inputs &amp; outputs…
+        </button>
+      </div>
+    </div>
+  );
+};
+
 const MasterFxIndicator: React.FC = () => {
   const attached = useMixLiveRackStore((s) => s.attached);
   const chain = useEffectChainStore((s) => s.chain);
@@ -775,6 +868,7 @@ export const PlayerFooter: React.FC = () => {
           </button>
           <div className="flex items-center gap-4 shrink-0">
             <MasterFxIndicator />
+            <AudioOutIndicator />
             <div className="flex items-center gap-2.5">
               <button
                 type="button"

--- a/frontend/src/components/audio/WaveformEditor.tsx
+++ b/frontend/src/components/audio/WaveformEditor.tsx
@@ -53,6 +53,7 @@ import { StemsRunModal, type StemsRunOptions } from '../library/StemsRunModal';
 import { EffectWindowsHost, FxChainList, openEffectWindow, type FxScope } from './EffectWindows';
 import { ensureStems } from '../../lib/djStems';
 import { useFeatureToggleStore } from '../../state/featureToggleStore';
+import { SurfaceAudio } from './IoDeviceSelect';
 
 const TRACK_HEADER_PX = 180;
 const DECODE_TIMEOUT_MS = 15000;
@@ -4870,7 +4871,9 @@ export const WaveformEditor: React.FC<{ onSwitchTab?: (tab: string) => void }> =
           {/* Phase: review */}
           {inpaintPanel.kind === 'review' && (
             <>
-              <audio controls src={inpaintPanel.blobUrl} className="w-full h-8 mt-1" />
+              {/* Outside the shared graph, so it follows the 'preview' surface
+                  output rather than the main mix. */}
+              <SurfaceAudio surface="preview" controls src={inpaintPanel.blobUrl} className="w-full h-8 mt-1" />
               <div className="flex gap-2">
                 <button
                   onClick={() => acceptInpaint(inpaintPanel.blob)}

--- a/frontend/src/components/audio/vocal2midi/Vocal2MidiPanel.tsx
+++ b/frontend/src/components/audio/vocal2midi/Vocal2MidiPanel.tsx
@@ -41,6 +41,8 @@ import { AssistantOrb } from './AssistantOrb';
 import { usePianoRollStore, type PianoNote } from '../../../state/pianoRollStore';
 import { encodeWav } from '../../../lib/wavEncode';
 import { logInfo, logWarn } from '../../../state/logStore';
+import { getEngineCtx } from '../../../state/playerStore';
+import { surfaceDeviceId, useIoDevicesStore } from '../../../state/ioDevicesStore';
 import { InstrumentPicker } from '../InstrumentPicker';
 
 const HISTORY_KEY = 'vocal2midi_recordings';
@@ -138,6 +140,7 @@ export const Vocal2MidiPanel: React.FC = () => {
 
   // recorder refs (ported from the source App)
   const audioCtxRef = useRef<AudioContext | null>(null);
+  const sinkRef = useRef<GainNode | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const processorRef = useRef<ScriptProcessorNode | null>(null);
@@ -164,9 +167,20 @@ export const Vocal2MidiPanel: React.FC = () => {
   /* ── recorder (ported YIN capture) ─────────────────────────────────────── */
   const startRecording = useCallback(async () => {
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      // This panel is rendered INSIDE the MIDI tab, a few pixels under a
+      // microphone picker it used to ignore entirely. It follows the same
+      // surface now (with its own override available in Settings).
+      const deviceId = surfaceDeviceId('vocal2midi');
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: deviceId ? { deviceId } : true,
+      });
+      useIoDevicesStore.getState().notePermissionGranted();
       streamRef.current = stream;
-      const ctx = new (window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
+      // The SHARED engine context, not a private one. A second AudioContext is
+      // a second hardware output stream that ignores the chosen main output —
+      // and this one was never closed, so every recording session leaked one.
+      const ctx = getEngineCtx();
+      if (ctx.state === 'suspended') await ctx.resume();
       audioCtxRef.current = ctx;
 
       const an = ctx.createAnalyser();
@@ -181,7 +195,14 @@ export const Vocal2MidiPanel: React.FC = () => {
       const proc = ctx.createScriptProcessor(2048, 1, 1);
       processorRef.current = proc;
       src.connect(proc);
-      proc.connect(ctx.destination);
+      // Pull the processor through a MUTED sink so onaudioprocess keeps being
+      // called without routing the microphone at the speakers (the same shape
+      // the YIN capture path uses).
+      const sink = ctx.createGain();
+      sink.gain.value = 0;
+      sinkRef.current = sink;
+      proc.connect(sink);
+      sink.connect(ctx.destination);
 
       startTimeRef.current = ctx.currentTime;
       bufferRef.current = [];
@@ -265,6 +286,10 @@ export const Vocal2MidiPanel: React.FC = () => {
     rec.stop();
     sourceRef.current?.disconnect();
     processorRef.current?.disconnect();
+    // The muted sink lives on the SHARED context, so it has to be released
+    // here — nothing closes that context.
+    sinkRef.current?.disconnect();
+    sinkRef.current = null;
     await new Promise<void>((resolve) => { rec.onstop = () => resolve(); });
     streamRef.current?.getTracks().forEach((t) => t.stop());
 

--- a/frontend/src/components/audio/vocal2midi/Vocal2MidiPanel.tsx
+++ b/frontend/src/components/audio/vocal2midi/Vocal2MidiPanel.tsx
@@ -41,6 +41,7 @@ import { AssistantOrb } from './AssistantOrb';
 import { usePianoRollStore, type PianoNote } from '../../../state/pianoRollStore';
 import { encodeWav } from '../../../lib/wavEncode';
 import { logInfo, logWarn } from '../../../state/logStore';
+import { describeMicFailure } from '../../../lib/micErrors';
 import { getEngineCtx } from '../../../state/playerStore';
 import { surfaceDeviceId, useIoDevicesStore } from '../../../state/ioDevicesStore';
 import { InstrumentPicker } from '../InstrumentPicker';
@@ -258,8 +259,12 @@ export const Vocal2MidiPanel: React.FC = () => {
       rec.ondataavailable = (ev) => { if (ev.data.size) chunksRef.current.push(ev.data); };
       rec.start();
     } catch (err) {
-      logWarn('vocal2midi', `mic error: ${String(err)}`);
-      setStatus('mic error - check permission');
+      // "check permission" was wrong for three of the four real causes — a
+      // machine with no microphone, a device another program holds, and an
+      // unmeetable constraint all sent the user to the permission dialog.
+      const failure = describeMicFailure(err, 'this recorder');
+      logWarn('vocal2midi', failure.message);
+      setStatus(failure.message);
     }
   }, []);
 

--- a/frontend/src/components/layout/MidiPanel.tsx
+++ b/frontend/src/components/layout/MidiPanel.tsx
@@ -33,6 +33,7 @@ import { IoSurfaceSelect } from '../audio/IoDeviceSelect';
 import { useIoDevicesStore, useResolvedSurface } from '../../state/ioDevicesStore';
 import { useLibraryStore } from '../../state/libraryStore';
 import { logInfo, logWarn } from '../../state/logStore';
+import { describeMicFailure, shouldAnnounceMicFailure } from '../../lib/micErrors';
 import { usePianoRollStore, type PianoNote } from '../../state/pianoRollStore';
 import { usePlayerStore } from '../../state/playerStore';
 import { useBottomPanelStore } from '../../state/bottomPanelStore';
@@ -184,8 +185,16 @@ export const MidiPanel: React.FC = () => {
         void refreshInputs();
       } catch (e) {
         if (!cancelled) {
+          // Re-enumerate first: a device that went away raises the "not
+          // connected" notice from the store, in one place.
           void refreshInputs();
-          logWarn('vocal', `mic monitor unavailable: ${String(e)}`);
+          // A machine with no microphone is not a fault, and this effect re-runs
+          // on every device change and remount — so classify it, say it once,
+          // and only call it a warning when something is actually wrong.
+          const failure = describeMicFailure(e, 'the level meter');
+          if (shouldAnnounceMicFailure(failure, 'the level meter')) {
+            (failure.benign ? logInfo : logWarn)('vocal', failure.message);
+          }
         }
       }
     })();

--- a/frontend/src/components/layout/MidiPanel.tsx
+++ b/frontend/src/components/layout/MidiPanel.tsx
@@ -26,11 +26,11 @@ import {
   type VocalArtifactDoc,
 } from '../../lib/vocalExport';
 import {
-  listAudioInputs,
-  queryMicPermission,
   startInputMonitor,
   type InputMonitor,
 } from '../../lib/vocalToMidi';
+import { IoSurfaceSelect } from '../audio/IoDeviceSelect';
+import { useIoDevicesStore, useResolvedSurface } from '../../state/ioDevicesStore';
 import { useLibraryStore } from '../../state/libraryStore';
 import { logInfo, logWarn } from '../../state/logStore';
 import { usePianoRollStore, type PianoNote } from '../../state/pianoRollStore';
@@ -128,11 +128,13 @@ export const MidiPanel: React.FC = () => {
   const [artifact, setArtifact] = useState<VocalArtifactDoc | null>(null);
   const [validateMsg, setValidateMsg] = useState('');
   const [arpOn, setArpOn] = useState(false);
-  const [inputs, setInputs] = useState<MediaDeviceInfo[]>([]);
-  const [deviceId, setDeviceId] = useState<string>(
-    () => localStorage.getItem('vocal.inputDeviceId') ?? '',
-  );
-  const [micPerm, setMicPerm] = useState<string>('unknown');
+  // The device comes from the global I/O menu (Settings -> Inputs & outputs),
+  // with a per-surface override right here. It used to be a useState seeded
+  // from localStorage with NO try/catch — which threw during render in a
+  // browser with site data blocked — and the SING pitch lane kept a second,
+  // never-reconciled copy of the very same key.
+  const deviceId = useResolvedSurface('midiVocal').deviceId;
+  const micPerm = useIoDevicesStore((s) => s.micPermission);
   const monitorRef = useRef<InputMonitor | null>(null);
   const recorderRef = useRef<MediaRecorder | null>(null);
   const recordStartRef = useRef(0);
@@ -163,14 +165,7 @@ export const MidiPanel: React.FC = () => {
   })();
 
   const refreshInputs = useCallback(async () => {
-    setMicPerm(await queryMicPermission());
-    setInputs(await listAudioInputs());
-  }, []);
-
-  const pickDevice = useCallback((id: string) => {
-    setDeviceId(id);
-    if (id) localStorage.setItem('vocal.inputDeviceId', id);
-    else localStorage.removeItem('vocal.inputDeviceId');
+    await useIoDevicesStore.getState().refresh();
   }, []);
 
   // Always-on input monitor while the tab is open: opens the mic + an analyser so
@@ -189,7 +184,7 @@ export const MidiPanel: React.FC = () => {
         void refreshInputs();
       } catch (e) {
         if (!cancelled) {
-          setMicPerm(await queryMicPermission());
+          void refreshInputs();
           logWarn('vocal', `mic monitor unavailable: ${String(e)}`);
         }
       }
@@ -399,26 +394,13 @@ export const MidiPanel: React.FC = () => {
     <div className="h-full w-full flex flex-col bg-zinc-950 text-zinc-200">
       {/* tools toolbar — vocal recording is the input; the rest operate on the roll */}
       <div className="shrink-0 flex flex-wrap items-center gap-2 px-2 py-1.5 border-b border-white/8">
-        {/* Vocal input */}
-        <label htmlFor="midi-input-device" className="sr-only">
-          Microphone input
-        </label>
-        <select
+        {/* Vocal input — an override of the global microphone (Settings). */}
+        <IoSurfaceSelect
+          surface="midiVocal"
           id="midi-input-device"
-          name="midi-input-device"
-          value={deviceId}
-          onChange={(e) => pickDevice(e.target.value)}
-          aria-label="Microphone input"
-          title="Microphone input device used for recording and the level meter"
-          className="max-w-40 bg-zinc-800 border border-zinc-500 text-zinc-100 text-[10px] font-mono px-1 py-1 rounded"
-        >
-          <option value="">System default input</option>
-          {inputs.map((d) => (
-            <option key={d.deviceId} value={d.deviceId}>
-              {d.label || `Mic ${d.deviceId.slice(0, 6)}`}
-            </option>
-          ))}
-        </select>
+          label="Microphone input"
+          className="max-w-40 text-[10px]"
+        />
         {micPerm === 'denied' && (
           <span className="text-[9px] font-mono text-rose-400">mic blocked</span>
         )}

--- a/frontend/src/components/layout/SettingsModal.tsx
+++ b/frontend/src/components/layout/SettingsModal.tsx
@@ -6,7 +6,7 @@ import { useOnboardingStore } from '../../onboarding/onboardingStore';
  * The body is a CSS multi-column layout (1 / 2 / 3 columns at <lg / lg / 2xl)
  * so the browser balances the sections' heights across columns; each section
  * is `break-inside-avoid` so it never splits. Reading order: Models,
- * Autoprocesses, Layout, Modules, Storage. At 1366x768 it degrades to two
+ * Autoprocesses, Layout, Inputs & outputs, Modules, Storage. At 1366x768 it degrades to two
  * balanced columns (and the body scrolls if it must). Every section lives in
  * ./settings/*; this file is the shell: backdrop, header (launch mode, artist,
  * restart, shutdown, close), the column body, and the sponsor footer.
@@ -19,6 +19,7 @@ import { StorageSection } from './settings/StorageSection';
 import { AutoprocessSection } from './settings/AutoprocessSection';
 import { ModulesSection } from './settings/ModulesSection';
 import { LayoutSection } from './settings/LayoutSection';
+import { IoSection } from './settings/IoSection';
 import { RestartServerButton, ShutdownServerButton } from './settings/ServerButtons';
 
 export const SettingsModal: React.FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {
@@ -201,6 +202,7 @@ export const SettingsModal: React.FC<{ open: boolean; onClose: () => void }> = (
             <div className="break-inside-avoid mb-3"><ModelsSection /></div>
             <div className="break-inside-avoid mb-3"><AutoprocessSection /></div>
             <div className="break-inside-avoid mb-3"><LayoutSection /></div>
+            <div className="break-inside-avoid mb-3"><IoSection /></div>
             <div className="break-inside-avoid mb-3"><ModulesSection /></div>
             <div className="break-inside-avoid mb-3"><StorageSection /></div>
           </div>

--- a/frontend/src/components/layout/settings/IoSection.tsx
+++ b/frontend/src/components/layout/settings/IoSection.tsx
@@ -247,8 +247,9 @@ export const IoSection: React.FC = () => {
         theDAW cannot enumerate them from here.
       </p>
       <p className={NOTE}>
-        Voice commands in the assistant orb always use the system default; the browser&apos;s speech
-        API has no device setting.
+        Voice commands always use the system default microphone. In theDAW the browser&apos;s speech
+        API has no device setting; the UNDERFIT orb runs inside underfit&apos;s own page on another
+        origin, which cannot read these settings at all.
       </p>
       <p className={`${NOTE} ${SECTION_META}`}>
         Lyria, Foundry, Sway, UNDERFIT and the VJ canvas make sound in their own windows — theDAW

--- a/frontend/src/components/layout/settings/IoSection.tsx
+++ b/frontend/src/components/layout/settings/IoSection.tsx
@@ -1,0 +1,259 @@
+/**
+ * Settings → Inputs & outputs.
+ *
+ * Six global device slots, then a collapsed disclosure holding the fine-grained
+ * half: one row per surface that can be pointed somewhere else. Every override
+ * row's first option reads "Default (<the device the global slot resolves to
+ * right now>)", so a user with several interfaces can see what they are
+ * overriding before they override it.
+ *
+ * What is deliberately NOT a control here is as important as what is. A slot
+ * that cannot be wired end to end gets a sentence, not a dead dropdown: the VJ
+ * camera list lives on the VJ's own origin, the assistant's speech API has no
+ * device parameter, and the embedded panels that make sound in their own
+ * windows cannot be routed from here at all.
+ */
+import React, { useState } from 'react';
+import { AlertTriangle, Headphones, RefreshCw, SlidersHorizontal } from 'lucide-react';
+import { IoGlobalSelect, IoSurfaceSelect } from '../../audio/IoDeviceSelect';
+import { describeMidiInputs, toggleMidiPort } from '../../../lib/midiPortFilter';
+import {
+  midiInputConfig,
+  resolveGlobal,
+  setMidiInputSelection,
+  useIoDevicesStore,
+} from '../../../state/ioDevicesStore';
+import { IO_SURFACES } from '../../../state/ioSurfaces';
+import { useFeatureToggleStore } from '../../../state/featureToggleStore';
+import { getEngineOutputInfo } from '../../../state/playerStore';
+import { BODY, BTN_GHOST, CARD, SECTION_META, SectionHeader, Segmented } from './shared';
+
+const ROW = 'flex flex-wrap items-center gap-1.5 px-1.5 py-1 border-b border-white/5 last:border-b-0';
+const ROW_LABEL = 'text-[11px] font-mono uppercase tracking-wider text-zinc-300 w-28 shrink-0';
+const META = 'text-[11px] font-mono text-zinc-500';
+const NOTE = 'text-[11px] text-zinc-500 px-1.5 py-1';
+
+export const IoSection: React.FC = () => {
+  const supports = useIoDevicesStore((s) => s.supports);
+  const micPermission = useIoDevicesStore((s) => s.micPermission);
+  const labelsKnown = useIoDevicesStore((s) => s.labelsKnown);
+  const midiIn = useIoDevicesStore((s) => s.midiIn);
+  const refresh = useIoDevicesStore((s) => s.refresh);
+  const refreshDisplays = useIoDevicesStore((s) => s.refreshDisplays);
+  const io = useFeatureToggleStore((s) => s.settings.io);
+  const [open, setOpen] = useState(false);
+
+  const main = resolveGlobal('audio_output');
+  const cue = resolveGlobal('cue_output');
+  const midiCfg = midiInputConfig();
+  const engine = getEngineOutputInfo();
+  // Subscribing to `io` is what re-renders this whole section when a choice
+  // lands (the selects read the resolved values through their own hooks).
+  const overrideCount = IO_SURFACES.filter((s) => io?.overrides?.[s.id] !== undefined).length;
+
+  // Pre-listening into the same device you are mixing on defeats the point, but
+  // it is a legitimate thing to do while there is only one output — so it is a
+  // warning, not a block.
+  const cueClashes = !!cue.deviceId && cue.deviceId === main.deviceId;
+
+  return (
+    <div>
+      <SectionHeader
+        icon={<SlidersHorizontal className="w-3.5 h-3.5 text-purple-400 shrink-0" />}
+        title="Inputs & outputs"
+        tip="Pick the devices theDAW plays through and listens to. These are saved on the server, so the same choices apply whether you open theDAW in a browser or as the desktop app. Every surface can be pointed somewhere else under Per-surface."
+        meta={overrideCount > 0 ? `${overrideCount} override${overrideCount === 1 ? '' : 's'}` : undefined}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            void refresh();
+            void refreshDisplays();
+          }}
+          aria-label="Re-scan devices"
+          title="Re-scan connected devices"
+          className={`${BTN_GHOST} ml-1`}
+        >
+          <RefreshCw className="w-3 h-3" />
+        </button>
+      </SectionHeader>
+
+      <div className={CARD}>
+        {/* Main mix ------------------------------------------------------- */}
+        <div className={ROW}>
+          <span className={ROW_LABEL}>Main out</span>
+          <IoGlobalSelect
+            slot="audio_output"
+            label="Main output device"
+            className="flex-1"
+            unsupported={
+              supports.ctxSink
+                ? undefined
+                : 'this browser cannot move the main output — the desktop app can'
+            }
+          />
+          {engine && (
+            <span className={META}>
+              {Math.round(engine.sampleRate / 100) / 10} kHz
+              {engine.outputLatencyMs != null ? ` · ${engine.outputLatencyMs} ms` : ''}
+            </span>
+          )}
+        </div>
+
+        {/* Headphone cue --------------------------------------------------- */}
+        <div className={ROW}>
+          <span className={ROW_LABEL}>
+            <Headphones className="w-3 h-3 inline mr-1 -mt-0.5" />
+            Cue out
+          </span>
+          <IoGlobalSelect
+            slot="cue_output"
+            label="Headphone (cue) output device"
+            className="flex-1"
+            unsupported={
+              supports.elementSink ? undefined : 'this browser cannot route the cue bus'
+            }
+          />
+          {cueClashes && (
+            <span className="inline-flex items-center gap-1 text-[11px] font-mono text-amber-300">
+              <AlertTriangle className="w-3 h-3 shrink-0" />
+              same as main — pre-listen will be audible in the mix
+            </span>
+          )}
+        </div>
+
+        {/* Microphone ------------------------------------------------------ */}
+        <div className={ROW}>
+          <span className={ROW_LABEL}>Microphone</span>
+          <IoGlobalSelect slot="audio_input" label="Microphone device" className="flex-1" />
+          {micPermission === 'denied' && (
+            <span className="text-[11px] font-mono text-rose-400">blocked by the browser</span>
+          )}
+        </div>
+
+        {/* MIDI in --------------------------------------------------------- */}
+        <div className={ROW}>
+          <span className={ROW_LABEL}>MIDI in</span>
+          <Segmented
+            value={midiCfg.mode}
+            options={[
+              ['all', 'All'],
+              ['some', 'Choose'],
+            ]}
+            onChange={(mode) =>
+              void setMidiInputSelection(
+                mode === 'all'
+                  ? { mode: 'all', ports: [] }
+                  : { mode: 'some', ports: midiIn.map((p) => ({ id: p.id, label: p.label })) },
+              )
+            }
+            ariaLabel="Which MIDI inputs are used"
+          />
+          <span className={META}>{describeMidiInputs(midiCfg, midiIn.length)}</span>
+          {!supports.midi && <span className={META}>Web MIDI unavailable</span>}
+        </div>
+        {midiCfg.mode === 'some' && (
+          <div className="px-1.5 pb-1 flex flex-col gap-0.5">
+            {midiIn.length === 0 && <span className={META}>nothing connected</span>}
+            {midiIn.map((port) => {
+              const id = `io-midi-in-${port.id}`;
+              const on = midiCfg.ports.some((p) => p.id === port.id || (!!p.label && p.label === port.label));
+              return (
+                <div key={port.id} className="flex items-center gap-1.5">
+                  <input
+                    id={id}
+                    name={id}
+                    type="checkbox"
+                    checked={on}
+                    onChange={(e) =>
+                      void setMidiInputSelection(
+                        toggleMidiPort(midiCfg, { id: port.id, label: port.label }, e.target.checked),
+                      )
+                    }
+                    className="accent-purple-500"
+                  />
+                  <label htmlFor={id} className={BODY}>
+                    {port.label}
+                  </label>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* MIDI out (thru) ------------------------------------------------- */}
+        <div className={ROW}>
+          <span className={ROW_LABEL}>MIDI out</span>
+          <IoGlobalSelect
+            slot="midi_output"
+            label="MIDI thru output port"
+            className="flex-1"
+            unsupported={supports.midi ? undefined : 'Web MIDI is unavailable in this browser'}
+          />
+          <span className={META}>thru only — no clock is sent</span>
+        </div>
+
+        {/* Pop-out display -------------------------------------------------- */}
+        <div className={ROW}>
+          <span className={ROW_LABEL}>Pop-out screen</span>
+          <IoGlobalSelect
+            slot="visual_display"
+            label="Monitor for pop-out windows"
+            className="flex-1"
+            unsupported={
+              supports.displays ? undefined : 'desktop app only — a browser cannot place a window on a monitor'
+            }
+          />
+        </div>
+
+        {/* Camera — a status row, NOT a picker. See the note below. --------- */}
+        <div className={ROW}>
+          <span className={ROW_LABEL}>Camera</span>
+          <span className={BODY}>Chosen inside the VJ panel</span>
+        </div>
+      </div>
+
+      {!labelsKnown && (
+        <p className={NOTE}>
+          Device names fill in the first time something opens the microphone — until then the browser
+          reports them blank.
+        </p>
+      )}
+
+      {/* The fine-grained half ------------------------------------------------ */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="io-per-surface"
+        className={`${BTN_GHOST} mt-1.5`}
+      >
+        {open ? 'Hide per-surface' : 'Per-surface…'}
+      </button>
+      <div id="io-per-surface" hidden={!open} className={`${CARD} mt-1.5`}>
+        {IO_SURFACES.map((surface) => (
+          <div key={surface.id} className={ROW}>
+            <span className={ROW_LABEL} title={surface.hint}>
+              {surface.label}
+            </span>
+            <IoSurfaceSelect surface={surface.id} className="flex-1" />
+          </div>
+        ))}
+      </div>
+
+      {/* Honest copy: what this menu cannot reach, and why. ------------------ */}
+      <p className={NOTE}>
+        The camera list lives in the VJ panel — device ids are scoped to the VJ&apos;s own origin, so
+        theDAW cannot enumerate them from here.
+      </p>
+      <p className={NOTE}>
+        Voice commands in the assistant orb always use the system default; the browser&apos;s speech
+        API has no device setting.
+      </p>
+      <p className={`${NOTE} ${SECTION_META}`}>
+        Lyria, Foundry, Sway, UNDERFIT and the VJ canvas make sound in their own windows — theDAW
+        cannot route those.
+      </p>
+    </div>
+  );
+};

--- a/frontend/src/components/layout/settings/shared.tsx
+++ b/frontend/src/components/layout/settings/shared.tsx
@@ -18,6 +18,11 @@ export const BODY = 'text-xs text-zinc-300';
 export const CARD = 'rounded border border-white/8 bg-white/3';
 export const INPUT =
   'min-w-0 rounded border border-white/10 bg-black/40 px-1.5 py-1 text-xs font-mono text-zinc-200 placeholder:text-zinc-500 outline-none focus:border-purple-500/50';
+/** Native <select>. A device list cannot be a Segmented group — the options are
+ *  discovered at runtime and there can be a dozen — so this is the modal's one
+ *  dropdown style. Always paired with a real <label htmlFor>. */
+export const SELECT =
+  'min-w-0 max-w-48 rounded border border-white/10 bg-black/40 px-1.5 py-1 text-xs font-mono text-zinc-200 outline-none focus:border-purple-500/50 disabled:opacity-50';
 
 const BTN_BASE =
   'inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[11px] font-black uppercase tracking-widest transition-colors disabled:opacity-40 disabled:cursor-default focus-visible:outline-none focus-visible:ring-1';

--- a/frontend/src/components/layout/sing/PitchLane.tsx
+++ b/frontend/src/components/layout/sing/PitchLane.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Loader2, Mic, MicOff } from 'lucide-react';
 import { fetchVocalArtifact, type VocalArtifactDoc } from '../../../lib/vocalExport';
-import { listAudioInputs } from '../../../lib/vocalToMidi';
+import { IoSurfaceSelect } from '../../audio/IoDeviceSelect';
+import { useIoDevicesStore, useResolvedSurface } from '../../../state/ioDevicesStore';
 import { pollVocalJob } from '../../../lib/lyricsClient';
 import { useLyricsStore } from '../../../state/lyricsStore';
 import { logError } from '../../../state/logStore';
@@ -16,7 +17,6 @@ export interface PitchLaneProps {
   activeLineRef: React.MutableRefObject<number>;
 }
 
-const MIC_DEVICE_KEY = 'vocal.inputDeviceId';
 const WINDOW_BEFORE_MS = 1200;
 const WINDOW_AFTER_MS = 2800;
 const PLAYHEAD_POS = 0.3;
@@ -72,14 +72,11 @@ export const PitchLane: React.FC<PitchLaneProps> = ({ entryId, getPosMs, activeL
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const [artifact, setArtifact] = useState<VocalArtifactDoc | null | 'loading'>('loading');
   const [analyzing, setAnalyzing] = useState<string | null>(null);
-  const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
-  const [deviceId, setDeviceId] = useState<string>(() => {
-    try {
-      return localStorage.getItem(MIC_DEVICE_KEY) ?? '';
-    } catch {
-      return '';
-    }
-  });
+  // One source of truth: the global microphone (Settings -> Inputs & outputs)
+  // with a per-surface override in the strip below. This used to be a second,
+  // independent copy of the same localStorage key the MIDI tab wrote, so
+  // changing the mic in one place left the other one open on the old device.
+  const deviceId = useResolvedSurface('singPitch').deviceId;
   const [micError, setMicError] = useState<string | null>(null);
   const [liveText, setLiveText] = useState('');
   const micOn = useLyricsStore((s) => s.micOn);
@@ -115,10 +112,6 @@ export const PitchLane: React.FC<PitchLaneProps> = ({ entryId, getPosMs, activeL
   useEffect(() => {
     void loadArtifact();
   }, [loadArtifact]);
-
-  useEffect(() => {
-    listAudioInputs().then(setDevices).catch(() => setDevices([]));
-  }, []);
 
   const analyzeMelody = async () => {
     if (analyzing) return;
@@ -176,7 +169,16 @@ export const PitchLane: React.FC<PitchLaneProps> = ({ entryId, getPosMs, activeL
       })
       .catch((e) => {
         if (cancelled) return;
-        setMicError(e instanceof Error ? e.message : String(e));
+        const name = e instanceof Error ? e.name : '';
+        // A device that went away mid-session is not a permission problem, and
+        // saying "permission denied" for it sends the user to the wrong fix.
+        // Re-enumerating raises the "not connected" notice from one place.
+        if (name === 'OverconstrainedError' || name === 'NotFoundError') {
+          setMicError('the chosen microphone is not connected');
+          void useIoDevicesStore.getState().refresh();
+        } else {
+          setMicError(e instanceof Error ? e.message : String(e));
+        }
         setMicOn(false);
       });
     return () => {
@@ -346,16 +348,6 @@ export const PitchLane: React.FC<PitchLaneProps> = ({ entryId, getPosMs, activeL
     };
   }, [activeLineRef, micOn]);
 
-  const chooseDevice = (id: string) => {
-    setDeviceId(id);
-    try {
-      if (id) localStorage.setItem(MIC_DEVICE_KEY, id);
-      else localStorage.removeItem(MIC_DEVICE_KEY);
-    } catch {
-      /* private mode */
-    }
-  };
-
   return (
     <div className="shrink-0 border-b border-white/10 bg-[#0a080f]">
       <div className="flex flex-wrap items-center gap-2 px-2 py-1 text-[9px] font-mono text-zinc-400">
@@ -381,19 +373,14 @@ export const PitchLane: React.FC<PitchLaneProps> = ({ entryId, getPosMs, activeL
         >
           {micOn ? <Mic className="w-3 h-3" /> : <MicOff className="w-3 h-3" />} MIC {micOn ? 'ON' : 'OFF'}
         </button>
-        <label htmlFor="sing-mic" className="text-zinc-500">MIC</label>
-        <select
+        <IoSurfaceSelect
+          surface="singPitch"
           id="sing-mic"
-          name="sing-mic"
-          className="form-select text-[9px] px-1 py-0.5 max-w-40"
-          value={deviceId}
-          onChange={(e) => chooseDevice(e.target.value)}
-        >
-          <option value="">Default input</option>
-          {devices.map((d) => (
-            <option key={d.deviceId} value={d.deviceId}>{d.label || `Input ${d.deviceId.slice(0, 6)}`}</option>
-          ))}
-        </select>
+          label="MIC"
+          showLabel
+          labelClassName="text-zinc-500 shrink-0"
+          className="text-[9px] px-1 py-0.5 max-w-40"
+        />
         <label htmlFor="sing-mic-offset" className="text-zinc-500" title="Microphone latency compensation">MIC OFFSET ms</label>
         <input
           id="sing-mic-offset"

--- a/frontend/src/components/layout/sing/PitchLane.tsx
+++ b/frontend/src/components/layout/sing/PitchLane.tsx
@@ -6,6 +6,7 @@ import { useIoDevicesStore, useResolvedSurface } from '../../../state/ioDevicesS
 import { pollVocalJob } from '../../../lib/lyricsClient';
 import { useLyricsStore } from '../../../state/lyricsStore';
 import { logError } from '../../../state/logStore';
+import { describeMicFailure } from '../../../lib/micErrors';
 import { LineScore, MIN_CLARITY, scoreFrame } from './singSync';
 import { FrameRing, startSingMic, type SingMic } from './singPitch';
 
@@ -169,15 +170,14 @@ export const PitchLane: React.FC<PitchLaneProps> = ({ entryId, getPosMs, activeL
       })
       .catch((e) => {
         if (cancelled) return;
-        const name = e instanceof Error ? e.name : '';
         // A device that went away mid-session is not a permission problem, and
         // saying "permission denied" for it sends the user to the wrong fix.
-        // Re-enumerating raises the "not connected" notice from one place.
-        if (name === 'OverconstrainedError' || name === 'NotFoundError') {
-          setMicError('the chosen microphone is not connected');
+        // describeMicFailure separates the four real causes; re-enumerating
+        // raises the "not connected" notice from one place.
+        const failure = describeMicFailure(e, "SING's pitch lane");
+        setMicError(failure.message);
+        if (failure.kind === 'no-device' || failure.kind === 'overconstrained') {
           void useIoDevicesStore.getState().refresh();
-        } else {
-          setMicError(e instanceof Error ? e.message : String(e));
         }
         setMicOn(false);
       });

--- a/frontend/src/lib/audioSink.test.ts
+++ b/frontend/src/lib/audioSink.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Output routing: capability tiers and the element registry.
+ *
+ * The tier check decides whether the main-output control is a dropdown or a
+ * disabled row with a reason, so "does this runtime have setSinkId" has to be
+ * answered per API, not once. The registry is what lets the loose <audio>
+ * elements (mic take preview, inpaint preview, Nodefi) follow a device change
+ * they never subscribed to — including one that mounts after the change.
+ *
+ * Run: npx tsx src/lib/audioSink.test.ts
+ */
+import assert from 'node:assert/strict';
+
+const g = globalThis as unknown as Record<string, unknown>;
+
+class NoSinkContext {}
+class SinkContext {
+  setSinkId(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+class NoSinkMedia {}
+class SinkMedia {
+  setSinkId(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+g.AudioContext = SinkContext;
+g.HTMLMediaElement = SinkMedia;
+
+const {
+  applyElementSink,
+  refreshSinkElements,
+  registerSinkElement,
+  registeredSinkCount,
+  setSinkResolver,
+  supportsContextSink,
+  supportsElementSink,
+} = await import('./audioSink.ts');
+
+/* ── tier detection, per API, read at call time ──────────────────────────── */
+
+assert.equal(supportsContextSink(), true);
+assert.equal(supportsElementSink(), true);
+
+// Chromium before 110 / Firefox: an element can move, the whole graph cannot.
+// This is the case where the main-output select must be disabled with a reason
+// while the DJ cue select keeps working.
+g.AudioContext = NoSinkContext;
+assert.equal(supportsContextSink(), false, 'no context sink → main output is not offered');
+assert.equal(supportsElementSink(), true, 'the cue bus still routes');
+
+// Neither.
+g.HTMLMediaElement = NoSinkMedia;
+assert.equal(supportsElementSink(), false);
+
+// Nothing at all (the tsx/node runs these suites in).
+g.AudioContext = undefined;
+g.HTMLMediaElement = undefined;
+assert.equal(supportsContextSink(), false, 'an absent global is not a crash');
+assert.equal(supportsElementSink(), false);
+
+g.AudioContext = SinkContext;
+g.HTMLMediaElement = SinkMedia;
+
+/* ── applying to one element ─────────────────────────────────────────────── */
+
+interface FakeEl {
+  sinkId: string;
+  calls: string[];
+  setSinkId(id: string): Promise<void>;
+}
+
+const makeEl = (opts: { fail?: boolean } = {}): FakeEl => ({
+  sinkId: '',
+  calls: [],
+  async setSinkId(id: string) {
+    this.calls.push(id);
+    if (opts.fail) throw new Error('NotAllowedError');
+    this.sinkId = id;
+  },
+});
+
+{
+  const el = makeEl();
+  assert.equal(await applyElementSink(el as unknown as HTMLMediaElement, 'spk-1'), true);
+  assert.deepEqual(el.calls, ['spk-1']);
+  // Already there: no redundant call (setSinkId on a playing element glitches).
+  assert.equal(await applyElementSink(el as unknown as HTMLMediaElement, 'spk-1'), true);
+  assert.deepEqual(el.calls, ['spk-1']);
+}
+
+{
+  // A rejected device must not throw out of the apply layer — the element keeps
+  // playing where it was.
+  const el = makeEl({ fail: true });
+  assert.equal(await applyElementSink(el as unknown as HTMLMediaElement, 'gone'), false);
+}
+
+{
+  // An element on a runtime with no setSinkId at all.
+  const plain = { sinkId: '' } as unknown as HTMLMediaElement;
+  assert.equal(await applyElementSink(plain, 'spk-1'), false);
+}
+
+/* ── the registry ────────────────────────────────────────────────────────── */
+
+let current: Record<string, string> = { preview: 'spk-1', inpaint: '' };
+setSinkResolver((surface) => current[surface] ?? '');
+
+const preview = makeEl();
+const dispose = registerSinkElement('preview', preview as unknown as HTMLMediaElement);
+await Promise.resolve();
+assert.deepEqual(preview.calls, ['spk-1'], 'registering applies the current setting at once');
+assert.equal(registeredSinkCount(), 1);
+
+// The user picks a different output. Every registered element follows without
+// having subscribed to anything.
+current = { preview: 'spk-2', inpaint: 'spk-2' };
+refreshSinkElements();
+await Promise.resolve();
+assert.deepEqual(preview.calls, ['spk-1', 'spk-2']);
+
+// An element that mounts AFTER the change still lands on the right device.
+const late = makeEl();
+const disposeLate = registerSinkElement('preview', late as unknown as HTMLMediaElement);
+await Promise.resolve();
+assert.deepEqual(late.calls, ['spk-2'], 'a late element is not stuck on the default');
+assert.equal(registeredSinkCount(), 2);
+
+// A surface with no override resolves to '' — the OS default, explicitly.
+const mod = makeEl();
+current = { preview: 'spk-2', inpaint: '' };
+const disposeMod = registerSinkElement('inpaint', mod as unknown as HTMLMediaElement);
+await Promise.resolve();
+assert.deepEqual(mod.calls, [], 'already on the default, so nothing is called');
+
+// Unmounting stops the element following (and drops the reference).
+dispose();
+assert.equal(registeredSinkCount(), 2);
+current = { preview: 'spk-3', inpaint: 'spk-3' };
+refreshSinkElements();
+await Promise.resolve();
+assert.deepEqual(preview.calls, ['spk-1', 'spk-2'], 'a disposed element is never touched again');
+assert.deepEqual(late.calls, ['spk-2', 'spk-3']);
+
+disposeLate();
+disposeMod();
+assert.equal(registeredSinkCount(), 0);
+
+// A null ref (the element has not mounted yet) is a no-op, not a crash.
+const noop = registerSinkElement('preview', null);
+noop();
+assert.equal(registeredSinkCount(), 0);
+
+// Installing a new resolver re-applies immediately.
+const fresh = makeEl();
+registerSinkElement('preview', fresh as unknown as HTMLMediaElement);
+await Promise.resolve();
+setSinkResolver(() => 'spk-9');
+await Promise.resolve();
+assert.equal(fresh.calls.at(-1), 'spk-9');
+
+console.log('audioSink tiers + element registry passed');

--- a/frontend/src/lib/audioSink.ts
+++ b/frontend/src/lib/audioSink.ts
@@ -1,0 +1,100 @@
+/**
+ * The apply layer for audio OUTPUT routing — the only module that touches a
+ * sink API.
+ *
+ * Three tiers, and the app degrades down them visibly rather than silently:
+ *
+ *   1. `AudioContext.setSinkId` moves the whole shared graph (every one of the
+ *      modules that route through getMasterGain) in one call. Chromium 110+,
+ *      so the desktop app always has it. playerStore owns that call; this
+ *      module only reports whether it exists.
+ *   2. `HTMLMediaElement.setSinkId` moves ONE element. That is how the DJ cue
+ *      bus reaches a second output, and how the handful of loose <audio>
+ *      elements outside the graph follow their surface's setting.
+ *   3. Neither — an old browser. The main-output control is DISABLED with a
+ *      written reason. It deliberately does NOT fall back to re-routing the
+ *      graph tail through a MediaStreamDestination + hidden <audio>: that hop
+ *      destroys ctx.outputLatency, which the latency calibrator and the
+ *      play-along time map both read, so it would trade a device choice for
+ *      silently wrong timing.
+ *
+ * Loose elements register here instead of each subscribing to the store, so a
+ * device change re-applies to all of them at once and a late-mounted element
+ * gets the current sink the moment it registers.
+ */
+import { logError } from '../state/logStore';
+
+/** Can the shared AudioContext itself be moved to another device? */
+export const supportsContextSink = (): boolean =>
+  typeof AudioContext !== 'undefined' &&
+  typeof AudioContext.prototype === 'object' &&
+  'setSinkId' in AudioContext.prototype;
+
+/** Can a single <audio> element be moved to another device? */
+export const supportsElementSink = (): boolean =>
+  typeof HTMLMediaElement !== 'undefined' &&
+  typeof HTMLMediaElement.prototype === 'object' &&
+  'setSinkId' in HTMLMediaElement.prototype;
+
+type SinkCapableElement = HTMLMediaElement & {
+  setSinkId?: (id: string) => Promise<void>;
+  sinkId?: string;
+};
+
+/**
+ * Point one element at a device. '' = the OS default. Resolves false when the
+ * runtime cannot route (or the device rejected it) — callers keep playing on
+ * the default rather than treating it as fatal.
+ */
+export const applyElementSink = async (el: HTMLMediaElement, deviceId: string): Promise<boolean> => {
+  const target = el as SinkCapableElement;
+  if (typeof target.setSinkId !== 'function') return false;
+  if (target.sinkId === deviceId) return true;
+  try {
+    await target.setSinkId(deviceId);
+    return true;
+  } catch (e) {
+    logError('audio', `Output routing failed: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
+  }
+};
+
+/* ── the element registry ─────────────────────────────────────────────────── */
+
+/** Surface id -> resolved deviceId. Installed by the io store at boot. */
+type SinkResolver = (surface: string) => string;
+
+let resolver: SinkResolver = () => '';
+const registered = new Map<HTMLMediaElement, string>();
+
+/**
+ * Install the resolver and re-apply to everything already registered. The io
+ * store calls this once at boot and again whenever the settings change.
+ */
+export const setSinkResolver = (fn: SinkResolver): void => {
+  resolver = fn;
+  refreshSinkElements();
+};
+
+/**
+ * Follow a surface's output setting with one <audio>/<video> element. Returns
+ * the disposer; call it from the same effect that created the element.
+ */
+export const registerSinkElement = (surface: string, el: HTMLMediaElement | null): (() => void) => {
+  if (!el) return () => {};
+  registered.set(el, surface);
+  void applyElementSink(el, resolver(surface));
+  return () => {
+    registered.delete(el);
+  };
+};
+
+/** Re-apply the current resolution to every registered element. */
+export const refreshSinkElements = (): void => {
+  for (const [el, surface] of registered) {
+    void applyElementSink(el, resolver(surface));
+  }
+};
+
+/** Test/diagnostic read: how many elements are following a setting right now. */
+export const registeredSinkCount = (): number => registered.size;

--- a/frontend/src/lib/ioResolve.test.ts
+++ b/frontend/src/lib/ioResolve.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Device resolution: the table the whole I/O menu rests on.
+ *
+ * These are the orderings a real machine produces, not just end states — a
+ * device list that is still label-less because nothing has opened the mic yet,
+ * an id that rotated between two origins, an interface that was unplugged
+ * mid-session. Getting any of them wrong is silent: the user picks a device and
+ * hears nothing, or hears the wrong one and is never told.
+ *
+ * Run: npx tsx src/lib/ioResolve.test.ts
+ */
+import assert from 'node:assert/strict';
+
+import {
+  FOLLOW_GLOBAL,
+  isSystemDefault,
+  labelsAreKnown,
+  missingNoticeId,
+  overrideFromSelect,
+  overrideSelectValue,
+  resolveRef,
+  resolveSlot,
+  type LiveDevice,
+} from './ioResolve.ts';
+
+const live: LiveDevice[] = [
+  { id: 'default', label: 'Default - Speakers (Realtek)' },
+  { id: 'aaa111', label: 'Scarlett 2i2 USB' },
+  { id: 'bbb222', label: 'Headphones (WH-1000XM4)' },
+];
+
+/* ── empty ref = system default ──────────────────────────────────────────── */
+
+assert.equal(isSystemDefault({ id: '', label: '' }), true);
+assert.equal(isSystemDefault(null), true);
+assert.equal(isSystemDefault({ id: 'aaa111', label: '' }), false);
+
+{
+  const r = resolveRef({ id: '', label: '' }, live);
+  assert.equal(r.source, 'system');
+  assert.equal(r.deviceId, '', 'system default hands the browser an empty id');
+  assert.equal(r.label, '');
+  assert.equal(r.rewrite, undefined);
+}
+
+/* ── exact id hit ────────────────────────────────────────────────────────── */
+
+{
+  const r = resolveRef({ id: 'aaa111', label: 'Scarlett 2i2 USB' }, live);
+  assert.equal(r.source, 'exact');
+  assert.equal(r.deviceId, 'aaa111');
+  assert.equal(r.label, 'Scarlett 2i2 USB');
+  assert.equal(r.rewrite, undefined, 'nothing to re-persist when the id still fits');
+}
+
+{
+  // The OS renamed the device; the live name wins over the frozen one so the
+  // menu never shows a name the system no longer uses.
+  const r = resolveRef({ id: 'bbb222', label: 'Headphones (old name)' }, live);
+  assert.equal(r.source, 'exact');
+  assert.equal(r.label, 'Headphones (WH-1000XM4)');
+}
+
+/* ── id gone, label matches: recovered across an origin/id rotation ──────── */
+
+{
+  const r = resolveRef({ id: 'salted-from-the-other-origin', label: 'Scarlett 2i2 USB' }, live);
+  assert.equal(r.source, 'label');
+  assert.equal(r.deviceId, 'aaa111', 'recovered by label');
+  assert.deepEqual(r.rewrite, { id: 'aaa111', label: 'Scarlett 2i2 USB' }, 'the new id is handed back to be written');
+  assert.equal(r.missing, undefined);
+}
+
+/* ── neither matches: fall back to the system default AND say so ─────────── */
+
+{
+  const gone = { id: 'ccc333', label: 'Focusrite 18i20' };
+  const r = resolveRef(gone, live);
+  assert.equal(r.source, 'missing');
+  assert.equal(r.deviceId, '', 'falls back to the OS default rather than failing');
+  assert.deepEqual(r.missing, gone, 'the caller can name the device in the notice');
+  // One notice per (kind, id): the same absent device resolved from three
+  // surfaces must refresh one card, never stack three.
+  assert.equal(missingNoticeId('audioOut', gone), missingNoticeId('audioOut', { ...gone }));
+  assert.notEqual(missingNoticeId('audioOut', gone), missingNoticeId('audioIn', gone));
+  assert.notEqual(missingNoticeId('audioOut', gone), missingNoticeId('audioOut', { id: 'ddd', label: 'x' }));
+}
+
+/* ── pre-permission: a label-less list proves nothing ────────────────────── */
+
+// What Chrome actually returns before any getUserMedia has resolved.
+const blind: LiveDevice[] = [{ id: '', label: '' }];
+assert.equal(labelsAreKnown(blind), false);
+assert.equal(labelsAreKnown([]), false, 'an empty list is not "labels known" either');
+assert.equal(labelsAreKnown(live), true);
+
+{
+  const r = resolveRef({ id: 'aaa111', label: 'Scarlett 2i2 USB' }, blind);
+  assert.equal(r.source, 'unknown', 'no verdict while the labels are blank');
+  assert.equal(r.deviceId, 'aaa111', 'the saved id is still handed through');
+  assert.equal(r.missing, undefined, 'and NO "device is gone" notice is raised');
+}
+
+{
+  // Same ordering, one step later: permission granted, list re-enumerated.
+  const r = resolveRef({ id: 'aaa111', label: 'Scarlett 2i2 USB' }, live);
+  assert.equal(r.source, 'exact', 'the choice survives the permission transition');
+}
+
+{
+  // A label-only ref (saved on the other origin) cannot be matched blind.
+  const r = resolveRef({ id: '', label: 'Scarlett 2i2 USB' }, blind);
+  assert.equal(r.source, 'unknown');
+  assert.equal(r.deviceId, '', 'nothing to pass through, so the OS default plays');
+}
+
+{
+  // An EMPTY list is the same kind of ignorance, and the store leans on it:
+  // MIDI is opt-in and off by default, so "no ports enumerated" must not be
+  // read as "your controller is gone" and shown as a warning.
+  const r = resolveRef({ id: 'port-2', label: 'Ableton Push 2' }, []);
+  assert.equal(r.source, 'unknown');
+  assert.equal(r.missing, undefined, 'no notice for a list that was never populated');
+}
+
+/* ── precedence: override > global > system ──────────────────────────────── */
+
+{
+  const r = resolveSlot({ live, global: { id: 'aaa111', label: 'Scarlett 2i2 USB' } });
+  assert.equal(r.origin, 'global');
+  assert.equal(r.deviceId, 'aaa111');
+}
+
+{
+  const r = resolveSlot({
+    live,
+    global: { id: 'aaa111', label: 'Scarlett 2i2 USB' },
+    override: { id: 'bbb222', label: 'Headphones (WH-1000XM4)' },
+  });
+  assert.equal(r.origin, 'override');
+  assert.equal(r.deviceId, 'bbb222');
+}
+
+{
+  // An EXPLICIT system-default override beats a non-empty global: that is the
+  // whole reason '' and FOLLOW_GLOBAL have to be different option values.
+  const r = resolveSlot({ live, global: { id: 'aaa111', label: 'Scarlett 2i2 USB' }, override: { id: '', label: '' } });
+  assert.equal(r.origin, 'override');
+  assert.equal(r.source, 'system');
+  assert.equal(r.deviceId, '', 'ignores the global on purpose');
+}
+
+{
+  // No override key at all = follow the global.
+  const r = resolveSlot({ live, global: { id: 'aaa111', label: 'Scarlett 2i2 USB' }, override: undefined });
+  assert.equal(r.origin, 'global');
+  assert.equal(r.deviceId, 'aaa111');
+}
+
+{
+  const r = resolveSlot({ live });
+  assert.equal(r.origin, 'none');
+  assert.equal(r.source, 'system');
+}
+
+{
+  // A surface whose override is gone falls back on its own, WITHOUT quietly
+  // inheriting the global — the user asked for a specific device here.
+  const r = resolveSlot({
+    live,
+    global: { id: 'aaa111', label: 'Scarlett 2i2 USB' },
+    override: { id: 'ccc333', label: 'Focusrite 18i20' },
+  });
+  assert.equal(r.origin, 'override');
+  assert.equal(r.source, 'missing');
+  assert.equal(r.deviceId, '');
+}
+
+/* ── select-value round trip ─────────────────────────────────────────────── */
+
+assert.equal(overrideSelectValue(undefined), FOLLOW_GLOBAL);
+assert.equal(overrideSelectValue(null), FOLLOW_GLOBAL);
+assert.equal(overrideSelectValue({ id: '', label: '' }), '');
+assert.equal(overrideSelectValue({ id: 'aaa111', label: 'Scarlett 2i2 USB' }), 'aaa111');
+
+assert.equal(overrideFromSelect(FOLLOW_GLOBAL, live), null, 'follow-global deletes the entry');
+assert.deepEqual(overrideFromSelect('', live), { id: '', label: '' });
+assert.deepEqual(
+  overrideFromSelect('aaa111', live),
+  { id: 'aaa111', label: 'Scarlett 2i2 USB' },
+  'the label is captured at write time — that is what survives an id rotation',
+);
+assert.deepEqual(overrideFromSelect('unknown-id', live), { id: 'unknown-id', label: '' });
+
+console.log('ioResolve resolution table passed');

--- a/frontend/src/lib/ioResolve.ts
+++ b/frontend/src/lib/ioResolve.ts
@@ -1,0 +1,197 @@
+/**
+ * Device resolution — the pure half of the global input/output menu.
+ *
+ * A saved device choice cannot be a bare `deviceId` string. Browser device ids
+ * are salted per origin and rotate whenever site data is cleared, and this app
+ * runs on two origins for the same user (the Vite browser build on :5173 and
+ * the desktop app on app://, switched with Settings → launch mode). So every
+ * slot persists a `DeviceRef` — the id AND the label the device had when it was
+ * chosen — and this module turns that ref plus the live device list back into
+ * something to hand the browser:
+ *
+ *   1. exact id match          → use it
+ *   2. exact label match       → use it, and hand back a `rewrite` so the store
+ *                                can re-persist the ref with the new id
+ *   3. labels not known yet    → pass the saved id through unjudged; before the
+ *                                first getUserMedia every label is '' and NO
+ *                                conclusion about "gone" is available
+ *   4. nothing matched         → the system default, `source: 'missing'`, and
+ *                                the caller raises ONE visible notice. Never a
+ *                                silent substitution, and the saved ref is kept
+ *                                so re-plugging the device restores it.
+ *
+ * No DOM, no zustand, no side effects — every branch above is pinned in
+ * ioResolve.test.ts.
+ */
+
+/** Every device family the menu can target. */
+export type IoKind = 'audioOut' | 'audioIn' | 'midiIn' | 'midiOut' | 'display';
+
+/** A persisted device choice. Empty id AND empty label = "system default". */
+export interface DeviceRef {
+  id: string;
+  label: string;
+}
+
+/** One device as the platform reports it right now. */
+export interface LiveDevice {
+  id: string;
+  label: string;
+}
+
+/** The stored value for "no choice made — use whatever the OS picks". */
+export const SYSTEM_DEFAULT: DeviceRef = { id: '', label: '' };
+
+/**
+ * Per-surface select sentinel for "follow the global slot". It cannot be '' —
+ * '' already means "the OS default" everywhere in this codebase (the DJ cue
+ * select, the SING mic select, the MIDI tab's mic select all use it), so
+ * reusing it here would make "follow global" and "ignore global" the same
+ * option. A surface that follows the global simply has no `overrides` entry.
+ */
+export const FOLLOW_GLOBAL = '@global';
+
+export type ResolveSource =
+  /** Nothing was chosen. */
+  | 'system'
+  /** The saved id is in the live list. */
+  | 'exact'
+  /** The id rotated but a live device carries the saved label. */
+  | 'label'
+  /** Labels are still blank (pre-permission) — the id is passed through unjudged. */
+  | 'unknown'
+  /** The chosen device is not present. Fall back + tell the user. */
+  | 'missing';
+
+/** Where the winning ref came from, for the "Default (…)" copy in the UI. */
+export type ResolveOrigin = 'none' | 'global' | 'override';
+
+export interface Resolved {
+  /** What to hand the browser. '' = let the OS decide. */
+  deviceId: string;
+  /** Human name for the resolved device, '' when it is the OS default. */
+  label: string;
+  source: ResolveSource;
+  origin: ResolveOrigin;
+  /** Set when `source === 'label'`: re-persist the ref as this. */
+  rewrite?: DeviceRef;
+  /** Set when `source === 'missing'`: what the user had chosen. */
+  missing?: DeviceRef;
+}
+
+/** True when the ref carries no choice at all. */
+export const isSystemDefault = (ref: DeviceRef | null | undefined): boolean =>
+  !ref || (!ref.id && !ref.label);
+
+/**
+ * Are the reported labels usable yet?
+ *
+ * `enumerateDevices()` returns entries with EMPTY labels until a
+ * `getUserMedia` has resolved once, and Chrome reports a single blank
+ * placeholder per kind before that. A list in that state proves nothing about
+ * whether a saved device is still plugged in, and it must never be rendered as
+ * a dropdown of blanks.
+ */
+export const labelsAreKnown = (live: readonly LiveDevice[]): boolean =>
+  live.length > 0 && live.some((d) => d.label !== '');
+
+/** Dedupe key for the "that device is gone" notice: one per kind + id. */
+export const missingNoticeId = (kind: IoKind, ref: DeviceRef): string =>
+  `io:missing:${kind}:${ref.id || ref.label}`;
+
+const clean = (ref: DeviceRef | null | undefined): DeviceRef => ({
+  id: ref?.id ?? '',
+  label: ref?.label ?? '',
+});
+
+/**
+ * Resolve ONE ref against the live list. `labelsKnown` defaults to reading the
+ * list itself; pass it explicitly when the caller already tracks permission
+ * state (MIDI ports, for instance, always carry names).
+ */
+export function resolveRef(
+  ref: DeviceRef | null | undefined,
+  live: readonly LiveDevice[],
+  labelsKnown: boolean = labelsAreKnown(live),
+): Omit<Resolved, 'origin'> {
+  const want = clean(ref);
+  if (isSystemDefault(want)) return { deviceId: '', label: '', source: 'system' };
+
+  const byId = want.id ? live.find((d) => d.id === want.id) : undefined;
+  if (byId) {
+    // Prefer the live label: a device renamed at the OS level should show its
+    // current name, not the one frozen into the setting.
+    return { deviceId: byId.id, label: byId.label || want.label, source: 'exact' };
+  }
+
+  if (want.label && labelsKnown) {
+    const byLabel = live.find((d) => d.label === want.label);
+    if (byLabel) {
+      return {
+        deviceId: byLabel.id,
+        label: byLabel.label,
+        source: 'label',
+        rewrite: { id: byLabel.id, label: byLabel.label },
+      };
+    }
+  }
+
+  // Cannot conclude "gone" from a list we have not been allowed to read. Hand
+  // the saved id through: the call sites use a SOFT `deviceId` constraint, so a
+  // stale id degrades to the OS default instead of throwing OverconstrainedError.
+  if (!labelsKnown) {
+    return { deviceId: want.id, label: want.label, source: 'unknown' };
+  }
+
+  return { deviceId: '', label: '', source: 'missing', missing: want };
+}
+
+export interface SlotInput {
+  /**
+   * The surface's own override. `undefined` (or a missing key) = follow the
+   * global slot; `{id:'',label:''}` = the OS default, deliberately ignoring the
+   * global.
+   */
+  override?: DeviceRef | null;
+  /** The global slot for this kind. */
+  global?: DeviceRef | null;
+  live: readonly LiveDevice[];
+  labelsKnown?: boolean;
+}
+
+/**
+ * Full precedence: per-surface override > global slot > system default.
+ *
+ * `origin` says which one won, so a UI can render "Default (Scarlett 2i2)" and
+ * a notice can name the surface that lost its device.
+ */
+export function resolveSlot(input: SlotInput): Resolved {
+  const { live, override, global } = input;
+  const labelsKnown = input.labelsKnown ?? labelsAreKnown(live);
+
+  if (override !== undefined && override !== null) {
+    return { ...resolveRef(override, live, labelsKnown), origin: 'override' };
+  }
+  if (!isSystemDefault(global)) {
+    return { ...resolveRef(global, live, labelsKnown), origin: 'global' };
+  }
+  return { deviceId: '', label: '', source: 'system', origin: 'none' };
+}
+
+/** The `<select>` value for a surface row: FOLLOW_GLOBAL, '' or a device id. */
+export const overrideSelectValue = (override: DeviceRef | null | undefined): string =>
+  override === undefined || override === null ? FOLLOW_GLOBAL : override.id;
+
+/**
+ * Turn a `<select>` value back into the override to store. `null` means "delete
+ * the entry" (follow the global again).
+ */
+export function overrideFromSelect(
+  value: string,
+  live: readonly LiveDevice[],
+): DeviceRef | null {
+  if (value === FOLLOW_GLOBAL) return null;
+  if (value === '') return { ...SYSTEM_DEFAULT };
+  const hit = live.find((d) => d.id === value);
+  return { id: value, label: hit?.label ?? '' };
+}

--- a/frontend/src/lib/micErrors.test.ts
+++ b/frontend/src/lib/micErrors.test.ts
@@ -1,0 +1,129 @@
+// Run with: npx tsx src/lib/micErrors.test.ts
+//
+// The case that mattered: a machine with no microphone logged
+// "mic monitor unavailable: NotFoundError: Requested device not found"
+// as a warning, on every open of the MIDI tab. These tests pin that it is now
+// classified benign, worded without a stack, and announced once.
+import assert from 'node:assert/strict';
+import {
+  describeMicFailure,
+  resetMicFailureLog,
+  shouldAnnounceMicFailure,
+  type MicFailureKind,
+} from './micErrors.ts';
+
+/** A DOMException as Chromium actually throws it from getUserMedia. */
+const domError = (name: string, message = ''): Error => {
+  const e = new Error(message || name);
+  e.name = name;
+  return e;
+};
+
+const WHAT = 'the level meter';
+
+// The reported error: no microphone attached. Benign, and it names the surface.
+{
+  const f = describeMicFailure(domError('NotFoundError', 'Requested device not found'), WHAT);
+  assert.equal(f.kind, 'no-device');
+  assert.equal(f.benign, true);
+  assert.ok(f.message.includes('No microphone is attached'), f.message);
+  assert.ok(f.message.includes(WHAT), f.message);
+  // The raw exception text must not leak into a benign message.
+  assert.ok(!f.message.includes('NotFoundError'), f.message);
+  assert.ok(!f.message.includes('Requested device not found'), f.message);
+}
+
+// The legacy alias for the same condition.
+{
+  assert.equal(describeMicFailure(domError('DevicesNotFoundError'), WHAT).kind, 'no-device');
+}
+
+// A mic exists but was refused: NOT benign, and it says what to do.
+{
+  const f = describeMicFailure(domError('NotAllowedError'), WHAT);
+  assert.equal(f.kind, 'denied');
+  assert.equal(f.benign, false);
+  assert.ok(/allow the microphone/i.test(f.message), f.message);
+}
+
+// Held by another program: its own case, its own fix.
+{
+  for (const name of ['NotReadableError', 'TrackStartError', 'AbortError']) {
+    const f = describeMicFailure(domError(name), WHAT);
+    assert.equal(f.kind, 'busy', name);
+    assert.equal(f.benign, false, name);
+    assert.ok(/another program/i.test(f.message), f.message);
+  }
+}
+
+// Constraints: reachable only for a constraint that is not the device id,
+// because the device id is passed soft on purpose.
+{
+  const f = describeMicFailure(domError('OverconstrainedError'), WHAT);
+  assert.equal(f.kind, 'overconstrained');
+  assert.ok(f.message.includes('system default'), f.message);
+}
+
+// No capture support at all.
+{
+  assert.equal(describeMicFailure(domError('TypeError'), WHAT).kind, 'unsupported');
+}
+
+// Anything unrecognised keeps the raw text rather than inventing a cause.
+{
+  const f = describeMicFailure(domError('WeirdError', 'something odd'), WHAT);
+  assert.equal(f.kind, 'unknown');
+  assert.equal(f.benign, false);
+  assert.ok(f.message.includes('something odd'), f.message);
+}
+
+// A non-Error rejection must not throw the classifier.
+{
+  for (const thrown of [undefined, null, 'a string', 42, {}]) {
+    const f = describeMicFailure(thrown, WHAT);
+    assert.equal(f.kind, 'unknown');
+    assert.ok(typeof f.message === 'string' && f.message.length > 0);
+  }
+}
+
+// Announced once per (surface, kind) — the effect re-runs on every device
+// change and remount, and the LOG must not fill with the same line.
+{
+  resetMicFailureLog();
+  const none = describeMicFailure(domError('NotFoundError'), WHAT);
+  assert.equal(shouldAnnounceMicFailure(none, WHAT), true, 'first time announces');
+  assert.equal(shouldAnnounceMicFailure(none, WHAT), false, 'second time is silent');
+
+  // A CHANGE of state is still worth saying, even on the same surface.
+  const denied = describeMicFailure(domError('NotAllowedError'), WHAT);
+  assert.equal(shouldAnnounceMicFailure(denied, WHAT), true, 'a different kind announces');
+  assert.equal(shouldAnnounceMicFailure(denied, WHAT), false);
+
+  // A different surface tracks separately.
+  assert.equal(shouldAnnounceMicFailure(none, 'SING pitch'), true, 'other surface announces');
+  assert.equal(shouldAnnounceMicFailure(none, WHAT), false, 'first surface still silent');
+
+  resetMicFailureLog();
+  assert.equal(shouldAnnounceMicFailure(none, WHAT), true, 'reset re-arms');
+}
+
+// Every kind is reachable from some real DOMException name, so no branch is dead.
+{
+  const seen = new Set<MicFailureKind>();
+  for (const name of [
+    'NotFoundError',
+    'NotAllowedError',
+    'NotReadableError',
+    'OverconstrainedError',
+    'TypeError',
+    'Nonsense',
+  ]) {
+    seen.add(describeMicFailure(domError(name), WHAT).kind);
+  }
+  assert.deepEqual(
+    [...seen].sort(),
+    ['busy', 'denied', 'no-device', 'overconstrained', 'unknown', 'unsupported'],
+  );
+}
+
+console.log('micErrors tests passed');

--- a/frontend/src/lib/micErrors.ts
+++ b/frontend/src/lib/micErrors.ts
@@ -1,0 +1,136 @@
+/**
+ * What a failed microphone open actually means, in words a user can act on.
+ *
+ * Every mic surface used to log the raw exception: the MIDI tab's always-on
+ * level monitor said
+ *
+ *     mic monitor unavailable: NotFoundError: Requested device not found
+ *
+ * on a machine that simply has no microphone attached. That reads as a broken
+ * feature, and it fires every time the tab is opened. The three cases behind
+ * that one string want three different responses:
+ *
+ *   - `NotFoundError` / `DevicesNotFoundError` — there is no microphone on this
+ *     machine. Nothing is wrong and there is nothing to fix; say so once, at
+ *     info level, and stop.
+ *   - `NotAllowedError` / `SecurityError` — a microphone exists and the user (or
+ *     policy) refused it. Actionable: name the permission.
+ *   - `NotReadableError` / `AbortError` — the device is there but another app
+ *     holds it. Also actionable, and a different fix.
+ *
+ * `OverconstrainedError` is listed for completeness: `startInputMonitor` and
+ * `startVocalCapture` pass `deviceId` as a SOFT constraint precisely so a stale
+ * id degrades to the OS default instead of rejecting, so seeing it means a
+ * constraint other than the device id could not be met.
+ *
+ * Pure: no DOM, no logging. The caller decides the level, because "no mic on a
+ * machine with no mic" is not a warning.
+ */
+
+/** How the caller should treat a mic-open failure. */
+export type MicFailureKind =
+  /** No capture device exists. Expected on plenty of machines. */
+  | 'no-device'
+  /** A device exists; permission was refused. */
+  | 'denied'
+  /** A device exists; something else is using it. */
+  | 'busy'
+  /** The browser cannot do capture at all. */
+  | 'unsupported'
+  /** Constraints other than the device id could not be satisfied. */
+  | 'overconstrained'
+  /** Anything we do not recognise — keep the raw text. */
+  | 'unknown'
+
+export interface MicFailure {
+  kind: MicFailureKind
+  /** One sentence for the LOG or a `role="alert"`. Never includes a stack. */
+  message: string
+  /** True when this is a normal state of the machine, not a fault. */
+  benign: boolean
+}
+
+/** `DOMException.name`, when the thrown thing has one. */
+function errorName(err: unknown): string {
+  if (typeof err === 'object' && err !== null) {
+    const name = (err as { name?: unknown }).name
+    if (typeof name === 'string') return name
+  }
+  return ''
+}
+
+function errorText(err: unknown): string {
+  if (err instanceof Error) return err.message || err.name
+  return String(err)
+}
+
+/**
+ * Classify a `getUserMedia` rejection.
+ *
+ * `what` names the surface for the message ("the level meter", "SING's pitch
+ * lane"), so one classifier serves every caller without a generic sentence.
+ */
+export function describeMicFailure(err: unknown, what: string): MicFailure {
+  switch (errorName(err)) {
+    case 'NotFoundError':
+    case 'DevicesNotFoundError':
+      return {
+        kind: 'no-device',
+        message: `No microphone is attached, so ${what} is off. Plug one in and reopen this tab.`,
+        benign: true,
+      }
+    case 'NotAllowedError':
+    case 'PermissionDeniedError':
+    case 'SecurityError':
+      return {
+        kind: 'denied',
+        message: `Microphone access was refused, so ${what} is off. Allow the microphone for theDAW and reopen this tab.`,
+        benign: false,
+      }
+    case 'NotReadableError':
+    case 'TrackStartError':
+    case 'AbortError':
+      return {
+        kind: 'busy',
+        message: `The microphone is in use by another program, so ${what} is off. Close whatever is holding it and reopen this tab.`,
+        benign: false,
+      }
+    case 'OverconstrainedError':
+    case 'ConstraintNotSatisfiedError':
+      return {
+        kind: 'overconstrained',
+        message: `The microphone cannot record in the format ${what} asked for. It will use the system default instead.`,
+        benign: false,
+      }
+    case 'TypeError':
+      return {
+        kind: 'unsupported',
+        message: `This build cannot open a microphone, so ${what} is off.`,
+        benign: false,
+      }
+    default:
+      return { kind: 'unknown', message: `${what} could not open the microphone: ${errorText(err)}`, benign: false }
+  }
+}
+
+/**
+ * True the first time a given (kind, surface) pair is seen this session.
+ *
+ * The monitor effect re-runs whenever the chosen device changes and whenever the
+ * panel remounts, so without this the same "no microphone" line stacks up in the
+ * LOG. Keyed on the kind as well as the surface so a state CHANGE — device
+ * appears, permission granted, device taken by another app — is still reported.
+ */
+const announced = new Set<string>()
+
+export function shouldAnnounceMicFailure(failure: MicFailure, what: string): boolean {
+  const key = `${what}:${failure.kind}`
+  if (announced.has(key)) return false
+  announced.add(key)
+  return true
+}
+
+/** Forget what has been announced. For tests, and for a deliberate re-probe. */
+export function resetMicFailureLog(): void {
+  announced.clear()
+}

--- a/frontend/src/lib/midiPortFilter.test.ts
+++ b/frontend/src/lib/midiPortFilter.test.ts
@@ -1,0 +1,96 @@
+/**
+ * MIDI input filtering. The failure mode this guards is a dead keyboard: a
+ * controller that works today must not stop working because the user once
+ * picked a device, and the Quest bridge (which is not a Web MIDI port at all)
+ * must never be filtered out by a port list it cannot appear in.
+ *
+ * Run: npx tsx src/lib/midiPortFilter.test.ts
+ */
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_MIDI_INPUT_CONFIG,
+  QUEST_PORT,
+  describeMidiInputs,
+  midiPortAllowed,
+  normalizeMidiInputConfig,
+  toggleMidiPort,
+  type MidiInputConfig,
+} from './midiPortFilter.ts';
+
+const launchkey = { id: 'port-1', name: 'Launchkey MK3 MIDI' };
+const push = { id: 'port-2', name: 'Ableton Push 2' };
+// Two of the same controller: the names collide, the ids never do.
+const pushTwin = { id: 'port-3', name: 'Ableton Push 2' };
+
+/* ── 'all' is the default and stays open ─────────────────────────────────── */
+
+assert.equal(DEFAULT_MIDI_INPUT_CONFIG.mode, 'all');
+assert.equal(midiPortAllowed(launchkey, DEFAULT_MIDI_INPUT_CONFIG), true);
+// A controller plugged in AFTER the choice was made: still allowed, no trip to
+// Settings needed.
+assert.equal(midiPortAllowed({ id: 'brand-new', name: 'Keystep' }, { mode: 'all', ports: [{ id: 'port-1', label: 'Launchkey MK3 MIDI' }] }), true);
+
+/* ── a malformed or missing config fails OPEN ────────────────────────────── */
+
+assert.equal(midiPortAllowed(launchkey, null), true);
+assert.equal(midiPortAllowed(launchkey, undefined), true);
+assert.equal(midiPortAllowed(launchkey, normalizeMidiInputConfig('nonsense')), true);
+assert.equal(midiPortAllowed(launchkey, normalizeMidiInputConfig({ mode: 'weird' })), true);
+
+/* ── 'some' passes only the saved ports ──────────────────────────────────── */
+
+const only: MidiInputConfig = { mode: 'some', ports: [{ id: 'port-2', label: 'Ableton Push 2' }] };
+assert.equal(midiPortAllowed(push, only), true);
+assert.equal(midiPortAllowed(launchkey, only), false, 'an unlisted port is silent');
+assert.equal(
+  midiPortAllowed(pushTwin, only),
+  true,
+  'the twin matches by NAME — the id rotated or a second identical unit is plugged in',
+);
+
+/* ── ids distinguish two ports sharing a name ────────────────────────────── */
+
+const byIdOnly: MidiInputConfig = { mode: 'some', ports: [{ id: 'port-2', label: '' }] };
+assert.equal(midiPortAllowed(push, byIdOnly), true);
+assert.equal(midiPortAllowed(pushTwin, byIdOnly), false, 'no label to fall back on, so the id decides');
+
+/* ── 'some' with nothing chosen means nothing, deliberately ──────────────── */
+
+const none: MidiInputConfig = { mode: 'some', ports: [] };
+assert.equal(midiPortAllowed(push, none), false);
+assert.equal(describeMidiInputs(none, 3), 'No inputs');
+
+/* ── the Quest bridge is never filtered ──────────────────────────────────── */
+
+assert.equal(midiPortAllowed(QUEST_PORT, none), true, 'the Quest bridge rides the bus, not Web MIDI');
+assert.equal(midiPortAllowed(QUEST_PORT, only), true);
+
+/* ── normalize: drops junk, keeps the shape the backend stores ───────────── */
+
+const normalized = normalizeMidiInputConfig({
+  mode: 'some',
+  ports: [{ id: 'port-1', label: 'Launchkey MK3 MIDI' }, null, 'x', { label: 'No id but a name' }, {}],
+});
+assert.equal(normalized.mode, 'some');
+assert.deepEqual(normalized.ports, [
+  { id: 'port-1', label: 'Launchkey MK3 MIDI' },
+  { id: '', label: 'No id but a name' },
+]);
+
+/* ── describe + toggle round trip ────────────────────────────────────────── */
+
+assert.equal(describeMidiInputs({ mode: 'all', ports: [] }, 2), 'All inputs (2)');
+assert.equal(describeMidiInputs(only, 3), '1 of 3 inputs');
+
+{
+  const on = toggleMidiPort({ mode: 'all', ports: [] }, { id: 'port-1', label: 'Launchkey MK3 MIDI' }, true);
+  assert.equal(on.mode, 'some', 'picking one port switches the mode');
+  assert.deepEqual(on.ports, [{ id: 'port-1', label: 'Launchkey MK3 MIDI' }]);
+  const off = toggleMidiPort(on, { id: 'port-1', label: 'Launchkey MK3 MIDI' }, false);
+  assert.deepEqual(off.ports, []);
+  const twice = toggleMidiPort(on, { id: 'port-1', label: 'Launchkey MK3 MIDI' }, true);
+  assert.deepEqual(twice.ports, [{ id: 'port-1', label: 'Launchkey MK3 MIDI' }], 'no duplicates');
+}
+
+console.log('midiPortFilter passed');

--- a/frontend/src/lib/midiPortFilter.ts
+++ b/frontend/src/lib/midiPortFilter.ts
@@ -1,0 +1,78 @@
+/**
+ * Which MIDI input ports are allowed to reach the app.
+ *
+ * The filter belongs at the Web MIDI boundary in App.tsx (where `input.id` is
+ * still in hand), NOT inside midiBus: the bus also carries the Quest bridge and
+ * the synthetic Sway surface, neither of which is a Web MIDI port, and filtering
+ * there would silence both.
+ *
+ * Default is `mode: 'all'` — a controller plugged in after the user made their
+ * choice must work without a trip to Settings. `mode: 'some'` with an empty
+ * list is a real choice (every controller muted), not a malformed setting; a
+ * config that is genuinely malformed fails OPEN, because a broken preference
+ * must never be the reason a keyboard went dead.
+ *
+ * Pure: no Web MIDI, no DOM. Pinned in midiPortFilter.test.ts.
+ */
+import type { DeviceRef } from './ioResolve';
+
+/**
+ * The Quest headset bridge publishes onto the MIDI bus over a WebSocket
+ * (state/questMidiClient.ts), so it has no MIDIInput and no port id. It is
+ * listed here so the menu can show it, and it is never filtered out.
+ */
+export const QUEST_PORT: DeviceRef = { id: 'thedaw:quest', label: 'Quest bridge (USB)' };
+
+export interface MidiInputConfig {
+  mode: 'all' | 'some';
+  ports: DeviceRef[];
+}
+
+export const DEFAULT_MIDI_INPUT_CONFIG: MidiInputConfig = { mode: 'all', ports: [] };
+
+/** Minimal shape of a Web MIDI input; `MIDIInput` satisfies it. */
+export interface MidiPortLike {
+  id: string;
+  name?: string | null;
+}
+
+/** Coerce whatever the settings payload carried into a usable config. */
+export function normalizeMidiInputConfig(raw: unknown): MidiInputConfig {
+  if (!raw || typeof raw !== 'object') return { ...DEFAULT_MIDI_INPUT_CONFIG };
+  const obj = raw as { mode?: unknown; ports?: unknown };
+  const mode = obj.mode === 'some' ? 'some' : 'all';
+  const ports = Array.isArray(obj.ports)
+    ? obj.ports
+        .filter((p): p is Record<string, unknown> => !!p && typeof p === 'object')
+        .map((p) => ({ id: String(p.id ?? ''), label: String(p.label ?? '') }))
+        .filter((p) => p.id || p.label)
+    : [];
+  return { mode, ports };
+}
+
+/**
+ * Is this port allowed through?
+ *
+ * Matching mirrors ioResolve: by id first, then by name — two identical
+ * controllers share a name but never an id, and an id can rotate between
+ * sessions while the name does not.
+ */
+export function midiPortAllowed(port: MidiPortLike, cfg: MidiInputConfig | null | undefined): boolean {
+  if (!cfg || cfg.mode !== 'some') return true;
+  if (port.id === QUEST_PORT.id) return true;
+  const name = port.name ?? '';
+  return cfg.ports.some((p) => (p.id && p.id === port.id) || (!!p.label && p.label === name));
+}
+
+/** "All inputs (2)" / "2 of 3 inputs" / "No MIDI inputs" for the menu row. */
+export function describeMidiInputs(cfg: MidiInputConfig, connected: number): string {
+  if (cfg.mode === 'all') return `All inputs (${connected})`;
+  if (cfg.ports.length === 0) return 'No inputs';
+  return `${cfg.ports.length} of ${connected} input${connected === 1 ? '' : 's'}`;
+}
+
+/** Add or remove one port from an explicit list, returning a complete config. */
+export function toggleMidiPort(cfg: MidiInputConfig, ref: DeviceRef, on: boolean): MidiInputConfig {
+  const without = cfg.ports.filter((p) => p.id !== ref.id);
+  return { mode: 'some', ports: on ? [...without, { ...ref }] : without };
+}

--- a/frontend/src/lib/nodefiLive.ts
+++ b/frontend/src/lib/nodefiLive.ts
@@ -19,7 +19,7 @@
  */
 import { nodeDef, type GraphEdge, type GraphNode, type NodeKind, type NodeRunStatus } from './nodefiTypes';
 import { useLibraryStore } from '../state/libraryStore';
-import { getEngineCtx } from '../state/playerStore';
+import { getEngineCtx, getMasterGain } from '../state/playerStore';
 import {
   getRackEffect,
   rackEffectDefaults,
@@ -344,7 +344,11 @@ export async function startLiveGraph(
         } else if (n.kind === 'lout') {
           const g = ctx.createGain();
           g.gain.value = num(n.params.gain, 0.9);
-          g.connect(ctx.destination);
+          // The master summing bus, NOT ctx.destination: straight to the
+          // destination this audible node bypassed the rack insert, the live
+          // FX, the analyser and the monitor gain — so the footer volume did
+          // not attenuate it and the meter never saw it.
+          g.connect(getMasterGain());
           inst.set(n.id, {
             inputs: { in: g },
             output: null,

--- a/frontend/src/lib/vocalToMidi.ts
+++ b/frontend/src/lib/vocalToMidi.ts
@@ -176,6 +176,20 @@ export interface VocalCaptureController {
   stop: (opts?: CaptureOptions) => VocalCapture;
 }
 
+/**
+ * Tell the device store that a getUserMedia just resolved, so it re-enumerates
+ * and the labels (blank until then) fill in everywhere at once. Imported lazily
+ * so this module stays usable without the store, and so a failure to load it
+ * can never break a capture that already succeeded.
+ */
+const notePermissionGranted = (): void => {
+  void import('../state/ioDevicesStore')
+    .then((m) => m.useIoDevicesStore.getState().notePermissionGranted())
+    .catch(() => {
+      /* the store is not in this bundle; labels fill in on the next refresh */
+    });
+};
+
 /** Available microphone inputs. Labels are blank until mic permission is granted
  * once, so call this after a successful capture (or permission prompt). */
 export const listAudioInputs = async (): Promise<MediaDeviceInfo[]> => {
@@ -200,12 +214,17 @@ export interface InputMonitor {
 export const startInputMonitor = async (deviceId?: string): Promise<InputMonitor> => {
   const stream = await navigator.mediaDevices.getUserMedia({
     audio: {
-      ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
+      // SOFT constraint, not `{ exact }`: the id has already been checked
+      // against the live device list by ioResolve, so a race between the
+      // enumerate and the open should degrade to the OS default rather than
+      // reject the whole capture with OverconstrainedError.
+      ...(deviceId ? { deviceId } : {}),
       echoCancellation: false,
       noiseSuppression: false,
       autoGainControl: false,
     },
   });
+  notePermissionGranted();
   const ctx = getEngineCtx();
   // Best-effort resume; on mount there may be no user gesture yet, so don't block.
   if (ctx.state === 'suspended') void ctx.resume().catch(() => {});
@@ -257,12 +276,14 @@ export const startVocalCapture = async (
 ): Promise<VocalCaptureController> => {
   const stream = await navigator.mediaDevices.getUserMedia({
     audio: {
-      ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
+      // Soft constraint — see startInputMonitor.
+      ...(deviceId ? { deviceId } : {}),
       echoCancellation: false,
       noiseSuppression: false,
       autoGainControl: false,
     },
   });
+  notePermissionGranted();
   const ctx = getEngineCtx();
   if (ctx.state === 'suspended') await ctx.resume();
   await ensureYinModule(ctx);

--- a/frontend/src/state/djEngine.ts
+++ b/frontend/src/state/djEngine.ts
@@ -144,6 +144,9 @@ let limiterEnabled = true; // brickwall on the DJ bus for clip safety (D5)
 let cueBus: GainNode | null = null;
 let cueDest: MediaStreamAudioDestinationNode | null = null;
 let cueAudioEl: HTMLAudioElement | null = null;
+// Cached choice, NOT the source of truth: the global I/O menu owns it
+// (settings io.cue_output) and pushes it here. Cached so a cue bus built after
+// the preference loaded is already routed to the headphones.
 let cueSinkId = '';
 // Sampler bank (D7): one-shot pads routed through djMaster (so they ride the DJ
 // mix + limiter + visualizer). Decoded buffers keyed by pad id.
@@ -185,6 +188,10 @@ function ensureCueBus(): GainNode {
   cueBus.connect(cueDest);
   cueAudioEl = new Audio();
   cueAudioEl.srcObject = cueDest.stream;
+  // The MediaStreamDestination does NOT follow the context's sinkId, which is
+  // exactly why cue works: the mains and the headphones stay independent by
+  // construction. Apply whatever the I/O menu already chose.
+  if (cueSinkId) void applyCueSink();
   return cueBus;
 }
 
@@ -820,14 +827,30 @@ export function setDeckCue(id: DeckId, on: boolean): void {
   if (on && cueAudioEl) void cueAudioEl.play().catch(() => { /* needs a gesture — the toggle click is one */ });
 }
 
-/** Route the cue bus to a specific output device (headphones). '' = default. */
+/** Push the cached choice onto the hidden cue element. */
+async function applyCueSink(): Promise<void> {
+  const el = cueAudioEl as (HTMLAudioElement & { setSinkId?: (id: string) => Promise<void> }) | null;
+  if (!el?.setSinkId) return;
+  try { await el.setSinkId(cueSinkId); } catch (e) { logError('dj', `cue setSinkId failed: ${e instanceof Error ? e.message : String(e)}`); }
+}
+
+/**
+ * Route the cue bus to a specific output device (headphones). '' = default.
+ *
+ * Called by the global I/O menu (state/ioDevicesStore), which is the single
+ * owner of the choice — the DJ tab's own cue select writes through it too, so
+ * both places always agree. Does NOT build the cue bus for an empty id: a user
+ * who never picks a cue device should not get an extra MediaStreamDestination
+ * (and an AudioContext) constructed at boot on their behalf.
+ */
 export async function setCueSinkId(deviceId: string): Promise<void> {
+  if (!deviceId && !cueBus) {
+    cueSinkId = '';
+    return;
+  }
   ensureCueBus();
   cueSinkId = deviceId;
-  const el = cueAudioEl as (HTMLAudioElement & { setSinkId?: (id: string) => Promise<void> }) | null;
-  if (el?.setSinkId) {
-    try { await el.setSinkId(deviceId); } catch (e) { logError('dj', `cue setSinkId failed: ${e instanceof Error ? e.message : String(e)}`); }
-  }
+  await applyCueSink();
 }
 
 export function getCueSinkId(): string {

--- a/frontend/src/state/featureToggleStore.ts
+++ b/frontend/src/state/featureToggleStore.ts
@@ -15,6 +15,7 @@
  */
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import type { DeviceRef } from '../lib/ioResolve';
 import { dismissFeatureGate, requireFeature } from '../notices/featureGateStore';
 import { logError } from './logStore';
 
@@ -73,6 +74,38 @@ export interface NotationSettings {
   musescore_path: string;
 }
 
+/** Which MIDI input ports are let through. 'all' = every port, including one
+ *  plugged in after the choice was made. */
+export interface MidiInputSelection {
+  mode: string;
+  ports: DeviceRef[];
+}
+
+/**
+ * Global input/output device choices + per-surface overrides.
+ *
+ * Every slot is a {id,label} pair, never a bare deviceId: ids are salted per
+ * origin and rotate when site data is cleared, and the same user opens theDAW
+ * both as a browser tab and as the desktop app. The label is the recovery key
+ * (see lib/ioResolve). Empty id AND label = "the system default".
+ *
+ * `overrides` is keyed by surface id (state/ioSurfaces). A surface with NO
+ * entry follows its global slot; an entry of {id:'',label:''} means "the OS
+ * default, ignoring the global".
+ *
+ * Every value here is replaced WHOLESALE by the backend's patch() — it does not
+ * deep-merge — so a writer must always send the complete object.
+ */
+export interface IoSettings {
+  audio_output: DeviceRef;
+  cue_output: DeviceRef;
+  audio_input: DeviceRef;
+  midi_inputs: MidiInputSelection;
+  midi_output: DeviceRef;
+  visual_display: DeviceRef;
+  overrides: Record<string, DeviceRef>;
+}
+
 export interface FeatureSettings {
   schema_version: number;
   app: AppSettings;
@@ -82,6 +115,7 @@ export interface FeatureSettings {
   idle: IdleSettings;
   vj: VjSettings;
   notation: NotationSettings;
+  io: IoSettings;
 }
 
 export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
@@ -118,6 +152,15 @@ export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
     artist: 'GANTASMO',
     musescore_path: '',
   },
+  io: {
+    audio_output: { id: '', label: '' },
+    cue_output: { id: '', label: '' },
+    audio_input: { id: '', label: '' },
+    midi_inputs: { mode: 'all', ports: [] },
+    midi_output: { id: '', label: '' },
+    visual_display: { id: '', label: '' },
+    overrides: {},
+  },
 };
 
 interface FeatureToggleState {
@@ -132,7 +175,7 @@ interface FeatureToggleState {
    * false when it was rolled back (the reason is in `error` and on the
    * notice card). Never throws.
    */
-  patch: (partial: DeepPartial<FeatureSettings>) => Promise<boolean>;
+  patch: (partial: FeatureSettingsPatch) => Promise<boolean>;
   clearError: () => void;
 }
 
@@ -140,7 +183,17 @@ type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
 };
 
-function mergeSettings(base: FeatureSettings, patch: DeepPartial<FeatureSettings>): FeatureSettings {
+/**
+ * `io` is deliberately NOT deep-partial: the backend store assigns a
+ * dict-valued key wholesale, so half an `audio_output` would REPLACE the whole
+ * slot and drop the label. Writers send complete slot objects; the io store's
+ * helpers are what build them.
+ */
+export type FeatureSettingsPatch = DeepPartial<Omit<FeatureSettings, 'io'>> & {
+  io?: Partial<IoSettings>;
+};
+
+function mergeSettings(base: FeatureSettings, patch: FeatureSettingsPatch): FeatureSettings {
   const next: FeatureSettings = {
     ...base,
     app: { ...DEFAULT_FEATURE_SETTINGS.app, ...(base.app ?? {}), ...(patch.app ?? {}) },
@@ -150,18 +203,34 @@ function mergeSettings(base: FeatureSettings, patch: DeepPartial<FeatureSettings
     idle: { ...base.idle, ...(patch.idle ?? {}) },
     vj: { ...base.vj, ...(patch.vj ?? {}) },
     notation: { ...DEFAULT_FEATURE_SETTINGS.notation, ...(base.notation ?? {}), ...(patch.notation ?? {}) },
+    // ONE level only, on purpose: it mirrors the backend's wholesale-replace
+    // semantics. Deep-merging here would make a deleted per-surface override
+    // resurrect itself on the next patch.
+    io: { ...DEFAULT_FEATURE_SETTINGS.io, ...(base.io ?? {}), ...(patch.io ?? {}) },
   };
   if (patch.schema_version != null) next.schema_version = patch.schema_version;
   return next;
 }
 
 /** "stems.auto_on_import = on" — what the failed save was, for the notice. */
-function describePatch(partial: DeepPartial<FeatureSettings>): string {
+function describePatch(partial: FeatureSettingsPatch): string {
   const parts: string[] = [];
   for (const [section, values] of Object.entries(partial)) {
     if (!values || typeof values !== 'object') continue;
     for (const [key, value] of Object.entries(values as Record<string, unknown>)) {
-      const shown = typeof value === 'boolean' ? (value ? 'on' : 'off') : String(value);
+      const shown =
+        typeof value === 'boolean'
+          ? value
+            ? 'on'
+            : 'off'
+          : value && typeof value === 'object'
+            ? // Device slots are {id,label}; the label is the half a person
+              // reads. Anything else nested (overrides, midi_inputs) just says
+              // it changed rather than printing [object Object].
+              typeof (value as { label?: unknown }).label === 'string'
+              ? (value as { label: string }).label || 'system default'
+              : 'updated'
+            : String(value);
       parts.push(`${section}.${key} = ${shown}`);
     }
   }

--- a/frontend/src/state/ioDevicesStore.ts
+++ b/frontend/src/state/ioDevicesStore.ts
@@ -1,0 +1,509 @@
+/**
+ * The single owner of "which device".
+ *
+ * Before this store there were three device preferences and no agreement
+ * between them: the MIDI tab and the SING pitch lane both persisted the key
+ * `vocal.inputDeviceId` into two React states that never reconciled in-session,
+ * and the DJ cue output persisted nowhere at all, resetting to the system
+ * default on every reload. Nothing subscribed to `devicechange`, so plugging an
+ * interface in never updated any list.
+ *
+ * What lives here: the LIVE device world (enumerated lists, permission state,
+ * runtime capabilities) and the apply layer. What does NOT live here: the
+ * choices themselves — those are in the backend settings store's `io` section
+ * (featureToggleStore), because the same user opens theDAW as a browser tab AND
+ * as the desktop app, which are two origins with two localStorage partitions.
+ *
+ * The resolution rules are in lib/ioResolve, pure and tested.
+ */
+import { create } from 'zustand';
+import {
+  applyElementSink,
+  refreshSinkElements,
+  setSinkResolver,
+  supportsContextSink,
+  supportsElementSink,
+} from '../lib/audioSink';
+import {
+  FOLLOW_GLOBAL,
+  isSystemDefault,
+  labelsAreKnown,
+  missingNoticeId,
+  overrideFromSelect,
+  resolveRef,
+  resolveSlot,
+  type DeviceRef,
+  type IoKind,
+  type LiveDevice,
+  type Resolved,
+} from '../lib/ioResolve';
+import { normalizeMidiInputConfig, type MidiInputConfig } from '../lib/midiPortFilter';
+import { dismissFeatureGate, requireFeature } from '../notices/featureGateStore';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  useFeatureToggleStore,
+  type IoSettings,
+} from './featureToggleStore';
+import { logInfo, logWarn } from './logStore';
+import { midiOutDevices, setMidiThruTarget } from './midiOutBus';
+import { setEngineSink } from './playerStore';
+import { GLOBAL_SLOT_FOR_KIND, IO_SURFACES, surfaceById, type SurfaceId } from './ioSurfaces';
+
+export type { DeviceRef, LiveDevice, Resolved } from '../lib/ioResolve';
+export { FOLLOW_GLOBAL } from '../lib/ioResolve';
+
+/** The global slots, named exactly as they are persisted. */
+export type IoSlot =
+  | 'audio_output'
+  | 'cue_output'
+  | 'audio_input'
+  | 'midi_output'
+  | 'visual_display';
+
+const SLOT_KIND: Record<IoSlot, IoKind> = {
+  audio_output: 'audioOut',
+  cue_output: 'audioOut',
+  audio_input: 'audioIn',
+  midi_output: 'midiOut',
+  visual_display: 'display',
+};
+
+interface IoDevicesState {
+  audioOut: LiveDevice[];
+  audioIn: LiveDevice[];
+  midiIn: LiveDevice[];
+  midiOut: LiveDevice[];
+  display: LiveDevice[];
+  /**
+   * False until a getUserMedia has resolved once: enumerateDevices() returns
+   * blank labels before that, and a list of blanks must never be rendered as a
+   * dropdown (it used to render as "Input 4f2a1b" and three rows of "Output").
+   */
+  labelsKnown: boolean;
+  /** True once enumerateDevices has returned at least once. */
+  enumerated: boolean;
+  micPermission: PermissionState | 'unknown';
+  supports: {
+    /** Move the whole shared graph — Chromium 110+. */
+    ctxSink: boolean;
+    /** Move one <audio> element — the DJ cue and the loose previews. */
+    elementSink: boolean;
+    enumerate: boolean;
+    midi: boolean;
+    /** Electron only: position a pop-out on a chosen monitor. */
+    displays: boolean;
+  };
+  refresh: () => Promise<void>;
+  refreshDisplays: () => Promise<void>;
+  /** Call from the resolved branch of every getUserMedia: labels exist now. */
+  notePermissionGranted: () => void;
+  /** App.tsx publishes the Web MIDI port lists here. */
+  setMidiPorts: (inputs: LiveDevice[]) => void;
+}
+
+const byKind = (s: IoDevicesState, kind: IoKind): LiveDevice[] => s[kind];
+
+export const useIoDevicesStore = create<IoDevicesState>()((set, get) => ({
+  audioOut: [],
+  audioIn: [],
+  midiIn: [],
+  midiOut: [],
+  display: [],
+  labelsKnown: false,
+  enumerated: false,
+  micPermission: 'unknown',
+  supports: {
+    ctxSink: false,
+    elementSink: false,
+    enumerate: false,
+    midi: false,
+    displays: false,
+  },
+
+  refresh: async () => {
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.enumerateDevices) return;
+    let all: MediaDeviceInfo[] = [];
+    try {
+      all = await navigator.mediaDevices.enumerateDevices();
+    } catch (e) {
+      logWarn('audio', `Device list unavailable: ${e instanceof Error ? e.message : String(e)}`);
+      return;
+    }
+    const pick = (kind: MediaDeviceKind): LiveDevice[] =>
+      all
+        .filter((d) => d.kind === kind)
+        .map((d) => ({ id: d.deviceId, label: d.label }))
+        // The blank placeholder Chrome returns pre-permission is not a device.
+        .filter((d) => d.id !== '' || d.label !== '');
+    const audioOut = pick('audiooutput');
+    const audioIn = pick('audioinput');
+    set({
+      audioOut,
+      audioIn,
+      enumerated: true,
+      labelsKnown: labelsAreKnown([...audioIn, ...audioOut]),
+    });
+    void queryMicPermission().then((micPermission) => set({ micPermission }));
+    syncResolution();
+  },
+
+  refreshDisplays: async () => {
+    const api = (window as unknown as { electronAPI?: { listDisplays?: () => Promise<Array<{ id: string; label: string }>> } })
+      .electronAPI;
+    if (!api?.listDisplays) return;
+    try {
+      const list = await api.listDisplays();
+      set({ display: list.map((d) => ({ id: d.id, label: d.label })) });
+    } catch (e) {
+      logWarn('vj', `Display list unavailable: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  },
+
+  notePermissionGranted: () => {
+    set({ micPermission: 'granted' });
+    void get().refresh();
+  },
+
+  setMidiPorts: (inputs) => {
+    set({ midiIn: inputs, midiOut: midiOutDevices() });
+    syncResolution();
+  },
+}));
+
+/** Current mic permission, or 'unknown' where the Permissions API is absent. */
+async function queryMicPermission(): Promise<PermissionState | 'unknown'> {
+  try {
+    const p = await navigator.permissions.query({ name: 'microphone' as PermissionName });
+    return p.state;
+  } catch {
+    return 'unknown';
+  }
+}
+
+/* ── reading the choices ──────────────────────────────────────────────────── */
+
+export const ioSettings = (): IoSettings =>
+  useFeatureToggleStore.getState().settings.io ?? DEFAULT_FEATURE_SETTINGS.io;
+
+export const midiInputConfig = (): MidiInputConfig =>
+  normalizeMidiInputConfig(ioSettings().midi_inputs);
+
+/** The live list for a device family. */
+export const liveDevices = (kind: IoKind): LiveDevice[] => byKind(useIoDevicesStore.getState(), kind);
+
+/**
+ * Is the live list for this family authoritative enough to declare a saved
+ * device "gone"?
+ *
+ * Audio: not until a getUserMedia has resolved, because every label is blank
+ * before that. MIDI and displays: their entries always carry a name, but an
+ * EMPTY list means nothing has been enumerated — MIDI is opt-in and off by
+ * default, and a browser has no display API — so an empty list is "we cannot
+ * tell", never "your device is missing". Getting this wrong shows a scary
+ * notice to a user who simply has MIDI switched off.
+ */
+const labelsKnownFor = (kind: IoKind): boolean =>
+  kind === 'audioIn' || kind === 'audioOut'
+    ? useIoDevicesStore.getState().labelsKnown
+    : liveDevices(kind).length > 0;
+
+/** Resolve one global slot against the live world. */
+export function resolveGlobal(slot: IoSlot): Resolved {
+  const kind = SLOT_KIND[slot];
+  return resolveSlot({
+    global: ioSettings()[slot],
+    live: liveDevices(kind),
+    labelsKnown: labelsKnownFor(kind),
+  });
+}
+
+/** Resolve one surface: its own override, else the global slot, else the OS. */
+export function resolveSurface(surface: SurfaceId): Resolved {
+  const def = surfaceById(surface);
+  const kind: IoKind = def?.kind ?? 'audioIn';
+  const io = ioSettings();
+  return resolveSlot({
+    override: io.overrides?.[surface],
+    global: io[GLOBAL_SLOT_FOR_KIND[def?.kind ?? 'audioIn']],
+    live: liveDevices(kind),
+    labelsKnown: labelsKnownFor(kind),
+  });
+}
+
+/** The deviceId a surface should open right now ('' = the OS default). */
+export const surfaceDeviceId = (surface: SurfaceId): string => resolveSurface(surface).deviceId;
+
+/** `undefined` when the surface follows its global slot. */
+export const surfaceOverride = (surface: SurfaceId): DeviceRef | undefined =>
+  ioSettings().overrides?.[surface];
+
+/* ── writing the choices ──────────────────────────────────────────────────── */
+
+const patchIo = (part: Partial<IoSettings>): Promise<boolean> =>
+  useFeatureToggleStore.getState().patch({ io: part });
+
+/**
+ * Set a global slot. Always writes the COMPLETE {id,label} object: the backend
+ * store assigns a dict-valued key wholesale rather than deep-merging, so a
+ * fragment would replace the slot and drop the label that makes the choice
+ * survive an id rotation.
+ */
+export const setGlobalDevice = async (slot: IoSlot, ref: DeviceRef): Promise<boolean> => {
+  const ok = await patchIo({ [slot]: { id: ref.id ?? '', label: ref.label ?? '' } } as Partial<IoSettings>);
+  if (ok) applyAll();
+  return ok;
+};
+
+/** Build a ref from a `<select>` value against the live list for that slot. */
+export const deviceRefFromId = (slot: IoSlot, id: string): DeviceRef => {
+  const hit = liveDevices(SLOT_KIND[slot]).find((d) => d.id === id);
+  return { id, label: id ? (hit?.label ?? '') : '' };
+};
+
+/** `null` removes the override so the surface follows its global slot again. */
+export const setSurfaceOverride = async (
+  surface: SurfaceId,
+  ref: DeviceRef | null,
+): Promise<boolean> => {
+  const next = { ...(ioSettings().overrides ?? {}) };
+  if (ref === null) delete next[surface];
+  else next[surface] = { id: ref.id ?? '', label: ref.label ?? '' };
+  // `overrides` is replaced wholesale, which is exactly what makes a deletion
+  // stick — a deep merge here would resurrect the entry we just dropped.
+  const ok = await patchIo({ overrides: next });
+  if (ok) applyAll();
+  return ok;
+};
+
+/** Set an override straight from a `<select>` value (FOLLOW_GLOBAL / '' / id). */
+export const setSurfaceOverrideFromSelect = (surface: SurfaceId, value: string): Promise<boolean> => {
+  const def = surfaceById(surface);
+  return setSurfaceOverride(surface, overrideFromSelect(value, liveDevices(def?.kind ?? 'audioIn')));
+};
+
+export const setMidiInputSelection = async (cfg: MidiInputConfig): Promise<boolean> => {
+  const ok = await patchIo({ midi_inputs: { mode: cfg.mode, ports: cfg.ports } });
+  if (ok) applyAll();
+  return ok;
+};
+
+/* ── notices: a chosen device that is not there ───────────────────────────── */
+
+/** Notice ids currently raised, so one absent device cannot stack cards. */
+const raised = new Set<string>();
+let syncing = false;
+
+function noticeFor(kind: IoKind, ref: DeviceRef, where: string): void {
+  const id = missingNoticeId(kind, ref);
+  if (raised.has(id)) return;
+  raised.add(id);
+  requireFeature({
+    id,
+    kind: 'error',
+    title: 'Device not connected',
+    message: `${ref.label || ref.id} is not connected — ${where} is using the system default. The choice is kept, so plugging it back in restores it.`,
+    action: {
+      label: 'Open Settings',
+      run: () => {
+        window.dispatchEvent(new CustomEvent('thedaw:open-settings'));
+      },
+    },
+    docsHint: 'Settings → Inputs & outputs',
+  });
+}
+
+function clearNotice(kind: IoKind, ref: DeviceRef): void {
+  const id = missingNoticeId(kind, ref);
+  if (!raised.delete(id)) return;
+  dismissFeatureGate(id);
+}
+
+/**
+ * Re-check every choice against the live world: raise a notice for anything
+ * that has gone missing, clear the notice when it comes back, and re-persist a
+ * ref whose id rotated but whose label still matches.
+ *
+ * Never called during render — it writes to two stores.
+ */
+export function syncResolution(): void {
+  if (syncing) return;
+  syncing = true;
+  try {
+    const io = ioSettings();
+    const check = (kind: IoKind, ref: DeviceRef | undefined, where: string, rewrite: (r: DeviceRef) => void) => {
+      if (!ref || isSystemDefault(ref)) return;
+      const r = resolveRef(ref, liveDevices(kind), labelsKnownFor(kind));
+      if (r.source === 'missing') noticeFor(kind, ref, where);
+      else clearNotice(kind, ref);
+      if (r.rewrite) {
+        logInfo('audio', `${r.label} came back with a new device id; the saved choice was updated.`);
+        rewrite(r.rewrite);
+      }
+    };
+
+    check('audioOut', io.audio_output, 'the main output', (r) => void setGlobalDevice('audio_output', r));
+    check('audioOut', io.cue_output, 'the DJ headphone cue', (r) => void setGlobalDevice('cue_output', r));
+    check('audioIn', io.audio_input, 'the microphone', (r) => void setGlobalDevice('audio_input', r));
+    check('midiOut', io.midi_output, 'MIDI thru', (r) => void setGlobalDevice('midi_output', r));
+    for (const surface of IO_SURFACES) {
+      check(surface.kind, io.overrides?.[surface.id], surface.label, (r) =>
+        void setSurfaceOverride(surface.id, r),
+      );
+    }
+  } finally {
+    syncing = false;
+  }
+}
+
+/* ── the apply layer ──────────────────────────────────────────────────────── */
+
+let lastCueId = '';
+let lastThruKey = '';
+
+/** Push every resolved choice at the thing that actually makes the sound. */
+export function applyAll(): void {
+  // 1. The whole shared graph (footer transport, sequencer, decks, mixer).
+  void setEngineSink(resolveGlobal('audio_output').deviceId);
+
+  // 2. The DJ cue bus — a separate device on purpose, so pre-listen is not
+  //    audible in the mains. Skipped entirely while nothing is chosen so a user
+  //    who never opens the menu gets no cue bus (and no AudioContext) built.
+  const cueId = resolveGlobal('cue_output').deviceId;
+  if (cueId !== lastCueId) {
+    const hadOne = lastCueId !== '';
+    lastCueId = cueId;
+    if (cueId || hadOne) {
+      void import('./djEngine')
+        .then((m) => m.setCueSinkId(cueId))
+        .catch(() => {
+          /* the DJ engine is not in this bundle yet; it applies on first use */
+        });
+    }
+  }
+
+  // 3. The loose <audio> elements outside the graph.
+  refreshSinkElements();
+
+  // 4. MIDI thru.
+  const thru = ioSettings().midi_output ?? { id: '', label: '' };
+  const key = `${thru.id}|${thru.label}`;
+  if (key !== lastThruKey) {
+    lastThruKey = key;
+    setMidiThruTarget(thru);
+  }
+
+  syncResolution();
+}
+
+/* ── one-time migration of the old localStorage mic key ───────────────────── */
+
+const LEGACY_MIC_KEY = 'vocal.inputDeviceId';
+let migrated = false;
+
+/**
+ * The MIDI tab and the SING pitch lane both wrote this key, in two React states
+ * that never reconciled. Adopt it as the GLOBAL microphone once, then leave the
+ * key in place for one release as a read-only fallback so rolling the build
+ * back does not lose the user's mic.
+ */
+function adoptLegacyMic(): void {
+  if (migrated) return;
+  // Only once the BACKEND has answered: the persisted local mirror can be stale
+  // on a first run in the other launch mode, and adopting against it would
+  // overwrite a device the user had already chosen on the other origin.
+  if (!useFeatureToggleStore.getState().loaded) return;
+  migrated = true;
+  const io = ioSettings();
+  if (!isSystemDefault(io.audio_input)) return;
+  let legacy = '';
+  try {
+    legacy = localStorage.getItem(LEGACY_MIC_KEY) ?? '';
+  } catch {
+    // Site data blocked. The old code read this in a useState initializer with
+    // no try/catch and threw during render; this is that bug's fix.
+    return;
+  }
+  if (!legacy) return;
+  const hit = liveDevices('audioIn').find((d) => d.id === legacy);
+  void setGlobalDevice('audio_input', { id: legacy, label: hit?.label ?? '' });
+  logInfo('audio', 'Adopted the old microphone choice into Settings → Inputs & outputs.');
+}
+
+/* ── boot ─────────────────────────────────────────────────────────────────── */
+
+let started = false;
+
+/**
+ * Start the one device-change subscription for the whole app and wire the apply
+ * layer. Idempotent; App.tsx calls it once.
+ */
+export function startIoDevices(): void {
+  if (started || typeof navigator === 'undefined') return;
+  started = true;
+
+  useIoDevicesStore.setState({
+    supports: {
+      ctxSink: supportsContextSink(),
+      elementSink: supportsElementSink(),
+      enumerate: !!navigator.mediaDevices?.enumerateDevices,
+      midi: 'requestMIDIAccess' in navigator,
+      displays: !!(window as unknown as { electronAPI?: { listDisplays?: unknown } }).electronAPI
+        ?.listDisplays,
+    },
+  });
+
+  // Loose <audio> elements ask the registry which device they belong on.
+  setSinkResolver((surface) => resolveSurface(surface as SurfaceId).deviceId);
+
+  // ONE devicechange subscription for the entire app (there were zero before),
+  // so every picker follows a hot-plug at once.
+  navigator.mediaDevices?.addEventListener?.('devicechange', () => {
+    logInfo('audio', 'Audio devices changed');
+    void useIoDevicesStore.getState().refresh();
+  });
+
+  void useIoDevicesStore.getState().refresh();
+  void useIoDevicesStore.getState().refreshDisplays();
+
+  // Re-apply whenever the choices change. The settings are read from the
+  // BACKEND at boot (not only when the Settings modal opens) — that round trip
+  // is what makes a device chosen in the browser build take effect in the
+  // desktop app, which is the whole reason these live server-side.
+  let lastIo = ioSettings();
+  let lastLoaded = useFeatureToggleStore.getState().loaded;
+  useFeatureToggleStore.subscribe((s) => {
+    const io = s.settings.io;
+    if (io === lastIo && s.loaded === lastLoaded) return;
+    lastIo = io;
+    lastLoaded = s.loaded;
+    adoptLegacyMic();
+    applyAll();
+  });
+  void useFeatureToggleStore.getState().refresh();
+  adoptLegacyMic();
+  applyAll();
+}
+
+/* ── React helpers ────────────────────────────────────────────────────────── */
+
+/** Re-renders when either the live list or the saved choice changes. */
+export function useResolvedSurface(surface: SurfaceId): Resolved {
+  const def = surfaceById(surface);
+  const kind: IoKind = def?.kind ?? 'audioIn';
+  useIoDevicesStore((s) => byKind(s, kind));
+  useIoDevicesStore((s) => s.labelsKnown);
+  useFeatureToggleStore((s) => s.settings.io);
+  return resolveSurface(surface);
+}
+
+export function useResolvedGlobal(slot: IoSlot): Resolved {
+  useIoDevicesStore((s) => byKind(s, SLOT_KIND[slot]));
+  useIoDevicesStore((s) => s.labelsKnown);
+  useFeatureToggleStore((s) => s.settings.io);
+  return resolveGlobal(slot);
+}
+
+/** Point one element at its surface's output and keep it there. */
+export const followSurfaceSink = (surface: SurfaceId, el: HTMLMediaElement | null): void => {
+  if (el) void applyElementSink(el, resolveSurface(surface).deviceId);
+};

--- a/frontend/src/state/ioDevicesStore.ts
+++ b/frontend/src/state/ioDevicesStore.ts
@@ -144,6 +144,9 @@ export const useIoDevicesStore = create<IoDevicesState>()((set, get) => ({
       labelsKnown: labelsAreKnown([...audioIn, ...audioOut]),
     });
     void queryMicPermission().then((micPermission) => set({ micPermission }));
+    // Labels may have just become readable, which is the condition the legacy
+    // mic adoption waits on.
+    adoptLegacyMic();
     syncResolution();
   },
 
@@ -291,6 +294,8 @@ export const setMidiInputSelection = async (cfg: MidiInputConfig): Promise<boole
 
 /** Notice ids currently raised, so one absent device cannot stack cards. */
 const raised = new Set<string>();
+/** Refs whose id rotation we have already tried to re-persist. See below. */
+const rewriteAttempted = new Set<string>();
 let syncing = false;
 
 function noticeFor(kind: IoKind, ref: DeviceRef, where: string): void {
@@ -335,7 +340,12 @@ export function syncResolution(): void {
       const r = resolveRef(ref, liveDevices(kind), labelsKnownFor(kind));
       if (r.source === 'missing') noticeFor(kind, ref, where);
       else clearNotice(kind, ref);
-      if (r.rewrite) {
+      if (r.rewrite && !rewriteAttempted.has(missingNoticeId(kind, ref))) {
+        // Once per ref per session. A failed PATCH rolls the settings back to
+        // the OLD id, which lands here again through the store subscription —
+        // without this the pair would spin a fetch loop against a backend that
+        // is down (the Restart server button in this very modal does that).
+        rewriteAttempted.add(missingNoticeId(kind, ref));
         logInfo('audio', `${r.label} came back with a new device id; the saved choice was updated.`);
         rewrite(r.rewrite);
       }
@@ -405,6 +415,9 @@ let migrated = false;
  * that never reconciled. Adopt it as the GLOBAL microphone once, then leave the
  * key in place for one release as a read-only fallback so rolling the build
  * back does not lose the user's mic.
+ *
+ * Called from `refresh()` as well as from the settings subscription, because it
+ * needs a device list whose LABELS are readable — see below.
  */
 function adoptLegacyMic(): void {
   if (migrated) return;
@@ -412,21 +425,42 @@ function adoptLegacyMic(): void {
   // on a first run in the other launch mode, and adopting against it would
   // overwrite a device the user had already chosen on the other origin.
   if (!useFeatureToggleStore.getState().loaded) return;
-  migrated = true;
   const io = ioSettings();
-  if (!isSystemDefault(io.audio_input)) return;
+  if (!isSystemDefault(io.audio_input)) {
+    migrated = true;
+    return;
+  }
   let legacy = '';
   try {
     legacy = localStorage.getItem(LEGACY_MIC_KEY) ?? '';
   } catch {
     // Site data blocked. The old code read this in a useState initializer with
     // no try/catch and threw during render; this is that bug's fix.
+    migrated = true;
     return;
   }
-  if (!legacy) return;
-  const hit = liveDevices('audioIn').find((d) => d.id === legacy);
-  void setGlobalDevice('audio_input', { id: legacy, label: hit?.label ?? '' });
-  logInfo('audio', 'Adopted the old microphone choice into Settings → Inputs & outputs.');
+  if (!legacy) {
+    migrated = true;
+    return;
+  }
+  // Wait for a list we can actually read. The old key held a bare deviceId, and
+  // a ref saved with no label cannot be recovered by label — so in the other
+  // launch mode (a second origin, where that id means nothing) it would resolve
+  // to 'missing' and raise a notice naming a salted hash the user has never
+  // seen. Adopt the LABEL too or do not adopt at all.
+  const live = liveDevices('audioIn');
+  if (!labelsAreKnown(live)) return;
+  migrated = true;
+  const hit = live.find((d) => d.id === legacy);
+  if (!hit) {
+    logInfo(
+      'audio',
+      'The old microphone choice is no longer connected; Settings → Inputs & outputs stays on the system default.',
+    );
+    return;
+  }
+  void setGlobalDevice('audio_input', { id: hit.id, label: hit.label });
+  logInfo('audio', `Adopted the old microphone choice (${hit.label}) into Settings → Inputs & outputs.`);
 }
 
 /* ── boot ─────────────────────────────────────────────────────────────────── */

--- a/frontend/src/state/ioSurfaces.test.ts
+++ b/frontend/src/state/ioSurfaces.test.ts
@@ -18,6 +18,17 @@ import { GLOBAL_SLOT_FOR_KIND, IO_SURFACES, surfaceById } from './ioSurfaces.ts'
 
 const SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
 const SKIP = new Set(['ioSurfaces.ts', 'ioSurfaces.test.ts']);
+/**
+ * Directories under src/ that are NOT part of theDAW's app bundle. They are
+ * built by their own vite entry into another page on another origin, with its
+ * own localStorage and no /api/settings of ours — so a surface id read only
+ * from there resolves to the default forever and the Settings row is a
+ * dropdown that does nothing. `assistantVoice` shipped exactly that way once.
+ *
+ *   src/orb-standalone   -> vite.orb.config.ts, underfit's dashboard on :8791
+ *   src/views/underfit   -> the orb component that entry mounts
+ */
+const OTHER_ORIGIN = ['orb-standalone', join('views', 'underfit')];
 
 function collect(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -28,7 +39,12 @@ function collect(dir: string, out: string[] = []): string[] {
   return out;
 }
 
-const sources = collect(SRC).map((f) => readFileSync(f, 'utf8'));
+const inAppBundle = (file: string): boolean =>
+  !OTHER_ORIGIN.some((d) => file.includes(join(SRC, d)));
+
+const sources = collect(SRC)
+  .filter(inAppBundle)
+  .map((f) => readFileSync(f, 'utf8'));
 
 /* ── every surface is actually wired to something ────────────────────────── */
 
@@ -37,7 +53,7 @@ for (const surface of IO_SURFACES) {
   const users = sources.filter((src) => quoted.some((q) => src.includes(q))).length;
   assert.ok(
     users > 0,
-    `surface "${surface.id}" is offered in Settings but no call site reads it — it would be a dropdown that does nothing`,
+    `surface "${surface.id}" is offered in Settings but no call site in theDAW's own bundle reads it — it would be a dropdown that does nothing`,
   );
 }
 

--- a/frontend/src/state/ioSurfaces.test.ts
+++ b/frontend/src/state/ioSurfaces.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The surface registry is a promise to the user: every row the I/O menu draws
+ * under "Per-surface" claims that changing it changes a device somewhere. This
+ * suite makes that claim checkable — each id has to be read by real code
+ * outside the registry, or the row is a control that does nothing.
+ *
+ * It fails in the useful direction too: adding a surface here and forgetting to
+ * wire it up is caught before it ships as a dead dropdown.
+ *
+ * Run: npx tsx src/state/ioSurfaces.test.ts
+ */
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { GLOBAL_SLOT_FOR_KIND, IO_SURFACES, surfaceById } from './ioSurfaces.ts';
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SKIP = new Set(['ioSurfaces.ts', 'ioSurfaces.test.ts']);
+
+function collect(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) collect(full, out);
+    else if (/\.tsx?$/.test(entry.name) && !SKIP.has(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+const sources = collect(SRC).map((f) => readFileSync(f, 'utf8'));
+
+/* ── every surface is actually wired to something ────────────────────────── */
+
+for (const surface of IO_SURFACES) {
+  const quoted = [`'${surface.id}'`, `"${surface.id}"`];
+  const users = sources.filter((src) => quoted.some((q) => src.includes(q))).length;
+  assert.ok(
+    users > 0,
+    `surface "${surface.id}" is offered in Settings but no call site reads it — it would be a dropdown that does nothing`,
+  );
+}
+
+/* ── the registry itself is coherent ─────────────────────────────────────── */
+
+const ids = IO_SURFACES.map((s) => s.id);
+assert.equal(new Set(ids).size, ids.length, 'surface ids are unique (they are React keys and DOM ids)');
+
+for (const surface of IO_SURFACES) {
+  assert.equal(surfaceById(surface.id)?.id, surface.id);
+  assert.ok(surface.label.length > 0, `${surface.id} needs a row label`);
+  assert.ok(surface.hint.length > 0, `${surface.id} needs hover copy saying what it changes`);
+  assert.ok(
+    GLOBAL_SLOT_FOR_KIND[surface.kind],
+    `${surface.id} has kind "${surface.kind}" with no global slot to fall back to`,
+  );
+  // The DOM id the select builds must be a valid, stable one.
+  assert.match(surface.id, /^[A-Za-z][A-Za-z0-9]*$/, `${surface.id} must be safe in an element id`);
+}
+
+assert.equal(surfaceById('not-a-surface'), undefined, 'an unknown id resolves to nothing, not a throw');
+assert.deepEqual(Object.keys(GLOBAL_SLOT_FOR_KIND).sort(), ['audioIn', 'audioOut']);
+
+console.log('ioSurfaces registry passed');

--- a/frontend/src/state/ioSurfaces.ts
+++ b/frontend/src/state/ioSurfaces.ts
@@ -1,0 +1,74 @@
+/**
+ * Every place in theDAW that opens a microphone or makes a sound of its own,
+ * and can therefore be pointed at a different device than the global default.
+ *
+ * A flat const registry rather than imperative registration: the Settings menu
+ * renders one row per entry with no coupling to the components, and a surface
+ * that is added here but never wired up would show as an override that does
+ * nothing — so the list is the contract, and every id below is read by a real
+ * call site.
+ *
+ * `kind` picks which live device list and which global slot the row falls back
+ * to. Surfaces are OVERRIDES; the global slots themselves live in the settings
+ * `io` section (audio_output, cue_output, audio_input, …).
+ */
+export type SurfaceKind = 'audioIn' | 'audioOut';
+
+export interface IoSurface {
+  id: string;
+  kind: SurfaceKind;
+  /** Row label in Settings. */
+  label: string;
+  /** Hover copy: what actually changes when this row is set. */
+  hint: string;
+}
+
+export const IO_SURFACES = [
+  {
+    id: 'midiVocal',
+    kind: 'audioIn',
+    label: 'MIDI tab — vocal',
+    hint: 'The always-on input monitor and the record button in the MIDI tab.',
+  },
+  {
+    id: 'singPitch',
+    kind: 'audioIn',
+    label: 'SING — pitch lane',
+    hint: 'The microphone the pitch lane listens to and scores.',
+  },
+  {
+    id: 'micRecorder',
+    kind: 'audioIn',
+    label: 'Mic recorder',
+    hint: 'The voice-memo recorder that imports takes into the library. Keeps echo cancellation and noise suppression ON, unlike the pitch paths.',
+  },
+  {
+    id: 'vocal2midi',
+    kind: 'audioIn',
+    label: 'Vocal → MIDI',
+    hint: 'The YIN note recorder inside the MIDI tab.',
+  },
+  {
+    id: 'assistantVoice',
+    kind: 'audioIn',
+    label: 'Assistant voice (UNDERFIT)',
+    hint: 'The push-to-talk clip the UNDERFIT orb uploads for transcription.',
+  },
+  {
+    id: 'preview',
+    kind: 'audioOut',
+    label: 'Clip previews',
+    hint: 'Mic takes, inpaint previews and Nodefi play through their own <audio> elements rather than the main graph, so they can be sent somewhere else.',
+  },
+] as const satisfies readonly IoSurface[];
+
+export type SurfaceId = (typeof IO_SURFACES)[number]['id'];
+
+export const surfaceById = (id: string): IoSurface | undefined =>
+  IO_SURFACES.find((s) => s.id === id);
+
+/** The global settings key a surface of this kind falls back to. */
+export const GLOBAL_SLOT_FOR_KIND: Record<SurfaceKind, 'audio_input' | 'audio_output'> = {
+  audioIn: 'audio_input',
+  audioOut: 'audio_output',
+};

--- a/frontend/src/state/ioSurfaces.ts
+++ b/frontend/src/state/ioSurfaces.ts
@@ -48,12 +48,12 @@ export const IO_SURFACES = [
     label: 'Vocal → MIDI',
     hint: 'The YIN note recorder inside the MIDI tab.',
   },
-  {
-    id: 'assistantVoice',
-    kind: 'audioIn',
-    label: 'Assistant voice (UNDERFIT)',
-    hint: 'The push-to-talk clip the UNDERFIT orb uploads for transcription.',
-  },
+  // NOT here: the UNDERFIT assistant orb. It is built by a SEPARATE entry
+  // (vite.orb.config.ts -> underfit/dashboard/assistant/underfit-orb.js) and
+  // runs inside underfit's own page on :8791 — a different origin with its own
+  // localStorage and no /api/settings of ours, so nothing chosen here could
+  // ever reach it. Offering the row would be a dropdown that does nothing;
+  // IoSection says so in words instead.
   {
     id: 'preview',
     kind: 'audioOut',

--- a/frontend/src/state/midiOutBus.ts
+++ b/frontend/src/state/midiOutBus.ts
@@ -1,0 +1,87 @@
+/**
+ * MIDI thru — the one net-new capability of the I/O menu.
+ *
+ * Everything that arrives on the MIDI bus (hardware ports, the Quest bridge,
+ * the Sway surface) is forwarded byte-for-byte to one chosen output port, so a
+ * controller can drive an external synth or a DAW over a virtual cable while
+ * theDAW is playing it too.
+ *
+ * Default is NO target, and with no target this module subscribes to nothing
+ * and sends nothing — it cannot surprise a user who never opens the menu. It is
+ * also thru ONLY: theDAW generates no clock, MTC or song-position, so none is
+ * sent (a clock generator is a separate feature, not a checkbox).
+ *
+ * App.tsx owns the single requestMIDIAccess and hands the output ports here.
+ */
+import type { DeviceRef, LiveDevice } from '../lib/ioResolve';
+import { resolveRef } from '../lib/ioResolve';
+import { logError, logInfo } from './logStore';
+import { subscribeToMidi } from './midiBus';
+
+interface OutPort {
+  id: string;
+  name: string;
+  send: (data: number[]) => void;
+}
+
+let ports: OutPort[] = [];
+let wanted: DeviceRef = { id: '', label: '' };
+let activeId = '';
+let unsubscribe: (() => void) | null = null;
+
+/** The output ports as live devices, for the menu. */
+export const midiOutDevices = (): LiveDevice[] => ports.map((p) => ({ id: p.id, label: p.name }));
+
+/** The port thru is actually sending to ('' = nothing is being sent). */
+export const activeThruPortId = (): string => activeId;
+
+const stop = (): void => {
+  unsubscribe?.();
+  unsubscribe = null;
+  activeId = '';
+};
+
+const start = (port: OutPort): void => {
+  if (activeId === port.id && unsubscribe) return;
+  stop();
+  activeId = port.id;
+  unsubscribe = subscribeToMidi((msg) => {
+    try {
+      port.send(msg.data);
+    } catch (e) {
+      // A port that vanished mid-stream throws on every message; stop rather
+      // than flooding the log, and let the next re-sync pick it up again.
+      logError('midi', `MIDI thru to ${port.name} failed: ${e instanceof Error ? e.message : String(e)}`);
+      stop();
+    }
+  });
+  logInfo('midi', `MIDI thru -> ${port.name}`);
+};
+
+/** Re-evaluate the wanted target against the ports currently open. */
+const sync = (): void => {
+  if (!wanted.id && !wanted.label) {
+    if (activeId) logInfo('midi', 'MIDI thru off');
+    stop();
+    return;
+  }
+  const resolved = resolveRef(wanted, midiOutDevices(), true);
+  const port = ports.find((p) => p.id === resolved.deviceId);
+  if (!port) {
+    stop();
+    return;
+  }
+  start(port);
+};
+
+/** App.tsx publishes the open output ports here (initial + every statechange). */
+export const setMidiOutputPorts = (list: OutPort[]): void => {
+  ports = list;
+  sync();
+};
+
+/** The chosen thru target. An empty ref means nothing is forwarded at all. */
+export const setMidiThruTarget = (ref: DeviceRef): void => {
+  wanted = { id: ref.id ?? '', label: ref.label ?? '' };
+  sync();
+};

--- a/frontend/src/state/playerStore.ts
+++ b/frontend/src/state/playerStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { logError, logInfo } from './logStore';
+import { logError, logInfo, logWarn } from './logStore';
 
 /**
  * Global playback engine — a single HTMLAudioElement piped through a single
@@ -111,6 +111,9 @@ export const ensureEngine = (): EngineHandles => {
   fxOut.connect(analyser);
   analyser.connect(monitor);
   monitor.connect(ctx.destination);
+  // A device may already have been chosen before anything built the graph
+  // (Settings loads before the first sound). Apply it now the graph exists.
+  void applyEngineSink(ctx);
 
   const audioEl = new Audio();
   audioEl.crossOrigin = 'anonymous';
@@ -160,6 +163,83 @@ export const ensureEngine = (): EngineHandles => {
   _mediaSrc = mediaSrc;
   return { ctx, master, analyser, audioEl };
 };
+
+/* ── main output device ───────────────────────────────────────────────────── */
+
+/**
+ * The device the whole graph is meant to play through ('' = the OS default).
+ * Held separately from `_appliedSinkId` because a choice can arrive before the
+ * context exists — Settings loads long before the first sound — and must then
+ * be applied by ensureEngine() rather than dropped.
+ */
+let _desiredSinkId = '';
+let _appliedSinkId = '';
+
+type SinkCapableContext = AudioContext & { setSinkId?: (id: string) => Promise<void> };
+
+/**
+ * Move the shared graph to `_desiredSinkId`.
+ *
+ * One call moves EVERY module that routes through getMasterGain (the footer
+ * transport, the sequencer, the DJ decks, the live mixer, previews) because
+ * they all share this context. `AudioContext.setSinkId` is not in the DOM lib
+ * yet, hence the cast — the same shape djEngine uses for the cue element.
+ *
+ * The context is never rebuilt to change a device: rebuilding would destroy the
+ * MediaElementAudioSourceNode (an element can be attached to exactly one, ever),
+ * the rack insert, the live-FX insert and every deck.
+ */
+async function applyEngineSink(ctx: AudioContext): Promise<boolean> {
+  const c = ctx as SinkCapableContext;
+  if (typeof c.setSinkId !== 'function') return false;
+  if (_appliedSinkId === _desiredSinkId) return true;
+  const before = ctx.outputLatency;
+  try {
+    await c.setSinkId(_desiredSinkId);
+    _appliedSinkId = _desiredSinkId;
+  } catch (e) {
+    logError('player', `Main output routing failed: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
+  }
+  const after = ctx.outputLatency;
+  // The play-along latency calibration and the score time map both read
+  // ctx.outputLatency, so a device with a different buffer size silently
+  // shifts every timing that was calibrated on the old one. Say so.
+  if (Number.isFinite(before) && Number.isFinite(after) && Math.abs(after - before) > 0.002) {
+    logWarn(
+      'player',
+      `Output latency changed ${Math.round(before * 1000)} ms -> ${Math.round(after * 1000)} ms with the new device; re-run the play-along latency calibration.`,
+    );
+  }
+  return true;
+}
+
+/**
+ * Choose the device the main mix plays through. '' = the OS default, which is
+ * exactly what a user who never opens the I/O menu gets: no setSinkId call is
+ * made while nothing has ever been chosen.
+ */
+export const setEngineSink = async (deviceId: string): Promise<boolean> => {
+  _desiredSinkId = deviceId;
+  if (!_ctx) return false; // ensureEngine() applies it when the graph is built
+  return applyEngineSink(_ctx);
+};
+
+/** The device the graph is actually on ('' = OS default). */
+export const getEngineSinkId = (): string => _appliedSinkId;
+
+/**
+ * Sample rate + output latency of the live graph, or null when nothing has
+ * built it yet. Read-only on purpose: it must NOT construct an AudioContext
+ * just because a settings panel is open.
+ */
+export const getEngineOutputInfo = (): { sampleRate: number; outputLatencyMs: number | null } | null =>
+  _ctx
+    ? {
+        sampleRate: _ctx.sampleRate,
+        outputLatencyMs: Number.isFinite(_ctx.outputLatency) ? Math.round(_ctx.outputLatency * 1000) : null,
+      }
+    : null;
 
 /** Other sources (editor preview, sequencer voices) connect here so they go through the same analyser. */
 export const getMasterGain = (): GainNode => ensureEngine().master;
@@ -443,6 +523,12 @@ export const dumpAudioChain = (): Record<string, unknown> => {
         ctxState: _ctx.state,
         sampleRate: _ctx.sampleRate,
         destinationChannels: _ctx.destination.channelCount,
+        // Which physical output the graph is on. Without this a "no sound"
+        // report is undiagnosable: the chain can be perfect and the audio
+        // still be going to a monitor nobody is listening to.
+        sinkId: _appliedSinkId || '(system default)',
+        sinkWanted: _desiredSinkId || '(system default)',
+        outputLatencyMs: Number.isFinite(_ctx.outputLatency) ? Math.round(_ctx.outputLatency * 1000) : null,
         master: gainOf(_master),
         rackInsertIn: gainOf(_insertIn),
         rackInsertOut: gainOf(_insertOut),

--- a/frontend/src/views/DJView.tsx
+++ b/frontend/src/views/DJView.tsx
@@ -35,6 +35,7 @@ import { useMidiDevicesStore } from '../state/midiDevicesStore';
 import { useDjSampler } from '../state/djSamplerStore';
 import { useDjSideList } from '../state/djSideListStore';
 import { useFeatureToggleStore } from '../state/featureToggleStore';
+import { IoGlobalSelect } from '../components/audio/IoDeviceSelect';
 import { ControlSurface } from '../components/surface/ControlSurface';
 import { InfiNightCredit } from '../components/ui/Credit';
 import { DJ_TARGETS } from '../state/bindableTargets';
@@ -544,22 +545,12 @@ export const DJView: React.FC = () => {
   const [source, setSource] = useState<Source>({ kind: 'library' });
   // Lifted out of the old Mixer so the surface widget closures can drive them.
   const [limiterOn, setLimiterOn] = useState(() => djEngine.getLimiter());
+  // The cue device is a GLOBAL slot in Settings -> Inputs & outputs, so the
+  // choice survives a reload (it used to live in a module variable and reset
+  // to the system default every time) and the DJ tab and the menu always
+  // agree. The one-shot enumerate that used to live here is gone: DJView never
+  // calls getUserMedia, so on this surface the labels could never fill in.
   const cueSupported = djEngine.isCueSupported();
-  const [cueDevices, setCueDevices] = useState<Array<{ id: string; label: string }>>([]);
-  const [cueDev, setCueDev] = useState(() => djEngine.getCueSinkId());
-  useEffect(() => {
-    if (!cueSupported || !navigator.mediaDevices?.enumerateDevices) return;
-    navigator.mediaDevices
-      .enumerateDevices()
-      .then((ds) =>
-        setCueDevices(
-          ds.filter((d) => d.kind === 'audiooutput').map((d) => ({ id: d.deviceId, label: d.label || 'Output' })),
-        ),
-      )
-      .catch(() => {
-        /* labels need permission; ids still resolve */
-      });
-  }, [cueSupported]);
 
   const entries = useLibraryStore((s) => s.entries);
   const analyzeAll = useDjAnalysisStore((s) => s.analyzeAll);
@@ -1036,7 +1027,7 @@ export const DJView: React.FC = () => {
     crossfader, onCrossfade: applyCrossfade,
     quantize, setQuantize, autoGain, setAutoGain,
     vinylSpinA, setVinylSpinA, vinylSpinB, setVinylSpinB,
-    limiterOn, setLimiterOn, cueSupported, cueDevices, cueDev, setCueDev,
+    limiterOn, setLimiterOn, cueSupported,
     midiMapOn: midiMapOpen, onToggleMidiMap: () => setMidiMapOpen((v) => !v),
     automixOn, onToggleAutomix: () => setAutomixOn((v) => !v),
   });
@@ -2762,7 +2753,7 @@ interface DjRegArgs {
   vinylSpinA: boolean; setVinylSpinA: (v: boolean) => void;
   vinylSpinB: boolean; setVinylSpinB: (v: boolean) => void;
   limiterOn: boolean; setLimiterOn: (v: boolean) => void;
-  cueSupported: boolean; cueDevices: Array<{ id: string; label: string }>; cueDev: string; setCueDev: (v: string) => void;
+  cueSupported: boolean;
   midiMapOn: boolean; onToggleMidiMap: () => void;
   automixOn: boolean; onToggleAutomix: () => void;
 }
@@ -3141,12 +3132,11 @@ function buildDjRegistry(p: DjRegArgs): WidgetRegistry {
   reg.cueDevice = { id: 'cueDevice', label: 'Cue Output', group: 'Mixer', kind: 'button', source: 'builtin', render: () => (
     <div className="h-full w-full grid place-items-center px-1">
       {p.cueSupported ? (
-        <div className="flex items-center gap-1 w-full" title="Headphone (cue) output device">
+        <div className="flex items-center gap-1 w-full">
           <Headphones className="w-2.5 h-2.5 text-zinc-500 shrink-0" />
-          <select value={p.cueDev} onChange={(e) => { p.setCueDev(e.target.value); void djEngine.setCueSinkId(e.target.value); }} className="flex-1 min-w-0 bg-[#0e0c18] border border-white/10 text-zinc-300 text-[8px] font-mono px-1 py-0.5 rounded focus:outline-none" style={{ colorScheme: 'dark' }} title="Cue output device">
-            <option value="">Default out</option>
-            {p.cueDevices.map((dv) => <option key={dv.id} value={dv.id}>{dv.label}</option>)}
-          </select>
+          {/* Was the app's oldest device picker and had only a `title` — no id,
+              no name, no <label>, no aria-label. Now the shared control. */}
+          <IoGlobalSelect slot="cue_output" id="dj-cue-output" label="Headphone (cue) output" className="flex-1 text-[8px] px-1 py-0.5" />
         </div>
       ) : <span className="text-[7px] font-mono text-zinc-700">cue n/a</span>}
     </div>

--- a/frontend/src/views/NodefiView.tsx
+++ b/frontend/src/views/NodefiView.tsx
@@ -30,6 +30,7 @@ import { logInfo } from '../state/logStore';
 import { useLibraryStore } from '../state/libraryStore';
 import { NODEFI_TEMPLATES, resolveTemplateSource } from '../data/nodefiTemplates';
 import { startLiveGraph, isLiveOnlyKind, type LiveController } from '../lib/nodefiLive';
+import { registerSinkElement } from '../lib/audioSink';
 import type { SavedNodeSet } from '../state/nodefiSetsStore';
 
 // Circular glossy nodes (see NODE_EDITOR reference): a fixed-diameter disc with
@@ -89,7 +90,11 @@ function PreviewButton({ url }: { url: string }): React.ReactElement {
     const a = new Audio(url);
     a.onended = () => setPlaying(false);
     audioRef.current = a;
+    // Outside the shared Web Audio graph, so AudioContext.setSinkId does not
+    // move it: it follows the 'preview' surface's output setting instead.
+    const unregister = registerSinkElement('preview', a);
     return () => {
+      unregister();
       a.pause();
       audioRef.current = null;
     };

--- a/frontend/src/views/VJView.tsx
+++ b/frontend/src/views/VJView.tsx
@@ -33,6 +33,7 @@ import { logError, logInfo, logWarn } from '../state/logStore';
 import { backendHttpBase, lanReachablePort } from '../lib/backendBase';
 import { importMedia, isMediaFile } from '../lib/mediaLibrary';
 import { describeQuestCastStatus, type QuestCastStatus } from '../components/vj/QuestCastPreview';
+import { resolveGlobal } from '../state/ioDevicesStore';
 
 
 /**
@@ -687,10 +688,17 @@ export const VJView: React.FC = () => {
     // 1280x800 is a reasonable default for a VJ canvas — big enough
     // to look good on a second monitor, small enough to not auto-
     // maximize on a single-screen setup.
+    //
+    // The chosen monitor (Settings -> Inputs & outputs -> Pop-out screen)
+    // rides along in the features string: the desktop app's window-open
+    // handler reads it and positions the window. A browser ignores the token,
+    // which is the honest outcome — no web API places a window on a monitor.
+    // window.open MUST stay inside this click handler (see DetachableWindow).
+    const display = resolveGlobal('visual_display').deviceId;
     const w = window.open(
       vjSrc,
       'sa3-vj-window',
-      'noopener=no,width=1280,height=800,location=no,menubar=no,toolbar=no,status=no',
+      `noopener=no,width=1280,height=800,location=no,menubar=no,toolbar=no,status=no${display ? `,thedawDisplay=${display}` : ''}`,
     );
     if (!w) {
       const m = 'Pop-out blocked — allow pop-ups for this origin, then try again.';

--- a/frontend/src/views/underfit/UnderfitAssistantOrb.tsx
+++ b/frontend/src/views/underfit/UnderfitAssistantOrb.tsx
@@ -30,7 +30,6 @@ import GantasmoOrb from "../../orb-kit/react/GantasmoOrb";
 import "../../orb-kit/styles/gantasmo-orb.css";
 import "../../orb-kit/chat/orb-chat.css";
 import "./underfit-orb.css";
-import { surfaceDeviceId, useIoDevicesStore } from "../../state/ioDevicesStore";
 
 // Assistant backend base URL. This orb is bundled INTO underfit's dashboard
 // (served on :8791). It talks to underfit's OWN assistant backend — a clone of
@@ -331,11 +330,11 @@ function useSpeechInput(onText: (t: string) => void) {
     if (!supported || recRef.current) return;
     let stream: MediaStream;
     try {
-      const deviceId = surfaceDeviceId("assistantVoice");
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: deviceId ? { deviceId } : true,
-      });
-      useIoDevicesStore.getState().notePermissionGranted();
+      // The OS default, deliberately. This file is built by a SEPARATE entry
+      // (vite.orb.config.ts) into underfit's own dashboard on :8791, so it has
+      // no access to theDAW's settings — reading the I/O menu here would
+      // silently always resolve to the default and make the menu a liar.
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     } catch (e) {
       // Say WHICH failure it was: "permission denied" for a device that is
       // simply unplugged sends the user to the wrong fix.

--- a/frontend/src/views/underfit/UnderfitAssistantOrb.tsx
+++ b/frontend/src/views/underfit/UnderfitAssistantOrb.tsx
@@ -30,6 +30,7 @@ import GantasmoOrb from "../../orb-kit/react/GantasmoOrb";
 import "../../orb-kit/styles/gantasmo-orb.css";
 import "../../orb-kit/chat/orb-chat.css";
 import "./underfit-orb.css";
+import { surfaceDeviceId, useIoDevicesStore } from "../../state/ioDevicesStore";
 
 // Assistant backend base URL. This orb is bundled INTO underfit's dashboard
 // (served on :8791). It talks to underfit's OWN assistant backend — a clone of
@@ -330,10 +331,24 @@ function useSpeechInput(onText: (t: string) => void) {
     if (!supported || recRef.current) return;
     let stream: MediaStream;
     try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    } catch {
-      // Mic permission denied / no device — surface as a one-shot note in input.
-      onText("[microphone unavailable — permission denied]");
+      const deviceId = surfaceDeviceId("assistantVoice");
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: deviceId ? { deviceId } : true,
+      });
+      useIoDevicesStore.getState().notePermissionGranted();
+    } catch (e) {
+      // Say WHICH failure it was: "permission denied" for a device that is
+      // simply unplugged sends the user to the wrong fix.
+      const name = e instanceof Error ? e.name : "";
+      const why =
+        name === "NotAllowedError" || name === "SecurityError"
+          ? "permission denied"
+          : name === "NotFoundError" || name === "OverconstrainedError"
+            ? "no microphone found"
+            : name === "NotReadableError"
+              ? "the microphone is in use by another app"
+              : name || "unknown error";
+      onText(`[microphone unavailable — ${why}]`);
       return;
     }
     streamRef.current = stream;

--- a/tests/test_settings_store.py
+++ b/tests/test_settings_store.py
@@ -1,0 +1,140 @@
+"""Settings store: the `io` device section, its migration, and the patch
+semantics the frontend depends on.
+
+The device menu persists here rather than in localStorage because the same
+user opens theDAW as a browser tab AND as the desktop app (app.launch_mode),
+which are two origins with two localStorage partitions. That makes these
+guarantees load-bearing:
+
+  - a settings file written by an older build gains `io` without losing a
+    single existing choice;
+  - `patch()` assigns a dict-valued key WHOLESALE, so the frontend must send
+    the complete object — pinned here so nobody "fixes" it into a deep merge
+    and silently changes what a partial PATCH means;
+  - a key that is not in DEFAULT_SETTINGS is dropped, not stored.
+"""
+
+import json
+
+from backend.modules.settings.store import (
+    DEFAULT_SETTINGS,
+    SCHEMA_VERSION,
+    SettingsStore,
+    _merge_defaults,
+)
+
+IO_SLOTS = (
+    "audio_output",
+    "cue_output",
+    "audio_input",
+    "midi_output",
+    "visual_display",
+)
+
+
+def test_io_defaults_are_system_default_everywhere():
+    io = DEFAULT_SETTINGS["io"]
+    for slot in IO_SLOTS:
+        assert io[slot] == {"id": "", "label": ""}, slot
+    # 'all' so a controller plugged in after the choice was made still works
+    # without a trip to Settings.
+    assert io["midi_inputs"] == {"mode": "all", "ports": []}
+    assert io["overrides"] == {}
+
+
+def test_v7_file_gains_io_without_losing_existing_choices():
+    old = {
+        "schema_version": 7,
+        "app": {"launch_mode": "desktop"},
+        "stems": {"auto_on_import": True, "device": "cpu"},
+        "notation": {"artist": "SOMEONE"},
+    }
+
+    merged = _merge_defaults(old)
+
+    assert merged["schema_version"] == SCHEMA_VERSION == 8
+    assert merged["io"] == DEFAULT_SETTINGS["io"]
+    assert merged["io"] is not DEFAULT_SETTINGS["io"], "must be a deep copy"
+    assert merged["app"]["launch_mode"] == "desktop"
+    assert merged["stems"]["device"] == "cpu"
+    assert merged["notation"]["artist"] == "SOMEONE"
+
+
+def test_existing_io_choices_survive_a_reload():
+    old = {
+        "schema_version": 8,
+        "io": {
+            "audio_output": {"id": "abc", "label": "Scarlett 2i2"},
+            "overrides": {"singPitch": {"id": "mic1", "label": "Yeti"}},
+        },
+    }
+
+    merged = _merge_defaults(old)
+
+    assert merged["io"]["audio_output"] == {"id": "abc", "label": "Scarlett 2i2"}
+    assert merged["io"]["overrides"] == {"singPitch": {"id": "mic1", "label": "Yeti"}}
+    # Slots the file never carried are filled from the defaults.
+    assert merged["io"]["cue_output"] == {"id": "", "label": ""}
+
+
+def test_patch_replaces_a_dict_slot_wholesale(tmp_path):
+    """The frontend MUST send a complete slot object. This is the reason."""
+    store = SettingsStore(tmp_path / "settings.json")
+
+    store.patch({"io": {"audio_output": {"id": "abc", "label": "Scarlett 2i2"}}})
+    assert store.get_section("io")["audio_output"] == {
+        "id": "abc",
+        "label": "Scarlett 2i2",
+    }
+
+    # A fragment REPLACES; it does not merge. The label is gone, not kept.
+    store.patch({"io": {"audio_output": {"id": "def"}}})
+    assert store.get_section("io")["audio_output"] == {"id": "def"}
+
+
+def test_patch_drops_an_unknown_io_key(tmp_path):
+    store = SettingsStore(tmp_path / "settings.json")
+
+    store.patch({"io": {"camera_input": {"id": "cam0", "label": "Webcam"}}})
+
+    assert "camera_input" not in store.get_section("io")
+
+
+def test_deleting_an_override_sticks(tmp_path):
+    """`overrides` is replaced wholesale, so dropping a key really removes it —
+    a deleted per-surface override must not resurrect on the next load."""
+    path = tmp_path / "settings.json"
+    store = SettingsStore(path)
+
+    store.patch(
+        {
+            "io": {
+                "overrides": {
+                    "singPitch": {"id": "mic1", "label": "Yeti"},
+                    "micRecorder": {"id": "mic2", "label": "Scarlett"},
+                }
+            }
+        }
+    )
+    store.patch(
+        {"io": {"overrides": {"micRecorder": {"id": "mic2", "label": "Scarlett"}}}}
+    )
+
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk["io"]["overrides"] == {
+        "micRecorder": {"id": "mic2", "label": "Scarlett"}
+    }
+    assert SettingsStore(path).get_section("io")["overrides"] == {
+        "micRecorder": {"id": "mic2", "label": "Scarlett"}
+    }
+
+
+def test_migrated_schema_is_persisted(tmp_path):
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"schema_version": 7, "vj": {}}), encoding="utf-8")
+
+    SettingsStore(path)
+
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk["schema_version"] == SCHEMA_VERSION
+    assert on_disk["io"]["midi_inputs"] == {"mode": "all", "ports": []}


### PR DESCRIPTION
This pull request introduces a new global input/output (I/O) device settings section and implements the infrastructure for selecting and persisting device choices, including per-surface overrides. It also adds support in the Electron desktop app for enumerating available displays and positioning pop-out windows on a user-chosen monitor. Additionally, the MIDI device selection logic is updated to respect the new settings, and related frontend state management is refactored to support these features.

**Major new features and improvements:**

### Global I/O device settings

* Added a new `io` section to `DEFAULT_SETTINGS` in `backend/modules/settings/store.py`, supporting global device choices (audio input/output, MIDI, display) and per-surface overrides. This includes schema migration logic to upgrade existing settings. [[1]](diffhunk://#diff-7760a10b2459f8537d1693d715a16a6aade2b7cabb94bbc1c8f65f16438448aaL26-R26) [[2]](diffhunk://#diff-7760a10b2459f8537d1693d715a16a6aade2b7cabb94bbc1c8f65f16438448aaR121-R149) [[3]](diffhunk://#diff-7760a10b2459f8537d1693d715a16a6aade2b7cabb94bbc1c8f65f16438448aaR222-R226)

### Electron desktop display support

* Exposed the list of attached displays to the frontend (`electron-ui/main/index.ts`, `electron-ui/preload/index.ts`) and enabled pop-out windows (e.g., VJ window) to be positioned on a specific monitor based on user selection. [[1]](diffhunk://#diff-4e8611dee52f0bab0d239b74d356255de9763a6f66fbb9baa344f66a222d5475R8) [[2]](diffhunk://#diff-4e8611dee52f0bab0d239b74d356255de9763a6f66fbb9baa344f66a222d5475L509-R520) [[3]](diffhunk://#diff-4e8611dee52f0bab0d239b74d356255de9763a6f66fbb9baa344f66a222d5475R537-R566) [[4]](diffhunk://#diff-4e8611dee52f0bab0d239b74d356255de9763a6f66fbb9baa344f66a222d5475R727-R743) [[5]](diffhunk://#diff-ddd206c520eac955e3494e99271126b40aec39b82eaa94bb6cc789f5cde660deR19-R22)

### MIDI device selection and filtering

* Updated frontend MIDI device handling to filter enabled input ports based on the new settings, and to publish both MIDI input and output port metadata for use in device pickers. The effect now reattaches on changes to the selected MIDI ports. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR62-R65) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR198-R206) [[3]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR235-R250) [[4]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR282-R304) [[5]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR344-R347)

### Documentation

* Added a section to `IN-THE-WORKS.md` outlining planned device I/O follow-ups, including camera picker, output routing for edit-module windows, and voice input improvements.

These changes lay the foundation for robust, user-configurable device routing and pop-out window management, especially in the desktop app, and improve the reliability and user experience of MIDI device selection.