### PR TITLE
Fix pinokio update and embedded apps

### DIFF
--- a/backend/modules/plugin/router.py
+++ b/backend/modules/plugin/router.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import shutil
 import subprocess
 import sys
 import threading
+from uuid import uuid4
 from email.utils import formatdate, parsedate_to_datetime
 from pathlib import Path
 
@@ -58,8 +60,75 @@ def _gan_path(plugin_id: str) -> Path:
     return GAN_DIR / f"{plugin_id}.gan"
 
 
-def _runtime_dir(plugin_id: str) -> Path:
+# Every write to an extracted runtime goes through this. Three endpoints and
+# the startup builder can all extract at once, and an iframe is reading the
+# same tree while they do.
+_RUNTIME_LOCK = threading.RLock()
+
+
+def _runtime_root(plugin_id: str) -> Path:
     return RUNTIME_DIR / plugin_id
+
+
+def _runtime_dir(plugin_id: str) -> Path:
+    """The directory an iframe is served from right now.
+
+    A published runtime lives in a versioned subdirectory named in the
+    ``current`` pointer file. Installs that predate versioning kept the assets
+    directly in the plugin's runtime root, and those keep working until the
+    next build replaces them.
+    """
+    root = _runtime_root(plugin_id)
+    try:
+        name = (root / "current").read_text(encoding="utf-8").strip()
+    except OSError:
+        name = ""
+    if name and (root / name / "index.html").is_file():
+        return root / name
+    return root
+
+
+def _prune_runtimes(root: Path, keep: str) -> None:
+    """Drop superseded versions and any pre-versioning leftovers.
+
+    Best-effort on purpose: on Windows a file an iframe still has open cannot
+    be removed, and a stale directory nothing points at costs only disk.
+    """
+    for child in root.iterdir():
+        if child.name in {keep, "current"}:
+            continue
+        try:
+            shutil.rmtree(child) if child.is_dir() else child.unlink()
+        except OSError:
+            pass
+
+
+def _publish_runtime(gan_path: Path, plugin_id: str) -> Path:
+    """Extract a .gan and publish it as the plugin's runtime, all or nothing.
+
+    Extraction used to write straight into the live directory, file by file,
+    while serve_runtime kept serving from it -- and serve_runtime only checks
+    that index.html exists, so a rebuild under an open surface could hand the
+    iframe an old document with new assets beside it. Each build now lands in
+    its own directory and the pointer flips once the whole tree is there.
+
+    The new directory is never renamed over an existing one: on Windows an
+    open handle anywhere inside a directory blocks that, which is the failure
+    mode a staging swap would have hit on exactly the surfaces this protects.
+    """
+    root = _runtime_root(plugin_id)
+    root.mkdir(parents=True, exist_ok=True)
+    version = f"v{uuid4().hex[:12]}"
+    with _RUNTIME_LOCK:
+        staging = root / f".staging-{version}"
+        GanFile.extract(str(gan_path), str(staging))
+        final = root / version
+        os.replace(staging, final)
+        pointer_tmp = root / f".current-{version}"
+        pointer_tmp.write_text(version, encoding="utf-8")
+        os.replace(pointer_tmp, root / "current")
+        _prune_runtimes(root, keep=version)
+    return final
 
 
 def _entry_url(plugin_id: str, manifest: dict) -> str:
@@ -73,9 +142,8 @@ def _ensure_runtime(plugin_id: str) -> dict:
     gan = _gan_path(plugin_id)
     if not gan.is_file():
         raise HTTPException(404, f"Plugin not found: {plugin_id}")
-    rt = _runtime_dir(plugin_id)
-    if not (rt / "index.html").is_file():
-        GanFile.extract(str(gan), str(rt))
+    if not (_runtime_dir(plugin_id) / "index.html").is_file():
+        _publish_runtime(gan, plugin_id)
     return GanFile.info(str(gan))
 
 
