### PR TITLE
fix(desktop): install to Program Files and the app still starts

### DIFF
--- a/backend/key_pool.py
+++ b/backend/key_pool.py
@@ -12,13 +12,12 @@ import logging
 import os
 import threading
 import time
-from pathlib import Path
 from typing import Optional
+from backend.lib import paths
 
 logger = logging.getLogger(__name__)
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-POOL_FILE = PROJECT_ROOT / "data" / "api_key_pools.json"
+POOL_FILE = paths.data_path("api_key_pools.json")
 
 SHORT_COOLDOWN = 60.0
 EXTENDED_COOLDOWN = 300.0

--- a/backend/lib/paths.py
+++ b/backend/lib/paths.py
@@ -1,0 +1,88 @@
+"""Where the backend is allowed to write.
+
+Everything the app persists — settings, registries, caches, the library,
+sidecar logs — lives under ONE root. That root is ``<project>/data`` in a dev
+checkout and in a per-user install, which is where the tree has always been.
+
+A packaged install can also land somewhere read-only. electron-builder.yml
+sets ``allowToChangeInstallationDirectory``, so a user can install into
+``C:/Program Files/theDAW``, and then nothing may be created beside the app:
+the first ``/api/settings`` call answered 500 because ``SettingsStore`` tried
+to ``mkdir <install>/data``. The desktop launcher probes the install directory
+and, when it cannot write there, points ``theDAW_DATA_DIR`` at a per-user
+directory (``getWritableRuntimeDir`` in ``electron-ui/main/index.ts``).
+
+So: **never compose ``PROJECT_ROOT / "data"`` directly.** Go through
+``data_path()`` / ``ensure_data_dir()`` and the whole tree relocates together.
+Read-only assets that ship with the app (docs, ``frontend/dist``, sidecar
+sources, bundled plugin assets) stay addressed from ``PROJECT_ROOT`` — those
+are install-directory *reads*, which work everywhere.
+
+The environment is read on every call, never cached, so a test that
+monkeypatches ``theDAW_DATA_DIR`` takes effect without reimporting anything.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+__all__ = [
+    "PROJECT_ROOT",
+    "data_dir",
+    "data_path",
+    "ensure_data_dir",
+    "is_relocated",
+    "library_root",
+    "rag_index_dir",
+]
+
+# backend/lib/paths.py -> parents[2] == the repo / install root.
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def is_relocated() -> bool:
+    """True when the writable data tree lives outside the install directory."""
+    return bool(os.getenv("theDAW_DATA_DIR"))
+
+
+def data_dir() -> Path:
+    """Root of the writable data tree. ``theDAW_DATA_DIR`` wins."""
+    configured = os.getenv("theDAW_DATA_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return PROJECT_ROOT / "data"
+
+
+def data_path(*parts: str) -> Path:
+    """``data_dir()`` joined with ``parts``. Does not create anything."""
+    return data_dir().joinpath(*parts)
+
+
+def ensure_data_dir(*parts: str) -> Path:
+    """``data_path(*parts)``, created (with parents) if it does not exist."""
+    d = data_path(*parts)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def library_root() -> Path:
+    """The generations/library tree. ``theDAW_GENERATIONS_DIR`` wins — that is
+    the user-facing knob for putting the audio library on another drive."""
+    configured = os.getenv("theDAW_GENERATIONS_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return data_path("generations")
+
+
+def rag_index_dir() -> Path:
+    """The assistant's chroma index. Written at runtime (the index is rebuilt
+    whenever the docs hash changes), so it follows the writable root when the
+    install directory is read-only; otherwise it stays at its historical
+    ``backend/rag_index`` so existing installs do not re-embed for nothing."""
+    configured = os.getenv("theDAW_RAG_INDEX_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    if is_relocated():
+        return data_path("rag_index")
+    return PROJECT_ROOT / "backend" / "rag_index"

--- a/backend/modules/backup/service.py
+++ b/backend/modules/backup/service.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator, Optional
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -82,15 +83,8 @@ class RootSpec:
 
 def user_data_roots() -> list[RootSpec]:
     """Every user-data root worth backing up, in a stable order."""
-    data_dir = PROJECT_ROOT / "data"
-    # Mirrors backend.modules.library.store.default_library_root without
-    # importing the library module (keeps this module import-light).
-    configured = os.getenv("theDAW_GENERATIONS_DIR")
-    library_path = (
-        Path(configured).expanduser().resolve()
-        if configured
-        else data_dir / "generations"
-    )
+    data_dir = paths.data_dir()
+    library_path = paths.library_root()
     return [
         RootSpec(
             id="library",

--- a/backend/modules/chimera/analysis.py
+++ b/backend/modules/chimera/analysis.py
@@ -33,6 +33,7 @@ from backend.lib.atomic import atomic_replace
 from backend.modules.chimera import structure, tempo
 from backend.modules.chimera.detect import detect_tempo_and_beats
 from backend.modules.chimera.types import BarFeature, BeatGrid, ClipAnalysis, Phrase
+from backend.lib import paths
 
 __all__ = [
     "CACHE_DIR",
@@ -52,7 +53,7 @@ __all__ = [
 
 log = logging.getLogger(__name__)
 
-CACHE_DIR = Path(__file__).resolve().parents[3] / "data" / "cache" / "chimera"
+CACHE_DIR = paths.data_path("cache", "chimera")
 CACHE_VERSION = 2
 ANALYSIS_SR = 22050
 DEFAULT_PHRASE_BARS = 8

--- a/backend/modules/foundry/sidecar.py
+++ b/backend/modules/foundry/sidecar.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
 from typing import Optional
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -45,8 +46,7 @@ PORT_POLL_INTERVAL_SEC = 0.5
 # output to a logfile instead of DEVNULL so a spawn that dies (missing dep,
 # bad package.json script) leaves a trail the /url and /status endpoints can
 # surface, instead of vanishing into a vague timeout.
-_REPO_ROOT = Path(__file__).resolve().parents[3]
-_LOG_PATH = _REPO_ROOT / "data" / "logs" / "foundry-sidecar.log"
+_LOG_PATH = paths.data_path("logs", "foundry-sidecar.log")
 
 
 @dataclass(frozen=True)

--- a/backend/modules/library/router.py
+++ b/backend/modules/library/router.py
@@ -39,6 +39,7 @@ from pydantic import BaseModel
 from .bundle import build_bundle_bytes
 from .store import AUDIO_EXTS, LibraryStore, _read_metadata, default_library_root
 from .tags import MAX_EMBEDDED_COVER_BYTES
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -49,8 +50,7 @@ _store: Optional[LibraryStore] = None
 def get_store() -> LibraryStore:
     global _store
     if _store is None:
-        project_root = Path(__file__).resolve().parents[3]
-        _store = LibraryStore(default_library_root(project_root))
+        _store = LibraryStore(default_library_root())
     return _store
 
 
@@ -522,11 +522,10 @@ _PERF_SETS_DIRNAME = "performance-sets"
 
 
 def _perf_sets_root() -> Path:
-    """`<project>/data/performance-sets/` — where external set builders
+    """`<data>/performance-sets/` — where external set builders
     (Z-AutoDJ) drop prepared sets: one folder per set containing the audio
     files plus a `performance.json` timeline."""
