### PR TITLE
fix(assistant): give the chat panel a background it never had

### DIFF
--- a/frontend/src/components/audio/FerroOrbCore.tsx
+++ b/frontend/src/components/audio/FerroOrbCore.tsx
@@ -13,7 +13,7 @@
  * Lazy-loaded (three.js must stay out of the first-paint bundle) and mounted
  * into GantasmoOrb via its coreOverlay prop, beneath the face SVG.
  */
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { EXRLoader } from 'three/addons/loaders/EXRLoader.js';
 import { createRenderGate } from '../../lib/renderGate';
@@ -31,6 +31,9 @@ const FOV = 65;
 
 const FerroOrbCore: React.FC = () => {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  // Bumped by `webglcontextrestored`. It is in this effect's deps, so a restore
+  // tears the dead scene down through the normal cleanup and builds a new one.
+  const [contextEpoch, setContextEpoch] = useState(0);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -45,15 +48,45 @@ const FerroOrbCore: React.FC = () => {
       // premultiplied canvas would darken the halo's fringe.
       renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, premultipliedAlpha: false });
     } catch {
-      // WebGL unavailable / context exhausted — the CSS gradient core beneath
-      // this overlay stays visible, so the orb still renders.
+      // WebGL unavailable, or the context budget is exhausted (the app keeps
+      // five live contexts, six once SCORE's highway mounts).
+      //
+      // This used to say the CSS gradient core beneath the overlay stayed
+      // visible "so the orb still renders". That stopped being true when the
+      // core was set to `background: transparent` (orb-kit/styles/
+      // gantasmo-orb.css) to remove the disc: with no canvas AND no core there
+      // is no orb at all, just a hole that shows the app through it — white
+      // wherever the backdrop is white, such as over SCORE's sheet.
+      //
+      // So paint the body here instead, feathered out before the rim so it
+      // never draws the hard-edged disc that was deliberately removed. This
+      // runs ONLY when there is no renderer; the normal path is untouched.
+      container.style.background =
+        'radial-gradient(circle at 50% 45%, #1a1030 0%, #0e0912 58%, rgba(14, 9, 18, 0) 78%)';
       return;
     }
     const canvas = renderer.domElement;
+    // Clear the no-WebGL fallback fill: this run has a renderer, and leaving the
+    // gradient behind a working transparent canvas would put back the disc.
+    container.style.background = '';
     canvas.style.display = 'block';
     canvas.style.width = '100%';
     canvas.style.height = '100%';
+    // preventDefault says "I intend to restore", which is only true if somebody
+    // actually rebuilds. Without the restore listener below, the render loop hit
+    // its `isContextLost()` bail and the orb stayed a transparent hole for the
+    // rest of the session — one eviction retired it permanently.
     canvas.addEventListener('webglcontextlost', (e) => e.preventDefault(), false);
+    canvas.addEventListener(
+      'webglcontextrestored',
+      () => {
+        // Bumping the epoch re-runs this effect: its cleanup disposes the dead
+        // renderer, scene, composer and observers, then setup starts again on
+        // the restored context.
+        if (!disposed) setContextEpoch((n) => n + 1);
+      },
+      false,
+    );
     container.appendChild(canvas);
 
     // Same tunables as CymaticsVisualizer's orb.
@@ -265,7 +298,7 @@ const FerroOrbCore: React.FC = () => {
       renderer.forceContextLoss();
       if (canvas.parentNode) canvas.parentNode.removeChild(canvas);
     };
-  }, []);
+  }, [contextEpoch]);
 
   return (
     <div

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,43 @@
 @theme {
   --font-sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+
+  /* The colour names orb-kit was written against.
+   *
+   * frontend/src/orb-kit/AssistantPanel.tsx and ProviderModelSelector.tsx were
+   * ported from a host whose Tailwind config defined `surface`, `border`,
+   * `primary` and `muted`. theDAW never did, so all 71 of their uses —
+   * `bg-surface/95`, `border-border`, `text-primary`, `text-muted`,
+   * `bg-primary`, `from-primary` — compiled to NOTHING. Confirmed against the
+   * shipped bundle: `.bg-surface`, `.border-border`, `.text-muted`,
+   * `.text-primary` and `.bg-primary` appear zero times in it, while
+   * `.backdrop-blur-sm` and `.shadow-2xl` on the very same element appear once
+   * each.
+   *
+   * The visible consequence: the assistant's chat panel had no fill at all. It
+   * was a bare `backdrop-filter: blur(8px)` pane, so it took the colour of
+   * whatever sat behind it. On theDAW's dark chrome that passed for deliberate
+   * dark glass, which is why it went unnoticed. Over the SCORE tab it does not:
+   * the sheet is painted white (ScoreView `[&>svg]:bg-white`, SheetStrip's
+   * `bg-white` pane), so the panel and its near-white text both went white and
+   * unreadable.
+   *
+   * The values are theDAW's OWN palette from the `:root` block below, not new
+   * colours, so the panel now matches every other panel in the app. Keep them
+   * in step with it:
+   *   surface = --panel · border = --panel-border · primary = --accent ·
+   *   muted = --text-secondary
+   * Literal hex rather than `var(--panel)` because `bg-surface/95` needs a
+   * colour Tailwind can mix an alpha into.
+   *
+   * `text-primary` is the ACCENT here, not body text — `bg-primary/20
+   * text-primary` at AssistantPanel.tsx:745 is an accent pill, and :847 uses it
+   * to emphasise a value beside a `text-muted` label. One token serves
+   * text/bg/from correctly. */
+  --color-surface: #110e1a;
+  --color-border: #231e38;
+  --color-primary: #8b5cf6;
+  --color-muted: #94a3b8;
 }
 
 /* Theme ink / border utilities (see lib/editThemes.ts + the APP THEMING block


### PR DESCRIPTION
The assistant panel and ProviderModelSelector were ported from a host whose Tailwind config defined surface/border/primary/muted. theDAW never did, so all 71 uses of bg-surface/95, border-border, text-primary, text-muted, bg-primary and from-primary compiled to nothing. Checked against the shipped bundle: .bg-surface, .border-border, .text-muted, .text-primary and .bg-primary appear zero times, while .backdrop-blur-sm and .shadow-2xl on the same element appear once each.

So the panel was a bare backdrop-filter: blur(8px) pane with no fill, showing whatever was behind it. On dark chrome that passed for deliberate dark glass. Over SCORE it does not: the sheet is painted white, so the panel and its near-white text both went white and unreadable. That is what the user saw in the exe. It is a latent bug, not a v0.1.7 regression -- bg-surface/95 dates from f473bb8.

The four tokens are theDAW's own palette from the :root block, not new colours, so the panel now matches every other panel: surface = --panel, border = --panel-border, primary = --accent, muted = --text-secondary. Verified in the built CSS: .bg-surface/95 now emits #110e1af2.

Also two failure-path bugs in the orb, from the commit that removed its disc: the WebGL-unavailable branch claimed the CSS core underneath stayed visible, which stopped being true when that core became transparent -- no canvas and no core is no orb, just a hole that goes white over a white backdrop. It now paints a feathered body, only on that branch, never drawing the rim that was deliberately removed. And webglcontextlost was preventDefault-ed with no webglcontextrestored listener, so one context eviction retired the orb for the session; a restore now rebuilds through the existing cleanup.