### PR TITLE
Sponsor links and update recovery

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+# Puts the "Sponsor" button at the top of the repository and the
+# "Sponsor this project" card in the sidebar — GitHub's own funding surface,
+# so no banner of our own is needed in the repo chrome.
+# Same destination as the in-app Sponsor entries (hamburger menu, Settings
+# footer) and the Pinokio launcher menu.
+github: [gantasmo]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/sponsors/gantasmo"><img src="https://img.shields.io/badge/Sponsor-theDAW-EA4AAA?logo=githubsponsors&logoColor=white" alt="Sponsor theDAW on GitHub Sponsors"></a>
   <a href="https://open.spotify.com/artist/4q5n0QgK6mvyuw8FRzhuNA"><img src="https://img.shields.io/badge/Listen-Spotify-1DB954?logo=spotify&logoColor=white" alt="Listen on Spotify"></a>
   <a href="https://www.youtube.com/@GANTASMO"><img src="https://img.shields.io/badge/Watch-YouTube-FF0000?logo=youtube&logoColor=white" alt="Watch on YouTube"></a>
   <a href="https://www.instagram.com/gantasmo"><img src="https://img.shields.io/badge/Follow-%40gantasmo-E4405F?logo=instagram&logoColor=white" alt="Follow @gantasmo on Instagram"></a>

--- a/frontend/src/components/menu/HamburgerMenu.tsx
+++ b/frontend/src/components/menu/HamburgerMenu.tsx
@@ -3,6 +3,7 @@ import {
   Archive,
   BookOpen,
   Compass,
+  ExternalLink,
   FilePlus2,
   FolderInput,
   FolderOpen,
@@ -40,11 +41,17 @@ export interface HamburgerMenuProps {
 interface MenuAction {
   id: string;
   label: string;
-  icon: React.ComponentType<{ className?: string }>;
+  /** Omitted by rows that carry no icon (the sponsor row). */
+  icon?: React.ComponentType<{ className?: string }>;
   iconCls: string;
   onSelect: () => void;
   /** Row shows an accent dot when the underlying toggle is on (Edit Layout). */
   active?: boolean;
+  /** Sponsor row: purple-filled, so it reads as an offer and not a setting. */
+  accent?: boolean;
+  /** Trailing arrow + native tooltip for rows that leave the app. */
+  external?: boolean;
+  title?: string;
 }
 
 interface MenuSection {
@@ -60,6 +67,16 @@ const TRIGGER_ACTIVE =
 
 const ITEM_CLS =
   'w-full flex items-center gap-2 px-2 py-1 rounded text-left text-[10px] text-zinc-300 hover:bg-purple-500/15 hover:text-zinc-100 transition-colors outline-none focus-visible:bg-purple-500/15 focus-visible:text-zinc-100 focus-visible:ring-1 focus-visible:ring-purple-400/60';
+/* The sponsor row: no icon, label centred in the row rather than left-aligned
+   with the rest of the menu. */
+const ITEM_ACCENT_CLS =
+  'justify-center border border-purple-400/50 bg-purple-500/20 text-purple-100 font-black uppercase tracking-wider hover:bg-purple-500/30 hover:text-white';
+
+/** Where every Sponsor entry points: the hamburger row here, the pinned row in
+ *  Settings, the README badge, .github/FUNDING.yml and the Pinokio menu. */
+const SPONSOR_URL = 'https://github.com/sponsors/gantasmo';
+const SPONSOR_TITLE =
+  'theDAW is independent and self-funded. A sponsorship keeps development going (food, coffee, and compute) and flows straight back into the software.';
 
 /**
  * App hamburger menu for the top header: project open/save, backup/migrate,
@@ -183,6 +200,23 @@ export const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
         { id: 'home-screen', label: 'Home Screen', icon: Home, iconCls: 'text-amber-300', onSelect: onOpenHome },
       ],
     },
+    {
+      label: 'Support',
+      items: [
+        {
+          id: 'sponsor',
+          label: 'Sponsor theDAW',
+          iconCls: '',
+          accent: true,
+          external: true,
+          title: SPONSOR_TITLE,
+          // In the desktop app window.open is intercepted by the main process
+          // (setWindowOpenHandler -> shell.openExternal), so this opens the
+          // system browser there and a new tab in the browser build.
+          onSelect: () => window.open(SPONSOR_URL, '_blank', 'noopener,noreferrer'),
+        },
+      ],
+    },
   ];
   const flatItems = sections.flatMap((s) => s.items);
 
@@ -300,10 +334,20 @@ export const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
                       itemRefs.current[refIndex] = el;
                     }}
                     onClick={() => selectItem(item)}
-                    className={`${ITEM_CLS} ${item.active ? 'bg-purple-500/10 text-purple-200' : ''}`}
+                    title={item.title}
+                    className={`${ITEM_CLS} ${item.accent ? ITEM_ACCENT_CLS : ''} ${
+                      item.active ? 'bg-purple-500/10 text-purple-200' : ''
+                    }`}
                   >
-                    <Icon className={`w-3.5 h-3.5 shrink-0 ${item.iconCls}`} />
-                    <span className="flex-1 min-w-0 truncate">{item.label}</span>
+                    {Icon && <Icon className={`w-3.5 h-3.5 shrink-0 ${item.iconCls}`} />}
+                    <span
+                      className={
+                        item.accent ? 'min-w-0 truncate' : 'flex-1 min-w-0 truncate'
+                      }
+                    >
+                      {item.label}
+                    </span>
+                    {item.external && <ExternalLink className="w-3 h-3 opacity-70 shrink-0" />}
                     {item.active && <span className="w-1.5 h-1.5 rounded-full bg-purple-400 shrink-0" />}
                   </button>
                 );


### PR DESCRIPTION
This pull request adds a "Sponsor theDAW" support option across the project, making it easier for users to support development. The changes include a new sponsor button in the hamburger menu, a sponsor badge in the `README.md`, and a GitHub funding configuration. The sponsor menu item is visually distinct and opens the sponsorship page in the user's browser.

**Support and Sponsorship Integration:**

* Added a "Sponsor theDAW" row to the hamburger menu in `HamburgerMenu.tsx`, with a unique accent style, external link icon, and tooltip, all pointing to the GitHub Sponsors page. [[1]](diffhunk://#diff-b459b295de40fd7c54478afb59d69f28d3b96e78223bb03cadad29c2de5ee2e3R203-R219) [[2]](diffhunk://#diff-b459b295de40fd7c54478afb59d69f28d3b96e78223bb03cadad29c2de5ee2e3R70-R79) [[3]](diffhunk://#diff-b459b295de40fd7c54478afb59d69f28d3b96e78223bb03cadad29c2de5ee2e3L303-R350)
* Updated the `MenuAction` interface to support optional icons, accent styling, external links, and tooltips for flexible menu item rendering.
* Added the `ExternalLink` icon import for use with external navigation menu items.
* Added a sponsor badge to the `README.md` for increased project visibility and support.
* Created a `.github/FUNDING.yml` file to enable the GitHub "Sponsor" button and funding banner.