-    project_root = Path(__file__).resolve().parents[3]
-    return project_root / "data" / _PERF_SETS_DIRNAME
+    return paths.data_path(_PERF_SETS_DIRNAME)
 
 
 def _load_perf_set(store: LibraryStore, set_dir: Path) -> Optional[dict[str, Any]]:

--- a/backend/modules/library/store.py
+++ b/backend/modules/library/store.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import shutil
 import time
 import uuid
@@ -31,6 +30,7 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 from .db import LibraryDB
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -128,13 +128,12 @@ class LibraryRecord:
         }
 
 
-def default_library_root(project_root: Path) -> Path:
-    """Resolve the library root path. Env override wins; otherwise it lives
-    alongside the existing generate artifacts so old data is picked up."""
-    configured = os.getenv("theDAW_GENERATIONS_DIR")
-    if configured:
-        return Path(configured).expanduser().resolve()
-    return project_root / "data" / "generations"
+def default_library_root() -> Path:
+    """Resolve the library root path. ``theDAW_GENERATIONS_DIR`` wins;
+    otherwise it lives alongside the existing generate artifacts, under the
+    writable data root (which is NOT the install directory when that is
+    read-only — see backend.lib.paths)."""
+    return paths.library_root()
 
 
 def _audio_url_for(api_prefix: str, entry_id: str) -> str:

--- a/backend/modules/lyria/sidecar.py
+++ b/backend/modules/lyria/sidecar.py
@@ -59,6 +59,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
 from typing import IO, Iterator, Optional
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -96,7 +97,7 @@ NPM_INSTALL_TIMEOUT_SEC = 600.0
 
 # Child-process output (npm install, the Express/tsx server) lands here so
 # failures are diagnosable rather than vanishing into DEVNULL.
-SIDECAR_LOG_PATH = _REPO_ROOT / "data" / "logs" / "lyria-sidecar.log"
+SIDECAR_LOG_PATH = paths.data_path("logs", "lyria-sidecar.log")
 
 # The upstream project the sidecar embeds (module.json / the docstrings name
 # it as StarskreamEXE/lyria-3-pro). ``start_install`` clones exactly this.
@@ -107,7 +108,7 @@ GIT_CLONE_TIMEOUT_SEC = 900.0
 # The GEMINI_API_KEY theDAW hands the child (see _child_env). Env wins, then
 # this file (POST /api/lyria/key), then the assistant's Gemini key pool so a
 # key pasted for the assistant serves Lyria too.
-_GEMINI_KEY_FILE = _REPO_ROOT / "data" / "lyria_gemini_key.json"
+_GEMINI_KEY_FILE = paths.data_path("lyria_gemini_key.json")
 
 
 @contextmanager

--- a/backend/modules/lyricanalysis/documents.py
+++ b/backend/modules/lyricanalysis/documents.py
@@ -45,6 +45,7 @@ from .schema import (
     Span,
     UpdateLyricDocumentRequest,
 )
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -84,12 +85,11 @@ MAX_REANCHOR_SHIFT = 16
 
 
 def documents_dir() -> Path:
-    """``<project>/data/lyric-documents``; ``theDAW_LYRIC_DOCS_DIR`` wins."""
+    """``<data>/lyric-documents``; ``theDAW_LYRIC_DOCS_DIR`` wins."""
     configured = os.getenv("theDAW_LYRIC_DOCS_DIR")
     if configured:
         return Path(configured).expanduser().resolve()
-    project_root = Path(__file__).resolve().parents[3]
-    return project_root / "data" / DIRNAME
+    return paths.data_path(DIRNAME)
 
 
 def new_id() -> str:

--- a/backend/modules/magenta/sidecar.py
+++ b/backend/modules/magenta/sidecar.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 import httpx
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +103,7 @@ _INSTALLER = _REPO_ROOT / "sidecars" / "magenta-rt2-nvidia" / "Setup-MRT2.bat"
 # Env default for the engine model; the in-app pick (``set_engine_model``) is
 # persisted in _MODEL_FILE and outranks it, see ``engine_model``.
 _ENGINE_MODEL = os.getenv("THEDAW_MAGENTA_MODEL", "mrt2_small")
