### PR TITLE
fix(vj, sway, updates): serve the embed builds per request, and stop …

### DIFF
--- a/backend/modules/sway/sidecar.py
+++ b/backend/modules/sway/sidecar.py
@@ -86,17 +86,17 @@ def is_static_mode() -> bool:
     return resolve_dist_dir() is not None
 
 
-# Set True by server.py when the /sway-app StaticFiles mount is actually
-# registered (mounting happens once, at server import). Routes must key the
-# "return the embed URL" decision off THIS, not is_static_mode(): a build
-# staged later in the session flips is_static_mode() true while no mount
-# exists, which would hand the iframe a /sway-app/ URL that 404s. The VJ
-# module learned this the hard way; the same race exists here.
+# Set True by server.py once the /sway-app route is registered, which it always
+# is. The route resolves the embed build per request
+# (server._serve_static_build), so a build staged mid-session serves
+# immediately rather than 404ing until the next backend restart.
 STATIC_MOUNTED = False
 
 
 def static_mount_active() -> bool:
-    return STATIC_MOUNTED
+    """True when a request to /sway-app would actually serve a build: the route
+    is registered AND an embed build is resolvable right now."""
+    return STATIC_MOUNTED and resolve_dist_dir() is not None
 
 
 def read_build_stamp() -> Optional[dict]:

--- a/backend/modules/updates/router.py
+++ b/backend/modules/updates/router.py
@@ -312,8 +312,25 @@ def _run_git(args: list[str], tail: list[str]) -> int:
     return proc.wait()
 
 
-def _tree_dirty() -> bool:
-    """Refuse to pull over local edits; True on any git failure (fail safe)."""
+# Lockfiles the setup step rewrites on an ordinary run: `npm install` in
+# frontend/ and electron-ui/, `uv sync` re-resolving. A clone dirtied only by
+# those was dirtied by its own launcher, not by the user, so an update restores
+# them instead of refusing. Refusing was a dead end for the Pinokio launcher,
+# whose Update runs a bare `git pull` and died with "Your local changes to the
+# following files would be overwritten by merge" with nothing the user could do
+# about it from inside the app.
+_TOOL_OWNED_PATHS = frozenset(
+    {
+        "uv.lock",
+        "frontend/package-lock.json",
+        "electron-ui/package-lock.json",
+    }
+)
+
+
+def _dirty_paths() -> list[str] | None:
+    """Tracked files with local modifications. None when git itself failed,
+    which is NOT the same as a clean tree and must not be treated as one."""
     try:
         out = subprocess.run(
             ["git", "status", "--porcelain", "--untracked-files=no"],
@@ -323,8 +340,19 @@ def _tree_dirty() -> bool:
             timeout=30,
         )
     except (OSError, subprocess.SubprocessError):
-        return True
-    return out.returncode != 0 or bool(out.stdout.strip())
+        return None
+    if out.returncode != 0:
+        return None
+    paths: list[str] = []
+    for line in out.stdout.splitlines():
+        entry = line[3:].strip()
+        if not entry:
+            continue
+        # A rename reads "old -> new"; the working-tree file is the new one.
+        if " -> " in entry:
+            entry = entry.split(" -> ", 1)[1]
+        paths.append(entry.strip('"'))
+    return paths
 
 
 def _set_apply(**fields: Any) -> None:
@@ -336,6 +364,19 @@ def _apply_worker() -> None:
     global _current_version
     tail: list[str] = []
     try:
+        # Restore the lockfiles the launcher rewrote, or the pull refuses to
+        # overwrite them. Checked again here, not just at the request, because
+        # a launch can dirty the tree between the two.
+        restore = sorted(p for p in (_dirty_paths() or []) if p in _TOOL_OWNED_PATHS)
+        if restore:
+            _set_apply(
+                step="restore",
+                message="Restoring lockfiles the setup step rewrote.",
+            )
+            _apply_log(
+                tail, f"restoring launcher-rewritten files: {', '.join(restore)}"
+            )
+            _run_git(["checkout", "--", *restore], tail)
         _set_apply(step="pull", message="Pulling the latest code.")
         rc = _run_git(["pull", "--ff-only"], tail)
         if rc != 0:
@@ -426,11 +467,21 @@ def apply_update() -> dict[str, Any]:
     with _apply_lock:
         if _apply["state"] in ("running", "restarting"):
             return dict(_apply)
-    if _tree_dirty():
+    dirty = _dirty_paths()
+    if dirty is None:
+        raise HTTPException(
+            status_code=503,
+            detail="git could not report this clone's status, so the update was not attempted.",
+        )
+    blocked = sorted(p for p in dirty if p not in _TOOL_OWNED_PATHS)
+    if blocked:
+        shown = ", ".join(blocked[:8])
+        if len(blocked) > 8:
+            shown += f", and {len(blocked) - 8} more"
         raise HTTPException(
             status_code=409,
             detail="This clone has uncommitted local changes, so the update would overwrite "
-            "them. Commit or stash them, then update again.",
+            f"them: {shown}. Commit or stash them, then update again.",
         )
     _set_apply(
         state="running",

--- a/backend/modules/vj/sidecar.py
+++ b/backend/modules/vj/sidecar.py
@@ -217,16 +217,18 @@ def is_static_mode() -> bool:
     return resolve_dist_dir() is not None
 
 
-# Set True by server.py when the /vj-app StaticFiles mount is actually
-# registered (mounting happens once, at server import). Routes must key the
-# "return the static URL" decision off THIS, not is_static_mode(): a dist
-# built later in the session flips is_static_mode() true while no mount
-# exists, which would hand the iframe a /vj-app/ URL that 404s.
+# Set True by server.py once the /vj-app route is registered, which it always
+# is. The route resolves the build per request (server._serve_static_build), so
+# a dist that appears mid-session — Pinokio's Update npm-installs the VJ
+# checkout while theDAW is running — serves immediately instead of 404ing until
+# the next backend restart.
 STATIC_MOUNTED = False
 
 
 def static_mount_active() -> bool:
-    return STATIC_MOUNTED
+    """True when a request to /vj-app would actually serve a build: the route
+    is registered AND a dist is resolvable right now."""
+    return STATIC_MOUNTED and resolve_dist_dir() is not None
 
 
 def ensure_static_dist() -> Path:

--- a/backend/server.py
+++ b/backend/server.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import numpy as np
 from fastapi import Body, FastAPI, Form, File, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 
 from backend.admin_routes import router as admin_router
 from backend.lib.audio_io import load_audio, load_audio_array, save_audio, save_subtype
@@ -2343,6 +2343,7 @@ async def get_log(since: int = 0, limit: int = 1000):
 app.include_router(assistant_router)
 app.include_router(admin_router)
 
+
 # VJ app served as a static production build (default when a build is
 # bundled/resolvable; theDAW_VJ_DEV=1 opts back into the Node dev server). This
 # removes the runtime Node.js requirement on end-user machines and makes the VJ
@@ -2350,29 +2351,61 @@ app.include_router(admin_router)
 # /vj-app (matching the VJ build's vite base) BEFORE the SPA catch-all below so
 # it isn't shadowed. In dev the frontend's Vite config proxies /vj-app -> :8600,
 # so the iframe loads it same-origin; in packaged/Docker it's already one origin.
+def _serve_static_build(dist: Path | None, rel: str, label: str) -> FileResponse:
+    """Serve one file out of an embedded app build, resolved PER REQUEST.
+
+    These builds are produced by a step that can run after the backend is
+    already up — Pinokio's Update npm-installs the VJ checkout while theDAW is
+    running — and an import-time ``app.mount`` freezes the decision at boot, so
+    the tab 404s until someone restarts the backend for reasons no error
+    message explains. Resolving here costs a stat per request and makes a build
+    that appears mid-session serve immediately.
+
+    Unknown paths fall back to ``index.html``, matching StaticFiles(html=True):
+    both builds are SPAs that route client-side.
+    """
+    if dist is None:
+        raise HTTPException(
+            status_code=404, detail=f"no {label} build is staged on this machine"
+        )
+    root = dist.resolve()
+    target = (
+        (root / rel.lstrip("/")).resolve() if rel.strip("/") else root / "index.html"
+    )
+    try:
+        target.relative_to(root)
+    except ValueError:
+        # A traversal attempt ("../../secrets"); never serve outside the build.
+        raise HTTPException(status_code=404, detail="not found") from None
+    if target.is_dir():
+        target = target / "index.html"
+    if not target.is_file():
+        target = root / "index.html"
+    if not target.is_file():
+        raise HTTPException(
+            status_code=404, detail=f"the staged {label} build has no index.html"
+        )
+    return FileResponse(target)
+
+
 try:
     from backend.modules.vj import sidecar as _vj_sidecar
 
-    if _vj_sidecar.is_static_mode():
-        _vj_dist = _vj_sidecar.resolve_dist_dir()
-        if _vj_dist is not None:
-            from fastapi.staticfiles import StaticFiles
+    @app.get(f"{_vj_sidecar.STATIC_MOUNT_PATH}/", include_in_schema=False)
+    @app.get(_vj_sidecar.STATIC_MOUNT_PATH + "/{rel:path}", include_in_schema=False)
+    def _serve_vj_app(rel: str = "") -> FileResponse:
+        return _serve_static_build(_vj_sidecar.resolve_dist_dir(), rel, "VJ")
 
-            app.mount(
-                _vj_sidecar.STATIC_MOUNT_PATH,
-                StaticFiles(directory=_vj_dist, html=True),
-                name="vj-app",
-            )
-            # Freeze the decision: routes return the /vj-app URL only when
-            # this mount really exists (see sidecar.static_mount_active).
-            _vj_sidecar.STATIC_MOUNTED = True
-            logger.info(
-                "vj: serving %s at %s (static build)",
-                _vj_dist,
-                _vj_sidecar.STATIC_MOUNT_PATH,
-            )
+    # The route exists from here on, so static_mount_active() only has to ask
+    # whether a build is resolvable right now.
+    _vj_sidecar.STATIC_MOUNTED = True
+    logger.info(
+        "vj: %s serves the build at %s",
+        _vj_sidecar.STATIC_MOUNT_PATH,
+        _vj_sidecar.resolve_dist_dir() or "(none staged yet)",
+    )
 except Exception as _vj_mount_err:  # noqa: BLE001 — never block boot on VJ
-    logger.warning("vj: static mount skipped: %s", _vj_mount_err)
+    logger.warning("vj: static route not registered: %s", _vj_mount_err)
 
 # SwayCommand cockpit served as a static embed build, same shape as the VJ mount
 # above and for the same reasons: one origin, no Node on the target machine,
@@ -2385,31 +2418,19 @@ except Exception as _vj_mount_err:  # noqa: BLE001 — never block boot on VJ
 try:
     from backend.modules.sway import sidecar as _sway_sidecar
 
-    _sway_dist = _sway_sidecar.resolve_dist_dir()
-    if _sway_dist is not None:
-        from fastapi.staticfiles import StaticFiles
+    @app.get(f"{_sway_sidecar.STATIC_MOUNT_PATH}/", include_in_schema=False)
+    @app.get(_sway_sidecar.STATIC_MOUNT_PATH + "/{rel:path}", include_in_schema=False)
+    def _serve_sway_app(rel: str = "") -> FileResponse:
+        return _serve_static_build(_sway_sidecar.resolve_dist_dir(), rel, "SwayCommand")
 
-        app.mount(
-            _sway_sidecar.STATIC_MOUNT_PATH,
-            StaticFiles(directory=_sway_dist, html=True),
-            name="sway-app",
-        )
-        # Freeze the decision: /api/sway/url hands out the embed URL only when
-        # this mount really exists (see sidecar.static_mount_active).
-        _sway_sidecar.STATIC_MOUNTED = True
-        logger.info(
-            "sway: serving %s at %s (static embed build)",
-            _sway_dist,
-            _sway_sidecar.STATIC_MOUNT_PATH,
-        )
-    else:
-        logger.info(
-            "sway: no embed build staged — the SWAY tab will explain how to "
-            "stage one (%s)",
-            _sway_sidecar.DIST_ENV,
-        )
+    _sway_sidecar.STATIC_MOUNTED = True
+    logger.info(
+        "sway: %s serves the embed build at %s",
+        _sway_sidecar.STATIC_MOUNT_PATH,
+        _sway_sidecar.resolve_dist_dir() or "(none staged yet)",
+    )
 except Exception as _sway_mount_err:  # noqa: BLE001 — never block boot on Sway
-    logger.warning("sway: static mount skipped: %s", _sway_mount_err)
+    logger.warning("sway: static route not registered: %s", _sway_mount_err)
 
 # Single-container / companion UI serving. Every API route lives under /api and
 # is registered above, BEFORE this mount, so the SPA catch-all can never shadow

--- a/tests/test_embedded_app_routes.py
+++ b/tests/test_embedded_app_routes.py
@@ -1,0 +1,93 @@
+"""/vj-app and /sway-app must serve a build that appeared AFTER boot.
+
+Both builds are produced by steps that can run while theDAW is already up —
+Pinokio's Update npm-installs the VJ checkout, `npm run fetch:sway` stages the
+cockpit — and the old code mounted them with ``app.mount`` at import, which
+froze the decision at boot: the tab 404'd until someone restarted the backend,
+with nothing on screen saying why. So the sequence, not the end state, is what
+these cover: import the app with NO build staged, stage one, then request it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.modules.sway import sidecar as sway_sidecar
+from backend.modules.vj import sidecar as vj_sidecar
+from backend.server import app
+
+CASES = (
+    ("/vj-app", vj_sidecar),
+    ("/sway-app", sway_sidecar),
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.mark.parametrize("mount,sidecar", CASES)
+def test_no_build_staged_is_a_clean_404(client, monkeypatch, mount, sidecar) -> None:
+    monkeypatch.setattr(sidecar, "resolve_dist_dir", lambda: None)
+    res = client.get(f"{mount}/")
+    assert res.status_code == 404
+    assert "build" in res.json()["detail"]
+
+
+@pytest.mark.parametrize("mount,sidecar", CASES)
+def test_build_staged_after_boot_serves_without_a_restart(
+    client, monkeypatch, tmp_path: Path, mount, sidecar
+) -> None:
+    # The app object was imported by the module-level import above, long before
+    # this directory existed — exactly the Pinokio ordering.
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<title>staged late</title>", encoding="utf-8")
+    (dist / "assets").mkdir()
+    (dist / "assets" / "app.js").write_text("export const x = 1\n", encoding="utf-8")
+    monkeypatch.setattr(sidecar, "resolve_dist_dir", lambda: dist)
+
+    root = client.get(f"{mount}/")
+    assert root.status_code == 200
+    assert "staged late" in root.text
+
+    asset = client.get(f"{mount}/assets/app.js")
+    assert asset.status_code == 200
+    assert "export const x" in asset.text
+
+    # A client-routed path the build has no file for renders the shell, the way
+    # StaticFiles(html=True) did.
+    deep = client.get(f"{mount}/some/client/route")
+    assert deep.status_code == 200
+    assert "staged late" in deep.text
+
+    # And the status the frontend pivots on agrees, without a restart.
+    assert sidecar.static_mount_active() is True
+
+
+@pytest.mark.parametrize("mount,sidecar", CASES)
+def test_cannot_escape_the_build_directory(
+    client, monkeypatch, tmp_path: Path, mount, sidecar
+) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("shell", encoding="utf-8")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("do not serve me", encoding="utf-8")
+    monkeypatch.setattr(sidecar, "resolve_dist_dir", lambda: dist)
+
+    res = client.get(f"{mount}/..%2Fsecret.txt")
+    assert res.status_code in (200, 404)
+    assert "do not serve me" not in res.text
+
+
+@pytest.mark.parametrize("mount,sidecar", CASES)
+def test_status_is_false_while_nothing_is_staged(monkeypatch, mount, sidecar) -> None:
+    """The route exists from boot, so 'mounted' alone must not read as ready —
+    that is what let /api/vj/status report ok while the iframe 404'd."""
+    monkeypatch.setattr(sidecar, "resolve_dist_dir", lambda: None)
+    assert sidecar.static_mount_active() is False

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -82,27 +82,62 @@ def test_apply_refuses_packaged_install(client):
     assert "desktop shell" in res.json()["detail"]
 
 
+class _NoopThread:
+    """Stands in for threading.Thread so /apply returns without doing the work."""
+
+    def __init__(self, target, daemon, name):
+        pass
+
+    def start(self) -> None:
+        pass
+
+
 def test_apply_refuses_dirty_tree(client, monkeypatch, tmp_path):
     (tmp_path / ".git").mkdir()
     monkeypatch.setattr(updates.shutil, "which", lambda name: "/usr/bin/git")
-    monkeypatch.setattr(updates, "_tree_dirty", lambda: True)
+    monkeypatch.setattr(updates, "_dirty_paths", lambda: ["backend/server.py"])
     res = client.post("/api/updates/apply")
     assert res.status_code == 409
-    assert "uncommitted" in res.json()["detail"]
+    detail = res.json()["detail"]
+    assert "uncommitted" in detail
+    # The old message named nothing, which left the user guessing what to stash.
+    assert "backend/server.py" in detail
+
+
+def test_apply_ignores_launcher_rewritten_lockfiles(client, monkeypatch, tmp_path):
+    """A clone that has only been launched has uv.lock / package-lock.json
+    modified by its own setup step. That must not block the update -- it is the
+    exact state Pinokio's Update died in."""
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(updates.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.setattr(
+        updates,
+        "_dirty_paths",
+        lambda: ["uv.lock", "frontend/package-lock.json"],
+    )
+    monkeypatch.setattr(updates.threading, "Thread", _NoopThread)
+    body = client.post("/api/updates/apply").json()
+    assert body["state"] == "running"
+
+
+def test_apply_refuses_when_git_status_fails(client, monkeypatch, tmp_path):
+    """A git that cannot report status is not a clean tree."""
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(updates.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.setattr(updates, "_dirty_paths", lambda: None)
+    res = client.post("/api/updates/apply")
+    assert res.status_code == 503
 
 
 def test_apply_starts_worker_and_reports_status(client, monkeypatch, tmp_path):
     (tmp_path / ".git").mkdir()
     monkeypatch.setattr(updates.shutil, "which", lambda name: "/usr/bin/git")
-    monkeypatch.setattr(updates, "_tree_dirty", lambda: False)
+    monkeypatch.setattr(updates, "_dirty_paths", lambda: [])
     started: list[str] = []
 
-    class _Thread:
+    class _Thread(_NoopThread):
         def __init__(self, target, daemon, name):
             started.append(name)
-
-        def start(self):
-            pass
 
     monkeypatch.setattr(updates.threading, "Thread", _Thread)
     body = client.post("/api/updates/apply").json()


### PR DESCRIPTION
…a launcher-dirtied lockfile blocking the update

Two ways a Pinokio install could not get to a working app.

1. /vj-app and /sway-app were app.mount()ed at server import, so whether the tab worked was decided at boot. Pinokio's Update npm-installs the VJ checkout WHILE theDAW is running: the build lands at 09:39, the backend started at 09:20, and from then on /api/vj/status happily reported {"mode":"static","ok":true} while /vj-app/ answered 404 — with nothing on screen saying "restart the backend". Both paths are now ordinary routes that resolve the build per request, so a build staged mid-session serves immediately, and static_mount_active() means "a request would really serve something" instead of "a mount existed at boot".

   Unknown paths still fall back to index.html (both builds are SPAs), and the resolved file is checked back against the build root, so the wider surface cannot be walked out of.

2. /api/updates/apply refused any dirty tree. But `npm install` and `uv sync` rewrite tracked lockfiles on an ordinary launch, so a clone that had only ever been RUN was already dirty and the update was unreachable from inside the app — the same state that made Pinokio's Update die on "Your local changes to the following files would be overwritten by merge". Those lockfiles are now restored from HEAD before the pull; anything else still blocks, and the 409 finally names the files instead of leaving the user to guess what to stash.

tests/test_embedded_app_routes.py covers the ordering rather than the end state: import the app with nothing staged, stage a build, then request it.