### PR TITLE
fix(sway, vj): name the failing hop instead of the status code

### DIFF
--- a/frontend/src/lib/apiJson.test.ts
+++ b/frontend/src/lib/apiJson.test.ts
@@ -1,0 +1,110 @@
+// Run with: npx tsx src/lib/apiJson.test.ts
+//
+// The reported symptom: the SWAY tab said "GET /api/sway/url returned HTTP
+// 502." That route never returns 502, so the status came from a hop in front
+// of the backend and meant the backend was unreachable. Seven clients share
+// this helper, so the message is fixed here once.
+import assert from 'node:assert/strict';
+import { BACKEND_UNREACHABLE, GATEWAY_TIMEOUT, UPSTREAM_UNAVAILABLE } from './httpError.ts';
+
+const res = (body: string, status: number, headers: Record<string, string> = {}): Response =>
+  new Response(body, { status, headers });
+
+// The helper is module-private, so exercise it through the exported getJson
+// with a stubbed fetch — the same path every caller takes.
+const withFetch = async (response: Response, run: () => Promise<unknown>): Promise<string> => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => response) as typeof fetch;
+  try {
+    await run();
+    return '<no error thrown>';
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  } finally {
+    globalThis.fetch = original;
+  }
+};
+
+const { getJson, postJson } = await import('./apiJson.ts');
+
+// A bare 502 from a proxy: names the failing hop instead of the status.
+{
+  const msg = await withFetch(res('Bad Gateway', 502), () => getJson('/api/sway/url'));
+  assert.equal(msg, `${BACKEND_UNREACHABLE} (Bad Gateway)`, msg);
+  assert.ok(!msg.includes('HTTP 502'), msg);
+}
+
+// An empty 502 body still explains itself.
+{
+  const msg = await withFetch(res('', 502), () => getJson('/api/vj/url'));
+  assert.equal(msg, BACKEND_UNREACHABLE, msg);
+}
+
+// 503 is the backend answering about a hop it does not own — a different
+// problem with a different fix, and it must not read as "backend is down".
+{
+  const msg = await withFetch(res('', 503), () => getJson('/api/x'));
+  assert.equal(msg, UPSTREAM_UNAVAILABLE, msg);
+  assert.notEqual(msg, BACKEND_UNREACHABLE);
+}
+
+// 504 is its own case.
+{
+  const msg = await withFetch(res('', 504), () => getJson('/api/x'));
+  assert.equal(msg, GATEWAY_TIMEOUT, msg);
+}
+
+// A FastAPI `detail` is a real answer from a real route, so it wins outright —
+// including on a 502 a router raised itself about an upstream call.
+{
+  const msg = await withFetch(
+    res(JSON.stringify({ detail: 'The cockpit build is not staged.' }), 502),
+    () => getJson('/api/sway/url'),
+  );
+  assert.equal(msg, 'The cockpit build is not staged.', msg);
+}
+
+// This app's own non-standard {error: "..."} bodies are still surfaced.
+{
+  const msg = await withFetch(res(JSON.stringify({ error: 'plugin scan failed' }), 500), () =>
+    getJson('/api/plugin/list'),
+  );
+  assert.equal(msg, 'plugin scan failed', msg);
+}
+
+// `error` wins over a generic status, and an empty `error` does not.
+{
+  const msg = await withFetch(res(JSON.stringify({ error: '   ' }), 500), () => getJson('/api/x'));
+  assert.ok(!msg.includes('   '), msg);
+  assert.ok(msg.length > 0);
+}
+
+// The Vite HTML fallback is markup, not a message, and must never be pasted
+// into the UI.
+{
+  const msg = await withFetch(res('<!doctype html><html><body>404</body></html>', 502), () =>
+    getJson('/api/x'),
+  );
+  assert.equal(msg, BACKEND_UNREACHABLE, msg);
+  assert.ok(!msg.includes('<'), msg);
+}
+
+// A 4xx with a plain-text body keeps the body: it is the server's own words.
+{
+  const msg = await withFetch(res('entry not found', 404), () => getJson('/api/x'));
+  assert.equal(msg, 'entry not found', msg);
+}
+
+// postJson shares the same path.
+{
+  const msg = await withFetch(res('Bad Gateway', 502), () => postJson('/api/x', { a: 1 }));
+  assert.equal(msg, `${BACKEND_UNREACHABLE} (Bad Gateway)`, msg);
+}
+
+// Reading the body twice would throw "body already read"; the helper clones.
+{
+  const msg = await withFetch(res(JSON.stringify({ error: 'once' }), 500), () => getJson('/api/x'));
+  assert.equal(msg, 'once', msg);
+}
+
+console.log('apiJson tests passed');