-_MODEL_FILE = _REPO_ROOT / "data" / "magenta_engine.json"
+_MODEL_FILE = paths.data_path("magenta_engine.json")
 _WSL_PYTHON = os.getenv("THEDAW_MAGENTA_WSL_PY", "~/mrt2/.venv/bin/python")
 # Native engine interpreter for Linux/macOS auto-spawn (Windows uses WSL). On
 # Linux this is the CUDA JAX venv; on macOS the magenta-rt[mlx] venv. The
@@ -115,7 +116,7 @@ _ENGINE_PKILL_PATTERN = "sidecars/magenta/server.py|studio_server.py"
 # ``mrt checkpoints download`` write here; the engine loads from here).
 _ASSETS_DIR = "~/Documents/Magenta/magenta-rt-v2"
 _CHECKPOINTS_DIR = f"{_ASSETS_DIR}/checkpoints"
-_LOG_DIR = _REPO_ROOT / "logs"
+_LOG_DIR = paths.data_path("logs")
 
 # ── the model catalog ───────────────────────────────────────────────────────
 #

--- a/backend/modules/plugin/router.py
+++ b/backend/modules/plugin/router.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 
 from backend.modules.plugin.gan_file import GanFile
 from backend.modules.plugin.owl_import import import_vst_foundry, source_fingerprint
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ router = APIRouter()
 
 # Repo-root anchored, so it resolves regardless of the process CWD.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
-GAN_DIR = _REPO_ROOT / "data" / "plugins"
+GAN_DIR = paths.data_path("plugins")
 RUNTIME_DIR = GAN_DIR / "_runtime"
 
 # In-repo source for the bundled "The Owl" plugin (the sidecar .gan).

--- a/backend/modules/project/media_access.py
+++ b/backend/modules/project/media_access.py
@@ -31,11 +31,12 @@ import os
 import tempfile
 from collections.abc import Iterable
 from pathlib import Path
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
-_ROOTS_STATE = _PROJECT_ROOT / "data" / "media_roots.json"
+_ROOTS_STATE = paths.data_path("media_roots.json")
 
 # A session root is remembered per opened project; the cap keeps a long-lived
 # install from accumulating an unbounded allowlist.
@@ -72,11 +73,12 @@ def _static_roots() -> list[Path]:
     roots: list[Path] = []
 
     # The library/generations tree, wherever the user pointed it.
-    configured = os.getenv("theDAW_GENERATIONS_DIR")
-    if configured:
-        roots.append(Path(configured).expanduser())
-    # data/ holds the default generations dir plus uploads, bundles and the
-    # media folders .tasmo archives extract into.
+    roots.append(paths.library_root())
+    # The data tree holds the default generations dir plus uploads, bundles
+    # and the media folders .tasmo archives extract into. Both the writable
+    # root and the in-install one: they differ when the install directory is
+    # read-only, and content that shipped with the app still reads fine.
+    roots.append(paths.data_dir())
     roots.append(_PROJECT_ROOT / "data")
     roots.append(Path(tempfile.gettempdir()) / "thedaw_transcode")
     roots.append(Path.home() / "Documents" / "theDAW Projects")

--- a/backend/modules/project/router.py
+++ b/backend/modules/project/router.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from backend.modules.project import media_access
 from backend.modules.project.tasmo_project import TasmoProject
 from backend.modules.project.tasmo_file import TasmoFile
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 router = APIRouter()
@@ -56,7 +57,7 @@ _AUDIO_EXTS = _BROWSER_OK_EXTS | _TRANSCODE_EXTS
 
 
 # --- Recent files tracking (in-memory, mirrored to disk so it survives restarts) ---
-_RECENT_PATH = Path(__file__).resolve().parents[3] / "data" / "recent_projects.json"
+_RECENT_PATH = paths.data_path("recent_projects.json")
 MAX_RECENT = 20
 
 

--- a/backend/modules/quest/service.py
+++ b/backend/modules/quest/service.py
@@ -24,11 +24,11 @@ from typing import Optional
 import httpx
 
 from backend.lib.atomic import atomic_replace
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
-_CONFIG_PATH = PROJECT_ROOT / "data" / "quest.json"
+_CONFIG_PATH = paths.data_path("quest.json")
 
 # theDAW-XR publishes the prebuilt Quest APK as a GitHub release asset; the
 # deploy dialog can pull the newest one instead of requiring a local build.
@@ -37,7 +37,7 @@ _XR_LATEST_URL = f"https://api.github.com/repos/{_XR_REPO_SLUG}/releases/latest"
 _HTTP_TIMEOUT_S = 8.0
 # The APK is ~150 MB; allow a slow connection to finish.
 _DOWNLOAD_TIMEOUT_S = 600.0
-_APK_DIR = PROJECT_ROOT / "data" / "quest"
+_APK_DIR = paths.data_path("quest")
 
 _EXE = "adb.exe" if os.name == "nt" else "adb"
 

--- a/backend/modules/rhythm/router.py
+++ b/backend/modules/rhythm/router.py
@@ -28,14 +28,13 @@ from pydantic import BaseModel
 from backend.lib.atomic import atomic_write
 
 from .engine import RHYTHM_VERSION, analyze_file
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Repo-root anchored, so it resolves regardless of the process CWD.
-_REPO_ROOT = Path(__file__).resolve().parents[3]
-CACHE_DIR = _REPO_ROOT / "data" / "rhythm"
+CACHE_DIR = paths.data_path("rhythm")
 
 
 def _cache_path(entry_id: str) -> Path:

--- a/backend/modules/settings/router.py
+++ b/backend/modules/settings/router.py
@@ -14,7 +14,6 @@ newer or older shape than the backend knows about.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any, Optional
 
 from fastapi import APIRouter, Body
@@ -30,8 +29,7 @@ _store: Optional[SettingsStore] = None
 def get_store() -> SettingsStore:
     global _store
     if _store is None:
-        project_root = Path(__file__).resolve().parents[3]
-        _store = SettingsStore(default_settings_path(project_root))
+        _store = SettingsStore(default_settings_path())
     return _store
 
 

