### PR TITLE
fix(learn): the lineage graphs fill the LEARN panel at every window s…

### DIFF
--- a/frontend/src/components/library/LineageModal.tsx
+++ b/frontend/src/components/library/LineageModal.tsx
@@ -640,12 +640,12 @@ export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, o
             effective scale of 1, matching the portaled modal and
             fullscreen paths.
 
-            Its size stays 100%. Under standardized CSS zoom (Chromium 128+,
-            every Electron this app ships) a percentage resolves against the
-            parent and is not scaled by the element's own zoom, so a box of
-            `100% * zoom` covered only `zoom` of the panel in each direction
-            at zoom < 1 and overflowed it, clipped, at zoom > 1.
-            lineageWrapperGuards.test.ts fails if the multiplier returns. */}
+            Its size stays 100%. A box of `100% * zoom` covered only `zoom`
+            of the panel in each direction at zoom < 1 and overflowed it,
+            clipped, at zoom > 1. Measured in Electron 42 with Chromium's
+            standardized CSS zoom and with its legacy zoom; 100% fills the
+            panel in both. lineageWrapperGuards.test.ts fails if the
+            multiplier returns. */}
         <div className="flex-1 min-h-0 relative">
           <div
             className="relative"

--- a/frontend/src/components/library/LineageModal.tsx
+++ b/frontend/src/components/library/LineageModal.tsx
@@ -636,19 +636,21 @@ export const LineageModal: React.FC<LineageModalProps> = ({ open, rootEntryId, o
             Shell's `.dense-layout` CSS zoom, which breaks the graph
             libraries' pointer math (three-render-objects raycasts and the
             SVG pan/drag both assume unzoomed CSS pixels). The inner
-            wrapper counter-zooms by 1/zoom and pre-scales its box by zoom
-            so the graph area runs at an effective scale of 1 — matching
-            the portaled modal and fullscreen paths, which stay untouched
-            (they get a plain full-size wrapper). */}
+            wrapper counter-zooms by 1/zoom so the graph area runs at an
+            effective scale of 1, matching the portaled modal and
+            fullscreen paths.
+
+            Its size stays 100%. Under standardized CSS zoom (Chromium 128+,
+            every Electron this app ships) a percentage resolves against the
+            parent and is not scaled by the element's own zoom, so a box of
+            `100% * zoom` covered only `zoom` of the panel in each direction
+            at zoom < 1 and overflowed it, clipped, at zoom > 1.
+            lineageWrapperGuards.test.ts fails if the multiplier returns. */}
         <div className="flex-1 min-h-0 relative">
           <div
             className="relative"
             style={useInlineLayout
-              ? {
-                  zoom: 'calc(1 / var(--layout-zoom, 1))',
-                  width: 'calc(100% * var(--layout-zoom, 1))',
-                  height: 'calc(100% * var(--layout-zoom, 1))',
-                }
+              ? { zoom: 'calc(1 / var(--layout-zoom, 1))', width: '100%', height: '100%' }
               : { width: '100%', height: '100%' }}
           >
             {loading && (

--- a/frontend/src/components/library/lineageWrapperGuards.test.ts
+++ b/frontend/src/components/library/lineageWrapperGuards.test.ts
@@ -3,13 +3,11 @@
  *
  * The Shell renders under CSS `zoom: var(--layout-zoom)`. A panel that needs
  * unzoomed pointer math (the LEARN graphs) counter-zooms with
- * `zoom: calc(1 / var(--layout-zoom))`. Under standardized CSS zoom, which is
- * what Chromium 128+ and every shipped Electron implement, a percentage size
- * resolves against the parent and ignores the element's own zoom. A wrapper
- * sized `calc(100% * var(--layout-zoom))` therefore covers `zoom` of its panel
- * in each direction below zoom 1 and overflows it above zoom 1. Measured in
- * Chromium 148: at zoom 0.85 the LEARN graph box was 1136x476 inside a
- * 1337x560 panel.
+ * `zoom: calc(1 / var(--layout-zoom))` and keeps its size at 100%. A wrapper
+ * sized `calc(100% * var(--layout-zoom))` covers `zoom` of its panel in each
+ * direction below zoom 1 and overflows it above zoom 1, under Chromium's
+ * standardized CSS zoom and under its legacy zoom. At zoom 0.85 the LEARN
+ * graph canvas measured 1136x476 inside a 1337x560 panel.
  *
  * This reads every .tsx under src and fails on any element that counter-zooms
  * and also multiplies its width or height by --layout-zoom.

--- a/frontend/src/components/library/lineageWrapperGuards.test.ts
+++ b/frontend/src/components/library/lineageWrapperGuards.test.ts
@@ -1,0 +1,61 @@
+/**
+ * A counter-zoom wrapper must not scale its own size by the layout zoom.
+ *
+ * The Shell renders under CSS `zoom: var(--layout-zoom)`. A panel that needs
+ * unzoomed pointer math (the LEARN graphs) counter-zooms with
+ * `zoom: calc(1 / var(--layout-zoom))`. Under standardized CSS zoom, which is
+ * what Chromium 128+ and every shipped Electron implement, a percentage size
+ * resolves against the parent and ignores the element's own zoom. A wrapper
+ * sized `calc(100% * var(--layout-zoom))` therefore covers `zoom` of its panel
+ * in each direction below zoom 1 and overflows it above zoom 1. Measured in
+ * Chromium 148: at zoom 0.85 the LEARN graph box was 1136x476 inside a
+ * 1337x560 panel.
+ *
+ * This reads every .tsx under src and fails on any element that counter-zooms
+ * and also multiplies its width or height by --layout-zoom.
+ */
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const srcRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const tsxFiles = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(full);
+    return entry.name.endsWith('.tsx') ? [full] : [];
+  });
+
+const COUNTER_ZOOM = /zoom:\s*['"`]calc\(1\s*\/\s*var\(--layout-zoom/;
+const SCALED_SIZE = /(width|height):\s*['"`]calc\(100%\s*\*\s*var\(--layout-zoom/;
+
+const offenders: string[] = [];
+for (const file of tsxFiles(srcRoot)) {
+  const lines = readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    if (!COUNTER_ZOOM.test(line)) return;
+    // A style object spans a few lines; check the counter-zoom line and the
+    // lines around it, which is where its width and height are written.
+    const window = lines.slice(Math.max(0, i - 4), i + 5).join('\n');
+    if (SCALED_SIZE.test(window)) offenders.push(`${relative(srcRoot, file)}:${i + 1}`);
+  });
+}
+
+assert.deepEqual(
+  offenders,
+  [],
+  'a counter-zoomed wrapper multiplies its size by --layout-zoom, so it fills only ' +
+    'part of its panel below zoom 1 and overflows above it: ' +
+    offenders.join(', '),
+);
+
+const lineage = readFileSync(join(srcRoot, 'components', 'library', 'LineageModal.tsx'), 'utf8');
+assert.match(
+  lineage,
+  /zoom:\s*'calc\(1 \/ var\(--layout-zoom, 1\)\)',\s*width:\s*'100%',\s*height:\s*'100%'/,
+  'the LEARN graph wrapper must counter-zoom and stay 100% of its panel',
+);
+
+console.log('lineage wrapper guards: ok');


### PR DESCRIPTION
This pull request addresses a critical bug in how the LEARN graph panel handles CSS zoom scaling, ensuring correct sizing and pointer math under varying zoom levels. The main changes include fixing the counter-zoom wrapper logic in `LineageModal.tsx` and adding a comprehensive test in `lineageWrapperGuards.test.ts` to prevent regressions.

**Bug fix: Counter-zoom wrapper sizing**

* Updated the inner wrapper in `LineageModal.tsx` to use only `zoom: calc(1 / var(--layout-zoom, 1))` with `width: '100%'` and `height: '100%'`, removing the previous scaling by `var(--layout-zoom, 1)`. This ensures the graph area always fills the panel correctly, regardless of zoom level.

**Testing and regression protection**

* Added `lineageWrapperGuards.test.ts`, which scans all `.tsx` files to assert that no counter-zoomed wrapper multiplies its size by `--layout-zoom`. It also directly verifies that `LineageModal.tsx` uses the correct style. This prevents future regressions and documents the correct approach.…cale