--- a/frontend/src/lib/apiJson.ts
+++ b/frontend/src/lib/apiJson.ts
@@ -25,8 +25,10 @@ async function handle<T>(r: Response): Promise<T> {
 async function describeApiError(r: Response): Promise<string> {
   const body = await r.clone().text();
   try {
-    const parsed = JSON.parse(body) as { error?: unknown };
-    if (typeof parsed.error === 'string' && parsed.error.trim()) return parsed.error.trim();
+    const parsed = JSON.parse(body) as { detail?: unknown; error?: unknown };
+    const hasDetail =
+      (typeof parsed.detail === 'string' && Boolean(parsed.detail.trim())) || Array.isArray(parsed.detail);
+    if (!hasDetail && typeof parsed.error === 'string' && parsed.error.trim()) return parsed.error.trim();
   } catch {
     /* not JSON, or no `error` key: fall through to the shared description */
   }

--- a/frontend/src/lib/apiJson.ts
+++ b/frontend/src/lib/apiJson.ts
@@ -2,20 +2,35 @@
 // Every backend route lives behind the Vite /api proxy (-> :8600), so URLs
 // are relative. Errors surface the FastAPI {detail} (or {error}) field.
 
+import { describeHttpError } from './httpError';
+
 async function handle<T>(r: Response): Promise<T> {
   if (!r.ok) {
-    let detail = `HTTP ${r.status}`;
-    try {
-      const j = (await r.json()) as { detail?: unknown; error?: unknown };
-      if (typeof j.detail === 'string') detail = j.detail;
-      else if (typeof j.error === 'string') detail = j.error;
-    } catch {
-      // Non-JSON body (e.g. the Vite HTML fallback when the backend is down).
-      detail = `${detail} — is the backend running on port 8600?`;
-    }
-    throw new Error(detail);
+    // describeHttpError reads the body once, prefers a FastAPI `detail`, and
+    // for 502/503/504 says WHICH hop failed -- theDAW's own backend, or the
+    // service behind it. Those are different problems with different fixes,
+    // and the previous version collapsed them: a non-JSON body (which is what
+    // a proxy sends when the backend is unreachable) produced
+    // `HTTP 502 - is the backend running on port 8600?` for a Hub timeout just
+    // as readily as for a dead backend.
+    //
+    // `error` is read here as well as `detail` because a few of this app's own
+    // routes answer with that key.
+    throw new Error(await describeApiError(r));
   }
   return (await r.json()) as T;
+}
+
+/** `describeHttpError`, plus this app's non-standard `{error: "..."}` bodies. */
+async function describeApiError(r: Response): Promise<string> {
+  const body = await r.clone().text();
+  try {
+    const parsed = JSON.parse(body) as { error?: unknown };
+    if (typeof parsed.error === 'string' && parsed.error.trim()) return parsed.error.trim();
+  } catch {
+    /* not JSON, or no `error` key: fall through to the shared description */
+  }
+  return describeHttpError(r);
 }
 
 export async function getJson<T>(url: string): Promise<T> {

--- a/frontend/src/views/SwayView.tsx
+++ b/frontend/src/views/SwayView.tsx
@@ -33,6 +33,7 @@ import { AlertTriangle, RefreshCw, Waves } from 'lucide-react';
 import { subscribeToMidi } from '../state/midiBus';
 import { getAnalyser } from '../state/playerStore';
 import { logInfo, logWarn } from '../state/logStore';
+import { describeHttpError } from '../lib/httpError';
 import { useMidiDevicesStore } from '../state/midiDevicesStore';
 import { useMidiTriggerStore } from '../state/midiTriggerStore';
 
@@ -126,7 +127,12 @@ export const SwayView: React.FC = () => {
       const res = await fetch('/api/sway/url');
       if (!res.ok) {
         setEmbedState('error');
-        setDetail(`GET /api/sway/url returned HTTP ${res.status}.`);
+        // "GET /api/sway/url returned HTTP 502." named the request and hid the
+        // cause. /api/sway/url never returns 502 -- that status comes from a
+        // hop in FRONT of the backend (the packaged app's proxy, or Vite's),
+        // meaning the backend was unreachable rather than the cockpit missing.
+        // describeHttpError says which hop failed and what to do about it.
+        setDetail(await describeHttpError(res));
         return;
       }
       const data = (await res.json()) as SwayUrlResponse;

--- a/frontend/src/views/VJView.tsx
+++ b/frontend/src/views/VJView.tsx
@@ -22,6 +22,7 @@ import { getAnalyser } from '../state/playerStore';
 import { usePlayerStore } from '../state/playerStore';
 import { useLibraryStore } from '../state/libraryStore';
 import { subscribeToMidi } from '../state/midiBus';
+import { describeHttpError } from '../lib/httpError';
 import { useMidiTriggerStore } from '../state/midiTriggerStore';
 import { getVjPlaybackState, registerVjPlaybackHandler, reportVjPlaybackState } from '../state/vjPlaybackBus';
 import { registerVjSetHandler, sendTrackToVj } from '../state/vjSetBus';
@@ -335,7 +336,10 @@ export const VJView: React.FC = () => {
     setStatus('loading');
     try {
       const r = await fetch('/api/vj/url');
-      if (!r.ok) throw new Error(`backend returned ${r.status}`);
+      // `backend returned 502` hid the cause: /api/vj/url never returns 502,
+      // so that status comes from a hop in FRONT of the backend and means the
+      // backend was unreachable, not that the VJ build is missing.
+      if (!r.ok) throw new Error(await describeHttpError(r));
       const j = (await r.json()) as {
         url: string;
         mode?: string;


### PR DESCRIPTION
The SWAY tab reported "GET /api/sway/url returned HTTP 502." That route never returns 502 (backend/modules/sway/router.py answers 200 with url: null and a reason when no cockpit build is staged), so the status came from a hop in FRONT of the backend -- the packaged app's proxy or Vite's -- and meant the backend was unreachable, not that the cockpit was missing. The message named the request and hid the cause. VJView had the same shape with "backend returned 502".

Both now use describeHttpError, which prefers a FastAPI detail and otherwise says which hop failed and what to do.

lib/apiJson.ts, shared by the vst, dawimport, project, gan, tour, lyric document and lyric analysis clients, had the same defect in its own words: any non-JSON body produced "HTTP 502 - is the backend running on port 8600?", which is right for a dead backend and wrong for every upstream failure that happens to arrive without JSON. It goes through the same helper now, keeping this app's non-standard {error: "..."} bodies, which describeHttpError does not know about.

Tests cover the case that was reported (a bare 502 from a proxy), 503 and 504 staying distinct from it, a FastAPI detail winning outright, an {error} body surviving, and the Vite HTML fallback never reaching the UI.