### PR TITLE
feat(library): import a folder from the toolbar, and three repeat modes

### DIFF
--- a/frontend/src/components/audio/PlayerFooter.tsx
+++ b/frontend/src/components/audio/PlayerFooter.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Volume2, Download, Share2, Heart, Repeat, Shuffle, VolumeX, Maximize2, MoreHorizontal, Cast, Check, Activity, ChevronUp, Headphones, Speaker } from 'lucide-react';
+import { Volume2, Download, Share2, Heart, Repeat, Repeat1, Shuffle, VolumeX, Maximize2, MoreHorizontal, Cast, Check, Activity, ChevronUp, Headphones, Speaker } from 'lucide-react';
 import { useGenerateStore } from '../../state/generateStore';
 import { usePlaybackStore } from '../../state/playbackStore';
 import { usePlayerStore } from '../../state/playerStore';
@@ -30,6 +30,18 @@ import {
 import { useEditThemeStore } from '../../state/editThemeStore';
 import { resolveEditThemeVars } from '../../lib/editThemes';
 import { LogActionButton } from '../layout/ProcessingLog';
+
+/** What each repeat state is called, in the tooltip and for a screen reader. */
+const REPEAT_LABEL: Record<'off' | 'all' | 'one', string> = {
+  off: 'Repeat off - play the list through and stop',
+  all: 'Repeat all - the list starts again at the end',
+  one: 'Repeat one - this track loops',
+};
+const REPEAT_KEY_LABEL: Record<'off' | 'all' | 'one', string> = {
+  off: 'LOOP',
+  all: 'ALL',
+  one: 'ONE',
+};
 
 const formatDuration = (sec: number | null | undefined): string => {
   if (sec == null || !Number.isFinite(sec) || sec < 0) return '--:--';
@@ -512,11 +524,11 @@ export const PlayerFooter: React.FC = () => {
   const engineLabel = usePlayerStore((s) => s.currentLabel);
   const engineDuration = usePlayerStore((s) => s.duration);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
-  const isLooping = usePlayerStore((s) => s.isLooping);
+  const repeatMode = usePlayerStore((s) => s.repeatMode);
   const hasTrack = usePlayerStore((s) => s.hasTrack);
   const toggle = usePlayerStore((s) => s.toggle);
   const seekByFraction = usePlayerStore((s) => s.seekByFraction);
-  const toggleLoop = usePlayerStore((s) => s.toggleLoop);
+  const cycleRepeat = usePlayerStore((s) => s.cycleRepeat);
   const setMasterGain = usePlayerStore((s) => s.setMasterGain);
   const load = usePlayerStore((s) => s.load);
   const currentEntryId = usePlayerStore((s) => s.currentEntryId);
@@ -777,16 +789,23 @@ export const PlayerFooter: React.FC = () => {
             overflow-hidden or a clip-path: the keys' focus outline draws
             outside them. */}
         <div data-tour="transport" className="shrink-0 flex items-stretch h-9 p-px gap-px rounded-xs border border-white/8 bg-black/40 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+          {/* Three states, one key: off -> the list plays through and stops,
+              all -> the list wraps, one -> this track repeats. aria-pressed is
+              deliberately absent: a tri-state control is not a toggle, so the
+              state travels in the label instead. */}
           <button
             type="button"
-            onClick={toggleLoop}
-            aria-label={isLooping ? 'Looping on' : 'Looping off'}
-            aria-pressed={isLooping}
-            title={isLooping ? 'Looping on' : 'Looping off'}
-            className={`${transportKey} ${isLooping ? transportKeyOn : transportKeyOff}`}
+            onClick={cycleRepeat}
+            aria-label={REPEAT_LABEL[repeatMode]}
+            title={`${REPEAT_LABEL[repeatMode]} - click to change`}
+            className={`${transportKey} ${repeatMode === 'off' ? transportKeyOff : transportKeyOn}`}
           >
-            <Repeat className="w-3.5 h-3.5" strokeWidth={1.5} absoluteStrokeWidth strokeLinecap="square" strokeLinejoin="miter" />
-            <span aria-hidden="true" className={keyLabel}>LOOP</span>
+            {repeatMode === 'one' ? (
+              <Repeat1 className="w-3.5 h-3.5" strokeWidth={1.5} absoluteStrokeWidth strokeLinecap="square" strokeLinejoin="miter" />
+            ) : (
+              <Repeat className="w-3.5 h-3.5" strokeWidth={1.5} absoluteStrokeWidth strokeLinecap="square" strokeLinejoin="miter" />
+            )}
+            <span aria-hidden="true" className={keyLabel}>{REPEAT_KEY_LABEL[repeatMode]}</span>
           </button>
           <button
             type="button"

--- a/frontend/src/state/playerStore.ts
+++ b/frontend/src/state/playerStore.ts
@@ -338,6 +338,21 @@ if (typeof window !== 'undefined') {
   window.addEventListener('touchstart', onFirstGesture, { once: false, passive: true });
 }
 
+/**
+ * Transport repeat, in the three states a music player has:
+ *   'off' - the track ends and the queue moves on; at the end of the list,
+ *           playback stops.
+ *   'all' - the queue wraps, so a library list plays forever.
+ *   'one' - the <audio> element loops natively and never fires `ended`.
+ *
+ * `isLooping` is kept in lockstep with `mode === 'one'` because MIDI mapping,
+ * the control-surface bridge and the live mixer all read and write that flag;
+ * they mean "loop this one thing", which is exactly 'one'.
+ */
+export type RepeatMode = 'off' | 'all' | 'one';
+
+export const REPEAT_ORDER: RepeatMode[] = ['off', 'all', 'one'];
+
 interface PlayerStoreState {
   // Currently-loaded track meta
   currentLabel: string | null;
@@ -346,6 +361,7 @@ interface PlayerStoreState {
   currentTime: number;
   isPlaying: boolean;
   isLooping: boolean;
+  repeatMode: RepeatMode;
   // Whether a track is loaded at all (for footer UI states)
   hasTrack: boolean;
 
@@ -357,6 +373,9 @@ interface PlayerStoreState {
   seek: (sec: number) => void;
   seekByFraction: (frac: number) => void;
   toggleLoop: () => void;
+  /** off -> all -> one -> off. What the LOOP key in the footer does. */
+  cycleRepeat: () => void;
+  setRepeatMode: (mode: RepeatMode) => void;
   setMasterGain: (gain: number) => void;
 }
 
@@ -366,7 +385,10 @@ export const usePlayerStore = create<PlayerStoreState>()((set, get) => ({
   duration: 0,
   currentTime: 0,
   isPlaying: false,
-  isLooping: true,
+  // Playing a track from the library plays the rest of the list after it, so
+  // the default is 'all' rather than looping the one track forever.
+  isLooping: false,
+  repeatMode: 'all',
   hasTrack: false,
 
   load: async (blob, meta) => {
@@ -481,10 +503,20 @@ export const usePlayerStore = create<PlayerStoreState>()((set, get) => ({
   },
 
   toggleLoop: () => {
-    const next = !get().isLooping;
-    set({ isLooping: next });
+    // Kept for the callers that mean "loop this one thing" (MIDI mapping, the
+    // control-surface bridge): it flips between 'one' and 'off'.
+    get().setRepeatMode(get().isLooping ? 'off' : 'one');
+  },
+
+  cycleRepeat: () => {
+    const i = REPEAT_ORDER.indexOf(get().repeatMode);
+    get().setRepeatMode(REPEAT_ORDER[(i + 1) % REPEAT_ORDER.length]);
+  },
+
+  setRepeatMode: (mode) => {
+    set({ repeatMode: mode, isLooping: mode === 'one' });
     const { audioEl } = ensureEngine();
-    audioEl.loop = next;
+    audioEl.loop = mode === 'one';
   },
 
   setMasterGain: (gain) => {

--- a/frontend/src/state/playlistQueue.ts
+++ b/frontend/src/state/playlistQueue.ts
@@ -1,8 +1,13 @@
 /**
- * Sequential play queue for the playlist suggester. Plays a list of library
- * entry ids in order through the global player, auto-advancing when each track
- * ends. Loop is turned off while a queue is active (so tracks actually end) and
- * the user's loop preference is restored when the queue finishes.
+ * Sequential play queue for the library and the playlist suggester. Plays a
+ * list of library entry ids through the global player, advancing when a track
+ * ends.
+ *
+ * Repeat mode decides what "ends" means: 'one' loops the <audio> element
+ * natively so the queue never advances, 'all' wraps at the end of the list,
+ * and 'off' stops there. The queue no longer forces loop off while it runs --
+ * it used to, which is why starting a list silently clobbered the user's loop
+ * setting and why playing a track from the library played only that track.
  */
 import { usePlayerStore, setQueueOnEnded } from './playerStore';
 import { useLibraryStore } from './libraryStore';
@@ -10,7 +15,6 @@ import { logInfo } from './logStore';
 
 let _queue: string[] = [];
 let _pos = -1;
-let _restoreLoop = false;
 
 const playId = async (id: string): Promise<boolean> => {
   const entry = useLibraryStore.getState().entries.find((e) => e.id === id);
@@ -27,34 +31,36 @@ const playId = async (id: string): Promise<boolean> => {
 };
 
 const advance = async (): Promise<void> => {
-  _pos += 1;
-  while (_pos < _queue.length) {
+  const wrap = usePlayerStore.getState().repeatMode === 'all';
+  // A track that fails to load is skipped; the guard counts attempts so a
+  // wrapping queue of entirely unloadable tracks cannot spin forever.
+  for (let tried = 0; tried < _queue.length; tried += 1) {
+    _pos += 1;
+    if (_pos >= _queue.length) {
+      if (!wrap) break;
+      _pos = 0;
+    }
     if (await playId(_queue[_pos])) return;
-    _pos += 1; // skip a track that failed to load and try the next
   }
   stopQueue();
 };
 
-/** Play the given entry ids in order, auto-advancing track to track. */
-export const startQueue = async (ids: string[]): Promise<void> => {
+/** Play `ids` in order, starting at `startIndex`, advancing track to track. */
+export const startQueue = async (ids: string[], startIndex = 0): Promise<void> => {
   if (ids.length === 0) return;
   _queue = ids.slice();
-  _pos = -1;
-  // Loop must be off so each track ends and the queue can advance.
-  const ps = usePlayerStore.getState();
-  _restoreLoop = ps.isLooping;
-  if (ps.isLooping) ps.toggleLoop();
+  _pos = Math.max(0, Math.min(startIndex, _queue.length - 1)) - 1;
   setQueueOnEnded(advance);
-  logInfo('library', `Playing a suggested playlist of ${ids.length} tracks`);
+  logInfo('library', `Playing ${ids.length} track${ids.length === 1 ? '' : 's'}`);
   await advance();
 };
 
-/** Stop the queue and restore the prior loop preference. */
+/** Stop the queue. Repeat mode is the user's setting and is left alone. */
 export const stopQueue = (): void => {
   _queue = [];
   _pos = -1;
   setQueueOnEnded(null);
-  const ps = usePlayerStore.getState();
-  if (_restoreLoop && !ps.isLooping) ps.toggleLoop();
-  _restoreLoop = false;
 };
+
+/** Ids currently queued, for a UI that wants to show what plays next. */
+export const queuedIds = (): string[] => _queue.slice();

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -5,10 +5,12 @@ import {
   LayoutGrid, List as ListIcon, Activity, Scissors, Layers, Wand2, PenLine,
   Package, Network, FileMusic, Loader2, Mic, Piano, ListOrdered,
   CheckSquare, Square, MoreHorizontal, Combine, Paintbrush, FileText, ChevronDown, Maximize2,
-  Film, Image as ImageIcon, Upload, RefreshCw, Tv2, Repeat, Info, Link2,
+  Film, Image as ImageIcon, Upload, RefreshCw, Tv2, Repeat, Info, Link2, FolderPlus,
 } from 'lucide-react';
 import { CoverArt } from '../catalog/CoverArt';
 import { importUrlToLibrary } from '../lib/onlineImport';
+import { importFolder } from '../lib/mediaLibrary';
+import { startQueue } from '../state/playlistQueue';
 import { DESKTOP_DROP_ORIGIN, dropHasLibraryOrFiles, entriesFromDrop } from '../lib/libraryDrop';
 import { ContextMenu, useContextMenu, type ContextMenuItem } from '../components/ui/ContextMenu';
 import { useConvertMenu } from '../convert/ConvertMenu';
@@ -778,11 +780,37 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
       }
       return;
     }
-    // Otherwise load and play through the global engine — visualizer + footer follow.
+    // Play the list, not the track: pressing play on a row queues everything
+    // currently visible (so a filter or a search narrows what plays) starting
+    // at that row. The transport's repeat mode decides what happens at the
+    // end — stop, wrap, or loop this one track.
+    const list = filteredEntries.map((e) => e.id);
+    const at = list.indexOf(entry.id);
+    if (at >= 0) {
+      await startQueue(list, at);
+      return;
+    }
     const blob = await useLibraryStore.getState().fetchAudioBlob(entry);
     await engineLoad(blob, { label: entry.title, entryId: entry.id });
     enginePlay();
     setPlayingId(entry.id);
+  };
+
+  const handleImportFolder = async () => {
+    try {
+      const res = await importFolder();
+      if (res.cancelled) return;
+      await useLibraryStore.getState().refresh();
+      logInfo(
+        'library',
+        `Added ${res.entries.length} track${res.entries.length === 1 ? '' : 's'} from ${res.folder}`,
+      );
+    } catch (e) {
+      logError(
+        'library',
+        `Folder import failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
   };
 
   // Compact analytics strip at the very top of the panel — the user
@@ -886,6 +914,14 @@ export const LibraryView: React.FC<{ onSwitchTab?: (tab: string) => void; onExpa
             title="Import a .mid file → piano roll"
           >
             <FileMusic className="w-3 h-3" />
+          </button>
+          <button
+            onClick={() => void handleImportFolder()}
+            className="p-1 rounded text-zinc-500 hover:text-purple-300"
+            title="Add a folder of audio to the library (files stay where they are)"
+            aria-label="Import a folder into the library"
+          >
+            <FolderPlus className="w-3 h-3" />
           </button>
           <button
             onClick={() => setLinkOpen((v) => !v)}


### PR DESCRIPTION
Playing a track from the library played that track and stopped. Pressing play on a row now queues everything currently visible, starting at that row, so a search or a filter decides what plays -- and the transport's repeat key says what happens when the list runs out.

That key is tri-state now, the way a music player's is: off plays the list through and stops, all wraps, one loops the current track natively. isLooping survives as "mode is one", because MIDI mapping, the control-surface bridge and the live mixer all read and write it meaning exactly that. The default moves from looping one track forever to playing the list.

The queue no longer forces loop off while it runs. It did, and restored the old value afterwards, which silently clobbered the setting whenever a queue was interrupted.

/api/library/import-folder and its client helper have existed since the folder-as-playlist work; nothing in the UI called them. A folder button sits in the library toolbar now. The files stay where they are -- each becomes a reference-in-place entry, so a 200 GB sample drive costs no disk.