--- a/backend/modules/settings/store.py
+++ b/backend/modules/settings/store.py
@@ -19,6 +19,7 @@ import threading
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -150,13 +151,15 @@ DEFAULT_SETTINGS: dict[str, Any] = {
 }
 
 
-def default_settings_path(project_root: Path) -> Path:
-    """Resolve the settings file path. Env override wins; otherwise it lives
-    next to the library generations directory."""
+def default_settings_path() -> Path:
+    """Resolve the settings file path. ``theDAW_SETTINGS_PATH`` wins;
+    otherwise it sits at the root of the writable data tree (which is NOT
+    the install directory when that is read-only — see
+    backend.lib.paths)."""
     configured = os.getenv("theDAW_SETTINGS_PATH")
     if configured:
         return Path(configured).expanduser().resolve()
-    return project_root / "data" / "settings.json"
+    return paths.data_path("settings.json")
 
 
 def _merge_defaults(payload: dict[str, Any]) -> dict[str, Any]:

--- a/backend/modules/storage/router.py
+++ b/backend/modules/storage/router.py
@@ -42,7 +42,8 @@ from stable_audio_3.model_configs import (
     rf_models,
 )
 
-from .store import PROJECT_ROOT, get_registry
+from .store import get_registry
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -184,9 +185,9 @@ def _windows_locations() -> list[tuple[str, str, Path]]:
         (
             "generations",
             "Generated audio library",
-            PROJECT_ROOT / "data" / "generations",
+            paths.library_root(),
         ),
