### PR TITLE
Fix loopback and error detail

### DIFF
--- a/backend/modules/hfauth/router.py
+++ b/backend/modules/hfauth/router.py
@@ -14,6 +14,15 @@ memory for 10 minutes, so the first call may return
 Handlers are sync ``def`` functions, so Starlette runs them on its worker
 thread pool -- the blocking httpx whoami call (10s timeout on login) never
 touches the event loop.
+
+Status codes, and why ``/login`` never answers 502: a 502 in this app means a
+gateway in front of the backend (the packaged app:// proxy, the Vite dev proxy)
+could not reach the backend at all, so nothing was asked of huggingface.co.
+This router's own upstream failures -- the Hub refused or could not be reached
+-- are the OPPOSITE fact, and they answer 503 plus the ``x-thedaw-hop:
+huggingface`` marker header. Both meanings once shared 502, which is how a
+loopback mismatch got reported as "couldn't reach huggingface.co"
+(gantasmo/theDAW#144). Frontend side: frontend/src/lib/httpError.ts.
 """
 
 from __future__ import annotations
@@ -39,6 +48,13 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 _TOKEN_PATH = Path(HF_TOKEN_PATH)
+
+# Marker on every response about a hop this backend does not own. The frontend
+# reads it to name the failing hop; the 503 status says the same thing on its
+# own, so a deployment that strips custom headers still reads correctly.
+HOP_HEADER = "x-thedaw-hop"
+HOP_HUGGINGFACE = "huggingface"
+_HUB_HEADERS = {HOP_HEADER: HOP_HUGGINGFACE}
 
 _WHOAMI_URL = "https://huggingface.co/api/whoami-v2"
 _LOGIN_URL = "https://huggingface.co/settings/tokens"
@@ -184,13 +200,19 @@ def login(body: LoginRequest) -> dict[str, Any]:
             raise HTTPException(
                 status_code=401, detail="Invalid Hugging Face token"
             ) from exc
+        # 503, NOT 502: the Hub answered badly. A 502 from anywhere in this app
+        # means the backend itself was never reached, which is the opposite
+        # claim -- see the module docstring.
         raise HTTPException(
-            status_code=502,
+            status_code=503,
             detail=f"huggingface.co returned HTTP {exc.response.status_code}",
+            headers=_HUB_HEADERS,
         ) from exc
     except (httpx.HTTPError, ValueError) as exc:
         raise HTTPException(
-            status_code=503, detail=f"Could not reach huggingface.co: {exc}"
+            status_code=503,
+            detail=f"Could not reach huggingface.co: {exc}",
+            headers=_HUB_HEADERS,
         ) from exc
 
     # Persist to huggingface_hub's standard token store (the same file the

--- a/electron-ui/electron.vite.config.ts
+++ b/electron-ui/electron.vite.config.ts
@@ -55,9 +55,17 @@ export default defineConfig({
       fs: {
         allow: [resolve(__dirname, '../frontend'), resolve(__dirname, '..')]
       },
+      // Every target below is the LITERAL 127.0.0.1, never 'localhost'.
+      // backend/run.py binds 0.0.0.0 — IPv4 only — while Node's resolver
+      // prefers ::1 for 'localhost' on Windows 11. When it does, the proxy
+      // cannot connect and answers 502, which the renderer reported as
+      // "couldn't reach huggingface.co" (issue #144). This is the DEV path
+      // theDAW.bat's desktop mode takes; main/index.ts already pinned the
+      // packaged proxy the same way. An address cannot resolve to the wrong
+      // family. Keep these in sync with frontend/vite.config.ts.
       proxy: {
         '/api': {
-          target: 'http://localhost:8600',
+          target: 'http://127.0.0.1:8600',
           changeOrigin: true,
           // WebSocket upgrade (xr control bus, questmidi) — without this the
           // proxy silently drops WS connections and the control manifest
@@ -71,7 +79,7 @@ export default defineConfig({
         // SPA fallback, which served the app's own index.html INTO the iframe —
         // the whole app nested inside itself (doubled header) in electron dev.
         '/vj-app': {
-          target: 'http://localhost:8600',
+          target: 'http://127.0.0.1:8600',
           changeOrigin: true,
           ws: true,
           timeout: 0,
@@ -83,7 +91,7 @@ export default defineConfig({
         // see the entire app nested inside itself, which is the single most
         // confusing failure in this pattern.
         '/sway-app': {
-          target: 'http://localhost:8600',
+          target: 'http://127.0.0.1:8600',
           changeOrigin: true,
           ws: true,
           timeout: 0,

--- a/electron-ui/main/index.ts
+++ b/electron-ui/main/index.ts
@@ -540,7 +540,11 @@ function loadRenderer(): void {
   if (!app.isPackaged && devURL) {
     mainWindow.loadURL(devURL)
   } else if (!app.isPackaged) {
-    mainWindow.loadURL('http://localhost:5173')
+    // 127.0.0.1, not 'localhost': the Vite dev server binds 0.0.0.0 (IPv4
+    // only, see electron.vite.config.ts) and Chromium prefers ::1 for
+    // 'localhost' on Windows, which loads a blank ERR_CONNECTION_REFUSED
+    // window with a running dev server sitting right there.
+    mainWindow.loadURL('http://127.0.0.1:5173')
   } else {
     mainWindow.loadURL('app://./index.html')
   }

--- a/frontend/src/components/dev/XrBusTester.tsx
+++ b/frontend/src/components/dev/XrBusTester.tsx
@@ -24,7 +24,8 @@ function wsUrl(): string {
     return `wss://${host}/api/xr/control/ws`;
   }
   // Desktop (app://) and local dev: connect straight to the backend.
-  return 'ws://localhost:8600/api/xr/control/ws';
+  // 127.0.0.1, never 'localhost' — see xrControlClient.wsUrl (issue #144).
+  return 'ws://127.0.0.1:8600/api/xr/control/ws';
 }
 
 const RANGE_KINDS = new Set(['knob', 'fader', 'crossfader', 'xy', 'xyz', 'jog']);

--- a/frontend/src/lib/backendBase.ts
+++ b/frontend/src/lib/backendBase.ts
@@ -6,10 +6,15 @@
 // /api/* to the backend, but anything that needs a genuine http origin (the VJ
 // iframe and its ?api= param, WebSockets, LAN/share/QR links shown to phones)
 // breaks when composed from app://. These helpers give those call sites the
-// backend's real http origin instead. The packaged backend always binds
-// http://localhost:8600 (electron-ui/main/index.ts BACKEND_BASE).
+// backend's real http origin instead.
+//
+// The host is the LITERAL 127.0.0.1, never 'localhost', and must stay that
+// way: backend/run.py binds 0.0.0.0 — IPv4 only — while Chromium prefers ::1
+// for 'localhost' on Windows 11, so a 'localhost' URL reaches nothing at all
+// with the backend running (issue #144). Same value as the packaged proxy's
+// BACKEND_BASE in electron-ui/main/index.ts.
 
-export const PACKAGED_BACKEND_HTTP_BASE = 'http://localhost:8600';
+export const PACKAGED_BACKEND_HTTP_BASE = 'http://127.0.0.1:8600';
 
 /** True when the page itself is served over http(s) (browser dev, Docker). */
 export const isHttpOrigin = (): boolean =>

--- a/frontend/src/lib/hfAuthClient.test.ts
+++ b/frontend/src/lib/hfAuthClient.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Which hop the Hugging Face auth client blames, and what it says about it.
+ *
+ * Two failures this pins (gantasmo/theDAW#144):
+ *   1. a backend outage used to come back from `fetchHfStatus` as a clean
+ *      "not signed in", so a dead backend and a missing token were the same
+ *      screen. It now reports `logged_in: null` plus an `error`.
+ *   2. 502 meant "our backend never answered" to the frontend and "the Hub
+ *      answered badly" to the backend — the same status carrying opposite
+ *      claims. The backend now answers 503 + `x-thedaw-hop: huggingface` for
+ *      the hop it does not own, and the messages below must never swap.
+ *
+ * Run: `npx tsx src/lib/hfAuthClient.test.ts` — `npm test` discovers it.
+ */
+import assert from 'node:assert/strict';
+import { HOP_HEADER, HOP_HUGGINGFACE, PROXY_ERROR_HEADER, PROXY_BACKEND_UNREACHABLE } from './httpError';
+import { HfAuthError, fetchHfStatus, hfLogin } from './hfAuthClient';
+
+const realFetch = globalThis.fetch;
+
+/** Answer every request with what `response` returns (or throw what it throws). */
+function serve(response: () => Response): void {
+  globalThis.fetch = (async () => response()) as typeof fetch;
+}
+
+/** The HfAuthError a sign-in attempt produced. Fails the suite if it resolved. */
+async function loginError(): Promise<HfAuthError> {
+  try {
+    await hfLogin('hf_token');
+  } catch (e) {
+    assert.ok(e instanceof HfAuthError, `expected HfAuthError, got ${String(e)}`);
+    return e;
+  }
+  return assert.fail('hfLogin resolved on a failing response');
+}
+
+// ── status: a real answer passes straight through ───────────────────────────
+serve(() =>
+  new Response(JSON.stringify({ logged_in: true, username: 'someone', token_source: 'stored' }), { status: 200 }),
+);
+const signedIn = await fetchHfStatus();
+assert.deepEqual(
+  { logged_in: signedIn.logged_in, username: signedIn.username, available: signedIn.available, error: signedIn.error },
+  { logged_in: true, username: 'someone', available: true, error: null },
+);
+
+// The Hub-unknown third state is still preserved end to end.
+serve(() => new Response(JSON.stringify({ logged_in: null, token_source: 'env', checking: true }), { status: 200 }));
+const unknown = await fetchHfStatus();
+assert.equal(unknown.logged_in, null);
+assert.equal(unknown.checking, true);
+assert.equal(unknown.error, null, 'the CALL worked; only the Hub verdict is unknown');
+
+// ── status: the module is off — a real "no", and the one the UI acts on ─────
+serve(() => new Response('{"detail":"Not Found"}', { status: 404 }));
+const off = await fetchHfStatus();
+assert.equal(off.available, false);
+assert.equal(off.logged_in, false);
+
+// ── status: an unreachable backend is NOT a signed-out user ─────────────────
+serve(() =>
+  new Response('theDAW backend unreachable at http://127.0.0.1:8600: net::ERR_CONNECTION_REFUSED', {
+    status: 502,
+    headers: { [PROXY_ERROR_HEADER]: PROXY_BACKEND_UNREACHABLE },
+  }),
+);
+const down = await fetchHfStatus();
+assert.equal(down.logged_in, null, 'never false — we did not measure a signed-out user');
+assert.equal(down.available, true, 'the module is presumed present; we just could not ask');
+assert.equal(down.error?.kind, 'backend-down');
+assert.ok(/did not answer/.test(down.error?.message ?? ''), down.error?.message);
+assert.ok(!/huggingface/i.test(down.error?.message ?? ''), 'the Hub is not blamed for a local failure');
+
+// fetch itself rejecting (backend still binding its port) reads the same way.
+globalThis.fetch = (async () => {
+  throw new TypeError('Failed to fetch');
+}) as typeof fetch;
+const thrown = await fetchHfStatus();
+assert.equal(thrown.logged_in, null);
+assert.equal(thrown.error?.kind, 'backend-down');
+
+// A 503 while ASKING for status is the Hub hop, not ours.
+serve(() =>
+  new Response('{"detail":"Could not reach huggingface.co: timed out"}', {
+    status: 503,
+    headers: { [HOP_HEADER]: HOP_HUGGINGFACE },
+  }),
+);
+const hubDown = await fetchHfStatus();
+assert.equal(hubDown.logged_in, null);
+assert.equal(hubDown.error?.kind, 'unreachable');
+
+// ── login: the Hub's own verdicts ───────────────────────────────────────────
+serve(() => new Response('{"detail":"Invalid Hugging Face token"}', { status: 401 }));
+assert.equal((await loginError()).kind, 'rejected');
+
+serve(() => new Response('{"detail":"Not Found"}', { status: 404 }));
+assert.equal((await loginError()).kind, 'disabled');
+
+serve(() => new Response(JSON.stringify({ logged_in: true, username: 'someone' }), { status: 200 }));
+assert.equal(await hfLogin('hf_token'), 'someone');
+
+// ── login: 503 + the hop marker = the Hub hop failed, and says so ───────────
+serve(() =>
+  new Response('{"detail":"Could not reach huggingface.co: [Errno 11001] getaddrinfo failed"}', {
+    status: 503,
+    headers: { [HOP_HEADER]: HOP_HUGGINGFACE },
+  }),
+);
+const hubUnreachable = await loginError();
+assert.equal(hubUnreachable.kind, 'unreachable');
+assert.match(hubUnreachable.message, /huggingface\.co/, 'the backend detail names the right hop');
+
+// The backend's OTHER upstream failure — the Hub answered, badly — is the same
+// hop and the same status, with its own words.
+serve(() =>
+  new Response('{"detail":"huggingface.co returned HTTP 500"}', {
+    status: 503,
+    headers: { [HOP_HEADER]: HOP_HUGGINGFACE },
+  }),
+);
+const hubErrored = await loginError();
+assert.equal(hubErrored.kind, 'unreachable');
+assert.equal(hubErrored.message, 'huggingface.co returned HTTP 500');
+
+// Status alone is enough if a deployment strips the marker header.
+serve(() => new Response('', { status: 503 }));
+assert.equal((await loginError()).kind, 'unreachable');
+
+// ── login: 502 = a gateway, so the Hub was never contacted ─────────────────
+serve(() =>
+  new Response('theDAW backend unreachable at http://127.0.0.1:8600: net::ERR_CONNECTION_REFUSED', {
+    status: 502,
+    headers: { [PROXY_ERROR_HEADER]: PROXY_BACKEND_UNREACHABLE },
+  }),
+);
+const gateway = await loginError();
+assert.equal(gateway.kind, 'backend-down');
+assert.ok(/did not answer/.test(gateway.message), gateway.message);
+assert.ok(!/huggingface/i.test(gateway.message), 'this is the inversion that sent a user to debug their internet');
+
+serve(() => new Response('', { status: 502 }));
+assert.equal((await loginError()).kind, 'backend-down');
+serve(() => new Response('', { status: 504 }));
+assert.equal((await loginError()).kind, 'backend-down');
+
+// ── login: anything else still says something ──────────────────────────────
+serve(() => new Response('{"detail":"Token validated but could not be stored: disk full"}', { status: 500 }));
+const stored = await loginError();
+assert.equal(stored.kind, 'unknown');
+assert.equal(stored.message, 'Token validated but could not be stored: disk full');
+
+serve(() => new Response('', { status: 418 }));
+assert.equal((await loginError()).message, 'Sign-in failed (HTTP 418).');
+
+globalThis.fetch = realFetch;
+console.log('hfAuthClient tests passed');

--- a/frontend/src/lib/hfAuthClient.ts
+++ b/frontend/src/lib/hfAuthClient.ts
@@ -8,11 +8,30 @@
 //   POST /api/hfauth/logout      -> { logged_in: false }
 //   GET  /api/hfauth/login-url   -> { url }
 //
-// `logged_in: null` is a real third state: the backend could not reach the Hub,
-// so it reports "unknown" rather than wrongly logging an offline user out.
+// `logged_in: null` is a real third state: nobody could get an answer about
+// this token — either the backend could not reach the Hub, or we could not
+// reach the backend. It is NOT "signed out"; reporting it as signed out is how
+// a dead backend came to look like a missing token.
+//
+// Which hop failed, and how we know (see ./httpError):
+//   503 + x-thedaw-hop: huggingface  the backend answered; the HUB hop failed
+//   502 / 504, no hop header         a gateway answered; the BACKEND never did
+// The backend used to raise 502 for a bad answer from the Hub, which meant the
+// same status carried both meanings and neither could be trusted (issue #144).
+
+import {
+  HOP_HEADER,
+  HOP_HUGGINGFACE,
+  BACKEND_UNREACHABLE,
+  describeHttpError,
+  detailFromResponse,
+} from './httpError';
 
 /** Where the detected token came from. 'env' wins over 'stored' on the backend. */
 export type HfTokenSource = 'env' | 'stored' | 'none';
+
+/** Which hop failed. 'rejected' = the Hub said no about the token itself. */
+export type HfFailureKind = 'rejected' | 'unreachable' | 'backend-down' | 'disabled' | 'unknown';
 
 export interface HfAuthStatus {
   logged_in: boolean | null;
@@ -26,6 +45,19 @@ export interface HfAuthStatus {
    * never succeed. Routers mount at import, so a toggle needs a restart.
    */
   available: boolean;
+  /**
+   * Set when the STATUS CALL ITSELF failed, so a caller can say "we could not
+   * ask" instead of showing a signed-out state it did not measure. Null on a
+   * successful call. `logged_in` is null whenever this is set.
+   */
+  error?: HfStatusError | null;
+}
+
+/** Why the status call could not produce an answer. */
+export interface HfStatusError {
+  kind: HfFailureKind;
+  /** A sentence to show the user as-is. */
+  message: string;
 }
 
 /** Thrown by `hfLogin` so callers can tell a bad token from a dead network. */
@@ -33,7 +65,7 @@ export class HfAuthError extends Error {
   constructor(
     message: string,
     /** 'rejected' = the Hub said no. 'unreachable' = we never got an answer. */
-    readonly kind: 'rejected' | 'unreachable' | 'backend-down' | 'disabled' | 'unknown',
+    readonly kind: HfFailureKind,
   ) {
     super(message);
     this.name = 'HfAuthError';
@@ -42,44 +74,67 @@ export class HfAuthError extends Error {
 
 export const HF_TOKENS_URL = 'https://huggingface.co/settings/tokens';
 
-/** Read the backend's `detail` field (FastAPI error shape) if present. */
-async function readDetail(res: Response): Promise<string | null> {
-  try {
-    const body = (await res.json()) as { detail?: unknown } | null;
-    const detail = body?.detail;
-    return typeof detail === 'string' ? detail : null;
-  } catch {
-    return null;
-  }
+/** Said when we could not even ask the backend. */
+const STATUS_UNKNOWN_SUFFIX = ' Until it answers, theDAW cannot tell whether you are signed in.';
+
+/**
+ * Which hop a failed hfauth response blames.
+ *
+ * The backend marks the one hop it does not own with `x-thedaw-hop:
+ * huggingface` and reports it as 503. A 502/504 without that marker came from
+ * a gateway in front of the backend, so huggingface.co was never contacted —
+ * the status alone is enough even if a deployment strips custom headers.
+ */
+function hopOf(res: Response): HfFailureKind {
+  if (res.headers.get(HOP_HEADER) === HOP_HUGGINGFACE) return 'unreachable';
+  if (res.status === 503) return 'unreachable';
+  if (res.status === 502 || res.status === 504) return 'backend-down';
+  return 'unknown';
 }
 
 /**
- * Current login state. Never throws — an unreachable backend or a disabled
- * hfauth module reports the same "not signed in" shape, so callers can render
- * the token field instead of an error.
+ * Current login state. Never throws, and never invents one: a call that could
+ * not be answered comes back as `logged_in: null` with `error` set, so a
+ * backend outage is distinguishable from a missing token. Callers that only
+ * check `logged_in === true` keep working unchanged.
  */
 export async function fetchHfStatus(): Promise<HfAuthStatus> {
+  let res: Response;
   try {
-    const res = await fetch('/api/hfauth/status');
-    if (res.status === 404) {
-      return { logged_in: false, username: null, token_source: 'none', available: false };
-    }
-    if (!res.ok) {
-      return { logged_in: false, username: null, token_source: 'none', available: true };
-    }
-    const data = (await res.json()) as Partial<HfAuthStatus> | null;
-    return {
-      logged_in: data?.logged_in ?? null,
-      username: data?.username ?? null,
-      token_source: data?.token_source ?? 'none',
-      checking: data?.checking ?? false,
-      available: true,
-    };
+    res = await fetch('/api/hfauth/status');
   } catch {
-    // Backend still booting or momentarily down — assume the module is there
-    // and let the sign-in attempt produce the real error.
-    return { logged_in: false, username: null, token_source: 'none', available: true };
+    // No response at all — the backend is still booting, or it is gone.
+    return {
+      logged_in: null,
+      username: null,
+      token_source: 'none',
+      available: true,
+      error: { kind: 'backend-down', message: BACKEND_UNREACHABLE + STATUS_UNKNOWN_SUFFIX },
+    };
   }
+  if (res.status === 404) {
+    return { logged_in: false, username: null, token_source: 'none', available: false, error: null };
+  }
+  if (!res.ok) {
+    const kind = hopOf(res);
+    const message = await describeHttpError(res);
+    return {
+      logged_in: null,
+      username: null,
+      token_source: 'none',
+      available: true,
+      error: { kind, message: message + (kind === 'backend-down' ? STATUS_UNKNOWN_SUFFIX : '') },
+    };
+  }
+  const data = (await res.json().catch(() => null)) as Partial<HfAuthStatus> | null;
+  return {
+    logged_in: data?.logged_in ?? null,
+    username: data?.username ?? null,
+    token_source: data?.token_source ?? 'none',
+    checking: data?.checking ?? false,
+    available: true,
+    error: null,
+  };
 }
 
 /**
@@ -106,28 +161,23 @@ export async function hfLogin(token: string): Promise<string> {
   if (res.status === 404) {
     throw new HfAuthError('The Hugging Face Auth module is turned off in Settings → Modules.', 'disabled');
   }
-  // 502 and 503 are NOT the same failure and must not read the same.
-  //
-  // 503 is the backend's own verdict — it tried whoami and could not reach the
-  // Hub (hfauth/router.py). 502 is theDAW's Electron proxy saying it could not
-  // reach the BACKEND; huggingface.co was never contacted. Reporting both as
-  // "couldn't reach huggingface.co" sent a user to test their internet, prove
-  // it worked, and file a bug against the wrong half of the app.
-  if (res.status === 502) {
-    const detail = await readDetail(res);
-    throw new HfAuthError(
-      detail ?? "theDAW's own backend did not answer — huggingface.co was never contacted.",
-      'backend-down',
-    );
+  // "We could not reach huggingface.co" and "we could not reach our own
+  // backend" are different problems with different fixes, and the message has
+  // to name the right one. A user who is told the Hub is down when the Hub is
+  // fine tests their internet, proves it works, and files a bug against the
+  // wrong half of the app — which is exactly what happened in issue #144.
+  const kind = hopOf(res);
+  if (kind === 'unreachable') {
+    // The backend answered: it reached out to the Hub and that hop failed. Its
+    // own detail already names what the Hub did, so prefer it verbatim.
+    const detail = await detailFromResponse(res);
+    throw new HfAuthError(detail ?? "Couldn't reach huggingface.co to check the token.", 'unreachable');
   }
-  if (res.status === 503) {
-    const detail = await readDetail(res);
-    throw new HfAuthError(
-      detail ?? "Couldn't reach huggingface.co to check the token.",
-      'unreachable',
-    );
+  if (kind === 'backend-down') {
+    // A gateway answered, not the backend, so nothing was asked of the Hub.
+    throw new HfAuthError(await describeHttpError(res), 'backend-down');
   }
-  const detail = await readDetail(res);
+  const detail = await detailFromResponse(res);
   throw new HfAuthError(detail ?? `Sign-in failed (HTTP ${res.status}).`, 'unknown');
 }
 

--- a/frontend/src/lib/httpError.test.ts
+++ b/frontend/src/lib/httpError.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The failed-Response → sentence helper, under plain node.
+ *
+ * Pins the failure that produced gantasmo/theDAW#144's "Model status failed:
+ * HTTP 502": a gateway answers with a plain-text or empty body, so `r.json()`
+ * throws and the old code fell all the way back to the bare status. Every case
+ * below asserts on the string a USER would read.
+ *
+ * Covered: a FastAPI `detail` body, a validation-list detail, a plain-text
+ * body, an empty body, an HTML error page, each of 502/503/504, and the
+ * `x-thedaw-proxy-error` header the packaged proxy sets and nothing used to
+ * read.
+ *
+ * Run: `npx tsx src/lib/httpError.test.ts` — `npm test` discovers it.
+ */
+import assert from 'node:assert/strict';
+import {
+  BACKEND_UNREACHABLE,
+  GATEWAY_TIMEOUT,
+  HOP_HEADER,
+  HOP_HUGGINGFACE,
+  PROXY_ERROR_HEADER,
+  PROXY_BACKEND_UNREACHABLE,
+  UPSTREAM_UNAVAILABLE,
+  describeHttpError,
+  detailFromResponse,
+  parseErrorBody,
+} from './httpError';
+
+const res = (body: string, status: number, headers?: Record<string, string>): Response =>
+  new Response(body, { status, headers });
+
+// ── parseErrorBody: what a body carries, and where it came from ─────────────
+assert.deepEqual(parseErrorBody('{"detail":"No checkpoint found there."}'), {
+  text: 'No checkpoint found there.',
+  fromDetail: true,
+});
+assert.deepEqual(parseErrorBody('{"detail":[{"msg":"field required"},{"msg":"not a path"}]}'), {
+  text: 'field required; not a path',
+  fromDetail: true,
+});
+assert.deepEqual(parseErrorBody('theDAW backend unreachable at http://127.0.0.1:8600: connect ECONNREFUSED'), {
+  text: 'theDAW backend unreachable at http://127.0.0.1:8600: connect ECONNREFUSED',
+  fromDetail: false,
+});
+assert.deepEqual(parseErrorBody(''), { text: null, fromDetail: false });
+assert.deepEqual(parseErrorBody('   \n  '), { text: null, fromDetail: false });
+assert.deepEqual(parseErrorBody('{"error":"nope"}'), { text: null, fromDetail: false }, 'JSON with no detail says nothing');
+assert.deepEqual(
+  parseErrorBody('<!DOCTYPE html><html><body>502 Bad Gateway</body></html>'),
+  { text: null, fromDetail: false },
+  'an HTML error page is markup, not a message',
+);
+// Newlines collapse and long bodies are capped, so one stack trace cannot
+// become the whole error line.
+assert.equal(parseErrorBody('line one\n  line two').text, 'line one line two');
+const long = parseErrorBody('x'.repeat(1000)).text ?? '';
+assert.ok(long.length <= 300 && long.endsWith('…'), `capped, got ${long.length}`);
+
+// ── the status the bug report showed: a 502 with nothing to say ─────────────
+const bare502 = await describeHttpError(res('', 502));
+assert.equal(bare502, BACKEND_UNREACHABLE);
+assert.ok(!/HTTP 502/.test(`Model status failed: ${bare502}`), 'the user never sees a bare status again');
+assert.ok(/backend/i.test(bare502) && !/huggingface/i.test(bare502), 'names our backend, blames nothing upstream');
+
+assert.equal(await describeHttpError(res('', 503)), UPSTREAM_UNAVAILABLE);
+assert.equal(await describeHttpError(res('', 504)), GATEWAY_TIMEOUT);
+assert.notEqual(UPSTREAM_UNAVAILABLE, BACKEND_UNREACHABLE, '502 and 503 must never read the same');
+
+// ── the packaged proxy: plain-text body + the header nothing used to read ───
+const proxyBody = 'theDAW backend unreachable at http://127.0.0.1:8600: net::ERR_CONNECTION_REFUSED';
+const proxied = await describeHttpError(
+  res(proxyBody, 502, { [PROXY_ERROR_HEADER]: PROXY_BACKEND_UNREACHABLE }),
+);
+assert.ok(proxied.startsWith(BACKEND_UNREACHABLE), 'the actionable sentence leads');
+assert.ok(proxied.includes(proxyBody), 'and the proxy text a bug report needs is kept');
+
+// The header is evidence about the hop, so it wins even over a JSON detail.
+const proxiedJson = await describeHttpError(
+  res('{"detail":"whatever"}', 502, { [PROXY_ERROR_HEADER]: PROXY_BACKEND_UNREACHABLE }),
+);
+assert.ok(proxiedJson.startsWith(BACKEND_UNREACHABLE));
+
+// ── a body that DID say something keeps its own words ───────────────────────
+// The Vite dev proxy's 502 is JSON, and already actionable.
+assert.equal(
+  await describeHttpError(res('{"detail":"Backend unreachable — is the server running on port 8600?"}', 502)),
+  'Backend unreachable — is the server running on port 8600?',
+);
+// A route of ours answering 502 about an upstream call is not relabelled.
+assert.equal(
+  await describeHttpError(res('{"detail":"RuntimeError: Cannot access gated repo"}', 502)),
+  'RuntimeError: Cannot access gated repo',
+);
+// Plain text at a gateway status is kept, behind the sentence that acts on it.
+const texty = await describeHttpError(res('upstream connect error', 503));
+assert.equal(texty, `${UPSTREAM_UNAVAILABLE} (upstream connect error)`);
+
+// ── non-gateway statuses: unchanged behaviour ───────────────────────────────
+assert.equal(await describeHttpError(res('{"detail":"No registered checkpoint"}', 404)), 'No registered checkpoint');
+assert.equal(await describeHttpError(res('', 404)), 'HTTP 404');
+assert.equal(await describeHttpError(res('', 500)), 'HTTP 500');
+
+// ── detailFromResponse: the body's own words, or nothing ────────────────────
+assert.equal(
+  await detailFromResponse(res('{"detail":"Could not reach huggingface.co: timeout"}', 503, { [HOP_HEADER]: HOP_HUGGINGFACE })),
+  'Could not reach huggingface.co: timeout',
+);
+assert.equal(await detailFromResponse(res('', 503)), null);
+
+console.log('httpError tests passed');

--- a/frontend/src/lib/httpError.ts
+++ b/frontend/src/lib/httpError.ts
@@ -1,0 +1,141 @@
+/**
+ * One place that turns a failed `Response` into a sentence a user can act on.
+ *
+ * Why this exists: every client here used to do
+ * `await r.json().then(j => j?.detail).catch(() => null)` and fall back to
+ * `HTTP ${r.status}`. That fallback fires exactly when the failure is NOT the
+ * backend's — a gateway answers with a plain-text or empty body, `r.json()`
+ * throws, whatever the body said is dropped on the floor, and the user reads
+ * "Model status failed: HTTP 502" (gantasmo/theDAW#144). The one string that
+ * carried the reason was the one string thrown away.
+ *
+ * So: read the body ONCE as text; use its `detail` when it is FastAPI JSON,
+ * use the raw text when it is not, and when it says nothing at all, give the
+ * gateway statuses a sentence that names WHICH HOP failed — theDAW's own
+ * backend, or the service behind it. Those are different problems with
+ * different fixes, and telling them apart is the whole point.
+ *
+ * A FastAPI `detail` outranks any sentence composed here, whatever the status:
+ * its presence proves a route of ours answered, so its own words are the truth
+ * about the failure. That also keeps this safe for a router that raises its own
+ * 502 for an upstream call (backend/modules/tour, /api/generate) — such a
+ * response always carries a `detail`, so it is never relabelled "our backend
+ * did not answer".
+ *
+ * A `Response` body can be read only once; every export that takes one
+ * consumes it.
+ */
+
+/**
+ * Set by the packaged app's own proxy (electron-ui/main/index.ts) when it
+ * could not reach the backend at all. Its body is plain text, never JSON.
+ */
+export const PROXY_ERROR_HEADER = 'x-thedaw-proxy-error';
+export const PROXY_BACKEND_UNREACHABLE = 'backend-unreachable';
+
+/**
+ * Set by the BACKEND on a failure it reports for a hop it does not own, so
+ * "our backend is down" and "the service our backend called is down" can never
+ * collapse into one status again. See backend/modules/hfauth/router.py.
+ */
+export const HOP_HEADER = 'x-thedaw-hop';
+export const HOP_HUGGINGFACE = 'huggingface';
+
+/** The request never reached theDAW's backend. Nothing upstream was contacted. */
+export const BACKEND_UNREACHABLE =
+  "theDAW's own backend did not answer, so the request never left this machine. " +
+  'It may still be starting — wait a moment and retry; if it keeps failing, restart theDAW.';
+
+/** The backend answered, but something it had to call did not. */
+export const UPSTREAM_UNAVAILABLE =
+  "theDAW's backend answered, but the service it had to call did not. Try again in a moment.";
+
+/** Somebody between here and the answer gave up waiting. */
+export const GATEWAY_TIMEOUT =
+  'The request timed out before an answer came back. Try again — the first check after a cold start can be slow.';
+
+/** Longest body text we will paste into a user-facing message. */
+const MAX_DETAIL = 300;
+
+function tidy(text: string): string {
+  const s = text.trim().replace(/\s+/g, ' ');
+  return s.length > MAX_DETAIL ? `${s.slice(0, MAX_DETAIL - 1)}…` : s;
+}
+
+export interface BodyMessage {
+  /** What the body said, or null when it said nothing usable. */
+  text: string | null;
+  /** True when it came from a FastAPI `detail` — i.e. a route of ours answered. */
+  fromDetail: boolean;
+}
+
+/**
+ * What an error body carries.
+ *
+ * The three shapes that actually arrive: FastAPI's `{"detail": "…"}`, FastAPI's
+ * validation list `{"detail": [{"msg": …}]}`, and a plain-text body from a
+ * proxy. An HTML error page is markup, not a message, so it is dropped rather
+ * than pasted into the UI.
+ */
+export function parseErrorBody(body: string): BodyMessage {
+  const text = body.trim();
+  if (!text) return { text: null, fromDetail: false };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    if (/^<(!doctype|html|\?xml)/i.test(text)) return { text: null, fromDetail: false };
+    return { text: tidy(text), fromDetail: false };
+  }
+  const detail = (parsed as { detail?: unknown } | null)?.detail;
+  if (typeof detail === 'string' && detail.trim()) return { text: tidy(detail), fromDetail: true };
+  if (Array.isArray(detail)) {
+    const msgs = detail
+      .map((e) => (e && typeof (e as { msg?: unknown }).msg === 'string' ? (e as { msg: string }).msg : null))
+      .filter((m): m is string => Boolean(m));
+    if (msgs.length) return { text: tidy(msgs.join('; ')), fromDetail: true };
+  }
+  return { text: null, fromDetail: false };
+}
+
+/** `parseErrorBody` over a Response. Consumes the body; never throws. */
+export async function readErrorBody(res: Response): Promise<BodyMessage> {
+  try {
+    return parseErrorBody(await res.text());
+  } catch {
+    return { text: null, fromDetail: false };
+  }
+}
+
+/** Just the message a response body carried, if any. Consumes the body. */
+export async function detailFromResponse(res: Response): Promise<string | null> {
+  return (await readErrorBody(res)).text;
+}
+
+/**
+ * A user-facing sentence for a non-ok `Response`. Consumes the body.
+ *
+ * Order: the proxy's own header is direct evidence about the failing hop, so it
+ * wins; then a FastAPI `detail`, which is a real answer from a real route; then
+ * a sentence for the gateway statuses, keeping whatever plain text the body did
+ * carry in parentheses so a bug report can quote the technical half.
+ */
+export async function describeHttpError(res: Response): Promise<string> {
+  const proxied = res.headers.get(PROXY_ERROR_HEADER) === PROXY_BACKEND_UNREACHABLE;
+  const { text, fromDetail } = await readErrorBody(res);
+  if (proxied) return text ? `${BACKEND_UNREACHABLE} (${text})` : BACKEND_UNREACHABLE;
+  if (fromDetail && text) return text;
+  const lead =
+    res.status === 502
+      ? // The only bare 502s in this app come from a gateway in front of the
+        // backend (the packaged app:// proxy, the Vite dev proxy). The backend
+        // reports failures it does not own as 503 + HOP_HEADER, on purpose.
+        BACKEND_UNREACHABLE
+      : res.status === 503
+        ? UPSTREAM_UNAVAILABLE
+        : res.status === 504
+          ? GATEWAY_TIMEOUT
+          : null;
+  if (lead) return text ? `${lead} (${text})` : lead;
+  return text ?? `HTTP ${res.status}`;
+}

--- a/frontend/src/lib/storageClient.test.ts
+++ b/frontend/src/lib/storageClient.test.ts
@@ -1,0 +1,79 @@
+/**
+ * What Settings → Models actually prints when a storage call fails.
+ *
+ * ModelsSection renders `Model status failed: {error.message}`, so the message
+ * thrown by storageClient's `json()` wrapper IS the user-visible string. This
+ * suite drives the real `fetchModelStatus` against a stubbed `fetch` and
+ * asserts on that whole rendered line — the bug report's "Model status failed:
+ * HTTP 502" (gantasmo/theDAW#144) is pinned here as a string that can never
+ * come back.
+ *
+ * Run: `npx tsx src/lib/storageClient.test.ts` — `npm test` discovers it.
+ */
+import assert from 'node:assert/strict';
+import { PROXY_ERROR_HEADER, PROXY_BACKEND_UNREACHABLE } from './httpError';
+import { fetchModelStatus } from './storageClient';
+
+const realFetch = globalThis.fetch;
+let lastUrl = '';
+
+/** Answer every request with `response`, recording the URL asked for. */
+function serve(response: () => Response): void {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    lastUrl = typeof input === 'string' ? input : String(input);
+    return response();
+  }) as typeof fetch;
+}
+
+/** The line the Settings panel renders for a failed model-status call. */
+async function renderedError(): Promise<string> {
+  try {
+    await fetchModelStatus();
+  } catch (e) {
+    return `Model status failed: ${e instanceof Error ? e.message : String(e)}`;
+  }
+  return assert.fail('fetchModelStatus resolved on a failing response');
+}
+
+// ── the reported failure: the packaged proxy could not reach the backend ────
+serve(() =>
+  new Response('theDAW backend unreachable at http://127.0.0.1:8600: net::ERR_CONNECTION_REFUSED', {
+    status: 502,
+    headers: { [PROXY_ERROR_HEADER]: PROXY_BACKEND_UNREACHABLE },
+  }),
+);
+const proxied = await renderedError();
+assert.equal(lastUrl, '/api/storage/model-status');
+assert.ok(proxied !== 'Model status failed: HTTP 502', 'the exact string from the bug report is gone');
+assert.ok(/did not answer/.test(proxied), `names the failing hop: ${proxied}`);
+assert.ok(/restart theDAW/i.test(proxied), 'and says what to do about it');
+assert.ok(/ERR_CONNECTION_REFUSED/.test(proxied), 'keeping the technical reason for a bug report');
+assert.ok(!/huggingface/i.test(proxied), 'nothing upstream is blamed for a local loopback failure');
+
+// ── a gateway with nothing to say at all ───────────────────────────────────
+serve(() => new Response('', { status: 502 }));
+assert.ok(/did not answer/.test(await renderedError()));
+serve(() => new Response('', { status: 504 }));
+assert.ok(/timed out/.test(await renderedError()));
+
+// ── the backend answered: its own words survive verbatim ───────────────────
+serve(() => new Response('{"detail":"No checkpoint found there."}', { status: 400 }));
+assert.equal(await renderedError(), 'Model status failed: No checkpoint found there.');
+
+// ── nothing to go on: the bare status is still the last resort ─────────────
+serve(() => new Response('', { status: 500 }));
+assert.equal(await renderedError(), 'Model status failed: HTTP 500');
+
+// ── a good answer is parsed, not shaped ────────────────────────────────────
+serve(() =>
+  new Response(JSON.stringify({ providers: [], usable_generation: true, local_only: false }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  }),
+);
+const ok = await fetchModelStatus();
+assert.equal(ok.usable_generation, true);
+assert.deepEqual(ok.providers, []);
+
+globalThis.fetch = realFetch;
+console.log('storageClient tests passed');

--- a/frontend/src/lib/storageClient.ts
+++ b/frontend/src/lib/storageClient.ts
@@ -4,6 +4,8 @@
 // checkpoints generate via their `local:<id>` ids) and the Settings → Models
 // & Storage panel (locations browser, HF cache table, local-only switch).
 
+import { describeHttpError } from './httpError';
+
 export interface RegisteredCheckpoint {
   id: string; // "local:<8-hex>" — what the Model dropdown submits
   name: string;
@@ -101,11 +103,12 @@ export interface ModelStatusResponse {
   local_only: boolean;
 }
 
+// Error text comes from describeHttpError, not from a bare `HTTP ${status}`.
+// This wrapper's message is what Settings → Models prints after "Model status
+// failed: ", so "HTTP 502" was the whole of what a user got when the app could
+// not reach its own backend — see frontend/src/lib/httpError.ts.
 async function json<T>(r: Response): Promise<T> {
-  if (!r.ok) {
-    const detail = await r.json().then((j) => j?.detail).catch(() => null);
-    throw new Error(typeof detail === 'string' ? detail : `HTTP ${r.status}`);
-  }
+  if (!r.ok) throw new Error(await describeHttpError(r));
   return r.json() as Promise<T>;
 }
 

--- a/frontend/src/state/questMidiClient.ts
+++ b/frontend/src/state/questMidiClient.ts
@@ -28,7 +28,10 @@ function wsUrl(): string {
   }
   // Desktop (app://) and local dev: connect straight to the backend — the
   // app:// handler can't upgrade WebSockets and dev proxies may lack ws:true.
-  return 'ws://localhost:8600/api/questmidi/ws';
+  // 127.0.0.1, never 'localhost': the backend binds 0.0.0.0 (IPv4 only) and
+  // Chromium resolves 'localhost' to ::1 on Windows, so the socket never
+  // connects (issue #144).
+  return 'ws://127.0.0.1:8600/api/questmidi/ws';
 }
 
 function scheduleReconnect(): void {

--- a/frontend/src/state/xrControlClient.ts
+++ b/frontend/src/state/xrControlClient.ts
@@ -84,7 +84,10 @@ function wsUrl(): string {
   }
   // Desktop app:// renderer — its protocol handler proxies HTTP /api/* but
   // cannot upgrade WebSockets, and the backend is always local on :8600.
-  return 'ws://localhost:8600/api/xr/control/ws';
+  // 127.0.0.1, never 'localhost': the backend binds 0.0.0.0 (IPv4 only) and
+  // Chromium resolves 'localhost' to ::1 on Windows, so the socket never
+  // connects (issue #144). The LAN cases are handled above, by origin.
+  return 'ws://127.0.0.1:8600/api/xr/control/ws';
 }
 
 async function buildManifest(): Promise<XrManifestEntry[]> {

--- a/tests/test_hfauth_router.py
+++ b/tests/test_hfauth_router.py
@@ -1,0 +1,155 @@
+"""Status codes for the Hugging Face auth router (backend.modules.hfauth).
+
+The point of this suite is one distinction the app got wrong for two days
+(gantasmo/theDAW#144): a 502 anywhere in theDAW means a gateway in front of the
+backend could not reach the backend, so nothing upstream was contacted. This
+router's own upstream failures are the OPPOSITE fact and must never borrow that
+code -- they answer 503 plus the ``x-thedaw-hop: huggingface`` marker. The
+frontend reads both (frontend/src/lib/hfAuthClient.ts).
+
+``_whoami`` is monkeypatched in the router namespace, so nothing here touches
+the network or the user's real token file.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.modules.hfauth import router as hfauth
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """A TestClient over an app mounting only the hfauth router.
+
+    The token path points at a tmp file and the whoami cache is reset, so a test
+    can never read or write the developer's real ~/.cache token.
+    """
+    monkeypatch.setattr(hfauth, "_TOKEN_PATH", tmp_path / "token")
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    with hfauth._cache_lock:
+        hfauth._cache.update(
+            {"token": None, "checked_at": 0.0, "logged_in": None, "username": None}
+        )
+
+    app = FastAPI()
+    app.include_router(hfauth.router, prefix="/api/hfauth")
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _status_error(code: int) -> httpx.HTTPStatusError:
+    """What httpx raises when the Hub answers with ``code``."""
+    request = httpx.Request("GET", hfauth._WHOAMI_URL)
+    return httpx.HTTPStatusError(
+        f"HTTP {code}", request=request, response=httpx.Response(code, request=request)
+    )
+
+
+def test_rejected_token_is_401(client, monkeypatch):
+    """The Hub's verdict on the token itself -- not a transport failure."""
+
+    def reject(token, timeout):
+        raise _status_error(401)
+
+    monkeypatch.setattr(hfauth, "_whoami", reject)
+    resp = client.post("/api/hfauth/login", json={"token": "hf_bad"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid Hugging Face token"
+    assert hfauth.HOP_HEADER not in resp.headers
+
+
+def test_hub_answered_badly_is_503_and_names_the_hop(client, monkeypatch):
+    """A non-auth HTTP error from huggingface.co. Was 502, which collided with
+    the gateway's "we never reached the backend" -- the exact inversion in #144."""
+
+    def hub_500(token, timeout):
+        raise _status_error(500)
+
+    monkeypatch.setattr(hfauth, "_whoami", hub_500)
+    resp = client.post("/api/hfauth/login", json={"token": "hf_good"})
+    assert resp.status_code == 503, "502 means OUR backend was never reached"
+    assert resp.headers[hfauth.HOP_HEADER] == hfauth.HOP_HUGGINGFACE
+    assert resp.json()["detail"] == "huggingface.co returned HTTP 500"
+
+
+def test_hub_unreachable_is_503_and_names_the_hop(client, monkeypatch):
+    """No answer at all from the Hub: same hop, same status, its own words."""
+
+    def offline(token, timeout):
+        raise httpx.ConnectError("getaddrinfo failed")
+
+    monkeypatch.setattr(hfauth, "_whoami", offline)
+    resp = client.post("/api/hfauth/login", json={"token": "hf_good"})
+    assert resp.status_code == 503
+    assert resp.headers[hfauth.HOP_HEADER] == hfauth.HOP_HUGGINGFACE
+    detail = resp.json()["detail"]
+    assert detail.startswith("Could not reach huggingface.co:")
+    assert "getaddrinfo failed" in detail
+
+
+def test_odd_payload_is_503_not_500(client, monkeypatch):
+    """A whoami answer with no username is still an upstream problem."""
+
+    def nonsense(token, timeout):
+        raise ValueError("whoami response had no username")
+
+    monkeypatch.setattr(hfauth, "_whoami", nonsense)
+    resp = client.post("/api/hfauth/login", json={"token": "hf_good"})
+    assert resp.status_code == 503
+    assert resp.headers[hfauth.HOP_HEADER] == hfauth.HOP_HUGGINGFACE
+
+
+def test_login_never_answers_502(client, monkeypatch):
+    """The guard, stated directly: no failure of this router may answer 502."""
+    failures = [
+        _status_error(500),
+        _status_error(429),
+        httpx.ReadTimeout("timed out"),
+        httpx.ConnectError("refused"),
+        ValueError("odd payload"),
+    ]
+    for exc in failures:
+
+        def raiser(token, timeout, exc=exc):
+            raise exc
+
+        monkeypatch.setattr(hfauth, "_whoami", raiser)
+        resp = client.post("/api/hfauth/login", json={"token": "hf_good"})
+        assert resp.status_code != 502, f"{type(exc).__name__} answered 502"
+
+
+def test_successful_login_stores_the_token(client, monkeypatch, tmp_path):
+    """The happy path still works, and writes the hub's standard token file."""
+    monkeypatch.setattr(hfauth, "_whoami", lambda token, timeout: "someone")
+    resp = client.post("/api/hfauth/login", json={"token": "hf_good"})
+    assert resp.status_code == 200
+    assert resp.json() == {"logged_in": True, "username": "someone"}
+    assert (tmp_path / "token").read_text(encoding="utf-8") == "hf_good"
+
+
+def test_status_reports_signed_out_without_a_token(client):
+    """No token on disk and no env var: a real, measured "no"."""
+    resp = client.get("/api/hfauth/status")
+    assert resp.status_code == 200
+    assert resp.json()["logged_in"] is False
+    assert resp.json()["token_source"] == "none"
+
+
+def test_status_never_fails_when_the_hub_is_down(client, monkeypatch, tmp_path):
+    """An offline check caches "unknown", so /status stays 200 with
+    ``logged_in: null`` instead of logging an offline user out."""
+    (tmp_path / "token").write_text("hf_good", encoding="utf-8")
+
+    def offline(token, timeout):
+        raise httpx.ConnectError("offline")
+
+    monkeypatch.setattr(hfauth, "_whoami", offline)
+    resp = client.get("/api/hfauth/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["logged_in"] is None
+    assert body["token_source"] == "stored"


### PR DESCRIPTION
This pull request addresses a longstanding confusion between backend and upstream (Hugging Face) failures, ensuring that error reporting and user messaging accurately reflect which service is unreachable or failing. The changes clarify status code handling, propagate a new marker header to distinguish failure sources, and update all frontend and backend code paths, including tests, to consistently interpret and display these errors. Additionally, all development and production code now consistently uses `127.0.0.1` instead of `localhost` to avoid IPv6/IPv4 resolution issues on Windows.

**Error handling and reporting improvements:**

* The backend (`hfauth/router.py`) now returns HTTP 503 (with a custom `x-thedaw-hop: huggingface` header) for Hugging Face upstream failures, distinguishing them from HTTP 502, which now strictly means the backend was unreachable. This prevents misreporting the source of failures to users. [[1]](diffhunk://#diff-5ad3a51c1bd13adf4086b561af3a526238aa85c5478bb0d07455604568bc4712R17-R25) [[2]](diffhunk://#diff-5ad3a51c1bd13adf4086b561af3a526238aa85c5478bb0d07455604568bc4712R52-R58) [[3]](diffhunk://#diff-5ad3a51c1bd13adf4086b561af3a526238aa85c5478bb0d07455604568bc4712R203-R215)
* The frontend (`hfAuthClient.ts`) and its tests (`hfAuthClient.test.ts`) have been refactored to interpret these status codes and headers correctly, so the UI can accurately inform the user whether the problem is with the backend or Hugging Face. The error object now includes a `kind` field and a user-facing `message`. [[1]](diffhunk://#diff-8849327c34b664632e712f467db4e10551990e2097bfd251ff6d2af303758741L11-R35) [[2]](diffhunk://#diff-8849327c34b664632e712f467db4e10551990e2097bfd251ff6d2af303758741R48-R68) [[3]](diffhunk://#diff-8849327c34b664632e712f467db4e10551990e2097bfd251ff6d2af303758741L45-L82) [[4]](diffhunk://#diff-8849327c34b664632e712f467db4e10551990e2097bfd251ff6d2af303758741L109-R180) [[5]](diffhunk://#diff-11b0560e3413628783c23be53d7fc7f3ad705fe63e16343732912c618b7fde7bR1-R157)

**Localhost/loopback address consistency:**

* All development and production URLs, proxies, and WebSocket endpoints have been updated to use `127.0.0.1` instead of `localhost`. This avoids failures on Windows where `localhost` may resolve to IPv6 (`::1`), but the backend binds only IPv4. [[1]](diffhunk://#diff-0cb75af8a2c520e22d0ad201e0cd9d7747ac3757ccc873506d909ef9f79a44cdR58-R68) [[2]](diffhunk://#diff-0cb75af8a2c520e22d0ad201e0cd9d7747ac3757ccc873506d909ef9f79a44cdL74-R82) [[3]](diffhunk://#diff-0cb75af8a2c520e22d0ad201e0cd9d7747ac3757ccc873506d909ef9f79a44cdL86-R94) [[4]](diffhunk://#diff-4e8611dee52f0bab0d239b74d356255de9763a6f66fbb9baa344f66a222d5475L543-R547) [[5]](diffhunk://#diff-d8eacdaf81a6071028134a39ec55aaad2d326e1bb4f958ddb2b75061f4328400L27-R28) [[6]](diffhunk://#diff-6aab7069782c76f57e7c6519a3533e25ccf29249956c8e058951aca203e20f38L9-R17)

**Test coverage:**

* A comprehensive test suite (`hfAuthClient.test.ts`) has been added to verify that all error conditions (backend down, Hugging Face down, bad token, etc.) are correctly surfaced and attributed in the UI.

These changes resolve user confusion, prevent misdiagnosis of outages, and improve the reliability of both error handling and local development.