@@ -126,7 +194,7 @@ def import_owl(req: ImportOwlRequest) -> dict:
     GAN_DIR.mkdir(parents=True, exist_ok=True)
     gan_path = _gan_path(manifest.id)
     manifest_dict = GanFile.save(manifest, assets, str(gan_path))
-    GanFile.extract(str(gan_path), str(_runtime_dir(manifest.id)))
+    _publish_runtime(gan_path, manifest.id)
 
     return {
         "manifest": manifest_dict,
@@ -137,7 +205,13 @@ def import_owl(req: ImportOwlRequest) -> dict:
 
 @router.get("/list")
 def list_plugins() -> dict:
-    """List installed .gan plugins (manifest summary each)."""
+    """List installed .gan plugins (manifest summary each).
+
+    Waits for the startup build when one is in flight: the MIX view lists once
+    on mount and only Ares has a follow-up call, so answering early on a fresh
+    install left the shelf empty until a manual reload.
+    """
+    _wait_for_bundled()
     GAN_DIR.mkdir(parents=True, exist_ok=True)
     out = []
     for gan in sorted(GAN_DIR.glob("*.gan")):
@@ -193,7 +267,7 @@ def open_plugin(req: OpenRequest) -> dict:
         dest = _gan_path(pid)
         if src.resolve() != dest.resolve():
             GanFile.install(str(src), str(dest))
-        GanFile.extract(str(dest), str(_runtime_dir(pid)))
+        _publish_runtime(dest, pid)
         return {"manifest": manifest, "entry_url": _entry_url(pid, manifest)}
 
     raise HTTPException(400, "Provide an id or a path.")
@@ -206,6 +280,10 @@ def package_owl() -> dict:
     carousel. Returns its path so the UI can reveal/share it like a VST bundle."""
     if not _OWL_PROJECT.is_file():
         raise HTTPException(500, f"Owl project asset missing: {_OWL_PROJECT}")
+    if not _OWL_BG.is_file():
+        # Packaging drops it and the surface opens blank, which is invisible
+        # until someone looks at the plugin. Say so where it can be found.
+        log.warning("plugin: Owl artwork missing at %s; packaging without it", _OWL_BG)
     owl_opts = dict(
         name="The Owl",
         plugin_id="the-owl",
@@ -222,7 +300,7 @@ def package_owl() -> dict:
         raise HTTPException(500, f"Owl package failed: {e}")
     GAN_DIR.mkdir(parents=True, exist_ok=True)
     manifest_dict = GanFile.save(manifest, assets, str(gan_path))
-    GanFile.extract(str(gan_path), str(_runtime_dir("the-owl")))
+    _publish_runtime(gan_path, "the-owl")
     return {"manifest": manifest_dict, "gan_path": str(gan_path), "rebuilt": True}
 
 
@@ -255,7 +333,7 @@ def package_ares() -> dict:
         raise HTTPException(500, f"Ares package failed: {e}")
     GAN_DIR.mkdir(parents=True, exist_ok=True)
     manifest_dict = GanFile.save(manifest, assets, str(gan_path))
-    GanFile.extract(str(gan_path), str(_runtime_dir("ares")))
+    _publish_runtime(gan_path, "ares")
     return {
         "manifest": manifest_dict,
         "gan_path": str(gan_path),
@@ -295,9 +373,10 @@ def delete_plugin(plugin_id: str) -> dict:
     if gan.is_file():
         gan.unlink()
         removed = True
-    rt = _runtime_dir(plugin_id)
-    if rt.is_dir():
-        shutil.rmtree(rt, ignore_errors=True)
+    with _RUNTIME_LOCK:
+        root = _runtime_root(plugin_id)
+        if root.is_dir():
+            shutil.rmtree(root, ignore_errors=True)
     if not removed:
         raise HTTPException(404, f"Plugin not found: {plugin_id}")
     return {"status": "deleted", "id": plugin_id}
@@ -349,6 +428,22 @@ def serve_runtime(plugin_id: str, asset_path: str, request: Request) -> Response
     return FileResponse(target, headers=headers)
 
 
+# Set once the startup build has finished (or failed). list_plugins waits on
+# it so a fresh install cannot answer an empty shelf that nothing refreshes:
+# the MIX view lists once on mount, and only Ares has a follow-up call.
+_BUNDLED_READY = threading.Event()
+_BUNDLED_STARTED = False
+# Long enough for a cold first build on a slow disk, short enough that a build
+# wedged on something unforeseen degrades to a stale list rather than a hung UI.
+_BUNDLED_WAIT_SEC = 20.0
+
+
+def _wait_for_bundled() -> None:
+    """Block briefly until the startup build has published, if one is running."""
+    if _BUNDLED_STARTED and not _BUNDLED_READY.is_set():
+        _BUNDLED_READY.wait(_BUNDLED_WAIT_SEC)
+
+
 def _build_bundled_plugins() -> None:
     """Build the two bundled .gan plugins if they are not installed yet.
 
@@ -365,13 +460,21 @@ def _build_bundled_plugins() -> None:
     """
 
     def _build() -> None:
-        for label, build in (("The Owl", package_owl), ("Ares", package_ares)):
-            try:
-                if build().get("rebuilt"):
-                    log.info("plugin: built the bundled %s package", label)
-            except Exception as e:  # noqa: BLE001 — a missing asset is not fatal
-                log.warning("plugin: bundled %s is unavailable: %s", label, e)
+        try:
+            for label, build in (("The Owl", package_owl), ("Ares", package_ares)):
+                try:
+                    if build().get("rebuilt"):
+                        log.info("plugin: built the bundled %s package", label)
+                except Exception as e:  # noqa: BLE001 — one missing asset is not fatal
+                    log.warning("plugin: bundled %s is unavailable: %s", label, e)
+        finally:
+            # Always, including after a crash in a packager: a listing that
+            # waits forever is worse than one that lists what is there.
+            _BUNDLED_READY.set()
 
+    global _BUNDLED_STARTED
+    _BUNDLED_STARTED = True
+    _BUNDLED_READY.clear()
     threading.Thread(target=_build, daemon=True, name="plugin-bundled").start()
 
 

--- a/backend/modules/plugin/router.py
+++ b/backend/modules/plugin/router.py
@@ -13,6 +13,7 @@ import logging
 import shutil
 import subprocess
 import sys
+import threading
 from email.utils import formatdate, parsedate_to_datetime
 from pathlib import Path
 
@@ -20,6 +21,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel
 
+from backend.core.startup import register_startup_hook
 from backend.modules.plugin.gan_file import GanFile
 from backend.modules.plugin.owl_import import import_vst_foundry, source_fingerprint
 
@@ -344,3 +346,32 @@ def serve_runtime(plugin_id: str, asset_path: str, request: Request) -> Response
     if _not_modified(request, etag, stat.st_mtime):
         return Response(status_code=304, headers=headers)
     return FileResponse(target, headers=headers)
+
+
+def _build_bundled_plugins() -> None:
+    """Build the two bundled .gan plugins if they are not installed yet.
+
+    Both are compiled from in-repo assets by package-owl / package-ares, and
+    nothing called those until a person opened the shelf and pressed a button.
+    A fresh install — Pinokio, or the packaged desktop app — therefore started
+    with an empty PLUGINS shelf and an empty MIX Studio tile, while the
+    machine that had once pressed the button kept working. Both builders
+    fingerprint their source and return the installed bundle untouched when it
+    matches, so running this on every start costs one hash after the first.
+
+    Off the startup path in a daemon thread: importing a Foundry project is a
+    second or two of work and nothing should wait on it.
+    """
+
+    def _build() -> None:
+        for label, build in (("The Owl", package_owl), ("Ares", package_ares)):
+            try:
+                if build().get("rebuilt"):
+                    log.info("plugin: built the bundled %s package", label)
+            except Exception as e:  # noqa: BLE001 — a missing asset is not fatal
+                log.warning("plugin: bundled %s is unavailable: %s", label, e)
+
+    threading.Thread(target=_build, daemon=True, name="plugin-bundled").start()
+
+
+register_startup_hook("plugin-bundled", _build_bundled_plugins)

--- a/electron-ui/electron-builder.yml
+++ b/electron-ui/electron-builder.yml
@@ -120,6 +120,15 @@ extraResources:
       - "!WHERE-WE-STAND.md"
   - from: ../frontend/public/USER_GUIDE.md
     to: python/frontend/public/USER_GUIDE.md
+  # The Owl's artwork. plugin/router.py composes the bundled the-owl.gan from
+  # backend/modules/plugin/assets/the-owl/project.json plus this image, and it
+  # resolves it at _REPO_ROOT/frontend/public/owl -- which in a packaged app is
+  # python/frontend/public/owl. Without this the installed app builds the Owl
+  # with no background and the surface opens blank.
+  - from: ../frontend/public/owl
+    to: python/frontend/public/owl
+    filter:
+      - "**/*"
   # Headless notation engraver: frontend/scripts (renderScorePdf.mjs via OSMD,
   # renderTabPdf.mjs via alphaTab) plus the production node_modules they import,
   # staged by scripts/fetch-notation-renderer.mjs (npm run fetch:notation).

--- a/tests/test_plugin_bundled_startup.py
+++ b/tests/test_plugin_bundled_startup.py
@@ -1,0 +1,157 @@
+"""The bundled plugins have to be there on a machine nobody has clicked on.
+
+The Owl and Ares are composed from in-repo assets by the package endpoints,
+and until the startup hook existed nothing called those: a fresh install came
+up with an empty PLUGINS shelf and an empty MIX Studio tile. These cover the
+three ways that can silently come back -- a packager that raises taking the
+other one with it, a listing that answers before the build publishes, and an
+extraction that overwrites a live runtime halfway through.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from backend.modules.plugin import router as plugin_router
+
+
+@pytest.fixture
+def runtime_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(plugin_router, "GAN_DIR", tmp_path / "plugins")
+    monkeypatch.setattr(plugin_router, "RUNTIME_DIR", tmp_path / "plugins" / "_runtime")
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_bundled_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plugin_router, "_BUNDLED_STARTED", False)
+    monkeypatch.setattr(plugin_router, "_BUNDLED_READY", threading.Event())
+
+
+def _drain() -> None:
+    """Wait out the hook's daemon thread (it sets the event when it is done)."""
+    assert plugin_router._BUNDLED_READY.wait(30), "bundled build never finished"
+
+
+def test_a_failing_owl_does_not_stop_ares(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[str] = []
+
+    def _owl() -> dict:
+        called.append("owl")
+        raise RuntimeError("Owl project asset missing")
+
+    def _ares() -> dict:
+        called.append("ares")
+        return {"rebuilt": True}
+
+    monkeypatch.setattr(plugin_router, "package_owl", _owl)
+    monkeypatch.setattr(plugin_router, "package_ares", _ares)
+
+    plugin_router._build_bundled_plugins()
+    _drain()
+
+    assert called == ["owl", "ares"]
+
+
+def test_the_gate_opens_even_when_both_packagers_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A listing that waits forever is worse than one that lists what is there."""
+
+    def _boom() -> dict:
+        raise RuntimeError("no assets in this install")
+
+    monkeypatch.setattr(plugin_router, "package_owl", _boom)
+    monkeypatch.setattr(plugin_router, "package_ares", _boom)
+
+    plugin_router._build_bundled_plugins()
+    _drain()
+    # And a listing returns rather than blocking for the full timeout.
+    monkeypatch.setattr(plugin_router, "_BUNDLED_WAIT_SEC", 0.2)
+    plugin_router._wait_for_bundled()
+
+
+def test_listing_waits_for_a_build_in_flight(
+    runtime_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The MIX view lists once on mount. If that lands before the build
+    publishes, the shelf stays empty until someone reloads."""
+    released = threading.Event()
+
+    def _slow_owl() -> dict:
+        released.wait(5)
+        (plugin_router.GAN_DIR).mkdir(parents=True, exist_ok=True)
+        return {"rebuilt": True}
+
+    monkeypatch.setattr(plugin_router, "package_owl", _slow_owl)
+    monkeypatch.setattr(plugin_router, "package_ares", lambda: {"rebuilt": False})
+
+    plugin_router._build_bundled_plugins()
+    assert not plugin_router._BUNDLED_READY.is_set()
+
+    order: list[str] = []
+
+    def _list() -> None:
+        plugin_router.list_plugins()
+        order.append("listed")
+
+    t = threading.Thread(target=_list, daemon=True)
+    t.start()
+    t.join(0.5)
+    assert order == [], "the listing answered before the build published"
+
+    released.set()
+    t.join(10)
+    assert order == ["listed"]
+
+
+def test_publishing_a_runtime_never_exposes_half_a_tree(
+    runtime_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """serve_runtime only checks that index.html exists, so an extraction that
+    writes over a live directory can hand the iframe an old document with new
+    assets beside it. Publishing swaps whole directories instead."""
+    seen: list[str] = []
+
+    def _fake_extract(gan: str, dest: str) -> None:
+        # Whatever a build writes, it writes somewhere nothing is serving from.
+        seen.append(Path(dest).name)
+        d = Path(dest)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "index.html").write_text(Path(gan).stem, encoding="utf-8")
+        (d / "asset.js").write_text(Path(gan).stem, encoding="utf-8")
+
+    monkeypatch.setattr(plugin_router.GanFile, "extract", staticmethod(_fake_extract))
+
+    first = plugin_router.GAN_DIR / "demo-v1.gan"
+    first.parent.mkdir(parents=True, exist_ok=True)
+    first.write_text("one", encoding="utf-8")
+    plugin_router._publish_runtime(first, "demo")
+
+    active = plugin_router._runtime_dir("demo")
+    assert (active / "index.html").read_text(encoding="utf-8") == "demo-v1"
+
+    second = plugin_router.GAN_DIR / "demo-v2.gan"
+    second.write_text("two", encoding="utf-8")
+    plugin_router._publish_runtime(second, "demo")
+
+    moved = plugin_router._runtime_dir("demo")
+    assert moved != active
+    # Every file in the published tree comes from the same build.
+    assert (moved / "index.html").read_text(encoding="utf-8") == "demo-v2"
+    assert (moved / "asset.js").read_text(encoding="utf-8") == "demo-v2"
+    # Extraction never targeted the directory being served.
+    assert all(name.startswith(".staging-") for name in seen)
+
+
+def test_a_pre_versioning_runtime_keeps_working(runtime_root: Path) -> None:
+    """Installs that predate versioning kept the assets in the plugin's runtime
+    root; they must keep serving until the next build replaces them."""
+    legacy = plugin_router.RUNTIME_DIR / "old-plugin"
+    legacy.mkdir(parents=True)
+    (legacy / "index.html").write_text("legacy", encoding="utf-8")
+
+    assert plugin_router._runtime_dir("old-plugin") == legacy


### PR DESCRIPTION
This pull request introduces a startup hook that ensures the two bundled `.gan` plugins ("The Owl" and "Ares") are automatically built in the background if they are not already installed. This improves the out-of-the-box experience by making sure the shelf and studio are populated on a fresh install, without requiring user interaction. The build process runs in a separate daemon thread so it does not block the main startup flow.

**Bundled plugin build and startup improvements:**

* Added `_build_bundled_plugins` function to build the bundled `.gan` plugins ("The Owl" and "Ares") if missing, running the build in a background daemon thread to avoid blocking startup.
* Registered `_build_bundled_plugins` as a startup hook using `register_startup_hook`, ensuring the plugins are built automatically on application start.
* Imported the necessary modules `threading` and `register_startup_hook` to support the new functionality.