-        ("rag-index", "Assistant RAG index", PROJECT_ROOT / "backend" / "rag_index"),
+        ("rag-index", "Assistant RAG index", paths.rag_index_dir()),
         (
             "torch-cache",
             "Torch hub cache (Demucs, MIDI models)",

--- a/backend/modules/storage/store.py
+++ b/backend/modules/storage/store.py
@@ -28,11 +28,11 @@ from pathlib import Path
 from typing import Any
 
 from stable_audio_3.model_configs import resolve_local_checkpoint
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
-REGISTRY_PATH = PROJECT_ROOT / "data" / "local_checkpoints.json"
+REGISTRY_PATH = paths.data_path("local_checkpoints.json")
 
 _DEFAULT: dict[str, Any] = {"local_only": True, "checkpoints": []}
 

--- a/backend/modules/suno/router.py
+++ b/backend/modules/suno/router.py
@@ -42,6 +42,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 
 from backend.lib.atomic import atomic_replace
+from backend.lib import paths
 
 router = APIRouter()
 
@@ -55,8 +56,6 @@ _ALLOWED_AUDIO_HOSTS = frozenset(
 )
 log = logging.getLogger(__name__)
 
-# backend/modules/suno/router.py -> parents[3] == theDAW repo root
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
 _DEFAULT_BASE = "https://api.suno.com"
 
 # Three preset voices provided by the hackathon API.
@@ -85,9 +84,7 @@ PRESET_VOICES = [
 
 
 def _data_dir() -> Path:
-    d = PROJECT_ROOT / "data"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+    return paths.ensure_data_dir()
 
 
 def _key_file() -> Path:

--- a/backend/modules/sway/router.py
+++ b/backend/modules/sway/router.py
@@ -33,11 +33,12 @@ from pydantic import BaseModel
 from backend.modules.project import media_access
 
 from . import sidecar
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 router = APIRouter()
 
-_PROJECTS_DIR = sidecar._REPO_ROOT / "data" / "sway-projects"
+_PROJECTS_DIR = paths.data_path("sway-projects")
 
 _template_media_registered = False
 

--- a/backend/modules/tour/discovery.py
+++ b/backend/modules/tour/discovery.py
@@ -20,6 +20,7 @@ from typing import Any, Optional
 import httpx
 
 from .vocab import annotate
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -57,8 +58,6 @@ _PLACE_TYPES = {
 # 20-30-50-100-500 mile radii before jumping 200 miles away".
 _RING_BOUNDS_MI = (50.0, 120.0, 250.0, 500.0)
 
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
-
 # Serialize + space out calls per provider (module-level: one backend process).
 _nominatim_lock = asyncio.Lock()
 _overpass_lock = asyncio.Lock()
@@ -67,9 +66,7 @@ _MIN_GAP_SEC = {"nominatim": 1.1, "overpass": 2.0}
 
 
 def _cache_dir() -> Path:
-    d = PROJECT_ROOT / "data" / "tour_cache"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+    return paths.ensure_data_dir("tour_cache")
 
 
 def _cache_get(name: str, ttl: int) -> Optional[Any]:

--- a/backend/modules/tour/router.py
+++ b/backend/modules/tour/router.py
@@ -27,12 +27,11 @@ from pydantic import BaseModel
 
 from . import discovery, enrich, routing
 from .vocab import GENRES, VIBES
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["tour"])
-
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 # Key registry: env var name -> short id used in /status + /config payloads.
 # ORS (openrouteservice) backs /route until/unless a self-hosted VROOM ships;
@@ -45,9 +44,7 @@ _KEYS = {
 
 
 def _data_dir() -> Path:
-    d = PROJECT_ROOT / "data"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+    return paths.ensure_data_dir()
 
 
 def _key_file() -> Path:

--- a/backend/modules/underfit/sidecar.py
+++ b/backend/modules/underfit/sidecar.py
@@ -39,6 +39,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock, Thread
 from typing import Optional
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ PORT_READY_TIMEOUT_SEC = 30.0
 PORT_POLL_INTERVAL_SEC = 0.5
 # Child stdout/stderr land here so a spawn that dies (missing venv dep,
 # port clash, traceback) can be diagnosed instead of vanishing.
-LOG_PATH = _REPO_ROOT / "data" / "underfit-sidecar.log"
+LOG_PATH = paths.data_path("underfit-sidecar.log")
 
 
 @dataclass

--- a/backend/modules/underfit/updater.py
+++ b/backend/modules/underfit/updater.py
@@ -28,6 +28,7 @@ from threading import Lock
 from typing import Optional
 
 from . import sidecar
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _PREFIX = "underfit"
 _SUBREPO_DIR = _REPO_ROOT / _PREFIX
 _GITREPO = _SUBREPO_DIR / ".gitrepo"
-_STATE = _REPO_ROOT / "data" / "underfit_update.json"
+_STATE = paths.data_path("underfit_update.json")
 _DEFAULT_REMOTE = "https://github.com/dada-bots/underfit.git"
 _DEFAULT_BRANCH = "main"
 _CHECK_TTL = 900  # 15 min — don't poll the network more often than this

--- a/backend/modules/updates/router.py
+++ b/backend/modules/updates/router.py
@@ -44,6 +44,7 @@ import httpx
 from fastapi import APIRouter, HTTPException
 
 from backend._update_sync import UPDATE_EXIT_CODE, run_dependency_sync
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ router = APIRouter()
 # backend/modules/updates/router.py -> parents[3] == repo root.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _PYPROJECT_PATH = _REPO_ROOT / "pyproject.toml"
-_CACHE_PATH = _REPO_ROOT / "data" / "updates_check.json"
+_CACHE_PATH = paths.data_path("updates_check.json")
 
 _REPO_SLUG = "gantasmo/theDAW"
 _RELEASES_URL = f"https://api.github.com/repos/{_REPO_SLUG}/releases"

--- a/backend/modules/vj/export.py
+++ b/backend/modules/vj/export.py
@@ -28,10 +28,11 @@ import time
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
-# Resolved against the project root for a relative ``export_root``.
+# Resolved against the writable data root for a relative ``export_root``.
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
@@ -118,11 +119,13 @@ SUPPORTED_CODECS = (*_VIDEO_CODECS.keys(), "pngseq")
 def resolve_export_dir(export_root: str, subfolder: str) -> Path:
     """Resolve ``<export_root>/<subfolder>`` into an absolute directory,
     creating it. A relative ``export_root`` resolves against the project
-    root. ``subfolder`` is sanitised so it can never escape the root.
+    root, or against the writable data root when the install directory is
+    read-only. ``subfolder`` is sanitised so it can never escape the root.
     """
     root = Path(export_root.strip() or "exports/vj").expanduser()
     if not root.is_absolute():
-        root = _PROJECT_ROOT / root
+        base = paths.data_dir() if paths.is_relocated() else _PROJECT_ROOT
+        root = base / root
     root = root.resolve()
 
     safe = _sanitize_subfolder(subfolder)

--- a/backend/modules/vj/sidecar.py
+++ b/backend/modules/vj/sidecar.py
@@ -56,6 +56,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
 from typing import IO, Iterator, Optional
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +103,7 @@ NPM_INSTALL_TIMEOUT_SEC = 600.0
 # Child-process output (npm install, vite dev/preview) lands here so failures
 # are diagnosable; previously it went to DEVNULL and a server that died before
 # ready reported only "exited (rc=1)" with no cause anywhere.
-SIDECAR_LOG_PATH = _REPO_ROOT / "data" / "logs" / "vj-sidecar.log"
+SIDECAR_LOG_PATH = paths.data_path("logs", "vj-sidecar.log")
 
 
 @contextmanager

--- a/backend/modules/vst/router.py
+++ b/backend/modules/vst/router.py
@@ -35,12 +35,13 @@ from backend.modules.vst.host import (
     process_with_plugin,
     list_builtin_effects,
 )
+from backend.lib import paths
 
 log = logging.getLogger(__name__)
 router = APIRouter()
 
 # Per-plugin captured editor state (from the native-GUI sidecar) lands here.
-_PRESET_DIR = Path(__file__).resolve().parents[3] / "data" / "vst_presets"
+_PRESET_DIR = paths.data_path("vst_presets")
 
 # Editor sidecars spawned by this process, so a crashed editor can be detected
 # instead of leaving the frontend polling a status that will never change.

--- a/backend/rag.py
+++ b/backend/rag.py
@@ -12,11 +12,12 @@ import re
 import threading
 from pathlib import Path
 from typing import Optional
+from backend.lib import paths
 
 logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-RAG_INDEX_DIR = PROJECT_ROOT / "backend" / "rag_index"
+RAG_INDEX_DIR = paths.rag_index_dir()
 
 DOC_PATHS = [
     PROJECT_ROOT / "CLAUDE.md",

--- a/backend/server.py
+++ b/backend/server.py
@@ -35,6 +35,7 @@ from backend.admin_routes import router as admin_router
 from backend.lib.audio_io import load_audio, load_audio_array, save_audio, save_subtype
 from backend.assistant_routes import router as assistant_router
 from backend.modules.loader import load_modules
+from backend.lib import paths
 
 # Heavy imports (torch, torchaudio, matplotlib, and the stable_audio_3 model
 # graph) total ~9.6s and are deliberately kept OFF module scope so uvicorn binds
@@ -440,12 +441,7 @@ def _condense_filename_text(text: str | None, fallback: str = "_") -> str:
 
 def _get_generation_artifacts_root() -> Path:
     """Return the local folder where generated audio + spectrograms are saved."""
-    configured = os.getenv("theDAW_GENERATIONS_DIR")
-    return (
-        Path(configured).expanduser().resolve()
-        if configured
-        else PROJECT_ROOT / "data" / "generations"
-    )
+    return paths.library_root()
 
 
 def _safe_filename(filename: str | None, fallback: str = "output.wav") -> str:

--- a/electron-ui/main/index.ts
+++ b/electron-ui/main/index.ts
@@ -96,15 +96,84 @@ const SHUTDOWN_URL = `${BACKEND_BASE}/api/admin/shutdown`
 // Packaged-app paths + first-run bootstrap
 //
 // In a packaged build the Python project, a bundled uv.exe, and ffmpeg.exe ship
-// under process.resourcesPath (see electron-builder.yml -> extraResources). The
-// per-user install directory is writable, so uv creates the venv next to the
-// bundled pyproject.toml on first launch and the backend writes its data/ tree
-// there. In dev none of this applies: the backend runs from the repo via uv on
-// PATH exactly as before.
+// under process.resourcesPath (see electron-builder.yml -> extraResources). In
+// dev none of this applies: the backend runs from the repo via uv on PATH
+// exactly as before.
+//
+// This used to assume the install directory was writable, because the NSIS
+// config asks for a per-user install under %LOCALAPPDATA%\Programs\theDAW. But
+// electron-builder.yml also sets allowToChangeInstallationDirectory, so a user
+// can install into C:\Program Files\theDAW, and then NOTHING may be written
+// beside the app. First run died on the very first step:
+//
+//   error: Failed to initialize cache at `.uv-cache`
+//   Caused by: failed to create directory
+//   `C:\Program Files\theDAW\resources\python\.uv-cache`: Access is denied.
+//
+// after which the backend exited 2 and every request answered 502. Three
+// separate things wanted to write into the install directory: uv's package
+// cache, the venv itself, and the backend's data/ tree. getWritableRuntimeDir
+// decides once where all three go.
 // ---------------------------------------------------------------------------
 
 function getPythonDir(): string {
   return app.isPackaged ? path.join(process.resourcesPath, 'python') : repoRoot
+}
+
+/** Per-user base for anything large. Deliberately LOCAL app data, not roaming:
+ *  the venv and uv's cache are several GB and a roaming profile syncs. */
+function localAppDataRoot(): string {
+  const local = process.env.LOCALAPPDATA
+  if (process.platform === 'win32' && local) return path.join(local, 'theDAW')
+  // app.getPath('userData') is already per-user and per-app everywhere else.
+  return app.getPath('userData')
+}
+
+/** Can we actually create a file in `dir`? Probed, never inferred from ACLs:
+ *  a directory can look writable and still refuse, and the reverse. */
+function isWritableDir(dir: string): boolean {
+  const probe = path.join(dir, `.thedaw-write-probe-${process.pid}`)
+  try {
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(probe, '')
+    fs.rmSync(probe, { force: true })
+    return true
+  } catch {
+    try {
+      fs.rmSync(probe, { force: true })
+    } catch {
+      /* nothing to clean up */
+    }
+    return false
+  }
+}
+
+let cachedRuntimeDir: string | null = null
+
+/**
+ * Where the packaged app may write: uv's cache, the venv, the data tree.
+ *
+ * The install directory when that is writable, which keeps every existing
+ * per-user install exactly as it was, venv included. Otherwise a per-user
+ * directory, so a Program Files install works without elevation.
+ */
+function getWritableRuntimeDir(): string {
+  if (!app.isPackaged) return repoRoot
+  if (cachedRuntimeDir) return cachedRuntimeDir
+  const pyDir = getPythonDir()
+  if (isWritableDir(pyDir)) {
+    cachedRuntimeDir = pyDir
+  } else {
+    const fallback = path.join(localAppDataRoot(), 'runtime')
+    log(`Install directory is read-only (${pyDir}); using ${fallback} for the venv, cache and data.`)
+    cachedRuntimeDir = fallback
+  }
+  return cachedRuntimeDir
+}
+
+/** True when the runtime had to move out of the install directory. */
+function runtimeIsRelocated(): boolean {
+  return app.isPackaged && getWritableRuntimeDir() !== getPythonDir()
 }
 
 function getToolsDir(): string {
@@ -121,10 +190,18 @@ function getUvCommand(): string {
   )
 }
 
-function venvPython(pyDir: string): string {
+/** The venv root. Beside the project when the install dir is writable, in the
+ *  per-user runtime dir when it is not. uv is pointed at it with
+ *  UV_PROJECT_ENVIRONMENT (buildBackendEnv), which relocates the environment
+ *  without moving the project. */
+function getVenvDir(): string {
+  return path.join(getWritableRuntimeDir(), '.venv')
+}
+
+function venvPython(venvRoot: string): string {
   return process.platform === 'win32'
-    ? path.join(pyDir, '.venv', 'Scripts', 'python.exe')
-    : path.join(pyDir, '.venv', 'bin', 'python')
+    ? path.join(venvRoot, 'Scripts', 'python.exe')
+    : path.join(venvRoot, 'bin', 'python')
 }
 
 // Environment for the backend + the uv sync step. Packaged builds prepend the
@@ -147,7 +224,16 @@ function buildBackendEnv(): NodeJS.ProcessEnv {
   // backend itself invokes (e.g. the on-demand Underfit trainer env). An
   // explicit UV_CACHE_DIR (e.g. from theDAW.bat's dev/web launch) is respected.
   const cacheKey = Object.keys(env).find((k) => k.toLowerCase() === 'uv_cache_dir')
-  if (!cacheKey) env.UV_CACHE_DIR = path.join(getPythonDir(), '.uv-cache')
+  if (!cacheKey) env.UV_CACHE_DIR = path.join(getWritableRuntimeDir(), '.uv-cache')
+  if (runtimeIsRelocated()) {
+    // The install directory is read-only, so the venv and the library cannot
+    // live beside the project. Both honour an env var, and an explicit value
+    // from the caller still wins.
+    if (!env.UV_PROJECT_ENVIRONMENT) env.UV_PROJECT_ENVIRONMENT = getVenvDir()
+    if (!env.theDAW_GENERATIONS_DIR) {
+      env.theDAW_GENERATIONS_DIR = path.join(getWritableRuntimeDir(), 'data', 'generations')
+    }
+  }
   return env
 }
 
@@ -168,8 +254,12 @@ function coreImportsOk(py: string): Promise<boolean> {
 
 function runUvSync(uvCmd: string, cwd: string): Promise<void> {
   return new Promise((resolve) => {
-    log(`Running ${uvCmd} sync --group dev in ${cwd}`)
-    const proc = spawn(uvCmd, ['sync', '--group', 'dev'], {
+    // --frozen: use the shipped uv.lock as-is and never rewrite it. Required
+    // when the install directory is read-only, and correct regardless -- the
+    // lock is generated with the build and must not be re-resolved on a user's
+    // machine.
+    log(`Running ${uvCmd} sync --frozen --group dev in ${cwd}`)
+    const proc = spawn(uvCmd, ['sync', '--frozen', '--group', 'dev'], {
       cwd,
       env: buildBackendEnv(),
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -217,7 +307,7 @@ function runUvSync(uvCmd: string, cwd: string): Promise<void> {
 async function ensurePythonEnv(): Promise<void> {
   if (!app.isPackaged) return
   const pyDir = getPythonDir()
-  const py = venvPython(pyDir)
+  const py = venvPython(getVenvDir())
   let ok = fs.existsSync(py)
   if (ok) ok = await coreImportsOk(py)
   if (ok) {
@@ -249,14 +339,17 @@ function spawnBackend(): void {
   const isWindows = process.platform === 'win32'
   const cwd = getPythonDir()
   const env = buildBackendEnv()
-  const devVenvPy = venvPython(cwd)
+  const devVenvPy = venvPython(path.join(cwd, '.venv'))
   const useDevVenv = !app.isPackaged && fs.existsSync(devVenvPy)
 
   if (app.isPackaged) {
     // The bundled uv is an absolute path, so it is invoked directly (no shell).
     backendProcess = spawn(
       getUvCommand(),
-      ['run', 'python', '-m', 'backend._supervisor'],
+      // --frozen for the same reason as the sync above: `uv run` re-checks the
+      // lock and would try to rewrite it, which fails in a read-only install.
+      // ensurePythonEnv has already built and verified the env by this point.
+      ['run', '--frozen', 'python', '-m', 'backend._supervisor'],
       {
         cwd,
         env,

--- a/electron-ui/main/index.ts
+++ b/electron-ui/main/index.ts
@@ -226,12 +226,18 @@ function buildBackendEnv(): NodeJS.ProcessEnv {
   const cacheKey = Object.keys(env).find((k) => k.toLowerCase() === 'uv_cache_dir')
   if (!cacheKey) env.UV_CACHE_DIR = path.join(getWritableRuntimeDir(), '.uv-cache')
   if (runtimeIsRelocated()) {
-    // The install directory is read-only, so the venv and the library cannot
-    // live beside the project. Both honour an env var, and an explicit value
-    // from the caller still wins.
+    // The install directory is read-only, so neither the venv nor anything the
+    // backend persists can live beside the project. Both honour an env var, and
+    // an explicit value from the caller still wins.
     if (!env.UV_PROJECT_ENVIRONMENT) env.UV_PROJECT_ENVIRONMENT = getVenvDir()
-    if (!env.theDAW_GENERATIONS_DIR) {
-      env.theDAW_GENERATIONS_DIR = path.join(getWritableRuntimeDir(), 'data', 'generations')
+    // theDAW_DATA_DIR moves the backend's WHOLE writable tree at once --
+    // settings.json, every registry, the caches, the library, sidecar logs.
+    // backend/lib/paths.py is the single resolver; pointing only the library
+    // elsewhere still left /api/settings answering 500 on first launch, because
+    // SettingsStore went on trying to mkdir <install>/data. A user-set
+    // theDAW_GENERATIONS_DIR still moves the library on its own.
+    if (!env.theDAW_DATA_DIR) {
+      env.theDAW_DATA_DIR = path.join(getWritableRuntimeDir(), 'data')
     }
   }
   return env

--- a/electron-ui/package.json
+++ b/electron-ui/package.json
@@ -20,6 +20,10 @@
     "dist:win:ci": "npm run fetch:tools && npm run fetch:vj && npm run fetch:foundry && npm run fetch:sway && npm run fetch:notation && electron-vite build && electron-builder --win --publish never",
     "dist:mac:ci": "npm run fetch:tools && npm run fetch:vj && npm run fetch:foundry && npm run fetch:sway && npm run fetch:notation && electron-vite build && electron-builder --mac --publish never"
   },
+  "allowScripts": [
+    "electron-winstaller",
+    "esbuild"
+  ],
   "dependencies": {
     "electron-updater": "^6.8.9"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,13 @@
     "test:import-audio": "tsx src/lib/importAudioFiles.test.ts",
     "test:library-drop": "tsx src/lib/libraryDrop.test.ts"
   },
+  "allowScripts": [
+    "@google/genai",
+    "core-js",
+    "esbuild",
+    "gl",
+    "protobufjs"
+  ],
   "dependencies": {
     "@coderline/alphatab": "^1.8.3",
     "@coderline/alphatab-vite": "^1.8.3",

--- a/scripts/ingest_suno_cache.py
+++ b/scripts/ingest_suno_cache.py
@@ -175,7 +175,7 @@ def main() -> None:
 
     from backend.modules.library.store import default_library_root
 
-    library_root = default_library_root(PROJECT_ROOT)
+    library_root = default_library_root()
     log.info("Library root: %s", library_root)
 
     count = ingest(selected, library_root)

--- a/tests/test_writable_data_dir.py
+++ b/tests/test_writable_data_dir.py
@@ -1,0 +1,130 @@
+"""The backend's writable data tree must follow ``theDAW_DATA_DIR``.
+
+A packaged install can land in ``C:/Program Files/theDAW``, where nothing may
+be created beside the app. The desktop launcher then points ``theDAW_DATA_DIR``
+at a per-user directory — which only works if EVERY writer resolves through
+``backend.lib.paths``. The last regression here shipped with the library
+relocated and ``settings.json`` still pointed at the install directory, so the
+first ``/api/settings`` call answered 500; the source sweep below is what
+catches that class of miss.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from backend.lib import paths
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_data_dir_defaults_to_the_project(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("theDAW_DATA_DIR", raising=False)
+    assert paths.data_dir() == paths.PROJECT_ROOT / "data"
+    assert not paths.is_relocated()
+
+
+def test_env_moves_the_whole_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("theDAW_DATA_DIR", str(tmp_path / "runtime-data"))
+    monkeypatch.delenv("theDAW_GENERATIONS_DIR", raising=False)
+    monkeypatch.delenv("theDAW_SETTINGS_PATH", raising=False)
+    monkeypatch.delenv("theDAW_RAG_INDEX_DIR", raising=False)
+
+    root = (tmp_path / "runtime-data").resolve()
+    assert paths.is_relocated()
+    assert paths.data_dir() == root
+    assert paths.data_path("settings.json") == root / "settings.json"
+    assert paths.library_root() == root / "generations"
+    # The chroma index is written at runtime, so it moves too.
+    assert paths.rag_index_dir() == root / "rag_index"
+
+    from backend.modules.library.store import default_library_root
+    from backend.modules.settings.store import default_settings_path
+
+    assert default_settings_path() == root / "settings.json"
+    assert default_library_root() == root / "generations"
+
+
+def test_generations_override_still_wins(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The user-facing 'put my library on another drive' knob outranks the
+    relocation, and moves the library only."""
+    monkeypatch.setenv("theDAW_DATA_DIR", str(tmp_path / "runtime-data"))
+    monkeypatch.setenv("theDAW_GENERATIONS_DIR", str(tmp_path / "D-drive"))
+    assert paths.library_root() == (tmp_path / "D-drive").resolve()
+    assert (
+        paths.data_path("settings.json")
+        == (tmp_path / "runtime-data").resolve() / "settings.json"
+    )
+
+
+def test_settings_store_writes_into_the_relocated_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The exact first-launch sequence a Program Files install runs: nothing
+    exists yet, and the store has to create its own directory."""
+    monkeypatch.setenv("theDAW_DATA_DIR", str(tmp_path / "runtime-data"))
+    monkeypatch.delenv("theDAW_SETTINGS_PATH", raising=False)
+
+    from backend.modules.settings.store import SettingsStore, default_settings_path
+
+    store = SettingsStore(default_settings_path())
+    assert store.path.is_file()
+    assert store.path.parent == (tmp_path / "runtime-data").resolve()
+    assert store.get_all()["schema_version"] >= 1
+
+
+# Every writable location in the backend has to come from backend.lib.paths.
+# A bare `<root> / "data"` is the bug this whole module exists to prevent.
+_BARE_DATA = re.compile(
+    r"(PROJECT_ROOT|_REPO_ROOT|project_root|repo_root)\s*/\s*\"data\""
+)
+
+# media_access deliberately keeps the in-install data dir as a READ root so
+# content that shipped with the app still resolves; paths.py owns the default.
+_ALLOWED = {
+    Path("backend/lib/paths.py"),
+    Path("backend/modules/project/media_access.py"),
+}
+
+
+def test_no_module_composes_its_own_data_dir() -> None:
+    tracked = subprocess.run(
+        ["git", "ls-files", "backend"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    offenders: list[str] = []
+    for rel in tracked:
+        if not rel.endswith(".py") or Path(rel) in _ALLOWED:
+            continue
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8", errors="replace")
+        for i, line in enumerate(text.splitlines(), 1):
+            if _BARE_DATA.search(line):
+                offenders.append(f"{rel}:{i}: {line.strip()}")
+    assert not offenders, (
+        "these write outside backend.lib.paths and break a read-only install:\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_paths_module_has_no_heavy_imports() -> None:
+    """It is imported by every module in the backend, including ones that load
+    before the app does; keep it to the standard library."""
+    proc = subprocess.run(
+        [sys.executable, "-c", "import backend.lib.paths"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
First run in C:\Program Files\theDAW died on its first step:

  error: Failed to initialize cache at `.uv-cache`
  Caused by: failed to create directory
  `C:\Program Files\theDAW\resources\python\.uv-cache`: Access is denied.

after which the backend exited 2 and every request answered 502 ("Failed to load entries: library.list: HTTP 502 Bad Gateway").

The code assumed the install directory was writable, and the comment said so, because the NSIS config asks for a per-user install under %LOCALAPPDATA%\Programs\theDAW. But electron-builder.yml also sets allowToChangeInstallationDirectory, so a user can point the installer at Program Files, and then nothing may be written beside the app. Three separate things wanted to: uv's package cache, the venv, and the backend's data tree. Only the first one got as far as reporting itself.

getWritableRuntimeDir decides once. It PROBES the install directory by creating and deleting a file rather than reasoning about ACLs, and when that works it returns the install directory exactly as before, so every existing per-user install keeps its venv and its data where they are. When it fails it returns %LOCALAPPDATA%\theDAW\runtime, and UV_CACHE_DIR, UV_PROJECT_ENVIRONMENT and theDAW_GENERATIONS_DIR all point there. UV_PROJECT_ENVIRONMENT relocating the venv out of the project was verified against the installed uv, not assumed.

Local app data, not the roaming profile Electron's userData points at on Windows: the venv and the wheel cache are several GB and roaming profiles sync.

`uv sync` and `uv run` both gain --frozen. Each re-checks uv.lock and would try to rewrite it, which cannot work in a read-only install, and re-resolving a lock that shipped with the build is wrong anywhere.

Verified: electron-vite build succeeds and the new resolver is in the built main bundle.